### PR TITLE
Make NuGet Package Search Service exposes inner exception messages

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -244,13 +244,27 @@ namespace NuGet.PackageManagement.VisualStudio
         public async ValueTask<SearchResultContextInfo> RefreshSearchAsync(CancellationToken cancellationToken)
         {
             Assumes.NotNull(_searchObject);
-            return await _searchObject.RefreshSearchAsync(cancellationToken);
+            try
+            {
+                return await _searchObject.RefreshSearchAsync(cancellationToken);
+            }
+            catch (FatalProtocolException ex)
+            {
+                throw new FatalProtocolException(ExceptionUtilities.DisplayMessage(ex));
+            }
         }
 
         public async ValueTask<SearchResultContextInfo> ContinueSearchAsync(CancellationToken cancellationToken)
         {
             Assumes.NotNull(_searchObject);
-            return await _searchObject.ContinueSearchAsync(cancellationToken);
+            try
+            {
+                return await _searchObject.ContinueSearchAsync(cancellationToken);
+            }
+            catch (FatalProtocolException ex)
+            {
+                throw new FatalProtocolException(ExceptionUtilities.DisplayMessage(ex));
+            }
         }
 
         public async ValueTask<SearchResultContextInfo> SearchAsync(
@@ -268,27 +282,34 @@ namespace NuGet.PackageManagement.VisualStudio
             Assumes.NotNullOrEmpty(packageSources);
             Assumes.NotNull(searchFilter);
 
-            IReadOnlyCollection<SourceRepository>? sourceRepositories = await _sharedServiceState.GetRepositoriesAsync(packageSources, cancellationToken);
-            IPackageFeed? packageFeed = await CreatePackageFeedAsync(
-                projectContextInfos,
-                targetFrameworks,
-                itemFilter,
-                isSolution,
-                useRecommender,
-                sourceRepositories,
-                cancellationToken);
-            Assumes.NotNull(packageFeed);
+            try
+            {
+                IReadOnlyCollection<SourceRepository>? sourceRepositories = await _sharedServiceState.GetRepositoriesAsync(packageSources, cancellationToken);
+                IPackageFeed? packageFeed = await CreatePackageFeedAsync(
+                    projectContextInfos,
+                    targetFrameworks,
+                    itemFilter,
+                    isSolution,
+                    useRecommender,
+                    sourceRepositories,
+                    cancellationToken);
+                Assumes.NotNull(packageFeed);
 
-            SourceRepository packagesFolderSourceRepository = await _packagesFolderLocalRepositoryLazy.GetValueAsync(cancellationToken);
-            IEnumerable<SourceRepository> globalPackageFolderRepositories = await GetAllPackageFoldersAsync(projectContextInfos, cancellationToken);
-            var metadataProvider = new MultiSourcePackageMetadataProvider(
-                sourceRepositories,
-                packagesFolderSourceRepository,
-                globalPackageFolderRepositories,
-                new VisualStudioActivityLogger());
+                SourceRepository packagesFolderSourceRepository = await _packagesFolderLocalRepositoryLazy.GetValueAsync(cancellationToken);
+                IEnumerable<SourceRepository> globalPackageFolderRepositories = await GetAllPackageFoldersAsync(projectContextInfos, cancellationToken);
+                var metadataProvider = new MultiSourcePackageMetadataProvider(
+                    sourceRepositories,
+                    packagesFolderSourceRepository,
+                    globalPackageFolderRepositories,
+                    new VisualStudioActivityLogger());
 
-            _searchObject = new SearchObject(packageFeed, metadataProvider, packageSources, PackageSearchMetadataMemoryCache);
-            return await _searchObject.SearchAsync(searchText, searchFilter, useRecommender, cancellationToken);
+                _searchObject = new SearchObject(packageFeed, metadataProvider, packageSources, PackageSearchMetadataMemoryCache);
+                return await _searchObject.SearchAsync(searchText, searchFilter, useRecommender, cancellationToken);
+            }
+            catch (FatalProtocolException ex)
+            {
+                throw new FatalProtocolException(ExceptionUtilities.DisplayMessage(ex));
+            }
         }
 
         public async ValueTask<int> GetTotalCountAsync(
@@ -305,20 +326,27 @@ namespace NuGet.PackageManagement.VisualStudio
             Assumes.NotNullOrEmpty(packageSources);
             Assumes.NotNull(searchFilter);
 
-            IReadOnlyCollection<SourceRepository>? sourceRepositories = await _sharedServiceState.GetRepositoriesAsync(packageSources, cancellationToken);
-            IPackageFeed? packageFeed = await CreatePackageFeedAsync(projectContextInfos, targetFrameworks, itemFilter, isSolution, recommendPackages: false, sourceRepositories, cancellationToken);
-            Assumes.NotNull(packageFeed);
+            try
+            {
+                IReadOnlyCollection<SourceRepository>? sourceRepositories = await _sharedServiceState.GetRepositoriesAsync(packageSources, cancellationToken);
+                IPackageFeed? packageFeed = await CreatePackageFeedAsync(projectContextInfos, targetFrameworks, itemFilter, isSolution, recommendPackages: false, sourceRepositories, cancellationToken);
+                Assumes.NotNull(packageFeed);
 
-            SourceRepository packagesFolderSourceRepository = await _packagesFolderLocalRepositoryLazy.GetValueAsync(cancellationToken);
-            IEnumerable<SourceRepository> globalPackageFolderRepositories = await GetAllPackageFoldersAsync(projectContextInfos, cancellationToken);
-            var metadataProvider = new MultiSourcePackageMetadataProvider(
-                sourceRepositories,
-                packagesFolderSourceRepository,
-                globalPackageFolderRepositories,
-                new VisualStudioActivityLogger());
+                SourceRepository packagesFolderSourceRepository = await _packagesFolderLocalRepositoryLazy.GetValueAsync(cancellationToken);
+                IEnumerable<SourceRepository> globalPackageFolderRepositories = await GetAllPackageFoldersAsync(projectContextInfos, cancellationToken);
+                var metadataProvider = new MultiSourcePackageMetadataProvider(
+                    sourceRepositories,
+                    packagesFolderSourceRepository,
+                    globalPackageFolderRepositories,
+                    new VisualStudioActivityLogger());
 
-            var searchObject = new SearchObject(packageFeed, metadataProvider, packageSources, searchCache: null);
-            return await searchObject.GetTotalCountAsync(maxCount, searchFilter, cancellationToken);
+                var searchObject = new SearchObject(packageFeed, metadataProvider, packageSources, searchCache: null);
+                return await searchObject.GetTotalCountAsync(maxCount, searchFilter, cancellationToken);
+            }
+            catch (FatalProtocolException ex)
+            {
+                throw new FatalProtocolException(ExceptionUtilities.DisplayMessage(ex));
+            }
         }
 
         public void Dispose()

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -77,29 +77,35 @@ namespace NuGet.PackageManagement.VisualStudio
             Assumes.NotNullOrEmpty(projectContextInfos);
             Assumes.NotNullOrEmpty(packageSources);
             Assumes.NotNull(searchFilter);
+            try
+            {
+                bool recommendPackages = false;
+                IReadOnlyCollection<SourceRepository> sourceRepositories = await _sharedServiceState.GetRepositoriesAsync(packageSources, cancellationToken);
+                IPackageFeed? packageFeed = await CreatePackageFeedAsync(
+                    projectContextInfos,
+                    targetFrameworks,
+                    itemFilter,
+                    isSolution,
+                    recommendPackages,
+                    sourceRepositories,
+                    cancellationToken);
+                Assumes.NotNull(packageFeed);
 
-            bool recommendPackages = false;
-            IReadOnlyCollection<SourceRepository> sourceRepositories = await _sharedServiceState.GetRepositoriesAsync(packageSources, cancellationToken);
-            IPackageFeed? packageFeed = await CreatePackageFeedAsync(
-                projectContextInfos,
-                targetFrameworks,
-                itemFilter,
-                isSolution,
-                recommendPackages,
-                sourceRepositories,
-                cancellationToken);
-            Assumes.NotNull(packageFeed);
+                SourceRepository packagesFolderSourceRepository = await _packagesFolderLocalRepositoryLazy.GetValueAsync(cancellationToken);
+                IEnumerable<SourceRepository> globalPackageFolderRepositories = await GetAllPackageFoldersAsync(projectContextInfos, cancellationToken);
+                var metadataProvider = new MultiSourcePackageMetadataProvider(
+                    sourceRepositories,
+                    packagesFolderSourceRepository,
+                    globalPackageFolderRepositories,
+                    new VisualStudioActivityLogger());
 
-            SourceRepository packagesFolderSourceRepository = await _packagesFolderLocalRepositoryLazy.GetValueAsync(cancellationToken);
-            IEnumerable<SourceRepository> globalPackageFolderRepositories = await GetAllPackageFoldersAsync(projectContextInfos, cancellationToken);
-            var metadataProvider = new MultiSourcePackageMetadataProvider(
-                sourceRepositories,
-                packagesFolderSourceRepository,
-                globalPackageFolderRepositories,
-                new VisualStudioActivityLogger());
-
-            var searchObject = new SearchObject(packageFeed, metadataProvider, packageSources, PackageSearchMetadataMemoryCache);
-            return await searchObject.GetAllPackagesAsync(searchFilter, cancellationToken);
+                var searchObject = new SearchObject(packageFeed, metadataProvider, packageSources, PackageSearchMetadataMemoryCache);
+                return await searchObject.GetAllPackagesAsync(searchFilter, cancellationToken);
+            }
+            catch (FatalProtocolException ex)
+            {
+                throw new FatalProtocolException(ExceptionUtilities.DisplayMessage(ex));
+            }
         }
 
         public async ValueTask<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo?)> GetPackageMetadataAsync(

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -514,7 +514,7 @@ namespace NuGet.Protocol
 
         private void ThrowIfHttpUriAndInsecureConnectionsNotAllowed(string uri)
         {
-            /*var parsedUri = new Uri(uri);
+            var parsedUri = new Uri(uri);
 
             if (string.Equals(parsedUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
             {
@@ -527,16 +527,6 @@ namespace NuGet.Protocol
                             _sourceUri.AbsoluteUri ?? "<unknown>",
                             uri));
                 }
-            }*/
-
-            if (!uri.Contains("https://api.nuget.org/v3/index.json"))
-            {
-                throw new HttpSourceException(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.Error_Insecure_HTTP,
-                            _sourceUri.AbsoluteUri ?? "<unknown>",
-                            uri));
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -514,7 +514,7 @@ namespace NuGet.Protocol
 
         private void ThrowIfHttpUriAndInsecureConnectionsNotAllowed(string uri)
         {
-            var parsedUri = new Uri(uri);
+            /*var parsedUri = new Uri(uri);
 
             if (string.Equals(parsedUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
             {
@@ -527,6 +527,16 @@ namespace NuGet.Protocol
                             _sourceUri.AbsoluteUri ?? "<unknown>",
                             uri));
                 }
+            }*/
+
+            if (!uri.Contains("https://api.nuget.org/v3/index.json"))
+            {
+                throw new HttpSourceException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.Error_Insecure_HTTP,
+                            _sourceUri.AbsoluteUri ?? "<unknown>",
+                            uri));
             }
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Follow up to https://github.com/NuGet/NuGet.Client/pull/6555

This PR makes sure Inner Exception messages are exposed at the nuget package search service level. As a result, clients listening to the service would be able to receive all the message instead of just the top-level message.

### Before
<img width="1661" height="1017" alt="image" src="https://github.com/user-attachments/assets/30126cb8-4224-46f2-843b-1619a8032f5d" />
### After
<img width="2190" height="1021" alt="image" src="https://github.com/user-attachments/assets/c97860bf-05b5-416c-818d-601a0302b3a0" />

**Note** The Http source exception in the second one is exposed

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
