### PR TITLE
remove redundant dictionary lookups in MarkTransitiveOrigin

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/PackageReferenceProject.cs
@@ -90,7 +90,7 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         /// <summary>
-        /// Gets the installed (top level) package references for this project. 
+        /// Gets the installed (top level) package references for this project.
         /// </summary>
         public override async Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
         {
@@ -484,27 +484,29 @@ namespace NuGet.PackageManagement.VisualStudio
                 visited.Add(current.PackageIdentity); // visited
 
                 // Lookup Transitive Origins Cache
-                TransitiveEntry cachedEntry;
-                if (!transitiveOriginsCache.TryGetValue(current.PackageIdentity.Id, out cachedEntry))
+                if (transitiveOriginsCache.TryGetValue(current.PackageIdentity.Id, out TransitiveEntry cachedEntry))
+                {
+                    if (cachedEntry.TryGetValue(fxRidEntry, out var packageReferences))
+                    {
+                        // Dictionary value is a List. If perf. is bad, change to HashSet.
+                        if (!packageReferences.Contains(top))
+                        {
+                            packageReferences.Add(top);
+                        }
+                    }
+                    else
+                    {
+                        cachedEntry[fxRidEntry] = [top];
+                    }
+                }
+                else
                 {
                     cachedEntry = new Dictionary<FrameworkRuntimePair, IList<PackageReference>>
                     {
-                        [fxRidEntry] = new List<PackageReference>()
+                        {fxRidEntry, [top]}
                     };
+                    transitiveOriginsCache[current.PackageIdentity.Id] = cachedEntry;
                 }
-
-                if (!cachedEntry.ContainsKey(fxRidEntry))
-                {
-                    cachedEntry[fxRidEntry] = new List<PackageReference>();
-                }
-
-                if (!cachedEntry[fxRidEntry].Contains(top)) // Dictionary value is a List. If perf. is bad, change to HashSet.
-                {
-                    cachedEntry[fxRidEntry].Add(top);
-                }
-
-                // Upsert Transitive Origins Cache
-                transitiveOriginsCache[current.PackageIdentity.Id] = cachedEntry;
 
                 foreach (PackageDependency dep in node.Dependencies.ToList()) // Casting to list to prevent backing allocations
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14432

## Description

* improve readability
* from 7 dictionary hashes to 4
* from 2 list contains to 1
* also split the above on if statements to the number to execute is conditionally smaller

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
