### PR TITLE
use cast instead of as and null check in CommandLineParser.AssignValue

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/CommandLineParser.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/CommandLineParser.cs
@@ -84,8 +84,7 @@ namespace NuGet.CommandLine
                 {
                     // If we were able to look up a parent of type ICollection<>, perform a Add operation on it.
                     // Note that we expect the value is a string.
-                    var stringValue = value as string;
-                    Debug.Assert(stringValue != null);
+                    var stringValue = (string)value;
 
                     dynamic list = property.GetValue(command, null);
                     // The parameter value is one or more semi-colon separated items that might support values also


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14434

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
