### PR TITLE
enable nullable in VSRestoreSettingsUtilityTests

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VSRestoreSettingsUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VSRestoreSettingsUtilityTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Configuration;
@@ -133,7 +134,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         [InlineData(@"C:\packagePath", @"C:\packagePath")]
         [InlineData(null, @"C:\defaultPackagesPath")]
         [InlineData("globalPackages", @"C:\project\globalPackages")]
-        public void VSRestoreSettingsUtilities_PackagePath(string packagesPath, string expectedPackagesPath)
+        public void VSRestoreSettingsUtilities_PackagePath(string? packagesPath, string expectedPackagesPath)
         {
             using (var mockBaseDirectory = TestDirectory.Create())
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14434

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
