### PR TITLE
Ensure stable order of files in the nuget package

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -1051,7 +1051,7 @@ namespace NuGet.Packaging
             var warningMessage = new StringBuilder();
 
             // Add files that might not come from expanding files on disk
-            foreach (IPackageFile file in new HashSet<IPackageFile>(Files))
+            foreach (IPackageFile file in new SortedSet<IPackageFile>(Files, Comparer<IPackageFile>.Create((a, b) => String.CompareOrdinal(a.Path, b.Path))))
             {
                 using (Stream stream = file.GetStream())
                 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -79,7 +79,6 @@ namespace NuGet.Packaging.Test
                     var files = archive.Entries
                         .Where(file => file.Name == "_._")
                         .Select(file => file.FullName)
-                        .OrderBy(s => s)
                         .ToArray();
 
                     // Assert
@@ -148,7 +147,6 @@ namespace NuGet.Packaging.Test
                     var files = archive.Entries
                         .Where(file => file.Name.StartsWith("foo"))
                         .Select(file => file.FullName)
-                        .OrderBy(s => s)
                         .ToArray();
 
                     // Assert
@@ -2788,21 +2786,20 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
                 using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
                 {
                     // Get raw filenames without un-escaping.
-                    var files = archive.Entries.Select(e => e.FullName).OrderBy(s => s).ToArray();
+                    var files = archive.Entries.Select(e => e.FullName).ToArray();
 
-                    // Linux sorts the first two in different order than Windows
-                    Assert.Contains<string>(@"[Content_Types].xml", files);
-                    Assert.Contains<string>(@"_rels/.rels", files);
+                    Assert.Equal(@"_rels/.rels", files[0]);
+                    Assert.Equal(@"test.nuspec", files[1]);
                     Assert.Equal(@"content/images/bread&butter.jpg", files[2]);
                     Assert.Equal(@"content/images/logo123?#78.png", files[3]);
                     Assert.Equal(@"lib/C#/test.dll", files[4]);
                     Assert.Equal(@"lib/name with spaces.dll", files[5]);
                     Assert.Equal(@"lib/regular.file.dll", files[6]);
 
-                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[7]);
-                    Assert.EndsWith(@".psmdcp", files[7]);
+                    Assert.Equal(@"[Content_Types].xml", files[7]);
+                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[8]);
+                    Assert.EndsWith(@".psmdcp", files[8]);
 
-                    Assert.Equal(@"test.nuspec", files[8]);
                 }
             }
         }
@@ -2830,17 +2827,14 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
 
                 using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
                 {
-                    var files = archive.GetFiles().OrderBy(s => s).ToArray();
+                    var files = archive.GetFiles().ToArray();
 
-                    // Linux sorts the first two in different order than Windows
-                    Assert.Contains<string>(@"[Content_Types].xml", files);
-                    Assert.Contains<string>(@"_rels/.rels", files);
+                    Assert.Equal(@"_rels/.rels", files[0]);
+                    Assert.Equal(@"test.nuspec", files[1]);
                     Assert.Equal(@"myfile", files[2]);
-
-                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[3]);
-                    Assert.EndsWith(@".psmdcp", files[3]);
-
-                    Assert.Equal(@"test.nuspec", files[4]);
+                    Assert.Equal(@"[Content_Types].xml", files[3]);
+                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[4]);
+                    Assert.EndsWith(@".psmdcp", files[4]);
 
                     using (var contentTypesReader = new StreamReader(archive.Entries.Single(file => file.FullName == @"[Content_Types].xml").Open()))
                     {
@@ -3040,14 +3034,13 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
 
                 using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
                 {
-                    var files = archive.GetFiles().OrderBy(s => s).ToArray();
+                    var files = archive.GetFiles().ToArray();
 
-                    // Linux sorts the first two in different order than Windows
-                    Assert.Contains<string>(@"[Content_Types].xml", files);
-                    Assert.Contains<string>(@"_rels/.rels", files);
-                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[2]);
-                    Assert.Equal(@"test.nuspec", files[3]);
-                    Assert.Equal(outputFile, files[4]);
+                    Assert.Equal(@"_rels/.rels", files[0]);
+                    Assert.Equal(@"test.nuspec", files[1]);
+                    Assert.Equal(outputFile, files[2]);
+                    Assert.Equal(@"[Content_Types].xml", files[3]);
+                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[4]);
                 }
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14448

## Description

We can add files to the nuget package in any order. To provide more reproducibility/deterministicness, add the files in the archive in a well-defined order.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
