### PR TITLE
enable nullable in NuGetUpdateCommandTests

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -1662,7 +1663,7 @@ namespace NuGet.CommandLine.Test
         [InlineData("Highest", "2.0.0")]
         [InlineData("HighestMinor", "1.2.0")]
         [InlineData("HighestPatch", "1.0.1")]
-        public async Task UpdateCommand_DependencyResolution_Success(string dependencyVersion, string expectedVersion)
+        public async Task UpdateCommand_DependencyResolution_Success(string? dependencyVersion, string expectedVersion)
         {
             using (var pathContext = new SimpleTestPathContext())
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -1714,7 +1714,7 @@ namespace NuGet.CommandLine.Test
                         testNuGetProjectContext,
                         CancellationToken.None);
                 }
-                string[] args;
+                string?[] args;
                 //Test the case where the code is not provided to ensure it works as expected. (Highest by default)
                 if (string.IsNullOrEmpty(dependencyVersion))
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14434

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
