### PR TITLE
Don't merge generic dependencies

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -350,9 +350,6 @@ namespace NuGet.ProjectModel
 
             if (packageSpec != null)
             {
-                // Add dependencies section
-                dependencies.AddRange(packageSpec.Dependencies);
-
                 // Add framework specific dependencies
                 var targetFrameworkInfo = packageSpec.GetTargetFramework(targetFramework);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Progress towards: https://github.com/NuGet/Home/issues/14446

## Description

Over the last few months me & Donnie have been doing work to deprecate project.json and a bunch of that work has been rewriting tests, moving them from project.json to PackageReference. 
project.json had the concept of generic dependencies, like PackageReference does not, it uses the TargetFrameworkInformation in the PackageSpec. 

This removal just makes sure that there are no tests using the generic deps anymore. 

Note that the full removal of this field will follow, but not ready yet as we need to firstly decouple the migrator from the existing code.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ Tests were rewritten over time to make sure this isn't relevant anymore, https://github.com/NuGet/NuGet.Client/pull/6376, https://github.com/NuGet/NuGet.Client/pull/6349 and https://github.com/NuGet/NuGet.Client/pull/6371
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
