### PR TITLE
Fix NuGet->SDK Codeflow

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
 
     <!-- Read docs/updating-packages.md before updating System.Text.Json's version -->
     <SystemTextJsonVersion Condition="'$(SystemTextJsonVersion)' == ''">8.0.5</SystemTextJsonVersion>
-    <SystemCommandLineVersion Condition="'$(SystemCommandLineVersion)' == ''">2.0.0-beta5.25208.1</SystemCommandLineVersion>
+    <SystemCommandLineVersion Condition="'$(SystemCommandLineVersion)' == ''">2.0.0-beta7.25363.101</SystemCommandLineVersion>
     <MSTestPackageVersion>3.4.3</MSTestPackageVersion>
   </PropertyGroup>
 

--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -1,4 +1,4 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 10.0.1xx -Version 10.0.100-preview.7.25351.106
+-Channel 10.0.1xx -Version 10.0.100-preview.7.25363.103
 -Channel 9.0 -Runtime dotnet
 -Channel 8.0 -Runtime dotnet

--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -1,4 +1,4 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 10.0.1xx -Version 10.0.100-preview.7.25363.103
+-Channel 10.0.1xx -Quality daily
 -Channel 9.0 -Runtime dotnet
 -Channel 8.0 -Runtime dotnet

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -111,8 +111,7 @@ namespace NuGet.CommandLine.XPlat
                 CancellationTokenSource tokenSource = new CancellationTokenSource();
                 tokenSource.CancelAfter(TimeSpan.FromMinutes(DotnetPackageSearchTimeOut));
                 int exitCodeValue = 0;
-                CommandLineConfiguration config = new(rootCommand);
-                ParseResult parseResult = rootCommand.Parse(args, config);
+                ParseResult parseResult = rootCommand.Parse(args);
 
                 try
                 {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -394,7 +394,7 @@ namespace Dotnet.Integration.Test
         public void Dispose()
         {
             KillDotnetExe(TestDotnetCli, _cliDirectory.Path, _templateDirectory.WorkingDirectory);
-            // _cliDirectory.Dispose();
+            _cliDirectory.Dispose();
             _templateDirectory.Dispose();
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -175,9 +175,11 @@ namespace Dotnet.Integration.Test
                 ["MSBuildSDKsPath"] = MsBuildSdksPath,
                 ["DOTNET_MULTILEVEL_LOOKUP"] = "0",
                 ["DOTNET_ROOT"] = _cliDirectory,
-                // need to force-override this because otherwise the MSBuildExtensionsPath
+                // We need to force-override this because otherwise the MSBuildExtensionsPath
                 // set from the _outer_ dotnet cli call (which could be any version) will override
-                // the one set by the _inner_ (test environment-specific) dotnet cli call we're about to make
+                // the one set by the _inner_ (test environment-specific) dotnet cli call we're about to make.
+                // We need to ensure that this points to the correct SDK directory because this value
+                // is used to locate many Tasks - especially those located by relative path or name.
                 ["MSBuildExtensionsPath"] = SdkDirectory.FullName
             };
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -175,6 +175,10 @@ namespace Dotnet.Integration.Test
                 ["MSBuildSDKsPath"] = MsBuildSdksPath,
                 ["DOTNET_MULTILEVEL_LOOKUP"] = "0",
                 ["DOTNET_ROOT"] = _cliDirectory,
+                // need to force-override this because otherwise the MSBuildExtensionsPath
+                // set from the _outer_ dotnet cli call (which could be any version) will override
+                // the one set by the _inner_ (test environment-specific) dotnet cli call we're about to make
+                ["MSBuildExtensionsPath"] = SdkDirectory.FullName
             };
 
             if (enableDiagnostics)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -390,7 +390,7 @@ namespace Dotnet.Integration.Test
         public void Dispose()
         {
             KillDotnetExe(TestDotnetCli, _cliDirectory.Path, _templateDirectory.WorkingDirectory);
-            _cliDirectory.Dispose();
+            // _cliDirectory.Dispose();
             _templateDirectory.Dispose();
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1458,8 +1458,8 @@ EndGlobal";
                 var targetPath = Path.Combine(testDirectory, "test.sln");
                 var standardDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "standard.dgspec.json");
                 var staticGraphDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "staticGraph.dgspec.json");
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /bl:first.binlog /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{standardDgSpecFile}\" {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /bl:second.binlog /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{staticGraphDgSpecFile}\" /p:RestoreUseStaticGraphEvaluation=true {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{standardDgSpecFile}\" {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{staticGraphDgSpecFile}\" /p:RestoreUseStaticGraphEvaluation=true {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
 
                 var regularDgSpec = File.ReadAllText(standardDgSpecFile);
                 var staticGraphDgSpec = File.ReadAllText(staticGraphDgSpecFile);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1436,36 +1436,34 @@ EndGlobal";
         [InlineData(false)]
         public void GenerateRestoreGraphFile_StandardAndStaticGraphRestore_AreEquivalent(bool usePackageSpecFactory)
         {
-            using (SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext())
+            SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
+            var testDirectory = pathContext.SolutionRoot;
+            var projectName1 = "ClassLibrary";
+            var projectName2 = "ConsoleApp";
+            var projectName3 = "WebApplication";
+
+            var environmentVariables = new Dictionary<string, string>
             {
-                var testDirectory = pathContext.SolutionRoot;
-                var projectName1 = "ClassLibrary";
-                var projectName2 = "ConsoleApp";
-                var projectName3 = "WebApplication";
+                { "NUGET_USE_NEW_PACKAGESPEC_FACTORY", usePackageSpecFactory.ToString() }
+            };
 
-                var environmentVariables = new Dictionary<string, string>
-                {
-                    { "NUGET_USE_NEW_PACKAGESPEC_FACTORY", usePackageSpecFactory.ToString() }
-                };
+            _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName1, " classlib", testOutputHelper: _testOutputHelper);
+            _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName2, " console", testOutputHelper: _testOutputHelper);
+            _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName3, " webapp", testOutputHelper: _testOutputHelper);
+            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, "new sln --name test", testOutputHelper: _testOutputHelper);
+            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName1}", testOutputHelper: _testOutputHelper);
+            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName2}", testOutputHelper: _testOutputHelper);
+            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName3}", testOutputHelper: _testOutputHelper);
+            var targetPath = Path.Combine(testDirectory, "test.sln");
+            var standardDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "standard.dgspec.json");
+            var staticGraphDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "staticGraph.dgspec.json");
+            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{standardDgSpecFile}\" {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
+            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{staticGraphDgSpecFile}\" /p:RestoreUseStaticGraphEvaluation=true {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
 
-                _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName1, " classlib", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName2, " console", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName3, " webapp", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, "new sln --name test", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName1}", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName2}", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName3}", testOutputHelper: _testOutputHelper);
-                var targetPath = Path.Combine(testDirectory, "test.sln");
-                var standardDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "standard.dgspec.json");
-                var staticGraphDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "staticGraph.dgspec.json");
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{standardDgSpecFile}\" {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{staticGraphDgSpecFile}\" /p:RestoreUseStaticGraphEvaluation=true {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
+            var regularDgSpec = File.ReadAllText(standardDgSpecFile);
+            var staticGraphDgSpec = File.ReadAllText(staticGraphDgSpecFile);
 
-                var regularDgSpec = File.ReadAllText(standardDgSpecFile);
-                var staticGraphDgSpec = File.ReadAllText(staticGraphDgSpecFile);
-
-                regularDgSpec.Should().BeEquivalentTo(staticGraphDgSpec);
-            }
+            regularDgSpec.Should().BeEquivalentTo(staticGraphDgSpec);
         }
 
         [Theory]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1436,34 +1436,36 @@ EndGlobal";
         [InlineData(false)]
         public void GenerateRestoreGraphFile_StandardAndStaticGraphRestore_AreEquivalent(bool usePackageSpecFactory)
         {
-            SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
-            var testDirectory = pathContext.SolutionRoot;
-            var projectName1 = "ClassLibrary";
-            var projectName2 = "ConsoleApp";
-            var projectName3 = "WebApplication";
-
-            var environmentVariables = new Dictionary<string, string>
+            using (SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext())
             {
-                { "NUGET_USE_NEW_PACKAGESPEC_FACTORY", usePackageSpecFactory.ToString() }
-            };
+                var testDirectory = pathContext.SolutionRoot;
+                var projectName1 = "ClassLibrary";
+                var projectName2 = "ConsoleApp";
+                var projectName3 = "WebApplication";
 
-            _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName1, " classlib", testOutputHelper: _testOutputHelper);
-            _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName2, " console", testOutputHelper: _testOutputHelper);
-            _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName3, " webapp", testOutputHelper: _testOutputHelper);
-            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, "new sln --name test", testOutputHelper: _testOutputHelper);
-            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName1}", testOutputHelper: _testOutputHelper);
-            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName2}", testOutputHelper: _testOutputHelper);
-            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName3}", testOutputHelper: _testOutputHelper);
-            var targetPath = Path.Combine(testDirectory, "test.sln");
-            var standardDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "standard.dgspec.json");
-            var staticGraphDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "staticGraph.dgspec.json");
-            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{standardDgSpecFile}\" {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
-            _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{staticGraphDgSpecFile}\" /p:RestoreUseStaticGraphEvaluation=true {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
+                var environmentVariables = new Dictionary<string, string>
+                {
+                    { "NUGET_USE_NEW_PACKAGESPEC_FACTORY", usePackageSpecFactory.ToString() }
+                };
 
-            var regularDgSpec = File.ReadAllText(standardDgSpecFile);
-            var staticGraphDgSpec = File.ReadAllText(staticGraphDgSpecFile);
+                _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName1, " classlib", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName2, " console", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName3, " webapp", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, "new sln --name test", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName1}", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName2}", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName3}", testOutputHelper: _testOutputHelper);
+                var targetPath = Path.Combine(testDirectory, "test.sln");
+                var standardDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "standard.dgspec.json");
+                var staticGraphDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "staticGraph.dgspec.json");
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /bl:first.binlog /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{standardDgSpecFile}\" {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /bl:second.binlog /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{staticGraphDgSpecFile}\" /p:RestoreUseStaticGraphEvaluation=true {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
 
-            regularDgSpec.Should().BeEquivalentTo(staticGraphDgSpec);
+                var regularDgSpec = File.ReadAllText(standardDgSpecFile);
+                var staticGraphDgSpec = File.ReadAllText(staticGraphDgSpecFile);
+
+                regularDgSpec.Should().BeEquivalentTo(staticGraphDgSpec);
+            }
         }
 
         [Theory]

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -195,6 +195,7 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(SdkDirSource).Sele
 #endif
             CopyPackSdkArtifacts(artifactsDirectory, pathToSdkInCli, configuration);
             CopyRestoreArtifacts(artifactsDirectory, pathToSdkInCli, configuration);
+            CopyNuGetSdkResolverArtifacts(artifactsDirectory, pathToSdkInCli, configuration);
         }
 
         private static void CopyRestoreArtifacts(string artifactsDirectory, string pathToSdkInCli, string configuration)
@@ -255,6 +256,23 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(SdkDirSource).Sele
                     jObject.WriteTo(writer);
                 }
             }
+        }
+
+        private static void CopyNuGetSdkResolverArtifacts(string artifactsDirectory, string pathToSdkInCli, string configuration)
+        {
+            var projectName = "Microsoft.Build.NuGetSdkResolver";
+            var projectArtifactsBinFolder = Path.Combine(artifactsDirectory, projectName, "bin", configuration);
+
+            var tfmToCopy = GetTfmToCopy(projectArtifactsBinFolder);
+            var frameworkArtifactsFolder = new DirectoryInfo(Path.Combine(projectArtifactsBinFolder, tfmToCopy));
+
+            // Copy the resolver assembly
+            var resolverAssemblySourcePath = Path.Combine(frameworkArtifactsFolder.FullName, projectName + ".dll");
+            var resolverAssemblyDestinationPath = Path.Combine(pathToSdkInCli, projectName + ".dll");
+            File.Copy(
+                sourceFileName: resolverAssemblySourcePath,
+                destFileName: resolverAssemblyDestinationPath,
+                overwrite: true);
         }
 
         private static string GetTfmToCopy(string projectArtifactsBinFolder)


### PR DESCRIPTION
Fixes: https://github.com/nuget/home/issues/14431

The VMR [updated S.CL](https://github.com/dotnet/dotnet/pull/1385) across the whole codebase, but that hasn't flowed back here yet (see https://github.com/NuGet/NuGet.Client/pull/6482 for discussion), but now this is blocking SDK codeflow. So this is the S.CL changes _only_ to unblock the rest of the product.