### PR TITLE
Surface projects with "Invalid framework identifier" issue

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -702,7 +702,7 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="projectInnerNodes">An <see cref="IReadOnlyDictionary{NuGetFramework,ProjectInstance} "/> containing the projects by their target framework.</param>
         /// <param name="isCpvmEnabled">A flag that is true if the Central Package Management was enabled.</param>
         /// <returns>A <see cref="List{TargetFrameworkInformation}" /> containing the target framework information for the specified project.</returns>
-        internal static List<TargetFrameworkInformation> GetTargetFrameworkInfos(IReadOnlyDictionary<string, IMSBuildProject> projectInnerNodes, bool isCpvmEnabled)
+        internal static List<TargetFrameworkInformation> GetTargetFrameworkInfos(IReadOnlyDictionary<string, IMSBuildProject> projectInnerNodes, bool isCpvmEnabled, Common.ILogger MSBuildLogger)
         {
             var targetFrameworkInfos = new List<TargetFrameworkInformation>(projectInnerNodes.Count);
 
@@ -750,6 +750,16 @@ namespace NuGet.Build.Tasks.Console
                     TargetAlias = targetAlias,
                     Warn = warn
                 };
+
+                try
+                {
+                    targetFrameworkInformation.FrameworkName.GetShortFolderName();
+                }
+                catch (FrameworkException)
+                {
+                    MSBuildLogger.Log(LogMessage.Create(LogLevel.Warning, $"Target Framework {targetFrameworkInformation.FrameworkName} resolved from '{projectInnerNode.Value.FullPath}' is invalid"));
+                    throw;
+                }
 
                 targetFrameworkInfos.Add(targetFrameworkInformation);
             }
@@ -925,7 +935,7 @@ namespace NuGet.Build.Tasks.Console
 
             RestoreAuditProperties auditProperties = MSBuildRestoreUtility.GetRestoreAuditProperties(project, projectsByTargetFramework.Values);
 
-            List<TargetFrameworkInformation> targetFrameworkInfos = GetTargetFrameworkInfos(projectsByTargetFramework, isCentralPackageManagementEnabled);
+            List<TargetFrameworkInformation> targetFrameworkInfos = GetTargetFrameworkInfos(projectsByTargetFramework, isCentralPackageManagementEnabled, MSBuildLogger);
 
             List<IMSBuildProject> innerNodes = projectsByTargetFramework.Values.ToList();
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

Locally during development on huge repo I got this exception during restore that doesn't have any details:
```
NuGet.Frameworks.FrameworkException: Invalid framework identifier ''.
   at NuGet.Frameworks.NuGetFramework.GetShortFolderName(IFrameworkNameProvider mappings)
   at NuGet.Commands.MSBuildRestoreUtility.<>c__DisplayClass7_0.<GetPackageSpec>b__0(TargetFrameworkInformation tfi)
   at NuGet.Shared.Extensions.ForEach[T](IEnumerable`1 enumeration, Action`1 action)
   at NuGet.Commands.MSBuildRestoreUtility.GetPackageSpec(IEnumerable`1 items)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at NuGet.Commands.MSBuildRestoreUtility.GetDependencySpec(IEnumerable`1 items, Boolean readOnly)
   at NuGet.Build.Tasks.RestoreTask.<ExecuteAsync>d__70.MoveNext()
```
I see that this has been reported already: [#10423](https://github.com/NuGet/Home/issues/10423)

Fixes: 

I debugged this and found a place where I can insert a message showing me the actual problem project, it now writes:
```
  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.RestoreEx.targets(19,5): warning : Target Framework _,Version=v0.0 resolved from 'D:\Platform\Source\Kernel\aoskernelNET\AosKernelNET.vcxproj' is invalid [D:\Platform\Source\dirs.proj]
```
This PR is likely does not do the output in the correct place, because I don't have a lot of insight in inner workings.

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [- ] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
