### PR TITLE
Simplify certificate validation logic while raising NU3043 error in dotnet.exe

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
@@ -236,16 +236,11 @@ namespace NuGet.CommandLine.XPlat
             {
                 bool isValidFingerprint = CertificateUtility.TryDeduceHashAlgorithm(fingerprint.Value(), out HashAlgorithmName hashAlgorithmName);
                 bool isSHA1 = hashAlgorithmName == HashAlgorithmName.SHA1;
-                int assemblyVersion = typeof(int).Assembly.GetName().Version.Major;
                 string message = string.Format(CultureInfo.CurrentCulture, Strings.SignCommandInvalidCertificateFingerprint, NuGetLogCode.NU3043);
 
-                if (!isValidFingerprint || (assemblyVersion >= 10 && isSHA1))
+                if (!isValidFingerprint || isSHA1)
                 {
                     throw new ArgumentException(message);
-                }
-                else if (isSHA1)
-                {
-                    logger.Log(LogMessage.Create(LogLevel.Warning, message));
                 }
             }
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -164,7 +164,7 @@ namespace Dotnet.Integration.Test
         internal CommandRunnerResult RunDotnetExpectFailure(string workingDirectory, string args = "", IReadOnlyDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null)
             => RunDotnet(workingDirectory, args, expectSuccess: false, environmentVariables, testOutputHelper);
 
-        private CommandRunnerResult RunDotnet(string workingDirectory, string args = "", bool expectSuccess = true, IReadOnlyDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null)
+        internal CommandRunnerResult RunDotnet(string workingDirectory, string args = "", bool expectSuccess = true, IReadOnlyDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null)
         {
             bool enableDiagnostics = CIDebug && !string.IsNullOrWhiteSpace(BinLogDirectory);
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -519,6 +519,15 @@ namespace Dotnet.Integration.Test
             }
         }
 
+        [PlatformFact(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Client.Engineering/issues/2781
+        public async Task DotnetSign_SignPackageWithInsecureCertificateFingerprint_ThrowsExceptionAsync()
+        {
+            var result = await ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName.SHA1);
+
+            Assert.False(result.Success, result.AllOutput);
+            Assert.True(result.Errors.Contains(_insecureCertificateFingerprintCode), result.Errors);
+        }
+
         [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Client.Engineering/issues/2781
         [InlineData(HashAlgorithmName.SHA256)]
         [InlineData(HashAlgorithmName.SHA384)]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSignTests.cs
@@ -525,7 +525,7 @@ namespace Dotnet.Integration.Test
             var result = await ExecuteSignPackageTestWithCertificateFingerprintAsync(HashAlgorithmName.SHA1);
 
             Assert.False(result.Success, result.AllOutput);
-            Assert.True(result.Errors.Contains(_insecureCertificateFingerprintCode), result.Errors);
+            Assert.True(result.AllOutput.Contains(_insecureCertificateFingerprintCode), result.AllOutput);
         }
 
         [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Client.Engineering/issues/2781
@@ -558,15 +558,17 @@ namespace Dotnet.Integration.Test
             IX509StoreCertificate storeCertificate = _signFixture.UntrustedSelfIssuedCertificateInCertificateStore;
             string certFingerprint = hashAlgorithmName == HashAlgorithmName.SHA1 ? storeCertificate.Certificate.Thumbprint :
                 SignatureTestUtility.GetFingerprint(storeCertificate.Certificate, hashAlgorithmName);
+            bool expectSuccess = hashAlgorithmName != HashAlgorithmName.SHA1;
 
             using (testServer.RegisterResponder(timestampService))
             {
                 // Act
-                CommandRunnerResult result = _dotnetFixture.RunDotnetExpectSuccess(
+                CommandRunnerResult result = _dotnetFixture.RunDotnet(
                     pathContext.PackageSource,
                     $"nuget sign {packageFilePath} " +
                     $"--certificate-fingerprint {certFingerprint} " +
                     $"--timestamper {timestampService.Url}",
+                    expectSuccess: expectSuccess,
                     testOutputHelper: _testOutputHelper);
 
                 return result;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
@@ -22,7 +22,7 @@ namespace NuGet.XPlat.FuncTest
     {
         private const string _invalidArgException = "Invalid value provided for '{0}'. The accepted values are {1}.";
         private readonly ITestOutputHelper _testOutputHelper;
-        private const string _sha1Hash = "89967D1DD995010B6C66AE24FF8E66885E6E03A8";
+        private const string Sha256Hash = "A591A6D40BF420404A011733CFB7B190D62C65BF0BCDA32B56C92B409B0F9DCA";
 
         public XplatSignTests(ITestOutputHelper testOutputHelper)
         {
@@ -91,7 +91,7 @@ namespace NuGet.XPlat.FuncTest
             // Arrange
             var packagePath = @"\\path\package.nupkg";
             var timestamper = "https://timestamper.test";
-            var certificateFingerprint = _sha1Hash;
+            var certificateFingerprint = Sha256Hash;
             var parsable = Enum.TryParse(storeName, ignoreCase: true, result: out StoreName parsedStoreName);
 
             SignCommandArgs(
@@ -116,7 +116,7 @@ namespace NuGet.XPlat.FuncTest
             // Arrange
             var packagePath = @"\\path\package.nupkg";
             var timestamper = "https://timestamper.test";
-            var certificateFingerprint = _sha1Hash;
+            var certificateFingerprint = Sha256Hash;
             var storeName = "random_store";
 
             SignCommandArgs(
@@ -146,7 +146,7 @@ namespace NuGet.XPlat.FuncTest
             // Arrange
             var packagePath = @"\\path\package.nupkg";
             var timestamper = "https://timestamper.test";
-            var certificateFingerprint = _sha1Hash;
+            var certificateFingerprint = Sha256Hash;
             var parsable = Enum.TryParse(storeLocation, ignoreCase: true, result: out StoreLocation parsedStoreLocation);
 
             SignCommandArgs(
@@ -172,7 +172,7 @@ namespace NuGet.XPlat.FuncTest
             // Arrange
             var packagePath = @"\\path\package.nupkg";
             var timestamper = "https://timestamper.test";
-            var certificateFingerprint = _sha1Hash;
+            var certificateFingerprint = Sha256Hash;
             var storeLocation = "random_location";
 
             SignCommandArgs(
@@ -312,7 +312,7 @@ namespace NuGet.XPlat.FuncTest
             // Arrange
             var packagePath = @"\\path\package.nupkg";
             var timestamper = "https://timestamper.test";
-            var certificateFingerprint = _sha1Hash;
+            var certificateFingerprint = Sha256Hash;
             var hashAlgorithm = "sha256";
             Enum.TryParse(hashAlgorithm, ignoreCase: true, result: out HashAlgorithmName parsedHashAlgorithm);
             var timestampHashAlgorithm = "sha512";
@@ -355,7 +355,7 @@ namespace NuGet.XPlat.FuncTest
             // Arrange
             var packagePath = @"\\path\package.nupkg";
             var timestamper = "https://timestamper.test";
-            var certificateSubjectName = _sha1Hash;
+            var certificateSubjectName = "test_cert_subject";
             var hashAlgorithm = "sha256";
             Enum.TryParse(hashAlgorithm, ignoreCase: true, result: out HashAlgorithmName parsedHashAlgorithm);
             var timestampHashAlgorithm = "sha512";
@@ -434,30 +434,8 @@ namespace NuGet.XPlat.FuncTest
                 });
         }
 
-        [Fact]
-        public void SignCommandArgParsing_LogsAWarningForInsecureCertificateFingerprint()
-        {
-            var packagePath = @"\\path\package.nupkg";
-            var timestamper = "https://timestamper.test";
-            var timestampHashAlgorithm = "sha512";
-            Enum.TryParse(timestampHashAlgorithm, ignoreCase: true, result: out HashAlgorithmName parsedTimestampHashAlgorithm);
-
-            SignCommandArgs(
-                (mockCommandRunner, testApp, getLogLevel, getParsedArg, logger) =>
-                {
-                    //Arrange
-                    var argList = new List<string>() { "sign", packagePath, "--certificate-fingerprint", "89967D1DD995010B6C66AE24FF8E66885E6E03A8", "--certificate-password", "password", "--timestamper", timestamper, "--timestamp-hash-algorithm", timestampHashAlgorithm };
-
-                    //Act
-                    testApp.Execute(argList.ToArray());
-
-                    //Assert
-                    Assert.Equal(expected: 1, actual: logger.Warnings);
-                    Assert.True(logger.WarningMessages.First().Contains(NuGetLogCode.NU3043.ToString()));
-                });
-        }
-
         [Theory]
+        [InlineData("89967D1DD995010B6C66AE24FF8E66885E6E03A8")] // 40 characters long SHA-1 hash
         [InlineData("89967D1DD995010B6C66AE24FF8E66885E6E03")] // 39 characters long not SHA-1 hash
         [InlineData("invalid-certificate-fingerprint")]
         public void SignCommandArgParsing_ThrowsAnExceptionForInvalidCertificateFingerprint(string certificateFingerprint)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Tracking: https://github.com/NuGet/Home/issues/13814

## Description

When we merged https://github.com/NuGet/NuGet.Client/pull/6171 PR, we added [custom logic](https://github.com/NuGet/NuGet.Client/pull/6171/files#diff-4cf20fb6a1c739714683d0b642b396837f22ccf7152372552d134b73cfddcad3R237-R248) to get different behavior if the version of .NET SDK is 10 or not. In .NET 10 we wanted [NU3043](https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu3043) to be raised as an error whereas in previous versions we wanted it to be a warning. 

Removed assembly version check when validating certificate fingerprints in this PR because we are only inserting into .NET 10 now. Now, an ArgumentException is thrown if the fingerprint is invalid or if the hash algorithm is SHA1, regardless of assembly version. Eliminate logging of warnings for SHA1 when assembly version is less than 10.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[ ] Added tests~ - No functional changes
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
