### PR TITLE
NU1803 should not download packages when treated as error

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -33,8 +33,6 @@ namespace NuGet.Commands
 
         private readonly LockFileBuilderCache _lockFileBuilderCache;
 
-        private bool _success;
-
         private Guid _operationId;
 
         private readonly Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>> _includeFlagGraphs
@@ -170,7 +168,6 @@ namespace NuGet.Commands
             _logger = collectorLogger;
             ParentId = request.ParentId;
 
-            _success = !request.AdditionalMessages?.Any(m => m.Level == LogLevel.Error) ?? true;
             _isLockFileEnabled = PackagesLockFileUtilities.IsNuGetLockFileEnabled(_request.Project);
             _enableNewDependencyResolver = _request.Project.RuntimeGraph.Supports.Count == 0 && ShouldUseNewResolverWithLockFile(_isLockFileEnabled, _request.Project) && !_request.Project.RestoreMetadata.UseLegacyDependencyResolver;
         }
@@ -231,20 +228,25 @@ namespace NuGet.Commands
 
                 telemetry.TelemetryEvent[NoOpResult] = false; // Getting here means we did not no-op.
 
-                _success &= BeforeGraphResolutionValidations(httpSourcesCount);
+                bool success = !_request.AdditionalMessages?.Any(m => m.Level == LogLevel.Error) ?? true;
+                success &= BeforeGraphResolutionValidations(httpSourcesCount);
 
                 var packagesLockFilePath = PackagesLockFileUtilities.GetNuGetLockFilePath(_request.Project);
                 PackagesLockFile packagesLockFile = null;
-                (bool isLockFileValid, bool regenerateLockFile, packagesLockFilePath, packagesLockFile) = await EvaluateLockFile(
+                (bool successfulResult, bool isLockFileValid, bool regenerateLockFile, packagesLockFilePath, packagesLockFile) = await EvaluateLockFile(
                     telemetry,
                     contextForProject,
                     packagesLockFilePath,
                     packagesLockFile,
+                    success,
                     token);
+                success &= successfulResult;
 
                 AnalyzePruningResults(_request.Project, telemetry.TelemetryEvent, _logger);
 
-                var graphs = await GenerateRestoreGraphsAsync(telemetry, contextForProject, token);
+                // if success == false, it generates an empty restore graph suitable to create an assets file with errors.
+                // Since the graph is empty, any code that analyzes the graph (like audit) will have nothing to do.
+                var graphs = await GenerateRestoreGraphsAsync(telemetry, contextForProject, success, token);
 
                 bool auditRan = false;
 
@@ -271,7 +273,7 @@ namespace NuGet.Commands
 
                 telemetry.StartIntervalMeasure();
 
-                _success &= await ValidateRestoreGraphsAsync(graphs, _logger);
+                success &= await ValidateRestoreGraphsAsync(graphs, _logger);
 
                 // Check package compatibility
                 IList<CompatibilityCheckResult> checkResults = await VerifyCompatibilityAsync(
@@ -285,13 +287,14 @@ namespace NuGet.Commands
 
                 if (checkResults.Any(r => !r.Success))
                 {
-                    _success = false;
+                    success = false;
                 }
 
                 telemetry.EndIntervalMeasure(ValidateRestoreGraphsDuration);
 
                 // Generate Targets/Props files
-                (IEnumerable<MSBuildOutputFile> msbuildOutputFiles,
+                (successfulResult,
+                    IEnumerable<MSBuildOutputFile> msbuildOutputFiles,
                     string assetsFilePath,
                     string cacheFilePath,
                     assetsFile,
@@ -309,13 +312,15 @@ namespace NuGet.Commands
                         packagesLockFile,
                         packagesLockFilePath,
                         cacheFile,
+                        success,
                         token);
+                success &= successfulResult;
 
                 restoreTime.Stop();
 
                 // Create result
                 var restoreResult = new RestoreResult(
-                    _success,
+                    success,
                     graphs,
                     checkResults,
                     msbuildOutputFiles,
@@ -451,7 +456,7 @@ namespace NuGet.Commands
                 {
                     telemetry.StartIntervalMeasure();
                     _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_RestoreNoOpFinish, _request.Project.Name));
-                    _success = true;
+                    bool success = true;
                     // Replay Warnings and Errors from an existing lock file in case of a no-op.
                     await MSBuildRestoreUtility.ReplayWarningsAndErrorsAsync(cacheFile.LogMessages, _logger);
 
@@ -459,7 +464,7 @@ namespace NuGet.Commands
 
                     restoreTime.Stop();
                     telemetry.TelemetryEvent[NoOpResult] = true;
-                    telemetry.TelemetryEvent[RestoreSuccess] = _success;
+                    telemetry.TelemetryEvent[RestoreSuccess] = success;
                     telemetry.TelemetryEvent[TotalUniquePackagesCount] = cacheFile.ExpectedPackageFilePaths?.Count ?? -1;
                     telemetry.TelemetryEvent[NewPackagesInstalledCount] = 0;
                     telemetry.TelemetryEvent[UpdatedAssetsFile] = false;
@@ -468,7 +473,7 @@ namespace NuGet.Commands
                     if (cacheFileAge.HasValue) { telemetry.TelemetryEvent[NoOpCacheFileAgeDays] = cacheFileAge.Value.TotalDays; }
 
                     return (new NoOpRestoreResult(
-                            _success,
+                            success,
                             _request.LockFilePath,
                             new Lazy<LockFile>(() => LockFileUtilities.GetLockFile(_request.LockFilePath, _logger)),
                             cacheFile,
@@ -524,7 +529,8 @@ namespace NuGet.Commands
             return !error;
         }
 
-        private async Task<(bool, bool, string, PackagesLockFile)> EvaluateLockFile(TelemetryActivity telemetry, RemoteWalkContext contextForProject, string packagesLockFilePath, PackagesLockFile packagesLockFile, CancellationToken token)
+        private async Task<(bool, bool, bool, string, PackagesLockFile)>
+            EvaluateLockFile(TelemetryActivity telemetry, RemoteWalkContext contextForProject, string packagesLockFilePath, PackagesLockFile packagesLockFile, bool success, CancellationToken token)
         {
             // evaluate packages.lock.json file
             var isLockFileValid = false;
@@ -539,30 +545,31 @@ namespace NuGet.Commands
                 telemetry.TelemetryEvent[LockFileEvaluationResult] = result;
 
                 regenerateLockFile = result; // Ensure that the lock file *does not* get rewritten, when the lock file is out of date and the status is false.
-                _success &= result;
+                success &= result;
             }
 
-            return (isLockFileValid, regenerateLockFile, packagesLockFilePath, packagesLockFile);
+            return (success, isLockFileValid, regenerateLockFile, packagesLockFilePath, packagesLockFile);
         }
 
-        private async Task<IEnumerable<RestoreTargetGraph>> GenerateRestoreGraphsAsync(TelemetryActivity telemetry, RemoteWalkContext contextForProject, CancellationToken token)
+        private async Task<IEnumerable<RestoreTargetGraph>> GenerateRestoreGraphsAsync(TelemetryActivity telemetry, RemoteWalkContext contextForProject, bool success, CancellationToken token)
         {
             IEnumerable<RestoreTargetGraph> graphs = null;
-            if (_success)
+            if (success)
             {
                 using (telemetry.StartIndependentInterval(GenerateRestoreGraphDuration))
                 {
                     if (NuGetEventSource.IsEnabled)
                         TraceEvents.BuildRestoreGraphStart(_request.Project.FilePath);
 
+                    bool resultSuccessful;
                     if (_enableNewDependencyResolver)
                     {
-                        graphs = await ExecuteRestoreAsync(_request.DependencyProviders.GlobalPackages, _request.DependencyProviders.FallbackPackageFolders, contextForProject, token, telemetry);
+                        (resultSuccessful, graphs) = await ExecuteRestoreAsync(_request.DependencyProviders.GlobalPackages, _request.DependencyProviders.FallbackPackageFolders, contextForProject, telemetry, success, token);
                     }
                     else
                     {
                         // Restore using the legacy code path if the optimized dependency resolution is disabled.
-                        graphs = await ExecuteLegacyRestoreAsync(_request.DependencyProviders.GlobalPackages, _request.DependencyProviders.FallbackPackageFolders, contextForProject, token, telemetry);
+                        (resultSuccessful, graphs) = await ExecuteLegacyRestoreAsync(_request.DependencyProviders.GlobalPackages, _request.DependencyProviders.FallbackPackageFolders, contextForProject, token, telemetry);
                     }
 
                     if (NuGetEventSource.IsEnabled)
@@ -590,7 +597,7 @@ namespace NuGet.Commands
             return graphs;
         }
 
-        private async Task<(IEnumerable<MSBuildOutputFile>, string, string, LockFile, IEnumerable<RestoreTargetGraph>, PackagesLockFile, string, CacheFile)> ProcessRestoreResultAsync(TelemetryActivity telemetry,
+        private async Task<(bool, IEnumerable<MSBuildOutputFile>, string, string, LockFile, IEnumerable<RestoreTargetGraph>, PackagesLockFile, string, CacheFile)> ProcessRestoreResultAsync(TelemetryActivity telemetry,
             List<NuGetv3LocalRepository> localRepositories,
             RemoteWalkContext contextForProject,
             bool isLockFileValid,
@@ -600,6 +607,7 @@ namespace NuGet.Commands
             PackagesLockFile packagesLockFile,
             string packagesLockFilePath,
             CacheFile cacheFile,
+            bool success,
             CancellationToken token)
         {
             string assetFilePath = null;
@@ -630,7 +638,7 @@ namespace NuGet.Commands
                         localRepositories,
                         _request,
                         assetFilePath,
-                        _success,
+                        success,
                         _logger);
                 }
 
@@ -646,7 +654,7 @@ namespace NuGet.Commands
                 {
                     telemetry.StartIntervalMeasure();
                     // validate package's SHA512
-                    _success &= ValidatePackagesSha512(packagesLockFile, assetsFile);
+                    success &= ValidatePackagesSha512(packagesLockFile, assetsFile);
                     telemetry.EndIntervalMeasure(ValidatePackagesShaDuration);
 
                     // clear out the existing lock file so that we don't over-write the same file
@@ -678,12 +686,12 @@ namespace NuGet.Commands
 
                 var logs = logsEnumerable
                     .ToList();
-                _success &= !logs.Any(l => l.Level == LogLevel.Error);
+                success &= !logs.Any(l => l.Level == LogLevel.Error);
                 assetsFile.LogMessages = logs;
 
                 if (cacheFile != null)
                 {
-                    cacheFile.Success = _success;
+                    cacheFile.Success = success;
                     cacheFile.ProjectFilePath = _request.Project.FilePath;
                     cacheFile.LogMessages = assetsFile.LogMessages;
                     cacheFile.ExpectedPackageFilePaths = NoOpRestoreUtilities.GetRestoreOutput(_request, assetsFile);
@@ -710,10 +718,11 @@ namespace NuGet.Commands
                 }
 
                 telemetry.TelemetryEvent[NewPackagesInstalledCount] = graphs.Where(g => !g.InConflict).SelectMany(g => g.Install).Distinct().Count();
-                telemetry.TelemetryEvent[RestoreSuccess] = _success;
+                telemetry.TelemetryEvent[RestoreSuccess] = success;
             }
 
-            return (msbuildOutputFiles,
+            return (success,
+                msbuildOutputFiles,
                 assetFilePath,
                 cacheFilePath,
                 assetsFile,
@@ -1640,20 +1649,21 @@ namespace NuGet.Commands
             return checkResults;
         }
 
-        private async Task<IEnumerable<RestoreTargetGraph>> ExecuteLegacyRestoreAsync(
+        private async Task<(bool, IEnumerable<RestoreTargetGraph>)> ExecuteLegacyRestoreAsync(
             NuGetv3LocalRepository userPackageFolder,
             IReadOnlyList<NuGetv3LocalRepository> fallbackPackageFolders,
             RemoteWalkContext context,
             CancellationToken token,
             TelemetryActivity telemetryActivity)
         {
+            bool success = true;
             if (_request.Project.TargetFrameworks.Count == 0)
             {
                 var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_ProjectDoesNotSpecifyTargetFrameworks, _request.Project.Name, _request.Project.FilePath);
                 await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1001, message));
 
-                _success = false;
-                return Enumerable.Empty<RestoreTargetGraph>();
+                success = false;
+                return (success, Enumerable.Empty<RestoreTargetGraph>());
             }
             _logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.Log_RestoringPackages, _request.Project.FilePath));
 
@@ -1715,13 +1725,12 @@ namespace NuGet.Commands
 
             if (!failed)
             {
-                var success = result.Item1;
                 allGraphs.AddRange(result.Item2);
-                _success = success;
+                success = result.Item1;
             }
             else
             {
-                _success = false;
+                success = false;
                 // When we fail to create the graphs, we want to write a `target` for each target framework
                 // in order to avoid missing target errors from the SDK build tasks and ensure that NuGet errors don't get cleared.
                 foreach (FrameworkRuntimePair frameworkRuntimePair in CreateFrameworkRuntimePairs(_request.Project, RequestRuntimeUtility.GetRestoreRuntimes(_request)))
@@ -1758,7 +1767,7 @@ namespace NuGet.Commands
             }
 
             // Walk additional runtime graphs for supports checks
-            if (_success && _request.CompatibilityProfiles.Any())
+            if (success && _request.CompatibilityProfiles.Any())
             {
                 Tuple<bool, List<RestoreTargetGraph>, RuntimeGraph> compatibilityResult = null;
                 using (telemetryActivity.StartIndependentInterval(CreateAdditionalRestoreTargetGraphDuration))
@@ -1776,7 +1785,7 @@ namespace NuGet.Commands
                     telemetryPrefix: "Additional-");
                 }
 
-                _success = compatibilityResult.Item1;
+                success = compatibilityResult.Item1;
 
                 // TryRestore may contain graphs that are already in allGraphs if the
                 // supports section contains the same TxM as the project framework.
@@ -1800,24 +1809,25 @@ namespace NuGet.Commands
             }
 
 
-            return allGraphs;
+            return (success, allGraphs);
         }
 
-        private async Task<IEnumerable<RestoreTargetGraph>> ExecuteRestoreAsync(
+        private async Task<(bool, IEnumerable<RestoreTargetGraph>)> ExecuteRestoreAsync(
             NuGetv3LocalRepository userPackageFolder,
             IReadOnlyList<NuGetv3LocalRepository> fallbackPackageFolders,
             RemoteWalkContext context,
-            CancellationToken token,
-            TelemetryActivity telemetryActivity)
+            TelemetryActivity telemetryActivity,
+            bool success,
+            CancellationToken token)
         {
             if (_request.Project.TargetFrameworks.Count == 0)
             {
                 var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_ProjectDoesNotSpecifyTargetFrameworks, _request.Project.Name, _request.Project.FilePath);
                 await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1001, message));
 
-                _success = false;
+                success = false;
 
-                return Enumerable.Empty<RestoreTargetGraph>();
+                return (success, Enumerable.Empty<RestoreTargetGraph>());
             }
 
             var projectRestoreRequest = new ProjectRestoreRequest(_request, _request.Project, _request.ExistingLockFile, _logger)
@@ -1855,7 +1865,7 @@ namespace NuGet.Commands
                 {
                     (bool Success, List<RestoreTargetGraph> Graphs, RuntimeGraph Runtimes) result = await dependencyGraphResolver.ResolveAsync(userPackageFolder, fallbackPackageFolders, context, projectRestoreCommand, localRepositories, token);
 
-                    _success &= result.Success;
+                    success &= result.Success;
 
                     graphs = result.Graphs;
 
@@ -1904,7 +1914,7 @@ namespace NuGet.Commands
                 }
             }
 
-            return graphs;
+            return (success, graphs);
         }
 
         internal static List<ExternalProjectReference> GetProjectReferences(RestoreRequest request)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -517,10 +517,16 @@ namespace NuGet.Commands
                         }
                         else
                         {
-                            _logger.Log(
-                                RestoreLogMessage.CreateWarning(
+                            var message = RestoreLogMessage.CreateWarning(
                                     NuGetLogCode.NU1803,
-                                    string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source)));
+                                    string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source));
+                            _logger.Log(message);
+
+                            // If the project treats this warning as an error, we should not continue
+                            if (message.Level == LogLevel.Error)
+                            {
+                                error = true;
+                            }
                         }
                     }
                 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -246,7 +246,8 @@ namespace NuGet.Commands
 
                 // if success == false, it generates an empty restore graph suitable to create an assets file with errors.
                 // Since the graph is empty, any code that analyzes the graph (like audit) will have nothing to do.
-                var graphs = await GenerateRestoreGraphsAsync(telemetry, contextForProject, success, token);
+                (successfulResult, var graphs) = await GenerateRestoreGraphsAsync(telemetry, contextForProject, success, token);
+                success &= successfulResult;
 
                 bool auditRan = false;
 
@@ -557,7 +558,7 @@ namespace NuGet.Commands
             return (success, isLockFileValid, regenerateLockFile, packagesLockFilePath, packagesLockFile);
         }
 
-        private async Task<IEnumerable<RestoreTargetGraph>> GenerateRestoreGraphsAsync(TelemetryActivity telemetry, RemoteWalkContext contextForProject, bool success, CancellationToken token)
+        private async Task<(bool, IEnumerable<RestoreTargetGraph>)> GenerateRestoreGraphsAsync(TelemetryActivity telemetry, RemoteWalkContext contextForProject, bool success, CancellationToken token)
         {
             IEnumerable<RestoreTargetGraph> graphs = null;
             if (success)
@@ -577,6 +578,7 @@ namespace NuGet.Commands
                         // Restore using the legacy code path if the optimized dependency resolution is disabled.
                         (resultSuccessful, graphs) = await ExecuteLegacyRestoreAsync(_request.DependencyProviders.GlobalPackages, _request.DependencyProviders.FallbackPackageFolders, contextForProject, token, telemetry);
                     }
+                    success &= resultSuccessful;
 
                     if (NuGetEventSource.IsEnabled)
                         TraceEvents.BuildRestoreGraphStop(_request.Project.FilePath);
@@ -600,7 +602,7 @@ namespace NuGet.Commands
                 });
             }
 
-            return graphs;
+            return (success, graphs);
         }
 
         private async Task<(bool, IEnumerable<MSBuildOutputFile>, string, string, LockFile, IEnumerable<RestoreTargetGraph>, PackagesLockFile, string, CacheFile)> ProcessRestoreResultAsync(TelemetryActivity telemetry,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -536,7 +536,9 @@ namespace NuGet.Commands
             return !error;
         }
 
-        private async Task<(bool, bool, bool, string, PackagesLockFile)>
+        private record struct EvaluateLockFileResult(bool Success, bool IsLockFileValid, bool RegenerateLockFile, string PackagesLockFilePath, PackagesLockFile PackagesLockFile);
+
+        private async Task<EvaluateLockFileResult>
             EvaluateLockFile(TelemetryActivity telemetry, RemoteWalkContext contextForProject, string packagesLockFilePath, PackagesLockFile packagesLockFile, bool success, CancellationToken token)
         {
             // evaluate packages.lock.json file
@@ -555,7 +557,7 @@ namespace NuGet.Commands
                 success &= result;
             }
 
-            return (success, isLockFileValid, regenerateLockFile, packagesLockFilePath, packagesLockFile);
+            return new EvaluateLockFileResult(success, isLockFileValid, regenerateLockFile, packagesLockFilePath, packagesLockFile);
         }
 
         private async Task<(bool, IEnumerable<RestoreTargetGraph>)> GenerateRestoreGraphsAsync(TelemetryActivity telemetry, RemoteWalkContext contextForProject, bool success, CancellationToken token)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -19,6 +19,7 @@ using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
+using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -3839,8 +3840,6 @@ namespace NuGet.Commands.FuncTest
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
             string httpSourceUrl = "http://unit.test/index.json";
             string httpsSourceUrl = "https://unit.test/index.json";
             pathContext.Settings.AddSource("http-feed", httpSourceUrl, "False");
@@ -3868,8 +3867,6 @@ namespace NuGet.Commands.FuncTest
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
-            var packageA = new SimpleTestPackageContext("a", "1.0.0");
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageA);
             string httpSourceUrl = "http://unit.test/index.json";
             string httpsSourceUrl = "https://unit.test/index.json";
             pathContext.Settings.AddSource("http-feed", httpSourceUrl, "False");
@@ -3886,9 +3883,49 @@ namespace NuGet.Commands.FuncTest
             var result = await command.ExecuteAsync();
 
             // Assert
+            result.Success.Should().BeTrue();
             result.LockFile.LogMessages.Should().HaveCount(1);
             IAssetsLogMessage logMessage = result.LockFile.LogMessages[0];
             logMessage.Code.Should().Be(NuGetLogCode.NU1803);
+            logMessage.Level.Should().Be(LogLevel.Warning);
+            Assert.Contains(httpSourceUrl, logMessage.Message);
+        }
+
+
+        [Fact]
+        public async Task Restore_WithHttpSourceSdkAnalysisLevelLowerThan90100WarningAsError_Errors()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            string httpSourceUrl = "http://unit.test/index.json";
+            pathContext.Settings.AddSource("http-feed", httpSourceUrl, "False");
+
+            var logger = new TestLogger();
+            ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
+            var projectPath = Path.Combine(pathContext.SolutionRoot, "my.csproj");
+            var packageSpecFactory = new TestPackageSpecFactory(projectPath, builder =>
+            {
+                builder.WithProperty(ProjectBuildProperties.TargetFramework, "net9.0")
+                       .WithProperty(ProjectBuildProperties.SdkAnalysisLevel, "8.0.400")
+                       .WithProperty(ProjectBuildProperties.TreatWarningsAsErrors, "true")
+                       .WithItem(ProjectItems.PackageReference, "SomePackage", [new("Version", "1.0.0")]);
+            });
+            PackageSpec project1Spec = packageSpecFactory.Build(settings);
+
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
+            var command = new RestoreCommand(request);
+
+            // Act
+            var result = await command.ExecuteAsync();
+
+            // Assert
+            result.Success.Should().BeFalse();
+            // Source has invalid URL, so we would expect protocol errors if graph resolver is run.
+            // But if graph resolver is not run, we expect only the insecure http message.
+            result.LockFile.LogMessages.Should().HaveCount(1);
+            IAssetsLogMessage logMessage = result.LockFile.LogMessages[0];
+            logMessage.Code.Should().Be(NuGetLogCode.NU1803);
+            logMessage.Level.Should().Be(LogLevel.Error);
             Assert.Contains(httpSourceUrl, logMessage.Message);
         }
 

--- a/test/TestUtilities/Test.Utility/TestPackageSpecFactory.cs
+++ b/test/TestUtilities/Test.Utility/TestPackageSpecFactory.cs
@@ -11,6 +11,7 @@ using NuGet.Commands.Restore.Utility;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
+using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 
 namespace Test.Utility;
@@ -49,12 +50,18 @@ public class TestPackageSpecFactory
             outerBuild.Properties["MSBuildProjectName"] = msbuildProjectName;
         }
 
+        if (!outerBuild.Properties.TryGetValue(ProjectBuildProperties.MSBuildProjectExtensionsPath, out _))
+        {
+            outerBuild.Properties[ProjectBuildProperties.MSBuildProjectExtensionsPath] = System.IO.Path.Combine(_directory, "obj");
+        }
+
         string? targetFramework = outerBuild.GetProperty("TargetFramework");
         string? targetFrameworks = outerBuild.GetProperty("TargetFrameworks");
+        string? targetFrameworkMoniker = outerBuild.GetProperty(ProjectBuildProperties.TargetFrameworkMoniker);
 
-        if (string.IsNullOrWhiteSpace(targetFramework) && string.IsNullOrWhiteSpace(targetFrameworks))
+        if (string.IsNullOrWhiteSpace(targetFramework) && string.IsNullOrWhiteSpace(targetFrameworks) && string.IsNullOrWhiteSpace(targetFrameworkMoniker))
         {
-            throw new ArgumentException("TargetFramework or TargetFrameworks must be set in the outer build.");
+            throw new ArgumentException("TargetFramework, TargetFrameworks, or TargetFrameworkMoniker must be set in the outer build.");
         }
         else if (!string.IsNullOrWhiteSpace(targetFrameworks) && !string.IsNullOrWhiteSpace(targetFramework))
         {
@@ -143,7 +150,13 @@ public class TestPackageSpecFactory
         else
         {
             targetFrameworks = new Dictionary<string, ITargetFramework>(StringComparer.OrdinalIgnoreCase);
-            string targetFramework = _outerBuild.GetProperty("TargetFramework") ?? throw new InvalidOperationException("TargetFramework must be set in the outer build.");
+            string targetFramework = _outerBuild.GetProperty(ProjectBuildProperties.TargetFramework);
+            if (string.IsNullOrWhiteSpace(targetFramework))
+            {
+                string targetFrameworkMoniker = _outerBuild.GetProperty(ProjectBuildProperties.TargetFrameworkMoniker)
+                    ?? throw new InvalidOperationException("TargetFramework or TargetFrameworkMoniker must be set in the outer build.");
+                targetFramework = string.Empty;
+            }
             targetFrameworks[targetFramework] = _outerBuild;
         }
 
@@ -312,6 +325,15 @@ public class TestPackageSpecFactory
                         targetPlatformMoniker = $"{targetPlatformIdentifier},Version={targetPlatformVersion}";
                         properties["TargetPlatformMoniker"] = targetPlatformMoniker;
                     }
+                }
+
+                if (!properties.TryGetValue(ProjectBuildProperties.SdkAnalysisLevel, out _)
+                    && framework is not null
+                    && framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, StringComparison.OrdinalIgnoreCase)
+                    && framework.Version.Major >= 9)
+                {
+                    string sdkAnalysisLevel = $"{framework.Version.Major}.0.100";
+                    properties[ProjectBuildProperties.SdkAnalysisLevel] = sdkAnalysisLevel;
                 }
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3230

## Description

I really should have done this sooner.  Addresses some feedback given to me in a live PR review for https://github.com/NuGet/NuGet.Client/pull/6351

* Refactor NuGet.Commands.RestoreCommand to remove `_success` as a class field.
   * I'm pretty sure there are some possible simplifications that could be made. For example, I think that in `EvaluateLockFile`, success always has the same value as one of the two bools that was already being returned. But I wanted to minimise risk of regressions, so I didn't try to be smart about it. I simply made success an input parameter where it was being read before, and added it as a return value where it was being written before.
* Added a comment before calling `GenerateRestoreGraphAsync` to make it clear that when restore is in an unsuccessful state going in, it's not going to actually resolve the graph. Just return an "empty" graph so that the assets file can be written with an error.
* Made it so when insecure http warnings are raised, but the warning is elevated to an error via `TreatWarningsAsErrors` or `WarningsAsErrors`, that it also exits early.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
