### PR TITLE
Update Xdt to 3.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
   <PropertyGroup>
     <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion Condition="'$(MicrosoftExtensionsFileProvidersAbstractionsPackageVersion)' == ''">6.0.0</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion Condition="'$(MicrosoftExtensionsFileSystemGlobbingPackageVersion)' == ''">6.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
-    <MicrosoftWebXdtPackageVersion Condition="'$(MicrosoftWebXdtPackageVersion)' == ''">3.0.0</MicrosoftWebXdtPackageVersion>
+    <MicrosoftWebXdtPackageVersion Condition="'$(MicrosoftWebXdtPackageVersion)' == ''">3.2.0</MicrosoftWebXdtPackageVersion>
     <SystemComponentModelCompositionPackageVersion Condition="'$(SystemComponentModelCompositionPackageVersion)' == ''">4.5.0</SystemComponentModelCompositionPackageVersion>
     <SystemMemoryPackageVersion Condition="'$(SystemMemoryPackageVersion)' == ''">4.6.3</SystemMemoryPackageVersion>
     <SystemSecurityCryptographyPkcsVersion Condition="'$(SystemSecurityCryptographyPkcsVersion)' == ''">9.0.6</SystemSecurityCryptographyPkcsVersion>

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -18,12 +18,6 @@
 
   <Target Name="LocalizeNonProjectFiles">
     <ItemGroup>
-      <NonProjectFilesToMove Include="$(PkgMicrosoft_Web_Xdt)\lib\netstandard2.0\Microsoft.Web.XmlTransform.dll">
-        <DestinationDir>$(ArtifactsDirectory)microsoft.web.xdt\lib\netstandard2.0\</DestinationDir>
-      </NonProjectFilesToMove>
-      <NonProjectFilesToMove Include="$(PkgMicrosoft_Web_Xdt)\lib\net40\Microsoft.Web.XmlTransform.dll">
-        <DestinationDir>$(ArtifactsDirectory)microsoft.web.xdt\lib\net40\</DestinationDir>
-      </NonProjectFilesToMove>
       <NonProjectFilesToMove Include="..\src\NuGet.Clients\NuGet.VisualStudio.Client\extension.vsixlangpack">
         <DestinationDir>$(ArtifactsDirectory)vsixlangpack\</DestinationDir>
       </NonProjectFilesToMove>

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -14,13 +14,6 @@
     <SignTargetsDependOn Condition="'$(SignPackages)' == 'true' AND '$(BuildRTM)' != 'true'">GetOutputNupkgs;GetOutputVsix</SignTargetsDependOn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <FilesToSign Include="$(ArtifactsDirectory)microsoft.web.xdt\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll">
-      <Authenticode>Microsoft400</Authenticode>
-      <StrongName>67</StrongName>
-    </FilesToSign>
-  </ItemGroup>
 
   <Target Name="Sign"
           BeforeTargets="AfterBuild"
@@ -32,13 +25,13 @@
              BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="FilesToSign" />
     </MSBuild>
-    
+
     <MSBuild Projects="$(VSIXProject)"
              Targets="GetThirdPartyAssemblies"
              BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="ThirdPartyAssembly" />
     </MSBuild>
-    
+
     <ItemGroup>
       <FilesToSign Include="%(ThirdPartyAssembly.TargetPath)" Authenticode="3PartySHA2" />
     </ItemGroup>

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -214,7 +214,7 @@ stages:
 
       - output: pipelineArtifact
         displayName: 'LocValidation: Publish Logs as an artifact'
-        condition: "succeeded()"
+        condition: "succeededOrFailed()"
         artifactName: LocValidationLogs
         targetPath: "$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs"
         sbomEnabled: true

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.Swix/Microsoft.VisualStudio.NuGet.BuildTools.Swix.swixproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.Swix/Microsoft.VisualStudio.NuGet.BuildTools.Swix.swixproj
@@ -15,14 +15,13 @@
 
   <PropertyGroup>
     <ReferenceOutputPath>$(ArtifactsDirectory)NuGet.VisualStudio.Client\bin\$(Configuration)\net472\</ReferenceOutputPath>
-    <XmlTransformPath>$(ArtifactsDirectory)microsoft.web.xdt\lib\net40\</XmlTransformPath>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- Variables added here will be usable in the swr file.  This is a semi colon delimited
           list of name=value items.  Use $(name) in the swr file to reference the variable.
     -->
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);XmlTransformPath=$(XmlTransformPath);BuildNumber=$(BuildNumber);MajorNuGetVersion=$(MajorNuGetVersion);MinorNuGetVersion=$(MinorNuGetVersion);PatchNuGetVersion=$(PatchNuGetVersion);MajorVSVersion=$(MajorVSVersion)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);ReferenceOutputPath=$(ReferenceOutputPath);BuildNumber=$(BuildNumber);MajorNuGetVersion=$(MajorNuGetVersion);MinorNuGetVersion=$(MinorNuGetVersion);PatchNuGetVersion=$(PatchNuGetVersion);MajorVSVersion=$(MajorVSVersion)</PackagePreprocessorDefinitions>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +32,6 @@
     <Copy SourceFiles="$(OutputPath)$(TargetName).vsix" DestinationFolder="$(VsixPublishDestination)" />
     <Copy SourceFiles="$(OutputPath)$(TargetName).json" DestinationFolder="$(VsixPublishDestination)" />
   </Target>
-  
+
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 </Project>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.Swix/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.Swix/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -4,41 +4,41 @@ package name=Microsoft.VisualStudio.NuGet.BuildTools
         version=$(MajorVSVersion).0.$(MajorNuGetVersion)0$(MinorNuGetVersion)0$(PatchNuGetVersion).$(BuildNumber)
         vs.package.productArch=neutral
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet
         file source=$(ReferenceOutputPath)Microsoft.Build.NuGetSdkResolver.dll
         file source=$(ReferenceOutputPath)Microsoft.Extensions.FileProviders.Abstractions.dll
         file source=$(ReferenceOutputPath)Microsoft.Extensions.FileSystemGlobbing.dll
         file source=$(ReferenceOutputPath)Microsoft.Extensions.Primitives.dll
-        file source=$(XmlTransformPath)Microsoft.Web.XmlTransform.dll
+        file source=$(ReferenceOutputPath)Microsoft.Web.XmlTransform.dll
         file source=$(ReferenceOutputPath)Newtonsoft.Json.dll
         file source=$(ReferenceOutputPath)NuGet.Build.Tasks.Console.exe
-        file source=$(ReferenceOutputPath)NuGet.Build.Tasks.Console.exe.config  
+        file source=$(ReferenceOutputPath)NuGet.Build.Tasks.Console.exe.config
         file source=$(ReferenceOutputPath)NuGet.Build.Tasks.dll
-        file source=$(ReferenceOutputPath)NuGet.Commands.dll  
-        file source=$(ReferenceOutputPath)NuGet.Common.dll  
-        file source=$(ReferenceOutputPath)NuGet.Configuration.dll  
+        file source=$(ReferenceOutputPath)NuGet.Commands.dll
+        file source=$(ReferenceOutputPath)NuGet.Common.dll
+        file source=$(ReferenceOutputPath)NuGet.Configuration.dll
         file source=$(ReferenceOutputPath)NuGet.Credentials.dll
-        file source=$(ReferenceOutputPath)NuGet.DependencyResolver.Core.dll  
-        file source=$(ReferenceOutputPath)NuGet.Frameworks.dll  
-        file source=$(ReferenceOutputPath)NuGet.LibraryModel.dll  
-        file source=$(ReferenceOutputPath)NuGet.PackageManagement.dll  
-        file source=$(ReferenceOutputPath)NuGet.Packaging.dll  
-        file source=$(ReferenceOutputPath)NuGet.ProjectModel.dll  
+        file source=$(ReferenceOutputPath)NuGet.DependencyResolver.Core.dll
+        file source=$(ReferenceOutputPath)NuGet.Frameworks.dll
+        file source=$(ReferenceOutputPath)NuGet.LibraryModel.dll
+        file source=$(ReferenceOutputPath)NuGet.PackageManagement.dll
+        file source=$(ReferenceOutputPath)NuGet.Packaging.dll
+        file source=$(ReferenceOutputPath)NuGet.ProjectModel.dll
         file source=$(ReferenceOutputPath)NuGet.props
-        file source=$(ReferenceOutputPath)NuGet.Protocol.dll  
-        file source=$(ReferenceOutputPath)NuGet.Resolver.dll  
+        file source=$(ReferenceOutputPath)NuGet.Protocol.dll
+        file source=$(ReferenceOutputPath)NuGet.Resolver.dll
         file source=$(ReferenceOutputPath)NuGet.RestoreEx.targets
         file source=$(ReferenceOutputPath)NuGet.targets
-        file source=$(ReferenceOutputPath)NuGet.Versioning.dll  
+        file source=$(ReferenceOutputPath)NuGet.Versioning.dll
         file source=$(ReferenceOutputPath)System.Buffers.dll
         file source=$(ReferenceOutputPath)System.Memory.dll
         file source=$(ReferenceOutputPath)System.Numerics.Vectors.dll
         file source=$(ReferenceOutputPath)System.Runtime.CompilerServices.Unsafe.dll
         file source=$(ReferenceOutputPath)System.Threading.Tasks.Dataflow.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\cs 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\cs
         file source=$(ReferenceOutputPath)cs\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)cs\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)cs\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)cs\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)cs\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)cs\NuGet.Common.resources.dll
@@ -54,9 +54,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\cs
         file source=$(ReferenceOutputPath)cs\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)cs\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\de 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\de
         file source=$(ReferenceOutputPath)de\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)de\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)de\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)de\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)de\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)de\NuGet.Common.resources.dll
@@ -72,9 +72,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\de
         file source=$(ReferenceOutputPath)de\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)de\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\es 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\es
         file source=$(ReferenceOutputPath)es\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)es\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)es\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)es\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)es\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)es\NuGet.Common.resources.dll
@@ -90,9 +90,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\es
         file source=$(ReferenceOutputPath)es\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)es\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\fr 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\fr
         file source=$(ReferenceOutputPath)fr\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)fr\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)fr\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)fr\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)fr\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)fr\NuGet.Common.resources.dll
@@ -108,9 +108,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\fr
         file source=$(ReferenceOutputPath)fr\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)fr\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\it 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\it
         file source=$(ReferenceOutputPath)it\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)it\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)it\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)it\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)it\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)it\NuGet.Common.resources.dll
@@ -126,9 +126,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\it
         file source=$(ReferenceOutputPath)it\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)it\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ja 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ja
         file source=$(ReferenceOutputPath)ja\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)ja\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)ja\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)ja\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)ja\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)ja\NuGet.Common.resources.dll
@@ -144,9 +144,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ja
         file source=$(ReferenceOutputPath)ja\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)ja\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ko 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ko
         file source=$(ReferenceOutputPath)ko\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)ko\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)ko\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)ko\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)ko\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)ko\NuGet.Common.resources.dll
@@ -162,9 +162,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ko
         file source=$(ReferenceOutputPath)ko\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)ko\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\pl 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\pl
         file source=$(ReferenceOutputPath)pl\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)pl\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)pl\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)pl\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)pl\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)pl\NuGet.Common.resources.dll
@@ -180,9 +180,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\pl
         file source=$(ReferenceOutputPath)pl\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)pl\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\pt-BR 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\pt-BR
         file source=$(ReferenceOutputPath)pt-BR\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)pt-BR\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)pt-BR\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)pt-BR\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)pt-BR\NuGet.Common.resources.dll
@@ -198,9 +198,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\pt-BR
         file source=$(ReferenceOutputPath)pt-BR\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)pt-BR\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ru 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ru
         file source=$(ReferenceOutputPath)ru\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)ru\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)ru\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)ru\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)ru\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)ru\NuGet.Common.resources.dll
@@ -216,9 +216,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ru
         file source=$(ReferenceOutputPath)ru\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)ru\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\tr 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\tr
         file source=$(ReferenceOutputPath)tr\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)tr\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)tr\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)tr\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)tr\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)tr\NuGet.Common.resources.dll
@@ -234,9 +234,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\tr
         file source=$(ReferenceOutputPath)tr\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)tr\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\zh-Hans 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\zh-Hans
         file source=$(ReferenceOutputPath)zh-Hans\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)zh-Hans\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)zh-Hans\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)zh-Hans\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)zh-Hans\NuGet.Common.resources.dll
@@ -252,9 +252,9 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\zh-Hans
         file source=$(ReferenceOutputPath)zh-Hans\NuGet.Resolver.resources.dll
         file source=$(ReferenceOutputPath)zh-Hans\NuGet.Versioning.resources.dll
 
-folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\zh-Hant 
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\zh-Hant
         file source=$(ReferenceOutputPath)zh-Hant\Microsoft.Build.NuGetSdkResolver.resources.dll
-        file source=$(XmlTransformPath)zh-Hant\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\Microsoft.Web.XmlTransform.resources.dll
         file source=$(ReferenceOutputPath)zh-Hant\NuGet.Build.Tasks.resources.dll
         file source=$(ReferenceOutputPath)zh-Hant\NuGet.Commands.resources.dll
         file source=$(ReferenceOutputPath)zh-Hant\NuGet.Common.resources.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
@@ -35,6 +35,7 @@ Microsoft.Extensions.FileProviders.Abstractions.dll
 Microsoft.Extensions.FileSystemGlobbing.dll
 Microsoft.Extensions.Primitives.dll
 Microsoft.Web.XmlTransform.dll
+Microsoft.Web.XmlTransform.resources.dll
 
 # Assembly XML Documentation we ship in the VSIX
 NuGet.PackageManagement.PowerShellCmdlets.dll-Help.xml

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -60,7 +60,7 @@
       <Link>Modules\NuGet\NuGet.PackageManagement.PowerShellCmdlets.dll-Help.xml</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(PkgMicrosoft_Web_Xdt)\lib\net40\Microsoft.Web.XmlTransform.dll">
+    <Content Include="$(PkgMicrosoft_Web_Xdt)\lib\netstandard20\Microsoft.Web.XmlTransform.dll">
       <Link>Microsoft.Web.XmlTransform.dll</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -362,7 +362,6 @@
     </MSBuild>
     <ItemGroup>
       <VSIXSourceItem Include="@(LocalizedFilesForVsix)" />
-      <_LocalizedFiles Include="$(ArtifactsDirectory)microsoft.web.xdt\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll" />
       <_LocalizedFiles Include="$(ArtifactsDirectory)vsixlangpack\**\extension.vsixlangpack" />
       <_VsixLocFiles Include="@(_LocalizedFiles)">
         <TargetPath>%(_LocalizedFiles.RecursiveDir)%(_LocalizedFiles.Filename)%(_LocalizedFiles.Extension)</TargetPath>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -60,10 +60,6 @@
       <Link>Modules\NuGet\NuGet.PackageManagement.PowerShellCmdlets.dll-Help.xml</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(PkgMicrosoft_Web_Xdt)\lib\netstandard20\Microsoft.Web.XmlTransform.dll">
-      <Link>Microsoft.Web.XmlTransform.dll</Link>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Content Include="$(ArtifactsDirectory)\Scripts\Add-WrapperMembers.ps1">
       <Link>Modules\NuGet\Add-WrapperMembers.ps1</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -94,6 +90,14 @@
     </Content>
     <Content Include="extension.vsixlangpack">
       <IncludeInVSIX>false</IncludeInVSIX>
+    </Content>
+    <!-- Explicitly include the XmlTransform resource packages.
+         These aren't automatically included by the VSSDK in the correct spot.
+         Work around https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2523215
+    -->
+    <Content Include="$(OutputPath)**/Microsoft.Web.XmlTransform.resources.dll">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="$(BuildCommonDirectory)NOTICES.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -334,11 +338,16 @@
       <AllVsixAssemblies Include="@(VSIXSourceItem->'%(FileName)%(Extension)')" Condition=" '%(Extension)' == '.dll' Or '%(Extension)' == '.xml' ">
         <SourceFile>%(VSIXSourceItem.Identity)</SourceFile>
       </AllVsixAssemblies>
+      <!-- Work around https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2523215 -->
+      <IncorrectCopyLocalSubDirAssemblies Include="@(VSIXSourceItem)" Condition="'%(VSIXSourceItem.VSIXSubPath)' == '' and '%(VSIXSourceItem.DestinationSubDirectory)' != ''">
+        <SourceFile>%(VSIXSourceItem.Identity)</SourceFile>
+      </IncorrectCopyLocalSubDirAssemblies>
     </ItemGroup>
     <ItemGroup>
       <SuppressPackaging Include="@(AllVsixAssemblies)" Exclude="@(IncludeVsixFilesList)" />
+      <SuppressPackaging Include="@(IncorrectCopyLocalSubDirAssemblies)" />
       <MissingRequiredAssemblies Include="@(IncludeVsixFilesList)" Exclude="@(AllVsixAssemblies)" />
-      <NotListedDependencies Include="@(SuppressPackaging)" Exclude="@(IgnoreVsixFilesList)" />
+      <NotListedDependencies Include="@(SuppressPackaging)" Exclude="@(IgnoreVsixFilesList);@(IncorrectCopyLocalSubDirAssemblies)" />
       <MissingIgnoredAssemblies Include="@(IgnoreVsixFilesList)" Exclude="@(AllVsixAssemblies)" />
       <VSIXSourceItem Remove="@(SuppressPackaging->'%(SourceFile)')" />
       <VSIXSourceItem Remove="@(AllVsixSymbols->'%(SourceFile)')" />


### PR DESCRIPTION
This version contains localization, which is a prereq to the xliff switchover. The diffs between 3.2.0 and 3.1.0 is just infra+localization, and 3.1.0 vs. 3.0.0 are mostly infra and one additional feature added in 2019.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
