### PR TITLE
Stop Audit from running if restore was not successful

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -757,6 +757,11 @@ namespace NuGet.Commands
         /// <returns>False if no vulnerability database could be found (so packages were not scanned for vulnerabilities), true otherwise.</returns>
         private async Task<bool> PerformAuditAsync(IEnumerable<RestoreTargetGraph> graphs, TelemetryActivity telemetry, CancellationToken token)
         {
+            if (!_success)
+            {
+                return false;
+            }
+            
             var audit = new AuditUtility(
                 _request.Project.RestoreMetadata.RestoreAuditProperties,
                 _request.Project.FilePath,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

Stop audit from running if restore was not successful so far.
either of must have failed if _success is false
* BeforeGraphResolutionValidations
 
```
success &= EnsureNotDeprecatedProjectJsonProjectType();
success &= AreCentralVersionRequirementsSatisfied(_request, httpSourcesCount);
success &= EvaluateHttpSourceUsage();
success &= HasValidPlatformVersions();
success &= PackageReferencesHaveVersions();
success &= ValidatePackageReferences();
```

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
