### PR TITLE
GetPackOutputItemsTask should honor OutputFileNamesWithoutVersion

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
@@ -31,6 +31,8 @@ namespace NuGet.Build.Tasks.Pack
 
         public bool IncludeSource { get; set; }
 
+        public bool OutputFileNamesWithoutVersion { get; set; }
+
         public string SymbolPackageFormat { get; set; }
 
         /// <summary>
@@ -50,9 +52,11 @@ namespace NuGet.Build.Tasks.Pack
                     PackageVersion));
             }
 
+            bool excludeVersion = OutputFileNamesWithoutVersion;
+
             var symbolPackageFormat = PackArgs.GetSymbolPackageFormat(MSBuildStringUtility.TrimAndGetNullForEmpty(SymbolPackageFormat));
-            var nupkgFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: true, symbols: false, symbolPackageFormat: symbolPackageFormat);
-            var nuspecFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: false, symbols: false, symbolPackageFormat: symbolPackageFormat);
+            var nupkgFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: true, symbols: false, symbolPackageFormat, excludeVersion);
+            var nuspecFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: false, symbols: false, symbolPackageFormat, excludeVersion);
 
             var outputs = new List<ITaskItem>();
             outputs.Add(new TaskItem(Path.Combine(PackageOutputPath, nupkgFileName)));
@@ -60,8 +64,8 @@ namespace NuGet.Build.Tasks.Pack
 
             if (IncludeSource || IncludeSymbols)
             {
-                var nupkgSymbolsFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: true, symbols: true, symbolPackageFormat: symbolPackageFormat);
-                var nuspecSymbolsFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: false, symbols: true, symbolPackageFormat: symbolPackageFormat);
+                var nupkgSymbolsFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: true, symbols: true, symbolPackageFormat, excludeVersion);
+                var nuspecSymbolsFileName = PackCommandRunner.GetOutputFileName(PackageId, version, isNupkg: false, symbols: true, symbolPackageFormat, excludeVersion);
 
                 outputs.Add(new TaskItem(Path.Combine(PackageOutputPath, nupkgSymbolsFileName)));
                 outputs.Add(new TaskItem(Path.Combine(NuspecOutputPath, nuspecSymbolsFileName)));

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -114,7 +114,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         PackageVersion="$(PackageVersion)"
         IncludeSymbols="$(IncludeSymbols)"
         IncludeSource="$(IncludeSource)"
-        SymbolPackageFormat="$(SymbolPackageFormat)">
+        SymbolPackageFormat="$(SymbolPackageFormat)"
+        OutputFileNamesWithoutVersion="$(OutputFileNamesWithoutVersion)">
 
       <Output
         TaskParameter="OutputPackItems"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Incremental Build and Clean are broken when OutputFileNamesWithoutVersion is true
Fixes: https://github.com/nuget/home/issues/12644

## Description
`GetPackOutputItemsTask` determines what the output path of the nupkg will be when `PackTask` runs.  However, instead of `PackTask` using the output determined by the former, it recalculates it itself.  The two file name calculations are different though because `PackTask` honors `OutputFileNamesWithoutVersion`, but `GetPackOutputItemsTask` doesn't even receive this value.  Thus, when `OutputFileNamesWithoutVersion` is true, the `Outputs` of `GenerateNuspec` is incorrect as it will be file names with the version in them, whereas the task will create the files without the version name in them.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
