### PR TITLE
remove redundant dictionary lookup in PrunePackageTree.PruneDowngrades

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/PrunePackageTree.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/PrunePackageTree.cs
@@ -109,9 +109,15 @@ namespace NuGet.PackageManagement
             }
 
             return packages.Where(package =>
-                (package.HasVersion && installed.ContainsKey(package.Id))
-                    ?
-                installed[package.Id] <= package.Version : true);
+            {
+                if (package.HasVersion &&
+                    installed.TryGetValue(package.Id, out NuGetVersion version))
+                {
+                    return version <= package.Version;
+                }
+
+                return true;
+            });
         }
 
         public static IEnumerable<SourcePackageDependencyInfo> PruneDisallowedVersions(IEnumerable<SourcePackageDependencyInfo> packages, IEnumerable<Packaging.PackageReference> packageReferences)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14432

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
