### PR TITLE
remove un-used HashSet instance in ResolverMetadataClient

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
@@ -125,7 +125,6 @@ namespace NuGet.Protocol
             var frameworkReducer = new FrameworkReducer();
             var dependencies = await GetDependencies(httpClient, registrationUri, packageId, range, cacheContext, log, token);
 
-            var result = new HashSet<RegistrationInfo>();
             var registrationInfo = new RegistrationInfo();
 
             registrationInfo.IncludePrerelease = true;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/14435

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
