### PR TITLE
Wire up nuspec-based pack to deterministic mode

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -40,6 +40,7 @@ namespace NuGet.Build.Tasks.Pack
                 BasePath = request.NuspecBasePath,
                 NoPackageAnalysis = request.NoPackageAnalysis,
                 NoDefaultExcludes = request.NoDefaultExcludes,
+                Deterministic = request.Deterministic,
                 WarningProperties = WarningProperties.GetWarningProperties(request.TreatWarningsAsErrors, request.WarningsAsErrors, request.NoWarn, request.WarningsNotAsErrors),
                 PackTargetArgs = new MSBuildPackTargetArgs()
             };


### PR DESCRIPTION

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

Fixes: 

## Description

When building nuspec-based packages, the deterministic-mode configuration is not flowed correctly to the PackageBuilder class (which is initialized using this PackArgs object). Seems like this was missed from the initial deterministic support in https://github.com/NuGet/NuGet.Client/pull/2989.

This commit is a no-op until deterministic mode is enabled and https://github.com/NuGet/Home/issues/8601 is fixed.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
