### PR TITLE
Update references to VS SDK and ServiceHub to the latest versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,7 +70,6 @@
     <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.11.8" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.4.2244" />
     <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface" Version="17.10.40170" />
-    <PackageVersion Include="Microsoft.VisualStudio.VCProjectEngine" Version="17.14.40264" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.14.2094" />
     <PackageVersion Include="Microsoft.Web.Xdt" Version="$(MicrosoftWebXdtPackageVersion)" />
     <PackageVersion Include="Moq" Version="4.18.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,6 @@
     <SystemMemoryPackageVersion Condition="'$(SystemMemoryPackageVersion)' == ''">4.6.3</SystemMemoryPackageVersion>
     <SystemSecurityCryptographyPkcsVersion Condition="'$(SystemSecurityCryptographyPkcsVersion)' == ''">9.0.6</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyProtectedDataVersion Condition="'$(SystemSecurityCryptographyProtectedDataVersion)' == ''">9.0.6</SystemSecurityCryptographyProtectedDataVersion>
-    <MicrosoftVisualStudioSdkForApex>18.0.1799-preview.1</MicrosoftVisualStudioSdkForApex>
   </PropertyGroup>
 
   <ItemGroup>
@@ -67,7 +66,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem" Version="17.4.221-pre" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Version="17.2.0-beta1-20502-01" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.VS" Version="17.4.221-pre" />
-    <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" />
+    <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="18.0.2345-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.11.8" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.4.2244" />
     <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface" Version="17.10.40170" />
@@ -123,7 +122,7 @@
               '$(MSBuildProjectFile)' == 'NuGet.VisualStudio.Contracts.csproj' OR
               '$(MSBuildProjectFile)' == 'NuGet.VisualStudio.Interop.csproj' OR
               '$(MSBuildProjectFile)' == 'NuGet.SolutionRestoreManager.Interop.csproj'">
-    <PackageVersion Include="Microsoft.ServiceHub.Framework" Version="4.8.3" />
+    <PackageVersion Include="Microsoft.ServiceHub.Framework" Version="4.8.55" />
     <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost" Version="17.10.191" />
     <PackageVersion Update="Microsoft.VisualStudio.SDK" Version="" />
     <!-- Microsoft.VisualStudio.Shell.15.0 has vulnerable dependencies System.Text.Json. When it's upgraded, try removing the pinned packages -->

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -34,6 +34,7 @@
       <package pattern="moq" />
       <package pattern="MSTest.TestAdapter" />
       <package pattern="MSTest.TestFramework" />
+      <package pattern="nerdbank.streams" />
       <package pattern="netstandard.library" />
       <package pattern="newtonsoft.json" />
       <package pattern="nuget.*" />
@@ -71,7 +72,6 @@
       <package pattern="Microsoft.VisualStudio.*" />
       <package pattern="Microsoft.VisualStudioEng.MicroBuild.Core" />
       <package pattern="Microsoft.VSSDK.BuildTools" />
-      <package pattern="nerdbank.streams" />
       <package pattern="stdole" />
       <package pattern="streamjsonrpc" />
       <package pattern="vslangproj" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -34,7 +34,6 @@
       <package pattern="moq" />
       <package pattern="MSTest.TestAdapter" />
       <package pattern="MSTest.TestFramework" />
-      <package pattern="nerdbank.streams" />
       <package pattern="netstandard.library" />
       <package pattern="newtonsoft.json" />
       <package pattern="nuget.*" />
@@ -72,6 +71,7 @@
       <package pattern="Microsoft.VisualStudio.*" />
       <package pattern="Microsoft.VisualStudioEng.MicroBuild.Core" />
       <package pattern="Microsoft.VSSDK.BuildTools" />
+      <package pattern="nerdbank.streams" />
       <package pattern="stdole" />
       <package pattern="streamjsonrpc" />
       <package pattern="vslangproj" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -535,7 +535,9 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             // Check if user unchecks the "Tools - Options - Project & Soltuions - Save new projects when created" option
+#pragma warning disable CS0618 // Type or member is obsolete
             value = GetVSSolutionProperty((int)(__VSPROPID2.VSPROPID_DeferredSaveSolution));
+#pragma warning restore CS0618 // Type or member is obsolete
             return (bool)value;
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.DataAI.NuGetRecommender.Contracts" />
     <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" />
-    <PackageReference Include="Microsoft.VisualStudio.VCProjectEngine" />
     <PackageReference Include="Microsoft.VisualStudio.Sdk" />
     <PackageReference Include="VsWebSite.Interop" />
   </ItemGroup>

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/NuGet.OptProf.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/NuGet.OptProf.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" ExcludeAssets="Compile" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.VisualStudio.Sdk" VersionOverride="$(MicrosoftVisualStudioSdkForApex)" />
+    <PackageReference Include="Microsoft.VisualStudio.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGet.Tests.Apex.Daily.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGet.Tests.Apex.Daily.csproj
@@ -19,7 +19,7 @@
  
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" ExcludeAssets="Compile" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.VisualStudio.Sdk" VersionOverride="$(MicrosoftVisualStudioSdkForApex)" />
+    <PackageReference Include="Microsoft.VisualStudio.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -26,7 +26,7 @@
  
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" ExcludeAssets="Compile" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.VisualStudio.Sdk" VersionOverride="$(MicrosoftVisualStudioSdkForApex)" />
+    <PackageReference Include="Microsoft.VisualStudio.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3338

## Description
Update ServiceHub to bring in the latest dependency versions. Additionally, update the VS SDK being referenced to avoid conflicts with the latest ServiceHub. This change addresses the concerns from: https://github.com/NuGet/NuGet.Client/pull/6520 and puts the reference to the VS SDK across projects in sync again.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
