### PR TITLE
Show Watermark example on Add Package Source dialog

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -156,7 +156,8 @@
                 "type": "string",
                 "title": "@Text_PackageSourceName_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
                 "uniqueness": "caseInsensitive",
-                "default": "Package source",
+                "default":  "",
+                "example": "Package source",
                 "messages": [
                   {
                     "text": "@Error_PackageSourceName_Missing;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
@@ -171,7 +172,8 @@
                 "pathKind": "folderOrUri",
                 "title": "@Text_PackageSourceUrl_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
                 "uniqueness": "caseInsensitive",
-                "default": "https://packagesource",
+                "default": "",
+                "example": "https://packagesource",
                 "messages": [
                   {
                     "text": "@Error_PackageSourceUri_Missing;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/14450

## Description

- Unified Settings now supports examples (Watermark text) on array item properties. This way, focusing on the textbox immediately allows typing while still showing the example text.

- Not including the default text appears to either be required or a bug ([Filed here internally](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2535183)).

<img width="370" height="375" alt="image" src="https://github.com/user-attachments/assets/271908af-695a-476a-989f-38467c56ad05" />

### Future considerations
- I believe what NuGet suggests could be improved. Maybe a nuget.org example and a folder feed example? That can be done separately.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
