### PR TITLE
Make official & Private builds retryable

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -190,7 +190,7 @@ stages:
 
       - output: pipelineArtifact
         displayName: 'Publish localizationArtifacts artifact'
-        condition: "or(eq(variables['OverridePublishLocalizationArtifact'], 'true'), and(succeededOrFailed(), eq(variables['IsOfficialBuild'], 'true')))"
+        condition: "or(eq(variables['OverridePublishLocalizationArtifact'], 'true'), and(succeeded(), eq(variables['IsOfficialBuild'], 'true')))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localizationArtifacts\\"
         artifactName: "localizationArtifacts"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
@@ -338,7 +338,7 @@ stages:
         displayName: 'Upload source-build log'
         condition: "or(failed(), eq(variables['System.debug'], 'true'))"
         targetPath: "artifacts/sb/log/source-inner-build.binlog"
-        artifactName: "Source-build log"
+        artifactName: "Source-build log - Attempt $(System.JobAttempt)"
         sbomEnabled: false
     steps:
     - template: /eng/pipelines/templates/Source_Build.yml@self
@@ -370,7 +370,7 @@ stages:
         displayName: 'Publish Test Freeze Dump'
         condition: "or(failed(), canceled())"
         targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
-        artifactName: "$(Agent.JobName)"
+        artifactName: "$(Agent.JobName) - Attempt $(System.JobAttempt)"
         sbomEnabled: false
 
       - output: pipelineArtifact
@@ -410,7 +410,7 @@ stages:
         displayName: 'Publish Test Freeze Dump'
         condition: "or(failed(), canceled())"
         targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
-        artifactName: "$(Agent.JobName)"
+        artifactName: "$(Agent.JobName) - Attempt $(System.JobAttempt)"
         sbomEnabled: false
 
       - output: pipelineArtifact
@@ -449,7 +449,7 @@ stages:
         displayName: 'Publish Test Freeze Dump'
         condition: "or(failed(), canceled())"
         targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
-        artifactName: "$(Agent.JobName)"
+        artifactName: "$(Agent.JobName) - Attempt $(System.JobAttempt)"
         sbomEnabled: false
 
       - output: pipelineArtifact
@@ -478,7 +478,7 @@ stages:
         displayName: 'Publish Test Freeze Dump'
         condition: "or(failed(), canceled())"
         targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
-        artifactName: "$(Agent.JobName)"
+        artifactName: "$(Agent.JobName) - Attempt $(System.JobAttempt)"
         sbomEnabled: false
 
       - output: pipelineArtifact
@@ -515,7 +515,7 @@ stages:
         displayName: 'Publish Test Freeze Dump'
         condition: "or(failed(), canceled())"
         targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
-        artifactName: "$(Agent.JobName)"
+        artifactName: "$(Agent.JobName) - Attempt $(System.JobAttempt)"
         sbomEnabled: false
 
       - output: pipelineArtifact


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

Azure DevOps makes pipeline artifacts immutable, meaning that retrying a failed job that publishes artifacts will fail all future attempts to write to the same artifact name. So, the names either need to change every run, or only publish on successful runs.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
