### PR TITLE
Allow Insecure Connections is configurable from Package Sources VS Options page

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -23,6 +23,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             string source,
             string name,
             bool isEnabled,
+            bool allowInsecureConnections,
             List<PackageSource> packageSources)
         {
             string trimmedLookupName = lookupName?.Trim() ?? string.Empty;
@@ -49,19 +50,15 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             // Create and validate a new Package Source since an existing one was not found.
             if (foundByName is null)
             {
-                packageSource = new PackageSource(trimmedSource, trimmedName, isEnabled);
-                SetAllowInsecureConnectionsProperty(packageSource);
+                packageSource = new PackageSource(trimmedSource, trimmedName, isEnabled)
+                {
+                    AllowInsecureConnections = allowInsecureConnections,
+                };
+
                 EnsureValidSources(packageSource);
             }
             else // Found an existing source to update.
             {
-                bool isHttpSourceChanged =
-                    foundByName.IsHttp
-                    && !string.Equals(
-                        trimmedSource,
-                        foundByName.Source,
-                        StringComparison.OrdinalIgnoreCase);
-
                 // Preserve existing properties by cloning the package source.
                 packageSource = new PackageSource(
                     trimmedSource,
@@ -75,15 +72,10 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                     ClientCertificates = foundByName.ClientCertificates,
                     Description = foundByName.Description,
                     ProtocolVersion = foundByName.ProtocolVersion,
-                    AllowInsecureConnections = foundByName.AllowInsecureConnections,
+                    AllowInsecureConnections = allowInsecureConnections,
                     DisableTLSCertificateValidation = foundByName.DisableTLSCertificateValidation,
                     MaxHttpRequestsPerSource = foundByName.MaxHttpRequestsPerSource,
                 };
-
-                if (isHttpSourceChanged)
-                {
-                    SetAllowInsecureConnectionsProperty(packageSource);
-                }
             }
 
             return packageSource;
@@ -161,23 +153,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 {
                     throw new ArgumentException(message: Strings.Error_PackageSource_UniqueSource);
                 }
-            }
-        }
-
-        private static void SetAllowInsecureConnectionsProperty(PackageSource packageSource)
-        {
-            _ = packageSource ?? throw new ArgumentNullException(nameof(packageSource));
-
-            if (packageSource.IsHttp && !packageSource.IsHttps)
-            {
-                packageSource.AllowInsecureConnections = true;
-            }
-
-            // An HTTP source has been changed to HTTPS, so allowing insecure connections
-            // is no longer needed.
-            if (packageSource.AllowInsecureConnections && packageSource.IsHttps)
-            {
-                packageSource.AllowInsecureConnections = false;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -200,6 +200,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
                     string source = packageSourceDictionary[MonikerSourceUrl].ToString();
                     bool isEnabled = (bool)packageSourceDictionary[MonikerIsEnabled];
+                    bool allowInsecureConnections = (bool)packageSourceDictionary[MonikerAllowInsecureConnections];
 
                     PackageSource packageSource =
                         PackageSourceValidator.FindExistingOrCreate(
@@ -207,6 +208,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                             source,
                             name,
                             isEnabled,
+                            allowInsecureConnections,
                             existingPackageSources);
 
                     packageSources.Add(packageSource);

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -331,6 +331,15 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow Insecure Connections.
+        /// </summary>
+        internal static string Text_AllowInsecureConnections_Header {
+            get {
+                return ResourceManager.GetString("Text_AllowInsecureConnections_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/).
         /// </summary>
         internal static string Text_ConfigurationFiles_CommonLink {

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -246,4 +246,7 @@
   <data name="Error_PackageSourceMappingSource_Missing" xml:space="preserve">
     <value>At least one source must be selected.</value>
   </data>
+  <data name="Text_AllowInsecureConnections_Header" xml:space="preserve">
+    <value>Allow Insecure Connections</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -189,6 +189,12 @@
                     "severity": "error"
                   }
                 ]
+              },
+              "allowInsecureConnections": {
+                "type": "boolean",
+                "title": "@Text_AllowInsecureConnections_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                "default": false,
+                "helpUri": "https://aka.ms/nuget-https-everywhere"
               }
             }
           },

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/NuGetExternalSettingsProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/NuGetExternalSettingsProviderTests.cs
@@ -58,7 +58,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         }
 
         [Fact]
-        public virtual async Task GetValueAsync_MonikerDoesNotExist_ThrowsInvalidOperationExceptionAsync()
+        public async Task GetValueAsync_MonikerDoesNotExist_ThrowsInvalidOperationExceptionAsync()
         {
             // Arrange
             VSSettings vsSettings = _vsSettings;
@@ -75,7 +75,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         }
 
         [Fact]
-        public virtual async Task SetValueAsync_MonikerDoesNotExist_ThrowsInvalidOperationExceptionAsync()
+        public async Task SetValueAsync_MonikerDoesNotExist_ThrowsInvalidOperationExceptionAsync()
         {
             // Arrange
             VSSettings vsSettings = _vsSettings;
@@ -93,7 +93,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         }
 
         [Fact]
-        public virtual async Task GetMessageTextAsync_Always_ThrowsNotImplementedExceptionAsync()
+        public async Task GetMessageTextAsync_Always_ThrowsNotImplementedExceptionAsync()
         {
             // Arrange
             VSSettings vsSettings = _vsSettings;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceValidatorTests.cs
@@ -240,6 +240,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             string lookupName = name;
             string source = "https://testsource3.com";
             bool isEnabled = true;
+            bool allowInsecureConnections = false;
 
             var packageSources = new List<PackageSource>
             {
@@ -248,7 +249,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(
+                lookupName,
+                source,
+                name,
+                isEnabled,
+                allowInsecureConnections,
+                packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -257,8 +264,10 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             result.IsEnabled.Should().Be(isEnabled);
         }
 
-        [Fact]
-        public void FindExistingOrCreate_NewHttpSource_CreatesNewSource_WithAllowInsecureConnectionsSetToTrue()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void FindExistingOrCreate_NewHttpSource_CreatesNewSource_WithAllowInsecureConnectionsSet(bool allowInsecureConnections)
         {
             // Arrange
             string name = "TestSource3";
@@ -273,16 +282,20 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(
+                lookupName,
+                source,
+                name,
+                isEnabled,
+                allowInsecureConnections,
+                packageSources);
 
             // Assert
             result.Should().NotBeNull();
             result.Name.Should().Be(name);
             result.Source.Should().Be(source);
             result.IsEnabled.Should().Be(isEnabled);
-            result.AllowInsecureConnections
-                .Should()
-                .BeTrue(because: "New HTTP sources should allow insecure connections by default.");
+            result.AllowInsecureConnections.Should().Be(allowInsecureConnections);
         }
 
         [Fact]
@@ -312,7 +325,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(
+                lookupName,
+                source,
+                name,
+                isEnabled,
+                originalAllowInsecureConnections,
+                packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -336,11 +355,18 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             string name = "TestSource1";
             string source = "http://testsource1.com";
             bool isEnabled = true;
+            bool allowInsecureConnections = false;
 
             List<PackageSource> packageSources = new List<PackageSource>();
 
             // Act
-            Action act = () => PackageSourceValidator.FindExistingOrCreate(invalidId, source, name, isEnabled, packageSources);
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(
+                invalidId,
+                source,
+                name,
+                isEnabled,
+                allowInsecureConnections,
+                packageSources);
 
             // Assert
             ArgumentException exception = Assert.Throws<ArgumentException>(act);
@@ -358,11 +384,18 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             string lookupName = "TestSource1";
             string source = "http://testsource1.com";
             bool isEnabled = true;
+            bool allowInsecureConnections = false;
 
             List<PackageSource> packageSources = new List<PackageSource>();
 
             // Act
-            Action act = () => PackageSourceValidator.FindExistingOrCreate(lookupName, source, invalidName, isEnabled, packageSources);
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(
+                lookupName,
+                source,
+                invalidName,
+                isEnabled,
+                allowInsecureConnections,
+                packageSources);
 
             // Assert
             ArgumentException exception = Assert.Throws<ArgumentException>(act);
@@ -380,11 +413,18 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             string name = "TestSource1";
             string lookupName = name;
             bool isEnabled = true;
+            bool allowInsecureConnections = false;
 
             List<PackageSource> packageSources = new List<PackageSource>();
 
             // Act
-            Action act = () => PackageSourceValidator.FindExistingOrCreate(lookupName, invalidSource, name, isEnabled, packageSources);
+            Action act = () => PackageSourceValidator.FindExistingOrCreate(
+                lookupName,
+                invalidSource,
+                name,
+                isEnabled,
+                allowInsecureConnections,
+                packageSources);
 
             // Assert
             ArgumentException exception = Assert.Throws<ArgumentException>(act);
@@ -419,7 +459,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(
+                lookupName,
+                source,
+                name,
+                isEnabled,
+                originalAllowInsecureConnections,
+                packageSources);
 
             // Assert
             result.Should().NotBeNull();
@@ -433,111 +479,24 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             result.IsEnabled.Should().Be(isEnabled, because: "Only the source should have changed.");
         }
 
-        [Fact]
-        public void FindExistingOrCreate_UpdateHttptoHttpsSource_RemovesAllowInsecureConnectionsFromTargetOnly()
-        {
-            // Arrange
-            string sourceName1 = "unitTestingSourceName1";
-            string sourceUrl1 = "https://testsource1.com";
-            // AllowInsecureConnections is not needed but was already configured.
-            bool source1AllowInsecureConnections = true;
-
-            string sourceName2 = "unitTestingSourceName2";
-            string sourceUrl2 = "http://testsource2.com";
-
-            // AllowInsecureConnections is needed but was missing.
-            bool source2AllowInsecureConnections = false;
-
-            string sourceName3 = "unitTestingSourceName3";
-            string sourceUrl3 = "http://testsource3.com";
-            bool source3AllowInsecureConnections = true;
-
-            string targetUrl = "https://testsource3.com";
-            bool expectedAllowInsecureConnections = false;
-
-            // Configure 3 existing package sources
-            List<PackageSource> packageSources =
-            [
-                new PackageSource(sourceUrl1, sourceName1, isEnabled: true)
-                {
-                    AllowInsecureConnections = source1AllowInsecureConnections
-                },
-                new PackageSource(sourceUrl2, sourceName2, isEnabled: true)
-                {
-                    AllowInsecureConnections = source2AllowInsecureConnections
-                },
-                new PackageSource(sourceUrl3, sourceName3, isEnabled: true)
-                {
-                    AllowInsecureConnections = source3AllowInsecureConnections
-                }
-            ];
-
-            // Act
-            PackageSource result1 = PackageSourceValidator.FindExistingOrCreate(
-                lookupName: sourceName1,
-                sourceUrl1,
-                sourceName1,
-                isEnabled: true,
-                packageSources);
-
-            PackageSource result2 = PackageSourceValidator.FindExistingOrCreate(
-                lookupName: sourceName2,
-                sourceUrl2,
-                sourceName2,
-                isEnabled: true,
-                packageSources);
-
-            PackageSource result3 = PackageSourceValidator.FindExistingOrCreate(
-                lookupName: sourceName3,
-                targetUrl,
-                sourceName3,
-                isEnabled: true,
-                packageSources);
-
-            // Assert
-            result1.Should().NotBeNull();
-            result1.Source.Should().Be(sourceUrl1, because: "No changes were made to the package source.");
-            result1.Name.Should().Be(sourceName1, because: "No changes were made to the package source.");
-            result1.AllowInsecureConnections.Should().Be(source1AllowInsecureConnections, because: "No changes were made to the package source.");
-            result1.IsEnabled.Should().Be(true, because: "No changes were made to the package source.");
-
-            result2.Should().NotBeNull();
-            result2.Source.Should().Be(sourceUrl2, because: "No changes were made to the package source.");
-            result2.Name.Should().Be(sourceName2, because: "No changes were made to the package source.");
-            result2.AllowInsecureConnections.Should().Be(source2AllowInsecureConnections, because: "No changes were made to the package source.");
-            result2.IsEnabled.Should().Be(true, because: "No changes were made to the package source.");
-
-            result3.Should().NotBeNull();
-            result3.Source.Should().Be(targetUrl, because: "A source change was expected.");
-            result3.Name.Should().Be(sourceName3, because: "Only the source should have changed.");
-            result3.AllowInsecureConnections.Should().Be(expectedAllowInsecureConnections, because: "Changing from HTTP to HTTPS source no longer needs AllowInsecureConnections.");
-            result3.IsEnabled.Should().Be(true, because: "Only the source should have changed.");
-        }
-
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void FindExistingOrCreate_SwitchHTTPandHTTPS_UpdatesAllowInsecureConnections(bool isOriginallyHttps)
+        public void FindExistingOrCreate_FoundExistingByNameAndSource_UpdatesAllowInsecureConnections(bool originalAllowInsecureConnections)
         {
             // Arrange
-            string originalSourceProtocol = isOriginallyHttps ? "https://" : "http://";
-            string originalName = "TestSource1";
-            string originalSource = $"{originalSourceProtocol}testsource1.com";
-            bool originalAllowInsecureConnections = !isOriginallyHttps;
-            bool originalDisableTLSCertificateValidation = true;
-
-            string name = originalName;
+            string name = "TestSource1";
             string lookupName = name;
-            string expectedSourceProtocol = !isOriginallyHttps ? "https://" : "http://";
-            bool expectedAllowInsecureConnections = isOriginallyHttps;
-            string source = $"{expectedSourceProtocol}testsource1.com";
+            string source = "http://testsource1.com";
             bool isEnabled = true;
+            bool allowInsecureConnections = !originalAllowInsecureConnections; // Toggle allowInsecureConnections state
 
+            bool originalDisableTLSCertificateValidation = true;
             PackageSourceCredential originalCredential = GetTestPackageSourceCredential(name);
 
             var packageSources = new List<PackageSource>
             {
-                new PackageSource(source: originalSource, name: originalName, isEnabled)
+                new PackageSource(source, name, originalAllowInsecureConnections)
                 {
                     AllowInsecureConnections = originalAllowInsecureConnections,
                     DisableTLSCertificateValidation = originalDisableTLSCertificateValidation,
@@ -546,18 +505,24 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(
+                lookupName,
+                source,
+                name,
+                isEnabled,
+                allowInsecureConnections,
+                packageSources);
 
             // Assert
             result.Should().NotBeNull();
-            result.Source.Should().Be(source, because: "A source change was expected.");
+            result.AllowInsecureConnections.Should().Be(allowInsecureConnections, because: "The AllowInsecureConnections state should have been toggled.");
 
             // Verify unchanged properties.
-            result.Name.Should().Be(originalName, because: "Only the source should have changed.");
-            result.AllowInsecureConnections.Should().Be(expectedAllowInsecureConnections, because: "Updating the source to HTTP or HTTPS should add or remove AllowInsecureConnections.");
-            result.DisableTLSCertificateValidation.Should().Be(originalDisableTLSCertificateValidation, because: "Only the source should have changed.");
-            result.Credentials.Should().BeEquivalentTo(originalCredential, because: "Only the source should have changed.");
-            result.IsEnabled.Should().Be(isEnabled, because: "Only the source should have changed.");
+            result.Name.Should().Be(name, because: "Only AllowInsecureConnections should have changed.");
+            result.Source.Should().Be(source, because: "Only AllowInsecureConnections should have changed.");
+            result.DisableTLSCertificateValidation.Should().Be(originalDisableTLSCertificateValidation, because: "Only AllowInsecureConnections should have changed.");
+            result.Credentials.Should().BeEquivalentTo(originalCredential, because: "Only AllowInsecureConnections should have changed.");
+            result.IsEnabled.Should().Be(isEnabled, because: "Only AllowInsecureConnections should have changed.");
         }
 
         [Theory]
@@ -586,7 +551,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             };
 
             // Act
-            PackageSource result = PackageSourceValidator.FindExistingOrCreate(lookupName, source, name, isEnabled, packageSources);
+            PackageSource result = PackageSourceValidator.FindExistingOrCreate(
+                lookupName,
+                source,
+                name,
+                isEnabled,
+                originalAllowInsecureConnections,
+                packageSources);
 
             // Assert
             result.Should().NotBeNull();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
@@ -116,6 +116,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             packageSourceDictionary[PackageSourcesPage.MonikerSourceName] = newSourceName;
             packageSourceDictionary[PackageSourcesPage.MonikerSourceUrl] = newSourceUrl;
             packageSourceDictionary[PackageSourcesPage.MonikerIsEnabled] = true;
+            packageSourceDictionary[PackageSourcesPage.MonikerAllowInsecureConnections] = false;
 
             IList<IDictionary<string, object>> packageSourceDictionaryList =
                 new List<IDictionary<string, object>>(capacity: 1)
@@ -151,6 +152,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             packageSourceDictionary[PackageSourcesPage.MonikerSourceName] = "unitTestingSourceName";
             packageSourceDictionary[PackageSourcesPage.MonikerSourceUrl] = invalidSource;
             packageSourceDictionary[PackageSourcesPage.MonikerIsEnabled] = true;
+            packageSourceDictionary[PackageSourcesPage.MonikerAllowInsecureConnections] = false;
 
             IList<IDictionary<string, object>> packageSourceDictionaryList =
                 new List<IDictionary<string, object>>(capacity: 1)
@@ -195,6 +197,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             packageSourceDictionary[PackageSourcesPage.MonikerSourceName] = "unitTestingSourceName";
             packageSourceDictionary[PackageSourcesPage.MonikerSourceUrl] = invalidSource;
             packageSourceDictionary[PackageSourcesPage.MonikerIsEnabled] = true;
+            packageSourceDictionary[PackageSourcesPage.MonikerAllowInsecureConnections] = false;
 
             IList<IDictionary<string, object>> packageSourceDictionaryList =
                 new List<IDictionary<string, object>>(capacity: 1)
@@ -261,16 +264,19 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             packageSourceDictionary1[PackageSourcesPage.MonikerSourceName] = sourceName1;
             packageSourceDictionary1[PackageSourcesPage.MonikerSourceUrl] = sourceUrl1;
             packageSourceDictionary1[PackageSourcesPage.MonikerIsEnabled] = !isSource1Enabled; // Toggle the enabled state for the first source.
+            packageSourceDictionary1[PackageSourcesPage.MonikerAllowInsecureConnections] = false;
 
             Dictionary<string, object> packageSourceDictionary2 = new Dictionary<string, object>();
             packageSourceDictionary2[PackageSourcesPage.MonikerSourceName] = sourceName2;
             packageSourceDictionary2[PackageSourcesPage.MonikerSourceUrl] = sourceUrl2;
             packageSourceDictionary2[PackageSourcesPage.MonikerIsEnabled] = isSource2Enabled;
+            packageSourceDictionary2[PackageSourcesPage.MonikerAllowInsecureConnections] = false;
 
             Dictionary<string, object> packageSourceDictionary3 = new Dictionary<string, object>();
             packageSourceDictionary3[PackageSourcesPage.MonikerSourceName] = sourceName3;
             packageSourceDictionary3[PackageSourcesPage.MonikerSourceUrl] = sourceUrl3;
             packageSourceDictionary3[PackageSourcesPage.MonikerIsEnabled] = !isSource3Enabled; // Toggle the enabled state for the third source.
+            packageSourceDictionary3[PackageSourcesPage.MonikerAllowInsecureConnections] = false;
 
             IList<IDictionary<string, object>> packageSourceDictionaryList =
                 new List<IDictionary<string, object>>(capacity: 3)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14377

## Description

Adds an Allow Insecure Connections property to the package sources settings page in VS Options.
When an insecure HTTP resource exists for an HTTPS package source, a customer will now be able to enable Allow Insecure Connections directly from VS Options.

In legacy settings, a modal dialog was shown when adding an HTTP source before enabling this property.
However, now in Unified Settings, we want customers to explicitly opt-in to this flag.

VS settings will no longer automatically remove allow insecure connections when changing from an HTTP to HTTPS source.

|Action | Source Protocol | Check Allow Insecure Connections | Result |
|-----|--|--|--|
| Add/Edit |  HTTPS | Either | ✅ Saves state |
| Add/Edit |  HTTP | Unchecked | ❌ Error and cannot save package source |
| Add/Edit |  HTTP | Checked | ⚠️ Warning shown & saves with `allowInsecureConnections="true"` |

### Option to allow insecure connections on an HTTPS source in case the resources are insecure.
<img width="370" height="367" alt="image" src="https://github.com/user-attachments/assets/f5bdf056-42d8-45b4-88db-1bb426ea257a" />

### Now requires explicitly checking "Allow Insecure Connections" to opt-in rather than only showing the Warning.

<img width="370" height="431" alt="image" src="https://github.com/user-attachments/assets/e06e42f6-1a26-465e-b8f1-745d9c2bda34" />

### After opting-in, the Warning is still shown.

<img width="370" height="431" alt="image" src="https://github.com/user-attachments/assets/9cc77b7f-e939-4ff1-820f-683362d37447" />

### Allow Insecure Connections is now shown on the Package Sources table as a column which can be modified directly in the grid.

<img width="1117" height="487" alt="image" src="https://github.com/user-attachments/assets/dae09435-3a8b-4ea3-9e87-24e444baa2c4" />


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14039
