### PR TITLE
Add verbosity and interactive options to dotnet package update

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/CommonOptions.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/CommonOptions.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.CommandLine;
+using NuGet.Common;
+
+namespace NuGet.CommandLine.XPlat.Commands;
+
+internal static class CommonOptions
+{
+    internal static Option<VerbosityEnum?> GetVerbosityOption()
+    {
+        var verbosityOption = new Option<VerbosityEnum?>("--verbosity", "-v")
+        {
+            Description = Strings.Verbosity_Description
+        };
+        return verbosityOption;
+    }
+
+    internal static LogLevel ToLogLevel(this VerbosityEnum verbosity)
+    {
+        return verbosity switch
+        {
+            VerbosityEnum.q => LogLevel.Warning,
+            VerbosityEnum.quiet => LogLevel.Warning,
+            VerbosityEnum.m => LogLevel.Minimal,
+            VerbosityEnum.minimal => LogLevel.Minimal,
+            VerbosityEnum.n => LogLevel.Information,
+            VerbosityEnum.normal => LogLevel.Information,
+            VerbosityEnum.d => LogLevel.Verbose,
+            VerbosityEnum.detailed => LogLevel.Verbose,
+            VerbosityEnum.diag => LogLevel.Debug,
+            VerbosityEnum.diagnostic => LogLevel.Debug,
+            _ => throw new ArgumentOutOfRangeException(nameof(verbosity), verbosity, null)
+        };
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IVersionChooser.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IVersionChooser.cs
@@ -5,6 +5,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Versioning;
 
 namespace NuGet.CommandLine.XPlat.Commands.Package.Update
@@ -13,7 +14,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
     {
         Task<NuGetVersion?> GetLatestVersionAsync(
             string packageId,
-            ILoggerWithColor logger,
+            ILogger logger,
             CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateArgs.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using NuGet.Common;
 
 namespace NuGet.CommandLine.XPlat.Commands.Package.Update
 {
@@ -12,5 +13,9 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
         public required string Project { get; init; }
 
         public required IReadOnlyList<Package> Packages { get; init; }
+
+        public required bool Interactive { get; init; }
+
+        public required LogLevel LogLevel { get; init; }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommand.cs
@@ -9,28 +9,29 @@ using System.CommandLine;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 
 namespace NuGet.CommandLine.XPlat.Commands.Package.Update
 {
     internal static class PackageUpdateCommand
     {
-        internal static void Register(Command packageCommand)
+        internal static void Register(Command packageCommand, Option<bool> interactiveOption)
         {
             Func<ILoggerWithColor> getLogger = () =>
             {
-                var logger = new CommandOutputLogger(Common.LogLevel.Minimal);
+                var logger = new CommandOutputLogger(LogLevel.Information);
                 logger.HidePrefixForInfoAndMinimal = true;
                 return logger;
             };
-            Register(packageCommand, getLogger);
+            Register(packageCommand, interactiveOption, getLogger);
         }
 
-        internal static void Register(Command packageCommand, Func<ILoggerWithColor> getLogger)
+        internal static void Register(Command packageCommand, Option<bool> interactiveOption, Func<ILoggerWithColor> getLogger)
         {
-            Register(packageCommand, getLogger, PackageUpdateCommandRunner.Run);
+            Register(packageCommand, interactiveOption, getLogger, PackageUpdateCommandRunner.Run);
         }
 
-        internal static void Register(Command packageCommand, Func<ILoggerWithColor> getLogger, Func<PackageUpdateArgs, ILoggerWithColor, IDGSpecFactory, MSBuildAPIUtility, CancellationToken, Task<int>> action)
+        internal static void Register(Command packageCommand, Option<bool> interactiveOption, Func<ILoggerWithColor> getLogger, Func<PackageUpdateArgs, ILoggerWithColor, IDGSpecFactory, MSBuildAPIUtility, CancellationToken, Task<int>> action)
         {
             var command = new DocumentedCommand("update", Strings.PackageUpdateCommand_Description, "https://aka.ms/dotnet/package/update");
 
@@ -46,21 +47,35 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
             projectOption.Description = Strings.PackageUpdateCommand_ProjectOptionDescription;
             command.Options.Add(projectOption);
 
+            command.Options.Add(interactiveOption);
+
+            var verbosityOption = CommonOptions.GetVerbosityOption();
+            command.Options.Add(verbosityOption);
+
             packageCommand.Subcommands.Add(command);
             command.SetAction(async (args, cancellationToken) =>
             {
                 var logger = getLogger();
-                var project = args.GetValue(projectOption);
-                var packages = args.GetValue(packagesArguments) ?? [];
+
+                FileSystemInfo? project = args.GetValue(projectOption);
+                IReadOnlyList<Package> packages = args.GetValue(packagesArguments) ?? [];
+                bool interactive = args.GetValue(interactiveOption);
+                VerbosityEnum verbosity = args.GetValue(verbosityOption) ?? VerbosityEnum.normal;
+                LogLevel logLevel = verbosity.ToLogLevel();
 
                 var commandArgs = new PackageUpdateArgs
                 {
                     Project = project?.FullName ?? Environment.CurrentDirectory,
                     Packages = packages,
+                    Interactive = interactive,
+                    LogLevel = logLevel,
                 };
 
                 IDGSpecFactory dGSpecFactory = new DGSpecFactory();
-                MSBuildAPIUtility mSBuild = new(logger);
+                // MSBuildAPIUtility's output is different to what we want for package update.
+                // While it would probably be a good idea to align the output of all commands using MSBuildAPIUtility,
+                // in order to meet deadlines, we'll suppress its output, and leave improvements for later.
+                MSBuildAPIUtility mSBuild = new(NullLogger.Instance);
 
                 return await action(commandArgs, logger, dGSpecFactory, mSBuild, cancellationToken);
             });

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommand.cs
@@ -17,21 +17,10 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
     {
         internal static void Register(Command packageCommand, Option<bool> interactiveOption)
         {
-            Func<ILoggerWithColor> getLogger = () =>
-            {
-                var logger = new CommandOutputLogger(LogLevel.Information);
-                logger.HidePrefixForInfoAndMinimal = true;
-                return logger;
-            };
-            Register(packageCommand, interactiveOption, getLogger);
+            Register(packageCommand, interactiveOption, PackageUpdateCommandRunner.Run);
         }
 
-        internal static void Register(Command packageCommand, Option<bool> interactiveOption, Func<ILoggerWithColor> getLogger)
-        {
-            Register(packageCommand, interactiveOption, getLogger, PackageUpdateCommandRunner.Run);
-        }
-
-        internal static void Register(Command packageCommand, Option<bool> interactiveOption, Func<ILoggerWithColor> getLogger, Func<PackageUpdateArgs, ILoggerWithColor, IDGSpecFactory, MSBuildAPIUtility, CancellationToken, Task<int>> action)
+        internal static void Register(Command packageCommand, Option<bool> interactiveOption, Func<PackageUpdateArgs, IDGSpecFactory, MSBuildAPIUtility, CancellationToken, Task<int>> action)
         {
             var command = new DocumentedCommand("update", Strings.PackageUpdateCommand_Description, "https://aka.ms/dotnet/package/update");
 
@@ -55,8 +44,6 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
             packageCommand.Subcommands.Add(command);
             command.SetAction(async (args, cancellationToken) =>
             {
-                var logger = getLogger();
-
                 FileSystemInfo? project = args.GetValue(projectOption);
                 IReadOnlyList<Package> packages = args.GetValue(packagesArguments) ?? [];
                 bool interactive = args.GetValue(interactiveOption);
@@ -77,7 +64,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
                 // in order to meet deadlines, we'll suppress its output, and leave improvements for later.
                 MSBuildAPIUtility mSBuild = new(NullLogger.Instance);
 
-                return await action(commandArgs, logger, dGSpecFactory, mSBuild, cancellationToken);
+                return await action(commandArgs, dGSpecFactory, mSBuild, cancellationToken);
             });
         }
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.CommandLine.XPlat.Utility;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -22,259 +23,320 @@ using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
-namespace NuGet.CommandLine.XPlat.Commands.Package.Update
+namespace NuGet.CommandLine.XPlat.Commands.Package.Update;
+
+internal static class PackageUpdateCommandRunner
 {
-    internal static class PackageUpdateCommandRunner
+    internal static async Task<int> Run(PackageUpdateArgs args, ILoggerWithColor logger, IDGSpecFactory dGSpecFactory, MSBuildAPIUtility msbuild, CancellationToken cancellationToken)
     {
-        internal static async Task<int> Run(PackageUpdateArgs args, ILoggerWithColor logger, IDGSpecFactory dGSpecFactory, MSBuildAPIUtility msbuild, CancellationToken cancellationToken)
+        logger.LogLevel = args.LogLevel;
+
+        XPlatUtility.ConfigureProtocol();
+        DefaultCredentialServiceUtility.SetupDefaultCredentialService(logger, nonInteractive: !args.Interactive);
+
+        // 1. Get DGSpec for project/solution
+        // 2. Find suitable version of package(s) to update
+        // 3. Preview restore to validate changes
+        // 4. Update MSBuild files
+        // 5. Commit restore if everything successful
+
+        // 1. Get DGSpec for project/solution
+        string settingsRoot = Directory.Exists(args.Project) ? args.Project : Path.GetDirectoryName(args.Project)!;
+        ISettings settings = Settings.LoadDefaultSettings(settingsRoot);
+
+        logger.LogVerbose(Strings.PackageUpdate_LoadingDGSpec);
+        var dgSpec = dGSpecFactory.GetDependencyGraphSpec(args.Project);
+
+        if (dgSpec is null || dgSpec.Restore is null || dgSpec.Restore.Count == 0)
         {
-            XPlatUtility.ConfigureProtocol();
-            DefaultCredentialServiceUtility.SetupDefaultCredentialService(logger, nonInteractive: false);
-
-            // 1. Get DGSpec for project/solution
-            // 2. Find suitable version of package(s) to update
-            // 3. Preview restore to validate changes
-            // 4. Update MSBuild files
-            // 5. Commit restore if everything successful
-
-            // 1. Get DGSpec for project/solution
-            string settingsRoot = Directory.Exists(args.Project) ? args.Project : Path.GetDirectoryName(args.Project)!;
-            ISettings settings = Settings.LoadDefaultSettings(settingsRoot);
-
-            var dgSpec = dGSpecFactory.GetDependencyGraphSpec(args.Project);
-
-            if (dgSpec is null || dgSpec.Restore is null || dgSpec.Restore.Count == 0)
-            {
-                logger.LogMinimal(
-                    string.Format(CultureInfo.CurrentCulture, Strings.Error_PathIsMissingOrInvalid, args.Project),
-                    ConsoleColor.Red);
-                return ExitCodes.Error;
-            }
-
-            if (dgSpec.Restore.Count > 1)
-            {
-                logger.LogMinimal(Strings.Unsupported_UpdatingMoreThanOneProject, ConsoleColor.Red);
-                return ExitCodes.Error;
-            }
-
-            // 2. Find suitable version of package(s) to update
-            // Source provider will be needed to find the package version and to restore, so create it here.
-            CachingSourceProvider sourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings));
-            using SourceCacheContext sourceCacheContext = new();
-            var versionChooser = new VersionChooser(sourceProvider, settings, sourceCacheContext);
-            (PackageDependency? packageToUpdate, List<NuGetFramework>? packageTfms) = await GetPackageToUpdateAsync(args.Packages, dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
-
-            if (packageToUpdate is null)
-            {
-                // GetPackagesToUpdateAsync is responsible for outputting an error message.
-                return ExitCodes.Error;
-            }
-
-            // 3. Preview restore to validate changes
-            var updatedPackageSpec = dgSpec.Projects[0].Clone();
-            PackageSpecOperations.AddOrUpdateDependency(updatedPackageSpec, packageToUpdate);
-
-            var updatedDgSpec = dgSpec.WithReplacedSpec(updatedPackageSpec).WithoutRestores();
-            updatedDgSpec.AddRestore(updatedPackageSpec.RestoreMetadata.ProjectUniqueName);
-
-            logger.LogDebug("Running Restore preview");
-
-            var restorePreviewResult = await PreviewUpdatePackageReferenceAsync(updatedDgSpec, sourceCacheContext, logger, cancellationToken);
-
-            logger.LogDebug("Restore preview completed");
-
-            if (!restorePreviewResult.Result.Success)
-            {
-                logger.LogMinimal(Strings.PackageUpdate_PreviewRestoreFailed, ConsoleColor.Red);
-                return ExitCodes.Error;
-            }
-
-            var libraryDependency = AddPackageReferenceCommandRunner.GenerateLibraryDependency(
-                updatedPackageSpec,
-                customPackagesPath: null,
-                restorePreviewResult,
-                packageTfms,
-                packageToUpdate);
-
-            // 4. Update MSBuild files
-            if (packageTfms!.Count == dgSpec.Projects[0].TargetFrameworks.Count)
-            {
-                // package is used by all project TFMs (no condition)
-
-                msbuild.AddPackageReference(dgSpec.Projects[0].FilePath, libraryDependency, noVersion: true);
-            }
-            else
-            {
-                var frameworkAliases = packageTfms
-                    .Select(e => AddPackageReferenceCommandRunner.GetAliasForFramework(dgSpec.Projects[0], e))
-                    .Where(originalFramework => originalFramework != null);
-
-                msbuild.AddPackageReferencePerTFM(dgSpec.Projects[0].FilePath, libraryDependency, frameworkAliases, noVersion: true);
-            }
-
-            // 5. Commit restore if everything successful
-            await RestoreRunner.CommitAsync(restorePreviewResult, CancellationToken.None);
-
-            return ExitCodes.Success;
+            logger.LogMinimal(
+                string.Format(CultureInfo.CurrentCulture, Strings.Error_PathIsMissingOrInvalid, args.Project),
+                ConsoleColor.Red);
+            return ExitCodes.Error;
         }
 
-        private static async Task<RestoreResultPair> PreviewUpdatePackageReferenceAsync(
-            DependencyGraphSpec dgSpec,
-            SourceCacheContext cacheContext,
-            ILogger logger,
-            CancellationToken cancellationToken)
+        logger.LogInformation(Format.PackageUpdate_UpdatingOutdatedPackages(args.Project));
+
+        if (dgSpec.Restore.Count > 1)
         {
-            var providerCache = new RestoreCommandProvidersCache();
+            logger.LogMinimal(Strings.Unsupported_UpdatingMoreThanOneProject, ConsoleColor.Red);
+            return ExitCodes.Error;
+        }
 
-            // Pre-loaded request provider containing the graph file
-            var providers = new List<IPreLoadedRestoreRequestProvider>
-                {
-                    new DependencyGraphSpecRequestProvider(providerCache, dgSpec)
-                };
+        // 2. Find suitable version of package(s) to update
+        // Source provider will be needed to find the package version and to restore, so create it here.
+        logger.LogVerbose(Strings.PackageUpdate_FindingUpdateVersions);
 
-            var globalPackagesFolder = dgSpec.GetProjectSpec(dgSpec.Restore.Single()).RestoreMetadata.PackagesPath;
+        CachingSourceProvider sourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings));
+        using SourceCacheContext sourceCacheContext = new();
+        var versionChooser = new VersionChooser(sourceProvider, settings, sourceCacheContext);
+        (PackageToUpdate? packageToUpdate, List<NuGetFramework>? packageTfms) = await GetPackageToUpdateAsync(args.Packages, dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
 
-            var restoreContext = new RestoreArgs()
+        if (packageToUpdate is null)
+        {
+            // GetPackagesToUpdateAsync is responsible for outputting an error message.
+            return ExitCodes.Error;
+        }
+
+        // 3. Preview restore to validate changes
+        var updatedPackageSpec = dgSpec.Projects[0].Clone();
+        PackageDependency packageDependency = new PackageDependency(packageToUpdate.Id, packageToUpdate.NewVersion);
+        PackageSpecOperations.AddOrUpdateDependency(updatedPackageSpec, packageDependency);
+
+        var updatedDgSpec = dgSpec.WithReplacedSpec(updatedPackageSpec).WithoutRestores();
+        updatedDgSpec.AddRestore(updatedPackageSpec.RestoreMetadata.ProjectUniqueName);
+
+        logger.LogDebug(Strings.PackageUpdate_PreviewRestore);
+
+        var restorePreviewResult = await PreviewUpdatePackageReferenceAsync(updatedDgSpec, sourceCacheContext, logger, cancellationToken);
+
+        if (!restorePreviewResult.Result.Success)
+        {
+            logger.LogMinimal(Strings.PackageUpdate_PreviewRestoreFailed, ConsoleColor.Red);
+            return ExitCodes.Error;
+        }
+
+        var libraryDependency = AddPackageReferenceCommandRunner.GenerateLibraryDependency(
+            updatedPackageSpec,
+            customPackagesPath: null,
+            restorePreviewResult,
+            packageTfms,
+            packageDependency);
+
+        // 4. Update MSBuild files
+        var projectName = Path.GetFileNameWithoutExtension(dgSpec.Projects[0].FilePath);
+        logger.LogInformation($"  {projectName}:");
+        logger.LogInformation($"    " + Format.PackageUpdate_UpdatedMessage(packageToUpdate.Id, packageToUpdate.CurrentVersion.ToShortString(), packageToUpdate.NewVersion.ToShortString()));
+        logger.LogInformation("");
+
+        if (packageTfms!.Count == dgSpec.Projects[0].TargetFrameworks.Count)
+        {
+            // package is used by all project TFMs (no condition)
+
+            msbuild.AddPackageReference(dgSpec.Projects[0].FilePath, libraryDependency, noVersion: true);
+        }
+        else
+        {
+            var frameworkAliases = packageTfms
+                .Select(e => AddPackageReferenceCommandRunner.GetAliasForFramework(dgSpec.Projects[0], e))
+                .Where(originalFramework => originalFramework != null);
+
+            msbuild.AddPackageReferencePerTFM(dgSpec.Projects[0].FilePath, libraryDependency, frameworkAliases, noVersion: true);
+        }
+
+        // 5. Commit restore if everything successful
+        await RestoreRunner.CommitAsync(restorePreviewResult, CancellationToken.None);
+
+        int updatedCount = 1;
+        int scannedCount = 1;
+        logger.LogMinimal(Format.PackageUpdate_FinalSummary(updatedCount, scannedCount), ConsoleColor.Green);
+
+        return ExitCodes.Success;
+    }
+
+    private static async Task<RestoreResultPair> PreviewUpdatePackageReferenceAsync(
+        DependencyGraphSpec dgSpec,
+        SourceCacheContext cacheContext,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var providerCache = new RestoreCommandProvidersCache();
+
+        // Restore outputs a lot of messages at normal verbosity, which update doesn't want.
+        var restoreLogger = new RemappedLevelLogger(
+            logger,
+            new RemappedLevelLogger.Mapping
             {
-                CacheContext = cacheContext,
-                LockFileVersion = LockFileFormat.Version,
-                Log = logger,
-                MachineWideSettings = new XPlatMachineWideSetting(),
-                GlobalPackagesFolder = globalPackagesFolder,
-                PreLoadedRequestProviders = providers
-                // Sources : No need to pass it, because SourceRepositories contains the already built SourceRepository objects
+                Information = LogLevel.Verbose,
+                Minimal = LogLevel.Verbose,
+            });
+
+        // Pre-loaded request provider containing the graph file
+        var providers = new List<IPreLoadedRestoreRequestProvider>
+            {
+                new DependencyGraphSpecRequestProvider(providerCache, dgSpec)
             };
 
-            // Generate Restore Requests. There will always be 1 request here since we are restoring for 1 project.
-            var restoreRequests = await RestoreRunner.GetRequests(restoreContext);
+        var globalPackagesFolder = dgSpec.GetProjectSpec(dgSpec.Restore.Single()).RestoreMetadata.PackagesPath;
 
-            // Run restore without commit. This will always return 1 Result pair since we are restoring for 1 request.
-            var restoreResult = await RestoreRunner.RunWithoutCommitAsync(restoreRequests, restoreContext, cancellationToken);
+        var restoreContext = new RestoreArgs()
+        {
+            CacheContext = cacheContext,
+            LockFileVersion = LockFileFormat.Version,
+            Log = restoreLogger,
+            MachineWideSettings = new XPlatMachineWideSetting(),
+            GlobalPackagesFolder = globalPackagesFolder,
+            PreLoadedRequestProviders = providers
+            // Sources : No need to pass it, because SourceRepositories contains the already built SourceRepository objects
+        };
 
-            return restoreResult.Single();
+        // Generate Restore Requests. There will always be 1 request here since we are restoring for 1 project.
+        var restoreRequests = await RestoreRunner.GetRequests(restoreContext);
+
+        // Run restore without commit. This will always return 1 Result pair since we are restoring for 1 request.
+        var restoreResult = await RestoreRunner.RunWithoutCommitAsync(restoreRequests, restoreContext, cancellationToken);
+
+        return restoreResult.Single();
+    }
+
+    internal static async Task<(PackageToUpdate?, List<NuGetFramework>?)> GetPackageToUpdateAsync(
+        IReadOnlyList<Package> packages,
+        PackageSpec project,
+        IVersionChooser versionChooser,
+        ISettings settings,
+        ILoggerWithColor logger,
+        CancellationToken cancellationToken)
+    {
+        if (packages is null || packages.Count == 0)
+        {
+            logger.LogMinimal(Strings.Unsupported_UpgradeAllPackages, ConsoleColor.Red);
+            return (null, null);
         }
 
-        internal static async Task<(PackageDependency?, List<NuGetFramework>?)> GetPackageToUpdateAsync(
-            IReadOnlyList<Package> packages,
-            PackageSpec project,
-            IVersionChooser versionChooser,
-            ISettings settings,
-            ILoggerWithColor logger,
-            CancellationToken cancellationToken)
+        if (packages.Count > 1)
         {
-            if (packages is null || packages.Count == 0)
-            {
-                logger.LogMinimal(Strings.Unsupported_UpgradeAllPackages, ConsoleColor.Red);
-                return (null, null);
-            }
+            logger.LogMinimal(Strings.Unsupported_MoreThanOnePackage, ConsoleColor.Red);
+            return (null, null);
+        }
 
-            if (packages.Count > 1)
-            {
-                logger.LogMinimal(Strings.Unsupported_MoreThanOnePackage, ConsoleColor.Red);
-                return (null, null);
-            }
+        var sourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+        if (sourceMapping.IsEnabled)
+        {
+            logger.LogMinimal(Strings.Unsupported_PackageSourceMapping, ConsoleColor.Red);
+            return (null, null);
+        }
 
-            var sourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
-            if (sourceMapping.IsEnabled)
-            {
-                logger.LogMinimal(Strings.Unsupported_PackageSourceMapping, ConsoleColor.Red);
-                return (null, null);
-            }
+        var package = packages.Single();
 
-            var package = packages.Single();
-
-            VersionRange? existingVersion = null;
-            List<NuGetFramework>? frameworks = null;
-            foreach (var tfm in project.TargetFrameworks)
+        VersionRange? existingVersion = null;
+        List<NuGetFramework>? frameworks = null;
+        foreach (var tfm in project.TargetFrameworks)
+        {
+            foreach (var dependency in tfm.Dependencies)
             {
-                foreach (var dependency in tfm.Dependencies)
+                if (string.Equals(package.Id, dependency.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (string.Equals(package.Id, dependency.Name, StringComparison.OrdinalIgnoreCase))
+                    if (frameworks is null)
                     {
-                        if (frameworks is null)
-                        {
-                            frameworks = new List<NuGetFramework>();
-                        }
-                        frameworks.Add(tfm.FrameworkName);
+                        frameworks = new List<NuGetFramework>();
+                    }
+                    frameworks.Add(tfm.FrameworkName);
 
-                        VersionRange tfmVersionRange;
-                        if (project.RestoreMetadata.CentralPackageFloatingVersionsEnabled)
+                    VersionRange tfmVersionRange;
+                    if (project.RestoreMetadata.CentralPackageFloatingVersionsEnabled)
+                    {
+                        if (!tfm.CentralPackageVersions.TryGetValue(
+                            package.Id,
+                            out CentralPackageVersion? centralVersion))
                         {
-                            if (!tfm.CentralPackageVersions.TryGetValue(
-                                package.Id,
-                                out CentralPackageVersion? centralVersion))
-                            {
-                                logger.LogMinimal(
-                                    Messages.Error_CouldNotFindPackageVersionForCpmPackage(package.Id),
-                                    ConsoleColor.Red);
-                                return (null, null);
-                            }
-                            tfmVersionRange = centralVersion.VersionRange;
+                            logger.LogMinimal(
+                                Messages.Error_CouldNotFindPackageVersionForCpmPackage(package.Id),
+                                ConsoleColor.Red);
+                            return (null, null);
                         }
-                        else
-                        {
-                            tfmVersionRange = dependency.LibraryRange.VersionRange ?? VersionRange.All;
-                        }
+                        tfmVersionRange = centralVersion.VersionRange;
+                    }
+                    else
+                    {
+                        tfmVersionRange = dependency.LibraryRange.VersionRange ?? VersionRange.All;
+                    }
 
-                        if (existingVersion == null)
+                    if (existingVersion == null)
+                    {
+                        existingVersion = tfmVersionRange;
+                    }
+                    else
+                    {
+                        if (tfmVersionRange != existingVersion)
                         {
-                            existingVersion = tfmVersionRange;
-                        }
-                        else
-                        {
-                            if (tfmVersionRange != existingVersion)
-                            {
-                                logger.LogMinimal(
-                                    Messages.Unsupported_UpdatePackageWithDifferentPerTfmVersions(package.Id, project.FilePath),
-                                    ConsoleColor.Red);
-                                return (null, null);
-                            }
+                            logger.LogMinimal(
+                                Messages.Unsupported_UpdatePackageWithDifferentPerTfmVersions(package.Id, project.FilePath),
+                                ConsoleColor.Red);
+                            return (null, null);
                         }
                     }
                 }
             }
+        }
 
-            if (existingVersion is null)
+        if (existingVersion is null)
+        {
+            logger.LogMinimal(Messages.Error_PackageNotReferenced(package.Id, project.FilePath), ConsoleColor.Red);
+            return (null, null);
+        }
+
+        VersionRange newVersion;
+        if (package.VersionRange is null)
+        {
+            // NuGet.Protocol outputs request and response info at normal verbosity, which update doesn't want.
+            var protocolLogger = new RemappedLevelLogger(
+                logger,
+                new RemappedLevelLogger.Mapping
+                {
+                    Information = LogLevel.Verbose,
+                });
+
+            NuGetVersion? highestVersion = await versionChooser.GetLatestVersionAsync(
+                package.Id,
+                protocolLogger,
+                cancellationToken);
+
+            if (highestVersion is null)
             {
-                logger.LogMinimal(Messages.Error_PackageNotReferenced(package.Id, project.FilePath), ConsoleColor.Red);
+                logger.LogMinimal(Messages.Error_NoVersionsAvailable(package.Id), ConsoleColor.Red);
                 return (null, null);
             }
 
-            VersionRange newVersion;
-            if (package.VersionRange is null)
+            if (existingVersion.MinVersion == highestVersion)
             {
-                NuGetVersion? highestVersion = await versionChooser.GetLatestVersionAsync(
-                    package.Id,
-                    logger,
-                    cancellationToken);
-
-                if (highestVersion is null)
-                {
-                    logger.LogMinimal(Messages.Error_NoVersionsAvailable(package.Id), ConsoleColor.Red);
-                    return (null, null);
-                }
-
-                if (existingVersion.MinVersion == highestVersion)
-                {
-                    logger.LogMinimal(Messages.Warning_AlreadyHighestVersion(package.Id, highestVersion.OriginalVersion, project.FilePath), ConsoleColor.Red);
-                    return (null, null);
-                }
-
-                newVersion = new VersionRange(highestVersion);
-            }
-            else
-            {
-                newVersion = package.VersionRange;
-                if (newVersion == existingVersion)
-                {
-                    logger.LogMinimal(Messages.Warning_AlreadyUsingSameVersion(package.Id, newVersion.OriginalString), ConsoleColor.Red);
-                    return (null, null);
-                }
+                logger.LogMinimal(Messages.Warning_AlreadyHighestVersion(package.Id, highestVersion.OriginalVersion, project.FilePath), ConsoleColor.Red);
+                return (null, null);
             }
 
-            PackageDependency packageToUpdate = new(package.Id, newVersion);
+            newVersion = new VersionRange(highestVersion);
+        }
+        else
+        {
+            newVersion = package.VersionRange;
+            if (newVersion == existingVersion)
+            {
+                logger.LogMinimal(Messages.Warning_AlreadyUsingSameVersion(package.Id, newVersion.OriginalString), ConsoleColor.Red);
+                return (null, null);
+            }
+        }
 
-            return (packageToUpdate, frameworks);
+        var packageToUpdate = new PackageToUpdate
+        {
+            Id = package.Id,
+            CurrentVersion = existingVersion,
+            NewVersion = newVersion
+        };
+
+        return (packageToUpdate, frameworks);
+    }
+
+    internal record PackageToUpdate
+    {
+        public required string Id { get; init; }
+        public required VersionRange CurrentVersion { get; init; }
+        public required VersionRange NewVersion { get; init; }
+    }
+
+    private static class Format
+    {
+        internal static string PackageUpdate_UpdatingOutdatedPackages(string projectPath)
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.PackageUpdate_UpdatingOutdatedPackages, projectPath);
+        }
+
+        internal static string PackageUpdate_UpdatedMessage(string packageId, string currentVersion, string newVersion)
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.PackageUpdate_UpdatedMessage, packageId, currentVersion, newVersion);
+        }
+
+        internal static string PackageUpdate_FinalSummary(int updatedCount, int scannedCount)
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.PackageUpdate_FinalSummary, updatedCount, scannedCount);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -27,13 +27,22 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update;
 
 internal static class PackageUpdateCommandRunner
 {
-    internal static async Task<int> Run(PackageUpdateArgs args, ILoggerWithColor logger, IDGSpecFactory dGSpecFactory, MSBuildAPIUtility msbuild, CancellationToken cancellationToken)
+    // This overload sets static state, so should not be used in tests.
+    internal static Task<int> Run(PackageUpdateArgs args, IDGSpecFactory dGSpecFactory, MSBuildAPIUtility msbuild, CancellationToken cancellationToken)
     {
-        logger.LogLevel = args.LogLevel;
+        ILoggerWithColor logger = new CommandOutputLogger(args.LogLevel)
+        {
+            HidePrefixForInfoAndMinimal = true
+        };
 
         XPlatUtility.ConfigureProtocol();
         DefaultCredentialServiceUtility.SetupDefaultCredentialService(logger, nonInteractive: !args.Interactive);
 
+        return Run(args, logger, dGSpecFactory, msbuild, cancellationToken);
+    }
+
+    internal static async Task<int> Run(PackageUpdateArgs args, ILoggerWithColor logger, IDGSpecFactory dGSpecFactory, MSBuildAPIUtility msbuild, CancellationToken cancellationToken)
+    {
         // 1. Get DGSpec for project/solution
         // 2. Find suitable version of package(s) to update
         // 3. Preview restore to validate changes

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/VersionChooser.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/VersionChooser.cs
@@ -32,7 +32,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update
 
         public async Task<NuGetVersion?> GetLatestVersionAsync(
             string packageId,
-            ILoggerWithColor logger,
+            ILogger logger,
             CancellationToken cancellationToken)
         {
             var sources = new List<SourceRepository>();

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/VerbosityEnum.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/VerbosityEnum.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.CommandLine.XPlat.Commands;
+
+internal enum VerbosityEnum
+{
+    quiet,
+    q,
+    minimal,
+    m,
+    normal,
+    n,
+    detailed,
+    d,
+    diagnostic,
+    diag
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGetCommands.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGetCommands.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.CommandLine;
 using System.Linq;
 using NuGet.CommandLine.XPlat.Commands.Package.Update;
@@ -16,9 +17,10 @@ public static class NuGetCommands
     /// <para>Adds NuGet's dotnet CLI commands to the dotnet CLI RootCommand object</para>
     /// </summary>
     /// <param name="rootCommand">The CLI's RootCommand instance</param>
+    /// <param name="interactiveOption">The .NET SDK has code to detect when output is redirected or </param>
     /// <remarks>Many of NuGet's commands are defined in the dotnet/sdk repo, and those run NuGet.CommandLine.XPlat.dll as a child process.
     /// Those commands are not added by this method.</remarks>
-    public static void Add(RootCommand rootCommand)
+    public static void Add(RootCommand rootCommand, Option<bool> interactiveOption)
     {
         var packageCommand = rootCommand.Subcommands.FirstOrDefault(c => c.Name == "package");
         if (packageCommand is null)
@@ -27,6 +29,17 @@ public static class NuGetCommands
             rootCommand.Subcommands.Add(packageCommand);
         }
 
-        PackageUpdateCommand.Register(packageCommand);
+        PackageUpdateCommand.Register(packageCommand, interactiveOption);
+    }
+
+    // To delete once the SDK starts using the other overload. Joys of public APIs.
+    public static void Add(RootCommand rootCommand)
+    {
+        var interactiveOption = new Option<bool>("--interactive")
+        {
+            Description = Strings.AddPkg_InteractiveDescription,
+            DefaultValueFactory = _ => Console.IsOutputRedirected
+        };
+        Add(rootCommand, interactiveOption);
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -88,6 +88,10 @@ namespace NuGet.CommandLine.XPlat
                 };
 
                 RootCommand rootCommand = new RootCommand();
+                // Commands called directly from the SDK CLI will use the SDK's common interactive option.
+                Option<bool> interactiveOption = new Option<bool>("--interactive");
+                interactiveOption.Description = Strings.AddPkg_InteractiveDescription;
+                interactiveOption.DefaultValueFactory = _ => Console.IsOutputRedirected;
 
                 if (args[0] == "package")
                 {
@@ -95,7 +99,7 @@ namespace NuGet.CommandLine.XPlat
                     rootCommand.Subcommands.Add(packageCommand);
 
                     PackageSearchCommand.Register(packageCommand, getHidePrefixLogger);
-                    PackageUpdateCommand.Register(packageCommand, getHidePrefixLogger);
+                    PackageUpdateCommand.Register(packageCommand, interactiveOption, getHidePrefixLogger);
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -99,7 +99,7 @@ namespace NuGet.CommandLine.XPlat
                     rootCommand.Subcommands.Add(packageCommand);
 
                     PackageSearchCommand.Register(packageCommand, getHidePrefixLogger);
-                    PackageUpdateCommand.Register(packageCommand, interactiveOption, getHidePrefixLogger);
+                    PackageUpdateCommand.Register(packageCommand, interactiveOption);
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 NuGet.CommandLine.XPlat.NuGetCommands
 static NuGet.CommandLine.XPlat.NuGetCommands.Add(System.CommandLine.RootCommand rootCommand) -> void
+static NuGet.CommandLine.XPlat.NuGetCommands.Add(System.CommandLine.RootCommand rootCommand, System.CommandLine.Option<bool> interactiveOption) -> void

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.CommandLine.XPlat {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -1545,6 +1545,33 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Updated {0} packages in {1} scanned packages..
+        /// </summary>
+        internal static string PackageUpdate_FinalSummary {
+            get {
+                return ResourceManager.GetString("PackageUpdate_FinalSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Finding versions of packages to update..
+        /// </summary>
+        internal static string PackageUpdate_FindingUpdateVersions {
+            get {
+                return ResourceManager.GetString("PackageUpdate_FindingUpdateVersions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loading Project(s)..
+        /// </summary>
+        internal static string PackageUpdate_LoadingDGSpec {
+            get {
+                return ResourceManager.GetString("PackageUpdate_LoadingDGSpec", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package reference in the form of a package identifier like &apos;Newtonsoft.Json&apos; or package identifier and version separated by &apos;@&apos; like &apos;Newtonsoft.Json@13.0.3&apos;..
         /// </summary>
         internal static string PackageUpdate_PackageArgumentDescription {
@@ -1554,11 +1581,38 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Running preview restore to check package compatibility..
+        /// </summary>
+        internal static string PackageUpdate_PreviewRestore {
+            get {
+                return ResourceManager.GetString("PackageUpdate_PreviewRestore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Preview restore with updated packages was not successful. Force mode is not yet available..
         /// </summary>
         internal static string PackageUpdate_PreviewRestoreFailed {
             get {
                 return ResourceManager.GetString("PackageUpdate_PreviewRestoreFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Updated {0} {1} to {2}.
+        /// </summary>
+        internal static string PackageUpdate_UpdatedMessage {
+            get {
+                return ResourceManager.GetString("PackageUpdate_UpdatedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Updating outdated packages in {0}.
+        /// </summary>
+        internal static string PackageUpdate_UpdatingOutdatedPackages {
+            get {
+                return ResourceManager.GetString("PackageUpdate_UpdatingOutdatedPackages", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.CommandLine.XPlat {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -1599,7 +1599,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Updated {0} {1} to {2}.
+        ///   Looks up a localized string similar to Updated {0} {1} to {2}..
         /// </summary>
         internal static string PackageUpdate_UpdatedMessage {
             get {
@@ -1608,7 +1608,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Updating outdated packages in {0}.
+        ///   Looks up a localized string similar to Updating outdated packages in {0}..
         /// </summary>
         internal static string PackageUpdate_UpdatingOutdatedPackages {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -1040,4 +1040,28 @@ Do not translate "PackageVersion"</comment>
   <data name="PackageUpdate_PackageArgumentDescription" xml:space="preserve">
     <value>Package reference in the form of a package identifier like 'Newtonsoft.Json' or package identifier and version separated by '@' like 'Newtonsoft.Json@13.0.3'.</value>
   </data>
+  <data name="PackageUpdate_UpdatingOutdatedPackages" xml:space="preserve">
+    <value>Updating outdated packages in {0}</value>
+    <comment>{0}: the project or solution that is being updated</comment>
+  </data>
+  <data name="PackageUpdate_LoadingDGSpec" xml:space="preserve">
+    <value>Loading Project(s).</value>
+  </data>
+  <data name="PackageUpdate_FindingUpdateVersions" xml:space="preserve">
+    <value>Finding versions of packages to update.</value>
+  </data>
+  <data name="PackageUpdate_PreviewRestore" xml:space="preserve">
+    <value>Running preview restore to check package compatibility.</value>
+  </data>
+  <data name="PackageUpdate_UpdatedMessage" xml:space="preserve">
+    <value>Updated {0} {1} to {2}</value>
+    <comment>{0}: package id
+{1}: existing version
+{2}: new version</comment>
+  </data>
+  <data name="PackageUpdate_FinalSummary" xml:space="preserve">
+    <value>Updated {0} packages in {1} scanned packages.</value>
+    <comment>{0}: Number of packages updated
+{1}: Package checked for updated versions</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -1041,7 +1041,7 @@ Do not translate "PackageVersion"</comment>
     <value>Package reference in the form of a package identifier like 'Newtonsoft.Json' or package identifier and version separated by '@' like 'Newtonsoft.Json@13.0.3'.</value>
   </data>
   <data name="PackageUpdate_UpdatingOutdatedPackages" xml:space="preserve">
-    <value>Updating outdated packages in {0}</value>
+    <value>Updating outdated packages in {0}.</value>
     <comment>{0}: the project or solution that is being updated</comment>
   </data>
   <data name="PackageUpdate_LoadingDGSpec" xml:space="preserve">
@@ -1054,7 +1054,7 @@ Do not translate "PackageVersion"</comment>
     <value>Running preview restore to check package compatibility.</value>
   </data>
   <data name="PackageUpdate_UpdatedMessage" xml:space="preserve">
-    <value>Updated {0} {1} to {2}</value>
+    <value>Updated {0} {1} to {2}.</value>
     <comment>{0}: package id
 {1}: existing version
 {2}: new version</comment>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
@@ -30,6 +30,12 @@ namespace NuGet.CommandLine.XPlat
             return logger;
         }
 
+        public LogLevel LogLevel
+        {
+            get => VerbosityLevel;
+            set => VerbosityLevel = value;
+        }
+
         public override void LogDebug(string data)
         {
             LogInternal(LogLevel.Debug, data);
@@ -143,7 +149,7 @@ namespace NuGet.CommandLine.XPlat
         {
             var currentColor = Console.ForegroundColor;
             Console.ForegroundColor = color;
-            Console.Write(data);
+            LogInternal(LogLevel.Minimal, data);
             Console.ForegroundColor = currentColor;
         }
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
@@ -30,12 +30,6 @@ namespace NuGet.CommandLine.XPlat
             return logger;
         }
 
-        public LogLevel LogLevel
-        {
-            get => VerbosityLevel;
-            set => VerbosityLevel = value;
-        }
-
         public override void LogDebug(string data)
         {
             LogInternal(LogLevel.Debug, data);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ILoggerWithColor.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ILoggerWithColor.cs
@@ -15,5 +15,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="data">The message text to be logged.</param>
         /// <param name="color">The ConsoleColor value to set the text color.</param>
         void LogMinimal(string data, ConsoleColor color);
+
+        LogLevel LogLevel { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ILoggerWithColor.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ILoggerWithColor.cs
@@ -15,7 +15,5 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="data">The message text to be logged.</param>
         /// <param name="color">The ConsoleColor value to set the text color.</param>
         void LogMinimal(string data, ConsoleColor color);
-
-        LogLevel LogLevel { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/RemappedLevelLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/RemappedLevelLogger.cs
@@ -1,0 +1,104 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using NuGet.Common;
+
+namespace NuGet.CommandLine.XPlat.Utility
+{
+    internal class RemappedLevelLogger : ILogger
+    {
+        private readonly ILogger _logger;
+        private readonly Mapping _mapping;
+
+        public RemappedLevelLogger(ILogger inner, Mapping mapping)
+        {
+            _logger = inner;
+            _mapping = mapping;
+        }
+
+        private LogLevel GetMappedLevel(LogLevel level)
+        {
+            return level switch
+            {
+                LogLevel.Debug => _mapping.Debug,
+                LogLevel.Verbose => _mapping.Verbose,
+                LogLevel.Information => _mapping.Information,
+                LogLevel.Minimal => _mapping.Minimal,
+                LogLevel.Warning => _mapping.Warning,
+                LogLevel.Error => _mapping.Error,
+                _ => throw new System.ArgumentOutOfRangeException(nameof(level), level, "Unknown log level")
+            };
+        }
+
+        public void Log(LogLevel level, string data)
+        {
+            var mappedLevel = GetMappedLevel(level);
+            _logger.Log(mappedLevel, data);
+        }
+
+        public void Log(ILogMessage message)
+        {
+            var mappedLevel = GetMappedLevel(message.Level);
+            _logger.Log(mappedLevel, message.Message);
+        }
+
+        public Task LogAsync(LogLevel level, string data)
+        {
+            var mappedLevel = GetMappedLevel(level);
+            return _logger.LogAsync(mappedLevel, data);
+        }
+
+
+        public Task LogAsync(ILogMessage message)
+        {
+            var mappedLevel = GetMappedLevel(message.Level);
+            return _logger.LogAsync(mappedLevel, message.Message);
+        }
+
+        public void LogDebug(string data)
+        {
+            _logger.Log(_mapping.Debug, data);
+        }
+
+        public void LogError(string data)
+        {
+            _logger.Log(_mapping.Error, data);
+        }
+
+        public void LogInformation(string data)
+        {
+            _logger.Log(_mapping.Information, data);
+        }
+
+        public void LogInformationSummary(string data)
+        {
+            _logger.Log(_mapping.Information, data);
+        }
+
+        public void LogMinimal(string data)
+        {
+            _logger.Log(_mapping.Minimal, data);
+        }
+
+        public void LogVerbose(string data)
+        {
+            _logger.Log(_mapping.Verbose, data);
+        }
+
+        public void LogWarning(string data)
+        {
+            _logger.Log(_mapping.Warning, data);
+        }
+
+        internal record Mapping
+        {
+            public LogLevel Debug { get; init; } = LogLevel.Debug;
+            public LogLevel Verbose { get; init; } = LogLevel.Verbose;
+            public LogLevel Information { get; init; } = LogLevel.Information;
+            public LogLevel Minimal { get; init; } = LogLevel.Minimal;
+            public LogLevel Warning { get; init; } = LogLevel.Warning;
+            public LogLevel Error { get; init; } = LogLevel.Error;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/RemappedLevelLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/RemappedLevelLogger.cs
@@ -6,7 +6,7 @@ using NuGet.Common;
 
 namespace NuGet.CommandLine.XPlat.Utility
 {
-    internal class RemappedLevelLogger : ILogger
+    internal class RemappedLevelLogger : LoggerBase
     {
         private readonly ILogger _logger;
         private readonly Mapping _mapping;
@@ -31,64 +31,16 @@ namespace NuGet.CommandLine.XPlat.Utility
             };
         }
 
-        public void Log(LogLevel level, string data)
+        public override void Log(ILogMessage message)
         {
-            var mappedLevel = GetMappedLevel(level);
-            _logger.Log(mappedLevel, data);
+            message.Level = GetMappedLevel(message.Level);
+            _logger.Log(message);
         }
 
-        public void Log(ILogMessage message)
+        public override Task LogAsync(ILogMessage message)
         {
-            var mappedLevel = GetMappedLevel(message.Level);
-            _logger.Log(mappedLevel, message.Message);
-        }
-
-        public Task LogAsync(LogLevel level, string data)
-        {
-            var mappedLevel = GetMappedLevel(level);
-            return _logger.LogAsync(mappedLevel, data);
-        }
-
-
-        public Task LogAsync(ILogMessage message)
-        {
-            var mappedLevel = GetMappedLevel(message.Level);
-            return _logger.LogAsync(mappedLevel, message.Message);
-        }
-
-        public void LogDebug(string data)
-        {
-            _logger.Log(_mapping.Debug, data);
-        }
-
-        public void LogError(string data)
-        {
-            _logger.Log(_mapping.Error, data);
-        }
-
-        public void LogInformation(string data)
-        {
-            _logger.Log(_mapping.Information, data);
-        }
-
-        public void LogInformationSummary(string data)
-        {
-            _logger.Log(_mapping.Information, data);
-        }
-
-        public void LogMinimal(string data)
-        {
-            _logger.Log(_mapping.Minimal, data);
-        }
-
-        public void LogVerbose(string data)
-        {
-            _logger.Log(_mapping.Verbose, data);
-        }
-
-        public void LogWarning(string data)
-        {
-            _logger.Log(_mapping.Warning, data);
+            message.Level = GetMappedLevel(message.Level);
+            return _logger.LogAsync(message);
         }
 
         internal record Mapping

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunner.GetPackageToUpdateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunner.GetPackageToUpdateTests.cs
@@ -62,7 +62,8 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
             // Assert
             packageToUpdate.Should().NotBeNull();
             packageToUpdate.Id.Should().Be("Contoso.Utils");
-            packageToUpdate.VersionRange.ToString().Should().Be("[1.2.3, )");
+            packageToUpdate.CurrentVersion.ToString().Should().Be("1.0.0");
+            packageToUpdate.NewVersion.ToString().Should().Be("[1.2.3, )");
             logger.Invocations.Count.Should().Be(0);
         }
 
@@ -103,7 +104,8 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
             // Assert
             packageToUpdate.Should().NotBeNull();
             packageToUpdate.Id.Should().Be("Contoso.Utils");
-            packageToUpdate.VersionRange.ToString().Should().Be("[3.4.5, )");
+            packageToUpdate.CurrentVersion.ToString().Should().Be("1.0.0");
+            packageToUpdate.NewVersion.ToString().Should().Be("[3.4.5, )");
             logger.Invocations.Count.Should().Be(0);
         }
 
@@ -139,7 +141,8 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
             // Assert
             packageToUpdate.Should().NotBeNull();
             packageToUpdate.Id.Should().Be("Contoso.Utils");
-            packageToUpdate.VersionRange.ToString().Should().Be("[1.2.3, 2.0.0)");
+            packageToUpdate.CurrentVersion.ToString().Should().Be("1.0.0");
+            packageToUpdate.NewVersion.ToString().Should().Be("[1.2.3, 2.0.0)");
             logger.Invocations.Count.Should().Be(0);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunner.GetPackageToUpdateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunner.GetPackageToUpdateTests.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using Moq;
 using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
@@ -62,7 +63,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
             // Assert
             packageToUpdate.Should().NotBeNull();
             packageToUpdate.Id.Should().Be("Contoso.Utils");
-            packageToUpdate.CurrentVersion.ToString().Should().Be("1.0.0");
+            packageToUpdate.CurrentVersion.ToString().Should().Be("[1.0.0, )");
             packageToUpdate.NewVersion.ToString().Should().Be("[1.2.3, )");
             logger.Invocations.Count.Should().Be(0);
         }
@@ -86,7 +87,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
 
             var versionChooser = new Mock<IVersionChooser>(MockBehavior.Strict);
             versionChooser
-                .Setup(v => v.GetLatestVersionAsync("Contoso.Utils", It.IsAny<ILoggerWithColor>(), It.IsAny<CancellationToken>()))
+                .Setup(v => v.GetLatestVersionAsync("Contoso.Utils", It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new NuGetVersion("3.4.5"));
 
             var sourceCacheContext = new SourceCacheContext();
@@ -104,7 +105,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
             // Assert
             packageToUpdate.Should().NotBeNull();
             packageToUpdate.Id.Should().Be("Contoso.Utils");
-            packageToUpdate.CurrentVersion.ToString().Should().Be("1.0.0");
+            packageToUpdate.CurrentVersion.ToString().Should().Be("[1.0.0, )");
             packageToUpdate.NewVersion.ToString().Should().Be("[3.4.5, )");
             logger.Invocations.Count.Should().Be(0);
         }
@@ -141,7 +142,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
             // Assert
             packageToUpdate.Should().NotBeNull();
             packageToUpdate.Id.Should().Be("Contoso.Utils");
-            packageToUpdate.CurrentVersion.ToString().Should().Be("1.0.0");
+            packageToUpdate.CurrentVersion.ToString().Should().Be("[1.0.0, )");
             packageToUpdate.NewVersion.ToString().Should().Be("[1.2.3, 2.0.0)");
             logger.Invocations.Count.Should().Be(0);
         }
@@ -165,7 +166,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update
 
             var versionChooser = new Mock<IVersionChooser>(MockBehavior.Strict);
             versionChooser
-                .Setup(v => v.GetLatestVersionAsync("Contoso.Utils", It.IsAny<ILoggerWithColor>(), It.IsAny<CancellationToken>()))
+                .Setup(v => v.GetLatestVersionAsync("Contoso.Utils", It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((NuGetVersion?)null);
             var logger = new Mock<ILoggerWithColor>();
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NullLoggerWithColor.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NullLoggerWithColor.cs
@@ -16,5 +16,11 @@ namespace NuGet.CommandLine.Xplat.Tests
         public void LogMinimal(string data, ConsoleColor color)
         {
         }
+
+        public LogLevel LogLevel
+        {
+            get => VerbosityLevel;
+            set => VerbosityLevel = value;
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14319

## Description

Functional changes:

* Output messages aligned with feature design spec
* Support `--verbosity` to get different levels of detail on the output. Default is `normal` verbosity.
* Added `--interactive`, so allow customers to force enable or disable interactive mode, which is important for when using a credential provider to authenticate to private feeds.

There's still room for improvement for the output messages, but it's better to add new functionality before spending a lot of time fine tuning the output.

Code things I want to highlight:

* Verbosity options is copying [what the .NET SDK does](https://github.com/dotnet/sdk/blob/main/src/Cli/Microsoft.DotNet.Cli.Utils/VerbosityOptions.cs), but we can't use it directly because those verbosity options aren't in a package we can reference
* The .NET SDK has a default value factory for `--interactive` that checks if stdout is being redirected, and also checks for common CI agent environment variables. I changed the API that the SDK registers NuGet commands with to take in the interactive option, so we'll get their implementation. But since NuGet.CommandLine.XPlat is also a console app that package update runs on, and until the SDK starts passing the option, we'll only check for stdout redirection. I don't see value in duplicating the environment variable list check.

Sample outputs

<details>
<summary>detailed verbosity</summary>

Successful:
```text
trace: Loading Project(s).
Updating outdated packages in D:\src\test\update
trace: Finding versions of packages to update.
trace:   CACHE https://api.nuget.org/v3/registration5-gz-semver2/microsoft.build/index.json
trace: Running restore with 32 concurrent jobs.
trace: Reading project file D:\src\test\update\ConsoleApp1\ConsoleApp1.csproj.
trace: The restore inputs for 'ConsoleApp1' have changed. Continuing restore.
trace: Restoring packages for D:\src\test\update\ConsoleApp1\ConsoleApp1.csproj...
trace: Scanning packages for runtime.json files...
trace: Scanning packages for runtime.json files...
trace:   CACHE https://api.nuget.org/v3/vulnerabilities/index.json
trace:   CACHE https://api.nuget.org/v3-vulnerabilities/2025.07.10.23.23.28/vulnerability.base.json
trace:   CACHE https://api.nuget.org/v3-vulnerabilities/2025.07.10.23.23.28/2025.07.16.23.23.50/vulnerability.update.json
trace: All packages and projects are compatible with net9.0.
trace: All packages and projects are compatible with .NETFramework,Version=v4.8.
trace: All packages and projects are compatible with net9.0 (win-x86).
trace: All packages and projects are compatible with .NETFramework,Version=v4.8 (win-x86).
  ConsoleApp1:
    Updated Microsoft.Build 17.0.8 to 17.14.8

trace: Committing restore...
trace: Assets file has not changed. Skipping assets file writing. Path: D:\src\test\update\ConsoleApp1\obj\project.assets.json
trace: Writing cache file to disk. Path: D:\src\test\update\ConsoleApp1\obj\project.nuget.cache
trace: Restored D:\src\test\update\ConsoleApp1\ConsoleApp1.csproj (in 338 ms).
Updated 1 packages in 1 scanned packages.
```

Error:
```
trace: Loading Project(s).
Updating outdated packages in D:\src\test\update
trace: Finding versions of packages to update.
trace:   CACHE https://api.nuget.org/v3/registration5-gz-semver2/microsoft.build/index.json
trace: Running restore with 32 concurrent jobs.
trace: Reading project file D:\src\test\update\ConsoleApp1\ConsoleApp1.csproj.
trace: The restore inputs for 'ConsoleApp1' have changed. Continuing restore.
trace: Restoring packages for D:\src\test\update\ConsoleApp1\ConsoleApp1.csproj...
trace: Scanning packages for runtime.json files...
trace: Scanning packages for runtime.json files...
trace:   CACHE https://api.nuget.org/v3/vulnerabilities/index.json
trace:   CACHE https://api.nuget.org/v3-vulnerabilities/2025.07.10.23.23.28/vulnerability.base.json
trace:   CACHE https://api.nuget.org/v3-vulnerabilities/2025.07.10.23.23.28/2025.07.16.23.23.50/vulnerability.update.json
error: Package Microsoft.Build 17.14.8 is not compatible with net8.0 (.NETCoreApp,Version=v8.0). Package Microsoft.Build 17.14.8 supports:
error:   - net472 (.NETFramework,Version=v4.7.2)
error:   - net9.0 (.NETCoreApp,Version=v9.0)
trace: All packages and projects are compatible with .NETFramework,Version=v4.8.
error: Package Microsoft.Build 17.14.8 is not compatible with net8.0 (.NETCoreApp,Version=v8.0) / win-x86. Package Microsoft.Build 17.14.8 supports:
error:   - net472 (.NETFramework,Version=v4.7.2)
error:   - net9.0 (.NETCoreApp,Version=v9.0)
trace: All packages and projects are compatible with .NETFramework,Version=v4.8 (win-x86).
Preview restore with updated packages was not successful. Force mode is not yet available.
```

</details>

<details>
<summary>Normal verbosity</summary>

Successful:
```text
Updating outdated packages in D:\src\test\update
  ConsoleApp1:
    Updated Microsoft.Build 17.0.8 to 17.14.8

Updated 1 packages in 1 scanned packages.
```

Error:
```text
Updating outdated packages in D:\src\test\update
error: Package Microsoft.Build 17.14.8 is not compatible with net8.0 (.NETCoreApp,Version=v8.0). Package Microsoft.Build 17.14.8 supports:
error:   - net472 (.NETFramework,Version=v4.7.2)
error:   - net9.0 (.NETCoreApp,Version=v9.0)
error: Package Microsoft.Build 17.14.8 is not compatible with net8.0 (.NETCoreApp,Version=v8.0) / win-x86. Package Microsoft.Build 17.14.8 supports:
error:   - net472 (.NETFramework,Version=v4.7.2)
error:   - net9.0 (.NETCoreApp,Version=v9.0)
Preview restore with updated packages was not successful. Force mode is not yet available.
```

</details>

<details>
<summary>Minimal</summary>

Successful:
```text
Updated 1 packages in 1 scanned packages.
```

Error:
```text
error: Package Microsoft.Build 17.14.8 is not compatible with net8.0 (.NETCoreApp,Version=v8.0). Package Microsoft.Build 17.14.8 supports:
error:   - net472 (.NETFramework,Version=v4.7.2)
error:   - net9.0 (.NETCoreApp,Version=v9.0)
error: Package Microsoft.Build 17.14.8 is not compatible with net8.0 (.NETCoreApp,Version=v8.0) / win-x86. Package Microsoft.Build 17.14.8 supports:
error:   - net472 (.NETFramework,Version=v4.7.2)
error:   - net9.0 (.NETCoreApp,Version=v9.0)
Preview restore with updated packages was not successful. Force mode is not yet available.
```

</details>

<details>
<summary>quirt</summary>

Successful commands do not have any output.

Commands with errors have the same output as minimal verbosity.

</details>

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ https://github.com/NuGet/Client.Engineering/issues/3337
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14354
