### PR TITLE
Allow restoring virtual projects

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -13,6 +13,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
@@ -102,7 +103,9 @@ namespace NuGet.Build.Tasks.Console
 
             string binaryLoggerParameters = GetBinaryLoggerParameters(_environment, options);
 
-            var dependencyGraphSpec = GetDependencyGraphSpec(entryProjectFilePath, globalProperties, interactive, binaryLoggerParameters, EnvironmentVariableWrapper.Instance);
+            var virtualProjectTextFile = GetVirtualProjectTextFileFunction(entryProjectFilePath, options);
+
+            var dependencyGraphSpec = GetDependencyGraphSpec(entryProjectFilePath, globalProperties, interactive, binaryLoggerParameters, EnvironmentVariableWrapper.Instance, virtualProjectTextFile);
 
             // If the dependency graph spec is null, something went wrong evaluating the projects, so return false
             if (dependencyGraphSpec == null)
@@ -188,7 +191,9 @@ namespace NuGet.Build.Tasks.Console
 
             string binaryLoggerParameters = GetBinaryLoggerParameters(_environment, options);
 
-            var dependencyGraphSpec = GetDependencyGraphSpec(entryProjectFilePath, globalProperties, interactive, binaryLoggerParameters, EnvironmentVariableWrapper.Instance);
+            var virtualProjectTextFile = GetVirtualProjectTextFileFunction(entryProjectFilePath, options);
+
+            var dependencyGraphSpec = GetDependencyGraphSpec(entryProjectFilePath, globalProperties, interactive, binaryLoggerParameters, EnvironmentVariableWrapper.Instance, virtualProjectTextFile);
 
             try
             {
@@ -213,6 +218,19 @@ namespace NuGet.Build.Tasks.Console
                 LogErrorFromException(e);
             }
             return false;
+        }
+
+        /// <summary>
+        /// Creates a function mapping from a project path to a file path containing the virtual project's XML text (or <see langword="null"/> if the project is not virtual). See <see cref="StaticGraphRestoreTaskBase.ProjectTextFile"/>.
+        /// </summary>
+        private static Func<string, string> GetVirtualProjectTextFileFunction(string entryProjectFilePath, IReadOnlyDictionary<string, string> options)
+        {
+            if (options.TryGetValue(nameof(StaticGraphRestoreTaskBase.ProjectTextFile), out string textFile))
+            {
+                return (path) => path == entryProjectFilePath ? textFile : null;
+            }
+
+            return _ => null;
         }
 
         /// <summary>
@@ -764,8 +782,15 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="entryProjectPath">The full path to a project or Visual Studio Solution File.</param>
         /// <param name="globalProperties">An <see cref="IDictionary{String,String}" /> containing the global properties to use when evaluation MSBuild projects.</param>
         /// <param name="interactive"><see langword="true" /> if the build is allowed to interact with the user, otherwise <see langword="false" />.</param>
+        /// <param name="virtualProjectTextFile">See <see cref="GetVirtualProjectTextFileFunction"/>.</param>
         /// <returns>A <see cref="DependencyGraphSpec" /> for the specified project if they could be loaded, otherwise <code>null</code>.</returns>
-        private DependencyGraphSpec GetDependencyGraphSpec(string entryProjectPath, IDictionary<string, string> globalProperties, bool interactive, string binaryLoggerParameters, IEnvironmentVariableReader environmentVariableReader)
+        private DependencyGraphSpec GetDependencyGraphSpec(
+            string entryProjectPath,
+            IDictionary<string, string> globalProperties,
+            bool interactive,
+            string binaryLoggerParameters,
+            IEnvironmentVariableReader environmentVariableReader,
+            Func<string, string> virtualProjectTextFile)
         {
             string envVar = environmentVariableReader.GetEnvironmentVariable("NUGET_USE_NEW_PACKAGESPEC_FACTORY");
             if (!string.Equals(envVar, bool.FalseString, StringComparison.OrdinalIgnoreCase))
@@ -798,7 +823,8 @@ namespace NuGet.Build.Tasks.Console
 
                         var packageSpec = PackageSpecFactory.GetPackageSpec(project, settings);
                         return packageSpec;
-                    });
+                    },
+                    virtualProjectTextFile);
             }
             else
             {
@@ -817,7 +843,8 @@ namespace NuGet.Build.Tasks.Console
                     {
                         var packageSpec = GetPackageSpec(project.OuterProject, project);
                         return packageSpec;
-                    });
+                    },
+                    virtualProjectTextFile);
             }
         }
 
@@ -829,7 +856,8 @@ namespace NuGet.Build.Tasks.Console
             Func<string, (ProjectInstance, string), TProject> createProjectFactory,
             Func<string, TProject, (ProjectInstance, string), TProject> updateProjectFactory,
             Action<TProject> projectFinalizeDelegate,
-            Func<TProject, PackageSpec> getPackageSpec)
+            Func<TProject, PackageSpec> getPackageSpec,
+            Func<string, string> virtualProjectTextFile)
         {
             try
             {
@@ -838,7 +866,7 @@ namespace NuGet.Build.Tasks.Console
                 var entryProjects = GetProjectGraphEntryPoints(entryProjectPath, globalProperties);
 
                 // Load the projects via MSBuild and create an array of them since Parallel.ForEach is optimized for arrays
-                var projects = LoadProjects(entryProjects, interactive, binaryLoggerParameters, createProjectFactory, updateProjectFactory, projectFinalizeDelegate);
+                var projects = LoadProjects(entryProjects, interactive, binaryLoggerParameters, createProjectFactory, updateProjectFactory, projectFinalizeDelegate, virtualProjectTextFile);
 
                 // If no projects were loaded, return an empty DependencyGraphSpec
                 if (projects == null || projects.Count == 0)
@@ -1090,6 +1118,7 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="createProjectFactory">A factory method that creates a project adapter from an MSBuild ProjectInstance.</param>
         /// <param name="updateProjectFactory">A factory method that updates a project adapter with a target framework and MSBuild ProjectInstance.</param>
         /// <param name="projectFinalizeDelegate">An option delegate to finalize a project adapter once all projects have been evaluated.</param>
+        /// <param name="virtualProjectTextFile">See <see cref="GetVirtualProjectTextFileFunction"/>.</param>
         /// <returns>An <see cref="ICollection{ProjectWithInnerNodes}" /> object containing projects and their inner nodes if they are targeting multiple frameworks.</returns>
         private ConcurrentDictionary<string, TProject> LoadProjects<TProject>(
             IEnumerable<ProjectGraphEntryPoint> entryProjects,
@@ -1097,7 +1126,8 @@ namespace NuGet.Build.Tasks.Console
             string binaryLoggerParameters,
             Func<string, (ProjectInstance, string), TProject> createProjectFactory,
             Func<string, TProject, (ProjectInstance, string), TProject> updateProjectFactory,
-            Action<TProject> projectFinalizeDelegate)
+            Action<TProject> projectFinalizeDelegate,
+            Func<string, string> virtualProjectTextFile)
         {
             try
             {
@@ -1151,6 +1181,15 @@ namespace NuGet.Build.Tasks.Console
                         LoadSettings = ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports | ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition,
                         ProjectCollection = collection
                     };
+
+                    if (virtualProjectTextFile(path) is { } textFile)
+                    {
+                        using var textReader = File.OpenText(textFile);
+                        using var xmlReader = XmlReader.Create(textReader);
+                        var root = ProjectRootElement.Create(xmlReader, collection);
+                        root.FullPath = path;
+                        return ProjectInstance.FromProjectRootElement(root, projectOptions);
+                    }
 
                     return ProjectInstance.FromFile(path, projectOptions);
                 });

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -221,11 +221,11 @@ namespace NuGet.Build.Tasks.Console
         }
 
         /// <summary>
-        /// Creates a function mapping from a project path to a file path containing the virtual project's XML text (or <see langword="null"/> if the project is not virtual). See <see cref="StaticGraphRestoreTaskBase.ProjectTextFile"/>.
+        /// Creates a function mapping from a project path to a file path containing the virtual project's XML text (or <see langword="null"/> if the project is not virtual). See <see cref="StaticGraphRestoreTaskBase.VirtualProjectTextFile"/>.
         /// </summary>
         private static Func<string, string> GetVirtualProjectTextFileFunction(string entryProjectFilePath, IReadOnlyDictionary<string, string> options)
         {
-            if (options.TryGetValue(nameof(StaticGraphRestoreTaskBase.ProjectTextFile), out string textFile))
+            if (options.TryGetValue(nameof(StaticGraphRestoreTaskBase.VirtualProjectTextFile), out string textFile))
             {
                 return (path) => path == entryProjectFilePath ? textFile : null;
             }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -28,6 +28,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         NoCache="$(RestoreNoCache)"
         NoHttpCache="$(RestoreNoHttpCache)"
         ProjectFullPath="$(MSBuildProjectFullPath)"
+        ProjectTextFile="$(ProjectTextFile)"
         Recursive="$([MSBuild]::ValueOrDefault('$(RestoreRecursive)', 'true'))"
         RestorePackagesConfig="$(RestorePackagesConfig)"
         SolutionPath="$(SolutionPath)"

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.RestoreEx.targets
@@ -28,7 +28,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         NoCache="$(RestoreNoCache)"
         NoHttpCache="$(RestoreNoHttpCache)"
         ProjectFullPath="$(MSBuildProjectFullPath)"
-        ProjectTextFile="$(ProjectTextFile)"
+        VirtualProjectTextFile="$(VirtualProjectTextFile)"
         Recursive="$([MSBuild]::ValueOrDefault('$(RestoreRecursive)', 'true'))"
         RestorePackagesConfig="$(RestorePackagesConfig)"
         SolutionPath="$(SolutionPath)"

--- a/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs
@@ -66,6 +66,12 @@ namespace NuGet.Build.Tasks
         public string ProjectFullPath { get; set; }
 
         /// <summary>
+        /// Path to a file containing XML text content of the project file. If set, the project won't be read from <see cref="ProjectFullPath"/>,
+        /// but instead created only in memory from this text (but with its full path still set to <see cref="ProjectFullPath"/>).
+        /// </summary>
+        public string ProjectTextFile { get; set; }
+
+        /// <summary>
         /// Get or sets a value indicating whether or not the restore should restore all projects or just the entry project.
         /// </summary>
         public bool Recursive { get; set; }
@@ -365,10 +371,17 @@ namespace NuGet.Build.Tasks
 
         protected virtual Dictionary<string, string> GetOptions()
         {
-            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 [nameof(Recursive)] = Recursive.ToString()
             };
+
+            if (!string.IsNullOrEmpty(ProjectTextFile))
+            {
+                options[nameof(ProjectTextFile)] = ProjectTextFile;
+            }
+
+            return options;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/StaticGraphRestoreTaskBase.cs
@@ -69,7 +69,7 @@ namespace NuGet.Build.Tasks
         /// Path to a file containing XML text content of the project file. If set, the project won't be read from <see cref="ProjectFullPath"/>,
         /// but instead created only in memory from this text (but with its full path still set to <see cref="ProjectFullPath"/>).
         /// </summary>
-        public string ProjectTextFile { get; set; }
+        public string VirtualProjectTextFile { get; set; }
 
         /// <summary>
         /// Get or sets a value indicating whether or not the restore should restore all projects or just the entry project.
@@ -376,9 +376,9 @@ namespace NuGet.Build.Tasks
                 [nameof(Recursive)] = Recursive.ToString()
             };
 
-            if (!string.IsNullOrEmpty(ProjectTextFile))
+            if (!string.IsNullOrEmpty(VirtualProjectTextFile))
             {
-                options[nameof(ProjectTextFile)] = ProjectTextFile;
+                options[nameof(VirtualProjectTextFile)] = VirtualProjectTextFile;
             }
 
             return options;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Contributes to fixing https://github.com/dotnet/sdk/issues/49876.
Fixes https://github.com/NuGet/Home/issues/14148.

## Description

When building file-based apps, [the dotnet CLI will](https://github.com/dotnet/sdk/compare/main...jjonescz:dotnet-sdk:sprint-static-graph) create a temporary file with the XML project content somewhere on disk, pass its full path as MSBuild property `ProjectTextFile`, and NuGet RestoreTaskEx can pick it up to build the in-memory-only project instead of failing with "csproj not found".

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
