### PR TITLE
remove redundant GetManifestResourceNames in ManifestSchemaUtility

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
@@ -18,7 +18,7 @@ namespace NuGet.Packaging
     public static class ManifestSchemaUtility
     {
         /// <summary>
-        /// Baseline schema 
+        /// Baseline schema
         /// </summary>
         internal const string SchemaVersionV1 = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd";
 
@@ -34,7 +34,7 @@ namespace NuGet.Packaging
 
         /// <summary>
         /// Added 'targetFramework' attribute for 'dependency' elements.
-        /// Allow framework folders under 'content' and 'tools' folders. 
+        /// Allow framework folders under 'content' and 'tools' folders.
         /// </summary>
         internal const string SchemaVersionV4 = "http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd";
 
@@ -90,13 +90,6 @@ namespace NuGet.Packaging
 
                     // Update the xsd with the right schema namespace
                     var assembly = typeof(Manifest).Assembly;
-
-                    var names = assembly.GetManifestResourceNames();
-
-                    foreach (var s in names)
-                    {
-
-                    }
 
                     var stream = assembly.GetManifestResourceStream(schemaResourceName);
                     using (var reader = new StreamReader(stream))


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/14435

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
