### PR TITLE
fix parameter nullability in Constructor_SetReportAbuseUrl_Initialize…

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/DirectlyReferencedPackageModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/Package/DirectlyReferencedPackageModelTests.cs
@@ -33,7 +33,7 @@ namespace NuGet.PackageManagement.UI.Test.Models.Package
         [Theory]
         [InlineData(null)]
         [InlineData("String")]
-        public void Constructor_SetReportAbuseUrl_InitializeReportAbuseUrl(string reportAbuseUrl)
+        public void Constructor_SetReportAbuseUrl_InitializeReportAbuseUrl(string? reportAbuseUrl)
         {
             // Arrange
             var identity = new PackageIdentity("TestPackage", new NuGetVersion("1.0.0"));


### PR DESCRIPTION
…ReportAbuseUrl

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14434

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
