### PR TITLE
avoid some allocation in ProjectFactory.ProcessDependencies

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -856,10 +856,8 @@ namespace NuGet.CommandLine
             // Add the transform file to the package builder
             ProcessTransformFiles(builder, packages.SelectMany(GetTransformFiles));
 
-            var dependencies = new Dictionary<string, PackageDependency>();
-            dependencies = builder.DependencyGroups.SelectMany(d => d.Packages)
+            var dependencies = builder.DependencyGroups.SelectMany(d => d.Packages)
                 .ToDictionary(d => d.Id, StringComparer.OrdinalIgnoreCase);
-
 
             // Reduce the set of packages we want to include as dependencies to the minimal set.
             // Normally, packages.config has the full closure included, we only add top level
@@ -867,12 +865,14 @@ namespace NuGet.CommandLine
             foreach (var package in packages)
             {
                 // Don't add duplicate dependencies
-                if (dependencies.ContainsKey(package.GetIdentity().Id) || !FindDependency(package.GetIdentity(), packagesAndDependencies.Values))
+                var packageIdentity = package.GetIdentity();
+                if (dependencies.ContainsKey(packageIdentity.Id) ||
+                    !FindDependency(packageIdentity, packagesAndDependencies.Values))
                 {
                     continue;
                 }
 
-                var dependency = packagesAndDependencies[package.GetIdentity().Id].Item2;
+                var dependency = packagesAndDependencies[packageIdentity.Id].Item2;
                 dependencies[dependency.Id] = dependency;
             }
 
@@ -887,7 +887,6 @@ namespace NuGet.CommandLine
 
             var targetFramework = TargetFramework ?? NuGetFramework.AnyFramework;
             builder.DependencyGroups.Add(new PackageDependencyGroup(targetFramework, new HashSet<PackageDependency>(dependencies.Values)));
-
         }
 
         private bool FindDependency(PackageIdentity projectPackage, IEnumerable<Tuple<PackageReaderBase, Packaging.Core.PackageDependency>> packagesAndDependencies)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: removes a redundant dictionary construction, and two redundant calls to `package.GetIdentity()`

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
