### PR TITLE
Add package pruning telemetry

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -142,7 +142,6 @@ namespace NuGet.Commands
         private const string PackagePruningFrameworksUnsupportedCount = "Pruning.FrameworksUnsupported.Count";
         private const string PackagePruningRemovablePackagesCount = "Pruning.RemovablePackages.Count";
         private const string PackagePruningDirectCount = "Pruning.Pruned.Direct.Count";
-        //private const string PackagePruningTransitiveCount = "Pruning.Pruned.Transitive.Count";
 
         internal readonly bool _enableNewDependencyResolver;
         private readonly bool _isLockFileEnabled;
@@ -387,6 +386,42 @@ namespace NuGet.Commands
             }
 
             telemetry.TelemetryEvent[AuditEnabled] = auditEnabled ? "enabled" : "disabled";
+
+            PopulatePruningEnabledTelemetry(_request.Project, telemetry.TelemetryEvent);
+        }
+
+        internal static void PopulatePruningEnabledTelemetry(PackageSpec project, TelemetryEvent telemetryEvent)
+        {
+            int pruningEnabledCount = 0;
+            int pruningDisabledCount = 0;
+            int pruningNotApplicableCount = 0;
+
+            foreach (var framework in project.TargetFrameworks.NoAllocEnumerate())
+            {
+                bool isPruningEnabled = framework.PackagesToPrune.Count > 0;
+                bool isFrameworkPruningEnabledByDefault =
+                    StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetCoreApp) ||
+                    (StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetStandard) && framework.FrameworkName.Version.Major >= 2);
+
+                if (isPruningEnabled)
+                {
+                    pruningEnabledCount++;
+                }
+                else
+                {
+                    if (isFrameworkPruningEnabledByDefault)
+                    {
+                        pruningDisabledCount++;
+                    }
+                    else
+                    {
+                        pruningNotApplicableCount++;
+                    }
+                }
+            }
+            telemetryEvent[PackagePruningFrameworksEnabledCount] = pruningEnabledCount;
+            telemetryEvent[PackagePruningFrameworksDisabledCount] = pruningDisabledCount;
+            telemetryEvent[PackagePruningFrameworksUnsupportedCount] = pruningNotApplicableCount;
         }
 
         private async Task<(RestoreResult, bool, CacheFile)> EvaluateNoOpAsync(TelemetryActivity telemetry, CacheFile cacheFile, Stopwatch restoreTime)
@@ -786,8 +821,6 @@ namespace NuGet.Commands
                     SdkAnalysisLevelMinimums.V10_0_100) &&
                 HasFrameworkNewerThanNET10(project);
 
-            PopulatePruningEnabledTelemetry(project, telemetryEvent);
-
             Dictionary<string, List<string>> prunedDirectPackages = GetPrunableDirectPackages(project);
 
             telemetryEvent[PackagePruningDirectCount] = prunedDirectPackages?.Count ?? 0;
@@ -828,43 +861,45 @@ namespace NuGet.Commands
             static void RaiseNU1510WarningsIfNeeded(PackageSpec project, ILogger logger, bool enablePruningWarnings, Dictionary<string, List<string>> prunedDirectPackages, TelemetryEvent telemetry)
             {
                 Dictionary<string, string> aliasToTargetGraphName = null;
-                int removalPackagesCount = 0;
-                foreach (var prunedPackage in prunedDirectPackages)
+                int removablePackagesCount = 0;
+                if (prunedDirectPackages != null)
                 {
-                    // Do not warn if the package exists in any framework.
-                    if (prunedPackage.Value.Count != project.TargetFrameworks.Count)
+                    foreach (var prunedPackage in prunedDirectPackages)
                     {
-                        bool doesPackageRemain = false;
-                        foreach (var framework in project.TargetFrameworks)
+                        // Do not warn if the package exists in any framework.
+                        if (prunedPackage.Value.Count != project.TargetFrameworks.Count)
                         {
-                            if (!prunedPackage.Value.Contains(framework.TargetAlias))
+                            bool doesPackageRemain = false;
+                            foreach (var framework in project.TargetFrameworks)
                             {
-                                if (ContainsPackage(prunedPackage, framework))
+                                if (!prunedPackage.Value.Contains(framework.TargetAlias))
                                 {
-                                    doesPackageRemain = true;
-                                    break;
+                                    if (ContainsPackage(prunedPackage, framework))
+                                    {
+                                        doesPackageRemain = true;
+                                        break;
+                                    }
                                 }
                             }
+                            if (doesPackageRemain)
+                            {
+                                continue;
+                            }
                         }
-                        if (doesPackageRemain)
-                        {
-                            continue;
-                        }
-                    }
 
-                    removalPackagesCount++;
-                    if (enablePruningWarnings)
-                    {
-                        aliasToTargetGraphName ??= InitializeAliasToTargetGraphName(project);
-                        logger.Log(RestoreLogMessage.CreateWarning(
-                            NuGetLogCode.NU1510,
-                            string.Format(CultureInfo.CurrentCulture, Strings.Error_RestorePruningDirectPackageReference, prunedPackage.Key),
-                            prunedPackage.Key,
-                            prunedPackage.Value.Select(e => aliasToTargetGraphName[e]).ToArray()));
+                        removablePackagesCount++;
+                        if (enablePruningWarnings)
+                        {
+                            aliasToTargetGraphName ??= InitializeAliasToTargetGraphName(project);
+                            logger.Log(RestoreLogMessage.CreateWarning(
+                                NuGetLogCode.NU1510,
+                                string.Format(CultureInfo.CurrentCulture, Strings.Error_RestorePruningDirectPackageReference, prunedPackage.Key),
+                                prunedPackage.Key,
+                                prunedPackage.Value.Select(e => aliasToTargetGraphName[e]).ToArray()));
+                        }
                     }
                 }
-
-                telemetry[PackagePruningRemovablePackagesCount] = removalPackagesCount;
+                telemetry[PackagePruningRemovablePackagesCount] = removablePackagesCount;
             }
 
             static bool HasFrameworkNewerThanNET10(PackageSpec project)
@@ -901,40 +936,6 @@ namespace NuGet.Commands
                     }
                 }
                 return false;
-            }
-
-            static void PopulatePruningEnabledTelemetry(PackageSpec project, TelemetryEvent telemetryEvent)
-            {
-                int pruningEnabledCount = 0;
-                int pruningDisabledCount = 0;
-                int pruningNotApplicableCount = 0;
-
-                foreach (var framework in project.TargetFrameworks.NoAllocEnumerate())
-                {
-                    bool isPruningEnabled = framework.PackagesToPrune.Count > 0;
-                    bool isFrameworkPruningEnabledByDefault =
-                        StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetCoreApp) ||
-                        (StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetStandard) && framework.FrameworkName.Version.Major >= 2);
-
-                    if (isPruningEnabled)
-                    {
-                        pruningEnabledCount++;
-                    }
-                    else
-                    {
-                        if (isFrameworkPruningEnabledByDefault)
-                        {
-                            pruningDisabledCount++;
-                        }
-                        else
-                        {
-                            pruningNotApplicableCount++;
-                        }
-                    }
-                }
-                telemetryEvent[PackagePruningFrameworksEnabledCount] = pruningEnabledCount;
-                telemetryEvent[PackagePruningFrameworksDisabledCount] = pruningDisabledCount;
-                telemetryEvent[PackagePruningFrameworksUnsupportedCount] = pruningNotApplicableCount;
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -136,6 +136,14 @@ namespace NuGet.Commands
         private const string AuditSuppressedAdvisoriesTotalPackageDownloadWarningsSuppressedCount = "Audit.Vulnerability.PackageDownloads.TotalWarningsSuppressed.Count";
         private const string AuditSuppressedAdvisoriesDistinctPackageDownloadAdvisoriesSuppressedCount = "Audit.Vulnerability.PackageDownload.DistinctAdvisoriesSuppressed.Count";
 
+        // PackagePruning names
+        private const string PackagePruningFrameworksEnabledCount = "Pruning.FrameworksEnabled.Count";
+        private const string PackagePruningFrameworksDisabledCount = "Pruning.FrameworksDisabled.Count";
+        private const string PackagePruningFrameworksUnsupportedCount = "Pruning.FrameworksUnsupported.Count";
+        private const string PackagePruningRemovablePackagesCount = "Pruning.RemovablePackages.Count";
+        private const string PackagePruningDirectCount = "Pruning.Pruned.Direct.Count";
+        //private const string PackagePruningTransitiveCount = "Pruning.Pruned.Transitive.Count";
+
         internal readonly bool _enableNewDependencyResolver;
         private readonly bool _isLockFileEnabled;
 
@@ -235,7 +243,7 @@ namespace NuGet.Commands
                     packagesLockFile,
                     token);
 
-                AnalyzePruningResults(_request.Project, _logger);
+                AnalyzePruningResults(_request.Project, telemetry.TelemetryEvent, _logger);
 
                 var graphs = await GenerateRestoreGraphsAsync(telemetry, contextForProject, token);
 
@@ -769,7 +777,7 @@ namespace NuGet.Commands
             }
         }
 
-        internal static void AnalyzePruningResults(PackageSpec project, ILogger logger)
+        internal static void AnalyzePruningResults(PackageSpec project, TelemetryEvent telemetryEvent, ILogger logger)
         {
             bool enablePruningWarnings =
                 SdkAnalysisLevelMinimums.IsEnabled(
@@ -778,17 +786,13 @@ namespace NuGet.Commands
                     SdkAnalysisLevelMinimums.V10_0_100) &&
                 HasFrameworkNewerThanNET10(project);
 
-            if (!enablePruningWarnings)
-            {
-                return;
-            }
+            PopulatePruningEnabledTelemetry(project, telemetryEvent);
 
             Dictionary<string, List<string>> prunedDirectPackages = GetPrunableDirectPackages(project);
 
-            if (prunedDirectPackages != null)
-            {
-                RaiseNU1510WarningsIfNeeded(project, logger, prunedDirectPackages);
-            }
+            telemetryEvent[PackagePruningDirectCount] = prunedDirectPackages?.Count ?? 0;
+
+            RaiseNU1510WarningsIfNeeded(project, logger, enablePruningWarnings, prunedDirectPackages, telemetryEvent);
 
             static Dictionary<string, List<string>> GetPrunableDirectPackages(PackageSpec project)
             {
@@ -821,9 +825,10 @@ namespace NuGet.Commands
                 return prunedDirectPackages;
             }
 
-            static void RaiseNU1510WarningsIfNeeded(PackageSpec project, ILogger logger, Dictionary<string, List<string>> prunedDirectPackages)
+            static void RaiseNU1510WarningsIfNeeded(PackageSpec project, ILogger logger, bool enablePruningWarnings, Dictionary<string, List<string>> prunedDirectPackages, TelemetryEvent telemetry)
             {
                 Dictionary<string, string> aliasToTargetGraphName = null;
+                int removalPackagesCount = 0;
                 foreach (var prunedPackage in prunedDirectPackages)
                 {
                     // Do not warn if the package exists in any framework.
@@ -847,13 +852,19 @@ namespace NuGet.Commands
                         }
                     }
 
-                    aliasToTargetGraphName ??= InitializeAliasToTargetGraphName(project);
-                    logger.Log(RestoreLogMessage.CreateWarning(
-                        NuGetLogCode.NU1510,
-                        string.Format(CultureInfo.CurrentCulture, Strings.Error_RestorePruningDirectPackageReference, prunedPackage.Key),
-                        prunedPackage.Key,
-                        prunedPackage.Value.Select(e => aliasToTargetGraphName[e]).ToArray()));
+                    removalPackagesCount++;
+                    if (enablePruningWarnings)
+                    {
+                        aliasToTargetGraphName ??= InitializeAliasToTargetGraphName(project);
+                        logger.Log(RestoreLogMessage.CreateWarning(
+                            NuGetLogCode.NU1510,
+                            string.Format(CultureInfo.CurrentCulture, Strings.Error_RestorePruningDirectPackageReference, prunedPackage.Key),
+                            prunedPackage.Key,
+                            prunedPackage.Value.Select(e => aliasToTargetGraphName[e]).ToArray()));
+                    }
                 }
+
+                telemetry[PackagePruningRemovablePackagesCount] = removalPackagesCount;
             }
 
             static bool HasFrameworkNewerThanNET10(PackageSpec project)
@@ -890,6 +901,40 @@ namespace NuGet.Commands
                     }
                 }
                 return false;
+            }
+
+            static void PopulatePruningEnabledTelemetry(PackageSpec project, TelemetryEvent telemetryEvent)
+            {
+                int pruningEnabledCount = 0;
+                int pruningDisabledCount = 0;
+                int pruningNotApplicableCount = 0;
+
+                foreach (var framework in project.TargetFrameworks.NoAllocEnumerate())
+                {
+                    bool isPruningEnabled = framework.PackagesToPrune.Count > 0;
+                    bool isFrameworkPruningEnabledByDefault =
+                        StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetCoreApp) ||
+                        (StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetStandard) && framework.FrameworkName.Version.Major >= 2);
+
+                    if (isPruningEnabled)
+                    {
+                        pruningEnabledCount++;
+                    }
+                    else
+                    {
+                        if (isFrameworkPruningEnabledByDefault)
+                        {
+                            pruningDisabledCount++;
+                        }
+                        else
+                        {
+                            pruningNotApplicableCount++;
+                        }
+                    }
+                }
+                telemetryEvent[PackagePruningFrameworksEnabledCount] = pruningEnabledCount;
+                telemetryEvent[PackagePruningFrameworksDisabledCount] = pruningDisabledCount;
+                telemetryEvent[PackagePruningFrameworksUnsupportedCount] = pruningNotApplicableCount;
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
@@ -1293,15 +1293,13 @@ namespace NuGet.Commands.FuncTest
                 var restoreLogMessage = (RestoreLogMessage)testLogger.LogMessages.Single();
                 restoreLogMessage.Code.Should().Be(NuGetLogCode.NU1510);
                 restoreLogMessage.LibraryId.Should().Be("A");
-                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
-                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(1);
             }
             else
             {
                 testLogger.WarningMessages.Should().BeEmpty();
-                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
-                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(1);
             }
+            testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
+            testEvent["Pruning.Pruned.Direct.Count"].Should().Be(1);
         }
 
         [Theory]
@@ -1340,15 +1338,13 @@ namespace NuGet.Commands.FuncTest
                 var restoreLogMessage = (RestoreLogMessage)testLogger.LogMessages.Single();
                 restoreLogMessage.Code.Should().Be(NuGetLogCode.NU1510);
                 restoreLogMessage.LibraryId.Should().Be("A");
-                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
-                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(1);
             }
             else
             {
                 testLogger.WarningMessages.Should().BeEmpty();
-                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
-                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(1);
             }
+            testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
+            testEvent["Pruning.Pruned.Direct.Count"].Should().Be(1);
         }
 
         [Theory]
@@ -1406,16 +1402,14 @@ namespace NuGet.Commands.FuncTest
                 var restoreLogMessage = (RestoreLogMessage)testLogger.LogMessages.Single();
                 restoreLogMessage.Code.Should().Be(NuGetLogCode.NU1510);
                 restoreLogMessage.LibraryId.Should().Be("a");
-                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
-                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(2);
             }
             else
             {
                 testLogger.WarningMessages.Should().BeEmpty();
                 testEvent.Count.Should().Be(2);
-                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
-                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(2);
             }
+            testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
+            testEvent["Pruning.Pruned.Direct.Count"].Should().Be(2);
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
@@ -1283,8 +1283,9 @@ namespace NuGet.Commands.FuncTest
 
             var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", Path.GetTempPath(), rootProject);
             var testLogger = new TestLogger();
+            var testEvent = new TelemetryEvent("dummyEvent");
 
-            RestoreCommand.AnalyzePruningResults(projectSpec, testLogger);
+            RestoreCommand.AnalyzePruningResults(projectSpec, testEvent, testLogger);
 
             if (shouldWarn)
             {
@@ -1292,10 +1293,14 @@ namespace NuGet.Commands.FuncTest
                 var restoreLogMessage = (RestoreLogMessage)testLogger.LogMessages.Single();
                 restoreLogMessage.Code.Should().Be(NuGetLogCode.NU1510);
                 restoreLogMessage.LibraryId.Should().Be("A");
+                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
+                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(1);
             }
             else
             {
                 testLogger.WarningMessages.Should().BeEmpty();
+                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
+                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(1);
             }
         }
 
@@ -1325,8 +1330,9 @@ namespace NuGet.Commands.FuncTest
             projectSpec.RestoreMetadata.SdkAnalysisLevel = !string.IsNullOrEmpty(sdkAnalysisLevel) ? NuGetVersion.Parse(sdkAnalysisLevel) : null;
             projectSpec.RestoreMetadata.UsingMicrosoftNETSdk = true;
             var testLogger = new TestLogger();
+            var testEvent = new TelemetryEvent("dummyEvent");
 
-            RestoreCommand.AnalyzePruningResults(projectSpec, testLogger);
+            RestoreCommand.AnalyzePruningResults(projectSpec, testEvent, testLogger);
 
             if (shouldWarn)
             {
@@ -1334,10 +1340,14 @@ namespace NuGet.Commands.FuncTest
                 var restoreLogMessage = (RestoreLogMessage)testLogger.LogMessages.Single();
                 restoreLogMessage.Code.Should().Be(NuGetLogCode.NU1510);
                 restoreLogMessage.LibraryId.Should().Be("A");
+                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
+                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(1);
             }
             else
             {
                 testLogger.WarningMessages.Should().BeEmpty();
+                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
+                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(1);
             }
         }
 
@@ -1386,8 +1396,9 @@ namespace NuGet.Commands.FuncTest
 
             var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", Path.GetTempPath(), rootProject);
             var testLogger = new TestLogger();
+            var testEvent = new TelemetryEvent("dummyEvent");
 
-            RestoreCommand.AnalyzePruningResults(projectSpec, testLogger);
+            RestoreCommand.AnalyzePruningResults(projectSpec, testEvent, testLogger);
 
             if (shouldWarn)
             {
@@ -1395,10 +1406,15 @@ namespace NuGet.Commands.FuncTest
                 var restoreLogMessage = (RestoreLogMessage)testLogger.LogMessages.Single();
                 restoreLogMessage.Code.Should().Be(NuGetLogCode.NU1510);
                 restoreLogMessage.LibraryId.Should().Be("a");
+                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
+                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(2);
             }
             else
             {
                 testLogger.WarningMessages.Should().BeEmpty();
+                testEvent.Count.Should().Be(2);
+                testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
+                testEvent["Pruning.Pruned.Direct.Count"].Should().Be(2);
             }
         }
 
@@ -1443,14 +1459,17 @@ namespace NuGet.Commands.FuncTest
 
             var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", Path.GetTempPath(), rootProject);
             var testLogger = new TestLogger();
+            var testEvent = new TelemetryEvent("dummyEvent");
 
-            RestoreCommand.AnalyzePruningResults(projectSpec, testLogger);
+            RestoreCommand.AnalyzePruningResults(projectSpec, testEvent, testLogger);
 
 
             testLogger.WarningMessages.Should().HaveCount(1);
             var restoreLogMessage = (RestoreLogMessage)testLogger.LogMessages.Single();
             restoreLogMessage.Code.Should().Be(NuGetLogCode.NU1510);
             restoreLogMessage.LibraryId.Should().Be("B");
+            testEvent["Pruning.RemovablePackages.Count"].Should().Be(1);
+            testEvent["Pruning.Pruned.Direct.Count"].Should().Be(1);
         }
 
         // A 1.0.0 -> B 1.0.0
@@ -2381,6 +2400,93 @@ namespace NuGet.Commands.FuncTest
             restoreResult.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
             restoreResult.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
             restoreResult.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void PopulatePruningEnabledTelemetry_WithVariousFrameworks_PopulatesTelemetryCorrectly()
+        {
+            var rootProject = @"
+                {
+                  ""frameworks"": {
+                    ""net10.0"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        },
+                        ""packagesToPrune"": {
+                            ""a"" : ""(,1.0.0]"" 
+                        }
+                    },
+                    ""net9.0"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        },
+                        ""packagesToPrune"": {
+                            ""a"" : ""(,1.0.0]"" 
+                        }
+                    },
+                    ""net8.0"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        }
+                    },
+                    ""netstandard2.1"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        },
+                        ""packagesToPrune"": {
+                            ""a"" : ""(,1.0.0]"" 
+                        }
+                    },
+                    ""netstandard1.6"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        }
+                    },
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        }
+                    },
+                    ""net46"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        },
+                        ""packagesToPrune"": {
+                            ""a"" : ""(,1.0.0]"" 
+                        }
+                    },
+                  }
+                }";
+
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", Path.GetTempPath(), rootProject);
+            var testLogger = new TestLogger();
+            var testEvent = new TelemetryEvent("dummyEvent");
+
+            RestoreCommand.PopulatePruningEnabledTelemetry(projectSpec, testEvent);
+            testEvent["Pruning.FrameworksEnabled.Count"].Should().Be(4);
+            testEvent["Pruning.FrameworksDisabled.Count"].Should().Be(1);
+            testEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(2);
         }
 
         // Add a test where a new package is introduced, but a different package gets pruned, bringing the counter to be the same.

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2965,6 +2965,11 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["UpdatedAssetsFile"] = value => value.Should().Be(true),
                 ["UpdatedMSBuildFiles"] = value => value.Should().Be(true),
                 ["NETSdkVersion"] = value => value.Should().Be(null),
+                ["Pruning.FrameworksEnabled.Count"] = value => value.Should().BeOfType<int>(),
+                ["Pruning.FrameworksDisabled.Count"] = value => value.Should().BeOfType<int>(),
+                ["Pruning.FrameworksUnsupported.Count"] = value => value.Should().BeOfType<int>(),
+                ["Pruning.RemovablePackages.Count"] = value => value.Should().BeOfType<int>(),
+                ["Pruning.Pruned.Direct.Count"] = value => value.Should().BeOfType<int>(),
             };
 
             HashSet<string> actualProperties = new();
@@ -3077,7 +3082,8 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
 
-            projectInformationEvent.Count.Should().Be(35);
+            projectInformationEvent.Count.Should().Be(38);
+
             projectInformationEvent["RestoreSuccess"].Should().Be(true);
             projectInformationEvent["NoOpResult"].Should().Be(true);
             projectInformationEvent["IsCentralVersionManagementEnabled"].Should().Be(false);
@@ -3113,6 +3119,9 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             projectInformationEvent["UpdatedAssetsFile"].Should().Be(false);
             projectInformationEvent["UpdatedMSBuildFiles"].Should().Be(false);
             projectInformationEvent["NETSdkVersion"].Should().Be(NuGetVersion.Parse("10.0.100"));
+            projectInformationEvent["Pruning.FrameworksEnabled.Count"].Should().Be(0);
+            projectInformationEvent["Pruning.FrameworksDisabled.Count"].Should().Be(0);
+            projectInformationEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(1);
         }
 
         [Fact]
@@ -3170,7 +3179,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
 
-            projectInformationEvent.Count.Should().Be(41);
+            projectInformationEvent.Count.Should().Be(46);
             projectInformationEvent["RestoreSuccess"].Should().Be(true);
             projectInformationEvent["NoOpResult"].Should().Be(false);
             projectInformationEvent["TotalUniquePackagesCount"].Should().Be(2);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

Adding some package pruning telemetry to track the health metrics of the feature.
There is currently no telemetry on package pruning.

Question we want to answer: 
- Q1: Was pruning enabled for a restore? In this case, we can compare the number of potential vulnerability warnings in pruning enabled vs pruning  disabled projects.
- Q2: Was pruning explicitly disabled for a restore? We expect the feature to not break anyone and we don't expect people to disable it explicitly. Anything beyond SdkAnalysisLevel here implies that there's something wrong with the default pruning behavior.
- Q3: Are people directly referencing unnecessary packages? Normally this would be trending to 0. Currently we have NU1510 and we expect that to drive the numbers down. If those numbers remain high that'll mean we'd need to add more ways to tell customers that this packages are not necessary. Basically determine whether we need the future possibilities listed in https://github.com/NuGet/Home/blob/dev/accepted/2025/PrunePackageReference-with-direct-PackageReference.md#future-possibilities. 

To achieve that we'll add the follow values: 

- Pruning.FrameworksEnabled.Count
- Pruning.FrameworksDisabled.Count
- Pruning.FrameworksUnsupported.Count

These 3 help answer Q1 and Q2. Given that pruning is a per framework feature, it's the most meaningful way to track the feature being enabled.

- Pruning.RemovablePackages.Count
- Pruning.Pruned.Direct.Count

These 2 are the means to answer Q3, if Pruning.RemovablePackages.Count is higher than 0, but no NU1510 was reported, it would imply that we should be telling people by other means to remove the package.
The difference between that and Pruning.Pruned.Direct.Count would tell us about the scenarios where the package is necessary and where the recent direct pruning changes are actually benefitting. 

I do want to add telemetry for the pruned transitive dependencies, but that's harder to do and something that'd be hard to code up today to meet the preview deadline.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
