### PR TITLE
remove un-used identity instance in LocalV3FindPackageByIdResource

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
@@ -279,8 +279,6 @@ namespace NuGet.Protocol
                 FindPackageByIdDependencyInfo dependencyInfo = null;
                 if (DoesVersionExist(id, version))
                 {
-                    var identity = new PackageIdentity(id, version);
-
                     dependencyInfo = ProcessNuspecReader(
                         id,
                         version,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/14435

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
