### PR TITLE
remove un-used GetDirectoryName in MisplacedAssemblyOutsideLibRule

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Rules/MisplaceAssemblyOutsideLibRule.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Rules/MisplaceAssemblyOutsideLibRule.cs
@@ -35,7 +35,6 @@ namespace NuGet.Packaging.Rules
             foreach (var packageFile in getFiles())
             {
                 var file = PathUtility.GetPathWithDirectorySeparator(packageFile);
-                var directory = Path.GetDirectoryName(file);
 
                 if (!ValidFolders.Any(folder => file.StartsWith(folder, StringComparison.OrdinalIgnoreCase)))
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/14435

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
