### PR TITLE
Promote NU3043 warning to error in mssign and reposign commands

### DIFF
--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignAbstract.cs
@@ -154,7 +154,7 @@ namespace NuGet.MSSigning.Extensions
             }
         }
 
-        protected void ValidateCertificateInputs(ILogger logger)
+        protected void ValidateCertificateInputs()
         {
             if (string.IsNullOrEmpty(CertificateFile))
             {
@@ -176,22 +176,13 @@ namespace NuGet.MSSigning.Extensions
                         nameof(KeyContainer)));
             }
 
-            if (string.IsNullOrEmpty(CertificateFingerprint))
+            if (string.IsNullOrEmpty(CertificateFingerprint) ||
+                !CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out Common.HashAlgorithmName hashAlgorithmName) ||
+                hashAlgorithmName == Common.HashAlgorithmName.SHA1)
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                         NuGetMSSignCommand.MSSignCommandInvalidCertificateFingerprint,
-                        nameof(CertificateFingerprint)));
-            }
-            else
-            {
-                if (!CertificateUtility.TryDeduceHashAlgorithm(CertificateFingerprint, out Common.HashAlgorithmName hashAlgorithmName))
-                {
-                    throw new ArgumentException(NuGetMSSignCommand.MSSignCommandInvalidCertificateFingerprint);
-                }
-                else if (hashAlgorithmName == Common.HashAlgorithmName.SHA1)
-                {
-                    logger.Log(LogMessage.CreateWarning(NuGetLogCode.NU3043, NuGetMSSignCommand.MSSignCommandInvalidCertificateFingerprint));
-                }
+                        NuGetLogCode.NU3043));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/MSSignCommand.cs
@@ -40,7 +40,7 @@ namespace NuGet.MSSigning.Extensions
         {
             ValidatePackagePath();
             WarnIfNoTimestamper(Console);
-            ValidateCertificateInputs(Console);
+            ValidateCertificateInputs();
             EnsureOutputDirectory();
 
             var signingSpec = SigningSpecifications.V1;

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.Designer.cs
@@ -115,7 +115,7 @@ namespace NuGet.MSSigning.Extensions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for &apos;CertificateFingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
+        ///   Looks up a localized string similar to {0}: Invalid value for &apos;CertificateFingerprint&apos; option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
         /// </summary>
         internal static string MSSignCommandInvalidCertificateFingerprint {
             get {

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/NuGetMSSignCommand.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -203,6 +203,6 @@ nuget reposign MyPackage.nupkg -Timestamper http://timestamper.test -Certificate
     <value>Repository V3 service index URL.</value>
   </data>
   <data name="MSSignCommandInvalidCertificateFingerprint" xml:space="preserve">
-    <value>Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
+    <value>{0}: Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/RepoSignCommand.cs
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/RepoSignCommand.cs
@@ -53,7 +53,7 @@ namespace NuGet.MSSigning.Extensions
         {
             ValidatePackagePath();
             WarnIfNoTimestamper(Console);
-            ValidateCertificateInputs(Console);
+            ValidateCertificateInputs();
             EnsureOutputDirectory();
             ValidatePackageOwners();
 

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
@@ -289,12 +289,12 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
         }
 
         [CIOnlyFact]
-        public async Task MSSignCommand_SignPackageWithSHA1CertificateFingerprint_Raises_WarningAsync()
+        public async Task MSSignCommand_SignPackageWithSHA1CertificateFingerprint_RaisesExceptionAsync()
         {
             var result = await ExecuteMSSignCommandAsync(Common.HashAlgorithmName.SHA1);
 
-            result.Success.Should().BeTrue(because: result.AllOutput);
-            result.AllOutput.Should().Contain(_invalidCertificateFingerprintCode);
+            result.Success.Should().BeFalse(because: result.AllOutput);
+            result.Errors.Should().Contain(_invalidCertificateFingerprintCode);
         }
 
         [CIOnlyTheory]

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/MSSignCommandTests.cs
@@ -26,7 +26,6 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
     {
         private readonly string _noTimestamperWarningCode = NuGetLogCode.NU3002.ToString();
         private readonly string _invalidCertificateFingerprintCode = NuGetLogCode.NU3043.ToString();
-        private const string Sha1Hash = "89967D1DD995010B6C66AE24FF8E66885E6E03A8";
         private const string Sha256Hash = "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b55b046cbb7f506fb";
 
         private readonly TrustedTestCert<TestCertificate> _trustedTestCertWithPrivateKey;
@@ -60,7 +59,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFile = Path.Combine(dir, "non-existant-cert.pfx"),
                     CSPName = test.CertificateCSPName,
                     KeyContainer = test.CertificateKeyContainer,
-                    CertificateFingerprint = test.Cert.Thumbprint,
+                    CertificateFingerprint = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256),
                 };
                 signCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
@@ -87,7 +86,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFile = test.CertificatePath,
                     CSPName = "random nonexistant csp name",
                     KeyContainer = test.CertificateKeyContainer,
-                    CertificateFingerprint = test.Cert.Thumbprint,
+                    CertificateFingerprint = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256),
                 };
                 signCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
@@ -114,7 +113,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFile = test.CertificatePath,
                     CSPName = test.CertificateCSPName,
                     KeyContainer = "invalid-key-container",
-                    CertificateFingerprint = test.Cert.Thumbprint,
+                    CertificateFingerprint = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256),
                 };
                 signCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
@@ -124,10 +123,8 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             }
         }
 
-        [CIOnlyTheory]
-        [InlineData(Sha1Hash)]
-        [InlineData(Sha256Hash)]
-        public void GetAuthorSignRequest_InvalidFingerprint(string certificateFingerPrint)
+        [CIOnlyFact]
+        public void GetAuthorSignRequest_InvalidFingerprint()
         {
             var mockConsole = new Mock<IConsole>();
             var timestampUri = "http://timestamp.test/url";
@@ -143,7 +140,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFile = test.CertificatePath,
                     CSPName = test.CertificateCSPName,
                     KeyContainer = test.CertificateKeyContainer,
-                    CertificateFingerprint = certificateFingerPrint,
+                    CertificateFingerprint = Sha256Hash,
                 };
                 signCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
@@ -163,6 +160,8 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             using (var dir = TestDirectory.Create())
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
+                var actualCertFingerprint = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256);
+
                 var signCommand = new MSSignCommand
                 {
                     Console = mockConsole.Object,
@@ -170,7 +169,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFile = test.CertificatePath,
                     CSPName = test.CertificateCSPName,
                     KeyContainer = test.CertificateKeyContainer,
-                    CertificateFingerprint = test.Cert.Thumbprint,
+                    CertificateFingerprint = actualCertFingerprint,
                 };
                 signCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
 
@@ -180,7 +179,8 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                 // Assert
                 Assert.Equal(SignatureType.Author, signRequest.SignatureType);
                 Assert.NotNull(signRequest.Certificate);
-                Assert.Equal(signRequest.Certificate.Thumbprint, test.Cert.Thumbprint, StringComparer.Ordinal);
+                string expectedCertFingerprint = SignatureTestUtility.GetFingerprint(signRequest.Certificate, Common.HashAlgorithmName.SHA256);
+                Assert.Equal(expectedCertFingerprint, actualCertFingerprint, StringComparer.Ordinal);
                 Assert.NotNull(signRequest.PrivateKey);
             }
         }
@@ -193,8 +193,9 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             // Arrange
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256);
                 var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
-                var command = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
+                var command = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash}";
 
                 var result = CommandRunner.Run(
                     _nugetExePath,
@@ -215,8 +216,9 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             // Arrange
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256);
                 var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
-                var command = $"mssign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
+                var command = $"mssign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash}";
 
                 var result = CommandRunner.Run(
                     _nugetExePath,
@@ -236,8 +238,9 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             // Arrange
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256);
                 var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
-                var command = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
+                var command = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash}";
 
                 var result = CommandRunner.Run(
                     _nugetExePath,
@@ -266,9 +269,10 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             // Arrange
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256);
                 var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
-                var command = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
-                var commandWithOverwrite = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -Overwrite";
+                var command = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash}";
+                var commandWithOverwrite = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash} -Overwrite";
 
                 var result = CommandRunner.Run(
                     _nugetExePath,

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
@@ -26,7 +26,6 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
     {
         private readonly string _noTimestamperWarningCode = NuGetLogCode.NU3002.ToString();
         private readonly string _invalidCertificateFingerprintCode = NuGetLogCode.NU3043.ToString();
-        private const string Sha1Hash = "89967D1DD995010B6C66AE24FF8E66885E6E03A8";
         private const string Sha256Hash = "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b55b046cbb7f506fb";
 
         private readonly TrustedTestCert<TestCertificate> _trustedTestCertWithPrivateKey;
@@ -61,7 +60,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFile = Path.Combine(dir, "non-existant-cert.pfx"),
                     CSPName = test.CertificateCSPName,
                     KeyContainer = test.CertificateKeyContainer,
-                    CertificateFingerprint = test.Cert.Thumbprint,
+                    CertificateFingerprint = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256),
                     V3ServiceIndexUrl = v3serviceIndex,
                 };
                 reposignCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
@@ -90,7 +89,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFile = test.CertificatePath,
                     CSPName = "random nonexistant csp name",
                     KeyContainer = test.CertificateKeyContainer,
-                    CertificateFingerprint = test.Cert.Thumbprint,
+                    CertificateFingerprint = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256),
                     V3ServiceIndexUrl = v3serviceIndex,
                 };
                 reposignCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
@@ -119,7 +118,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFile = test.CertificatePath,
                     CSPName = test.CertificateCSPName,
                     KeyContainer = "invalid-key-container",
-                    CertificateFingerprint = test.Cert.Thumbprint,
+                    CertificateFingerprint = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256),
                     V3ServiceIndexUrl = v3serviceIndex,
                 };
                 reposignCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
@@ -131,7 +130,6 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
         }
 
         [CIOnlyTheory]
-        [InlineData(Sha1Hash)]
         [InlineData(Sha256Hash)]
         public void GetRepositorySignRequest_InvalidFingerprint(string certificateFingerPrint)
         {
@@ -179,7 +177,7 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
                     CertificateFile = test.CertificatePath,
                     CSPName = test.CertificateCSPName,
                     KeyContainer = test.CertificateKeyContainer,
-                    CertificateFingerprint = test.Cert.Thumbprint,
+                    CertificateFingerprint = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256),
                     V3ServiceIndexUrl = v3serviceIndex,
                 };
                 reposignCommand.Arguments.Add(Path.Combine(dir, "package.nupkg"));
@@ -205,7 +203,8 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
-                var command = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256);
+                var command = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
 
                 var result = CommandRunner.Run(
                     _nugetExePath,
@@ -227,7 +226,8 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
-                var command = $"reposign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256);
+                var command = $"reposign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
 
                 var result = CommandRunner.Run(
                     _nugetExePath,
@@ -248,7 +248,8 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
-                var command = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256);
+                var command = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
 
                 var result = CommandRunner.Run(
                     _nugetExePath,
@@ -278,8 +279,9 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
-                var authorSignCommand = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
-                var repoSignCommand = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256);
+                var authorSignCommand = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash}";
+                var repoSignCommand = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
 
                 var result = CommandRunner.Run(
                     _nugetExePath,
@@ -309,8 +311,9 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
-                var authorSignCommand = $"mssign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
-                var repoSignCommand = $"reposign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256);
+                var authorSignCommand = $"mssign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash}";
+                var repoSignCommand = $"reposign {unsignedPackageFile} -Timestamper {timestampService.Url} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
 
                 var result = CommandRunner.Run(
                     _nugetExePath,
@@ -339,8 +342,9 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
             using (var test = new MSSignCommandTestContext(_trustedTestCertWithPrivateKey.TrustedCert))
             {
                 var unsignedPackageFile = await package.CreateAsFileAsync(test.Directory, Guid.NewGuid().ToString());
-                var authorSignCommand = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint}";
-                var repoSignCommand = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {test.Cert.Thumbprint} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
+                string certSha256Hash = SignatureTestUtility.GetFingerprint(test.Cert, Common.HashAlgorithmName.SHA256);
+                var authorSignCommand = $"mssign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash}";
+                var repoSignCommand = $"reposign {unsignedPackageFile} -CertificateFile {test.CertificatePath} -CSPName \"{test.CertificateCSPName}\" -KeyContainer \"{test.CertificateKeyContainer}\" -CertificateFingerprint {certSha256Hash} -V3ServiceIndexUrl https://v3serviceIndex.test/api/index.json";
 
                 var result = CommandRunner.Run(
                     _nugetExePath,

--- a/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.MSSigning.Extensions.FuncTest/Commands/ReposignCommandTests.cs
@@ -370,12 +370,12 @@ namespace NuGet.MSSigning.Extensions.FuncTest.Commands
         }
 
         [CIOnlyFact]
-        public async Task RepoSignCommand_SignPackageWithSHA1CertificateFingerprint_Raises_WarningAsync()
+        public async Task RepoSignCommand_SignPackageWithSHA1CertificateFingerprint_RaisesExceptionAsync()
         {
             var result = await ExecuteRepoSignCommandAsync(Common.HashAlgorithmName.SHA1);
 
-            result.Success.Should().BeTrue(because: result.AllOutput);
-            result.AllOutput.Should().Contain(_invalidCertificateFingerprintCode);
+            result.Success.Should().BeFalse(because: result.AllOutput);
+            result.Errors.Should().Contain(_invalidCertificateFingerprintCode);
         }
 
         [CIOnlyTheory]

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetMSSignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetMSSignCommandTest.cs
@@ -13,7 +13,7 @@ namespace NuGet.MSSigning.Extensions.Test
         private const string NoPackageException = "No package was provided. For a list of accepted ways to provide a package, please visit https://docs.nuget.org/docs/reference/command-line-reference";
         private const string InvalidArgException = "Invalid value provided for '{0}'. For a list of accepted values, please visit https://learn.microsoft.com/nuget/reference/cli-reference/cli-ref-sign";
         private const string NoCertificateException = "No {0} provided or provided file is not a p7b file.";
-        private const string InvalidCertificateFingerprint = "Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).";
+        private const string InvalidCertificateFingerprint = "NU3043: Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).";
         private const string Sha256Hash = "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b55b046cbb7f506fb";
 
         [Fact]

--- a/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetReposignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.MSSigning.Extensions.Test/NuGetReposignCommandTest.cs
@@ -17,7 +17,7 @@ namespace NuGet.CommandLine.MSSigning.Extensions.Test
         private const string NoPackageException = "No package was provided. For a list of accepted ways to provide a package, please visit https://docs.nuget.org/docs/reference/command-line-reference";
         private const string InvalidArgException = "Invalid value provided for '{0}'. For a list of accepted values, please visit https://learn.microsoft.com/nuget/reference/cli-reference/cli-ref-sign";
         private const string NoCertificateException = "No {0} provided or provided file is not a p7b file.";
-        private const string InvalidCertificateFingerprint = "Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).";
+        private const string InvalidCertificateFingerprint = "NU3043: Invalid value for 'CertificateFingerprint' option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).";
         private const string Sha256Hash = "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b55b046cbb7f506fb";
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Tracking: https://github.com/NuGet/Home/issues/13962

## Description

Updated mssign and reposign commands to accept fingerprints from the SHA-2 family (SHA256, SHA384, or SHA512) instead of SHA-1. If a SHA-1 fingerprint or invalid value is passed, the commands raise an [NU3043](https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu3043) error indicating that SHA-1 is insecure. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~