### PR TITLE
Restore now raises NU1016 Error for project.json project types

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -339,6 +339,7 @@ namespace NuGet.Commands
         {
             var success = true;
 
+            success &= EnsureNotDeprecatedProjectJsonProjectType();
             success &= AreCentralVersionRequirementsSatisfied(_request, httpSourcesCount);
             success &= EvaluateHttpSourceUsage();
             success &= HasValidPlatformVersions();
@@ -1101,6 +1102,20 @@ namespace NuGet.Commands
             return result;
         }
 
+        private bool EnsureNotDeprecatedProjectJsonProjectType()
+        {
+            if (_request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson)
+            {
+                _logger.Log(
+                    RestoreLogMessage.CreateError(
+                        NuGetLogCode.NU1016,
+                        Strings.Error_ProjectJson_Deprecated));
+
+                return false;
+            }
+
+            return true;
+        }
         private string ConcatAsString<T>(IEnumerable<T> enumerable)
         {
             string result = null;

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -754,6 +754,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The project.json project type is deprecated. Migrate to PackageReference..
+        /// </summary>
+        internal static string Error_ProjectJson_Deprecated {
+            get {
+                return ResourceManager.GetString("Error_ProjectJson_Deprecated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The runtime.json specified in the project &apos;{0}&apos; could not be parsed. {1}.
         /// </summary>
         internal static string Error_ProjectRuntimeJsonIsUnreadable {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1165,6 +1165,6 @@ NuGet requires HTTPS sources. Refer to https://aka.ms/nuget-https-everywhere for
     <value>Content hash: {0}</value>
   </data>
   <data name="Error_ProjectJson_Deprecated" xml:space="preserve">
-    <value>The project.json project type is deprecated. Migrate to PackageReference.</value>
+    <value>Managing packages with project.json is deprecated. Migrate to PackageReference.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1164,4 +1164,7 @@ NuGet requires HTTPS sources. Refer to https://aka.ms/nuget-https-everywhere for
   <data name="VerifyCommand_ContentHash" xml:space="preserve">
     <value>Content hash: {0}</value>
   </data>
+  <data name="Error_ProjectJson_Deprecated" xml:space="preserve">
+    <value>The project.json project type is deprecated. Migrate to PackageReference.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -43,7 +43,7 @@ namespace NuGet.Common
     /// </para>
     ///
     /// <para>
-    /// All new codes need a corresponding MarkDown file under https://github.com/NuGet/docs.microsoft.com-nuget/tree/master/docs/reference/errors-and-warnings.
+    /// All new codes need a corresponding MarkDown file under https://github.com/NuGet/docs.microsoft.com-nuget/tree/main/docs/reference/errors-and-warnings.
     /// </para>
     /// </remarks>
     public enum NuGetLogCode
@@ -132,6 +132,11 @@ namespace NuGet.Common
         /// PackageReference without a version.
         /// </summary>
         NU1015 = 1015,
+
+        /// <summary>
+        /// Project.Json project type is not supported.
+        /// </summary>
+        NU1016 = 1016,
 
         /// <summary>
         /// Unable to resolve package, generic message for unknown type constraints.

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -134,7 +134,7 @@ namespace NuGet.Common
         NU1015 = 1015,
 
         /// <summary>
-        /// Project.Json project type is not supported.
+        /// The project.json project type is not supported.
         /// </summary>
         NU1016 = 1016,
 

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
 NuGet.Common.NuGetLogCode.NU1015 = 1015 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1016 = 1016 -> NuGet.Common.NuGetLogCode

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -455,6 +455,61 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
 
         [Fact]
+        public async Task RestoreCommand_ProjectJsonProjectType_LogsNU1016ErrorAsync()
+        {
+            // Arrange
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.3"": {
+                    ""dependencies"": {
+                    }
+                }
+              }
+            }";
+
+            using var workingDir = TestDirectory.Create();
+
+            var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+            var sourceDir = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+            var projectDir = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+            packagesDir.Create();
+            sourceDir.Create();
+            projectDir.Create();
+
+            File.WriteAllText(Path.Combine(projectDir.FullName, "project.json"), project1Json);
+
+            var specPath1 = Path.Combine(projectDir.FullName, "project.json");
+            var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1).WithTestRestoreMetadata();
+            spec1.RestoreMetadata.ProjectStyle = ProjectStyle.ProjectJson;
+
+            var logger = new TestLogger();
+            var request = new TestRestoreRequest(spec1, sources: Enumerable.Empty<PackageSource>(), packagesDirectory: packagesDir.FullName, logger)
+            {
+                LockFilePath = Path.Combine(projectDir.FullName, "project.lock.json")
+            };
+
+            // Act
+            var command = new RestoreCommand(request);
+            var result = await command.ExecuteAsync();
+            await result.CommitAsync(logger, CancellationToken.None);
+
+            // Assert
+            result.Success.Should().BeFalse();
+            result.LockFile.LogMessages.Count.Should().BeGreaterThanOrEqualTo(1);
+
+            IAssetsLogMessage resultLogMessage = result.LockFile.LogMessages.SingleOrDefault(logMessage => logMessage.Code == NuGetLogCode.NU1016);
+            resultLogMessage.Level.Should().Be(LogLevel.Error);
+            resultLogMessage.Message.Should().Be(Strings.Error_ProjectJson_Deprecated);
+        }
+
+        [Fact]
         public async Task RestoreCommand_FileUriV3FolderAsync()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -184,7 +184,7 @@ namespace NuGet.Test
         }
 
         // Verify that parent projects are restored when a child project is updated
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task InstallPackageTransitive_VerifyCacheInvalidated()
         {
             // Arrange
@@ -332,7 +332,7 @@ namespace NuGet.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task InstallPackageWithReadMeFile()
         {
             // Arrange
@@ -555,7 +555,7 @@ namespace NuGet.Test
             messages[0].Message.Should().Contain("Unable to find package nuget.core with version (>= 91.0.0)");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task UpdateAndRollbackPackage()
         {
             // Arrange
@@ -681,7 +681,7 @@ namespace NuGet.Test
             Assert.True(File.Exists(lockFile));
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task InstallUpdatedPackage()
         {
             // Arrange
@@ -730,7 +730,7 @@ namespace NuGet.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task UpdatePackageToHighest()
         {
             // Arrange
@@ -794,7 +794,7 @@ namespace NuGet.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task UpdateMultipleAndRollback()
         {
             // Arrange
@@ -879,7 +879,7 @@ namespace NuGet.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task UpdatePackageAll()
         {
             // Arrange
@@ -976,7 +976,7 @@ namespace NuGet.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task UpdatePackageAllNoop()
         {
             // Arrange
@@ -1548,7 +1548,7 @@ namespace NuGet.Test
             Assert.Equal(0, entityFrameworkTargets.Count());
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task InstallPackageWithInitPS1()
         {
             // Arrange
@@ -1588,7 +1588,7 @@ namespace NuGet.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task UninstallPackageDoesNotCallInitPs1()
         {
             // Arrange
@@ -1628,7 +1628,7 @@ namespace NuGet.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task UpdatePackageCallsInitPs1OnNewPackages()
         {
             // Arrange
@@ -1671,7 +1671,7 @@ namespace NuGet.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task PreviewUpdatesAsync_NoUpdatesAvailable()
         {
             using (var packageSource = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -182,7 +182,7 @@ namespace NuGet.PackageManagement.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task BuildIntegratedNuGetProject_IsRestoreRequiredMissingPackage()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -25,7 +25,7 @@ namespace NuGet.PackageManagement.Test
 {
     public class BuildIntegratedNuGetProjectTests
     {
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task BuildIntegratedNuGetProject_IsRestoreRequiredChangedSha512()
         {
             // Arrange
@@ -275,7 +275,7 @@ namespace NuGet.PackageManagement.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task BuildIntegratedNuGetProject_IsRestoreNotRequiredWithFloatingVersion()
         {
             // Arrange
@@ -353,7 +353,7 @@ namespace NuGet.PackageManagement.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task BuildIntegratedNuGetProject_IsRestoreRequiredWithNoChanges()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/BatchedEventTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/BatchedEventTests.cs
@@ -684,7 +684,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task InstallPackage_BuildIntegratedProject_BatchEvent_NotRaised()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
@@ -159,7 +159,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             }
         }
 
-        [Theory]
+        [Theory(Skip = "https://github.com/NuGet/Home/issues/10212")]
         [InlineData(false)]
         [InlineData(true)]
         public async Task PreviewInstallPackage_VersionNotInRange_RaiseTelemetryEventsWithErrorCodeNU1102(bool errorCodeExistsInJson)
@@ -323,7 +323,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithDupedWarningCodes()
         {
             // Arrange
@@ -513,7 +513,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task ExecuteNuGetProjectActions_BuildIntegrated_RaiseTelemetryEvents()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/OtherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/OtherTests.cs
@@ -386,7 +386,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
         public async Task ExecuteNuGetProjectActionsAsync_MixedProjects()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3333

## Description

As part of project.json deprecation, this change raises a new NU1016 error to break NuGet Restore for project.json projects.

> Managing packages with project.json is deprecated. Migrate to PackageReference.

The idea is to require manual migration at this iteration. Therefore, the project still loads, restore fails, and customers can use the Project.json to PackageReference migration tooling as described in https://aka.ms/nuget/projectjson.

- Introduces a new error code NU1016 which is raised for all `ProjectStyle.ProjectJson` project types.
- Added unit test `RestoreCommand_ProjectJsonProjectType_LogsNU1016ErrorAsync` to demonstrate the error.
- Skip all project.json tests as these are broken with this PR. The goal is to re-enable them under the PackageReference project style.

### Error list

Example of the "IntelliSense" error NU1016:

<img width="1242" height="272" alt="image" src="https://github.com/user-attachments/assets/984f78c4-5ac5-4a87-827c-7bd01929fa25" />

### Output pane

The NU1016 restore error in the output pane.

<img width="1241" height="267" alt="image" src="https://github.com/user-attachments/assets/a8d26eb4-aa32-4b13-9eb5-0c99fcc303f7" />


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14415
