### PR TITLE
Throw an exception for Http search in PackageSearchResourceV3

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -217,12 +217,11 @@ namespace NuGet.Protocol
 
         internal async Task<T> ProcessHttpStreamAsync<T>(
             HttpSourceRequest request,
-            string requestUri,
             Func<HttpResponseMessage, Task<T>> processAsync,
             ILogger log,
             CancellationToken token)
         {
-            ThrowIfHttpUriAndInsecureConnectionsNotAllowed(requestUri);
+            ThrowIfHttpUriAndInsecureConnectionsNotAllowed(request.RequestFactory().RequestUri.AbsoluteUri);
 
             return await ProcessResponseAsync(
                 request,

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -217,10 +217,13 @@ namespace NuGet.Protocol
 
         internal async Task<T> ProcessHttpStreamAsync<T>(
             HttpSourceRequest request,
+            string requestUri,
             Func<HttpResponseMessage, Task<T>> processAsync,
             ILogger log,
             CancellationToken token)
         {
+            ThrowIfHttpUriAndInsecureConnectionsNotAllowed(requestUri);
+
             return await ProcessResponseAsync(
                 request,
                 async response =>

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -225,7 +225,6 @@ namespace NuGet.Protocol
             return await Search(
                 (httpSource, uri) => httpSource.ProcessHttpStreamAsync(
                     new HttpSourceRequest(uri, Common.NullLogger.Instance),
-                    uri.AbsoluteUri,
                     s => ProcessHttpStreamTakeCountedItemAsync(s, take, cancellationToken),
                     Common.NullLogger.Instance,
                     cancellationToken),

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -225,6 +225,7 @@ namespace NuGet.Protocol
             return await Search(
                 (httpSource, uri) => httpSource.ProcessHttpStreamAsync(
                     new HttpSourceRequest(uri, Common.NullLogger.Instance),
+                    uri.AbsoluteUri,
                     s => ProcessHttpStreamTakeCountedItemAsync(s, take, cancellationToken),
                     Common.NullLogger.Instance,
                     cancellationToken),

--- a/test/TestUtilities/Test.Utility/ProtocolUtility.cs
+++ b/test/TestUtilities/Test.Utility/ProtocolUtility.cs
@@ -21,5 +21,10 @@ namespace Test.Utility
         {
             return string.Format(CultureInfo.InvariantCulture, "http://{0}/", Guid.NewGuid());
         }
+
+        public static string CreateHttpsServiceAddress()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "https://{0}/", Guid.NewGuid());
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
`PackageSearchResourceV3 ` makes an http request using `HttpSource.ProcessHttpStreamAsync`.

This PR makes sure the same pattern is applied here just like https://github.com/NuGet/NuGet.Client/pull/6555

* Throws an exception if a request is HTTP and allowInsecureConnections is not set
* This will affect: `dotnet package search` and `nuget search` commands.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
