### PR TITLE
Remove PackageSpec.Dependencies

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Migrate/ProjectJsonToPackageRefMigrator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Migrate/ProjectJsonToPackageRefMigrator.cs
@@ -76,7 +76,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
+#pragma warning disable CS0612 // Type or member is obsolete
             dependencies.AddRange(packageSpec.Dependencies);
+#pragma warning restore CS0612 // Type or member is obsolete
             foreach (var dependency in dependencies)
             {
                 await project.ProjectServices.References.AddOrUpdatePackageReferenceAsync(dependency, CancellationToken.None);

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -924,10 +924,7 @@ namespace NuGet.Build.Tasks.Pack
                     continue;
                 }
 
-                // First, add each of the generic package dependencies
-                AddDependencies(assetsFile.PackageSpec.Dependencies, dependenciesByFramework, framework, assetsFile, packageSpecificNoWarnProperties);
-
-                // Next, the framework-specific dependencies
+                // First, the framework-specific dependencies
                 var newFrameworkDependencies = AddDependencies(framework.Dependencies, dependenciesByFramework, framework, assetsFile, packageSpecificNoWarnProperties);
                 framework = new TargetFrameworkInformation(framework) { Dependencies = newFrameworkDependencies };
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
@@ -315,18 +315,8 @@ namespace NuGet.Commands
         private static string[] GetDependencyTargetGraphs(PackageSpec spec, LibraryDependency dependency)
         {
             var infos = new List<TargetFrameworkInformation>();
-
-            if (spec.Dependencies.Contains(dependency))
-            {
-                // If the dependency is top level add it for all tfms
-                infos.AddRange(spec.TargetFrameworks);
-            }
-            else
-            {
-                // Add all tfms where the dependency is found
-                infos.AddRange(spec.TargetFrameworks.Where(e => e.Dependencies.Contains(dependency)));
-            }
-
+            // Add all tfms where the dependency is found
+            infos.AddRange(spec.TargetFrameworks.Where(e => e.Dependencies.Contains(dependency)));
             // Convert framework to target graph name.
             return infos.Select(e => e.FrameworkName.ToString()).ToArray();
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -392,13 +392,6 @@ namespace NuGet.Commands
 
         private static void AddProjectFileDependenciesForSpec(PackageSpec project, LockFile lockFile)
         {
-            // Use empty string as the key of dependencies shared by all frameworks
-            lockFile.ProjectFileDependencyGroups.Add(new ProjectFileDependencyGroup(
-                string.Empty,
-                project.Dependencies
-                    .Select(group => group.LibraryRange.ToLockFileDependencyGroupString())
-                    .OrderBy(group => group, StringComparer.Ordinal)));
-
             foreach (var frameworkInfo in project.TargetFrameworks
                 .OrderBy(framework => framework.FrameworkName.ToString(),
                     StringComparer.Ordinal))
@@ -420,7 +413,6 @@ namespace NuGet.Commands
                     StringComparer.Ordinal))
             {
                 var dependencies = new List<LibraryRange>();
-                dependencies.AddRange(project.Dependencies.Select(e => e.LibraryRange));
                 dependencies.AddRange(frameworkInfo.Dependencies.Select(e => e.LibraryRange));
 
                 var targetGraph = targetGraphs.SingleOrDefault(graph =>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/PackageSpecificWarningProperties.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/PackageSpecificWarningProperties.cs
@@ -33,14 +33,6 @@ namespace NuGet.Commands
             // NuGetLogCode -> LibraryId -> Set of Frameworks.
             var warningProperties = new PackageSpecificWarningProperties();
 
-            foreach (var dependency in packageSpec.Dependencies)
-            {
-                foreach (var framework in packageSpec.TargetFrameworks)
-                {
-                    warningProperties.AddRangeOfCodes(dependency.NoWarn, dependency.Name, framework.FrameworkName);
-                }
-            }
-
             foreach (var framework in packageSpec.TargetFrameworks)
             {
                 foreach (var dependency in framework.Dependencies)
@@ -63,11 +55,6 @@ namespace NuGet.Commands
         {
             // NuGetLogCode -> LibraryId -> Set of Frameworks.
             var warningProperties = new PackageSpecificWarningProperties();
-
-            foreach (var dependency in packageSpec.Dependencies)
-            {
-                warningProperties.AddRangeOfCodes(dependency.NoWarn, dependency.Name, framework);
-            }
 
             var targetFrameworkInformation = packageSpec.GetTargetFramework(framework);
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
@@ -38,18 +38,13 @@ namespace NuGet.Commands
             FlattenDependencyTypesUnified(targetGraph, result);
 
             // Override flags for direct dependencies
-            var directDependencies = spec.Dependencies.ToList();
 
             // Add dependencies defined under the framework node
             var specFramework = spec.GetTargetFramework(targetGraph.Framework);
-            if (specFramework?.Dependencies != null)
-            {
-                directDependencies.AddRange(specFramework.Dependencies);
-            }
 
             // Override the flags for direct dependencies. This lets the
             // user take control when needed.
-            foreach (var dependency in directDependencies)
+            foreach (var dependency in specFramework?.Dependencies)
             {
                 LibraryIncludeFlags includeType = IsDependencyPruned(dependency, specFramework?.PackagesToPrune) ?
                     LibraryIncludeFlags.None :

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -633,8 +633,7 @@ namespace NuGet.Commands
             var frameworkInfo = spec.TargetFrameworks[index];
             var dependencies = frameworkInfo.Dependencies;
 
-            if (!spec.Dependencies
-                            .Concat(dependencies)
+            if (!dependencies
                             .Select(d => d.Name)
                             .Contains(dependency.Name, StringComparer.OrdinalIgnoreCase))
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
@@ -315,7 +315,7 @@ namespace NuGet.Commands
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.PropertyNotAllowed,
-                    nameof(spec.Dependencies));
+                    "dependencies");
 
                 throw RestoreSpecException.Create(message, files);
             }
@@ -409,8 +409,7 @@ namespace NuGet.Commands
 
         private static IEnumerable<LibraryDependency> GetAllDependencies(PackageSpec spec)
         {
-            return spec.Dependencies
-                .Concat(spec.TargetFrameworks.SelectMany(f => f.Dependencies));
+            return spec.TargetFrameworks.SelectMany(f => f.Dependencies);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
@@ -29,7 +29,6 @@ namespace NuGet.Commands
             {
                 Name = name, // make sure this package never collides with a dependency
                 FilePath = projectFilePath,
-                Dependencies = new List<LibraryDependency>(),
                 TargetFrameworks =
                 {
                     new TargetFrameworkInformation
@@ -161,7 +160,7 @@ namespace NuGet.Commands
                 return null;
             }
 
-            return spec.Dependencies.Concat(spec.TargetFrameworks.SelectMany(e => e.Dependencies)).SingleOrDefault();
+            return spec.TargetFrameworks.SelectMany(e => e.Dependencies).SingleOrDefault();
         }
 
         public static LockFileTargetLibrary GetToolTargetLibrary(LockFile toolLockFile, string toolId)

--- a/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
@@ -19,16 +19,14 @@ namespace NuGet.Commands
         public static ISet<LibraryDependency> GetAllPackageDependencies(this PackageSpec project)
         {
             // Remove non-package dependencies such as framework assembly references.
-            return new HashSet<LibraryDependency>(
-                project.Dependencies.Concat(project.TargetFrameworks.SelectMany(e => e.Dependencies))
+            return new HashSet<LibraryDependency>(project.TargetFrameworks.SelectMany(e => e.Dependencies)
                                     .Where(e => e.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)));
         }
 
         public static ISet<LibraryDependency> GetPackageDependenciesForFramework(this PackageSpec project, NuGetFramework framework)
         {
             // Remove non-package dependencies such as framework assembly references.
-            return new HashSet<LibraryDependency>(
-                project.Dependencies.Concat(project.GetTargetFramework(framework).Dependencies)
+            return new HashSet<LibraryDependency>(project.GetTargetFramework(framework).Dependencies
                                     .Where(e => e.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)));
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -121,14 +121,6 @@ namespace NuGet.ProjectModel
                     {
                         jsonReader.Skip();
                     }
-                    else if (jsonReader.ValueTextEquals(DependenciesPropertyName))
-                    {
-                        ReadDependencies(
-                            ref jsonReader,
-                            packageSpec.Dependencies,
-                            filePath,
-                            isGacOrFrameworkReference: false);
-                    }
                     else if (jsonReader.ValueTextEquals(FrameworksPropertyName))
                     {
                         ReadFrameworks(ref jsonReader, packageSpec);

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
@@ -62,33 +62,24 @@ namespace NuGet.ProjectModel
 
             foreach (var group in ProjectFileDependencyGroups)
             {
-                IOrderedEnumerable<string> actualDependencies;
                 var expectedDependencies = @group.Dependencies.OrderBy(x => x, StringComparer.Ordinal);
 
                 // If the framework name is empty, the associated dependencies are shared by all frameworks
-                if (string.IsNullOrEmpty(@group.FrameworkName))
-                {
-                    actualDependencies = spec.Dependencies
-                        .Select(x => x.LibraryRange.ToLockFileDependencyGroupString())
-                        .OrderBy(x => x, StringComparer.Ordinal);
-                }
-                else
-                {
-                    var framework = actualTargetFrameworks.FirstOrDefault(f => string.Equals(
-                                f.FrameworkName.DotNetFrameworkName,
-                                @group.FrameworkName,
-                                StringComparison.OrdinalIgnoreCase));
 
-                    if (framework == null)
-                    {
-                        return false;
-                    }
+                var framework = actualTargetFrameworks.FirstOrDefault(f => string.Equals(
+                            f.FrameworkName.DotNetFrameworkName,
+                            @group.FrameworkName,
+                            StringComparison.OrdinalIgnoreCase));
 
-                    actualDependencies = framework
-                        .Dependencies
-                        .Select(d => d.LibraryRange.ToLockFileDependencyGroupString())
-                        .OrderBy(x => x, StringComparer.Ordinal);
+                if (framework == null)
+                {
+                    return false;
                 }
+
+                IOrderedEnumerable<string> actualDependencies = framework
+                    .Dependencies
+                    .Select(d => d.LibraryRange.ToLockFileDependencyGroupString())
+                    .OrderBy(x => x, StringComparer.Ordinal);
 
                 if (!actualDependencies.SequenceEqual(expectedDependencies))
                 {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using NuGet.LibraryModel;
 using NuGet.RuntimeModel;
 using NuGet.Shared;
@@ -22,7 +21,7 @@ namespace NuGet.ProjectModel
         public static readonly NuGetVersion DefaultVersion = new NuGetVersion(1, 0, 0);
 
         public PackageSpec(IList<TargetFrameworkInformation> frameworks)
-            : this(frameworks, dependencies: null, runtimeGraph: null, restoreSettings: null)
+            : this(frameworks, runtimeGraph: null, restoreSettings: null)
         {
         }
 
@@ -32,13 +31,11 @@ namespace NuGet.ProjectModel
 
         internal PackageSpec(
             IList<TargetFrameworkInformation> frameworks,
-            IList<LibraryDependency> dependencies,
             RuntimeGraph runtimeGraph,
             ProjectRestoreSettings restoreSettings
             )
         {
             TargetFrameworks = frameworks;
-            Dependencies = dependencies ?? new List<LibraryDependency>();
             RuntimeGraph = runtimeGraph ?? RuntimeGraph.Empty;
             RestoreSettings = restoreSettings ?? new ProjectRestoreSettings();
         }
@@ -66,6 +63,7 @@ namespace NuGet.ProjectModel
         /// List of dependencies that apply to all frameworks.
         /// <see cref="ProjectStyle.PackageReference"/> based projects must not use this list and instead use the one in the <see cref="TargetFrameworks"/> property which is a list of the <see cref="TargetFrameworkInformation"/> type.
         /// </summary>
+        [Obsolete]
         public IList<LibraryDependency> Dependencies { get; set; }
 
         public IList<TargetFrameworkInformation> TargetFrameworks { get; private set; }
@@ -92,7 +90,6 @@ namespace NuGet.ProjectModel
 
             hashCode.AddObject(Version);
             hashCode.AddObject(IsDefaultVersion);
-            hashCode.AddSequence(Dependencies);
             hashCode.AddSequence(TargetFrameworks);
             hashCode.AddObject(RuntimeGraph);
             hashCode.AddObject(RestoreMetadata);
@@ -121,7 +118,6 @@ namespace NuGet.ProjectModel
 
             return EqualityUtility.EqualsWithNullCheck(Version, other.Version) &&
                    IsDefaultVersion == other.IsDefaultVersion &&
-                   EqualityUtility.OrderedEquals(Dependencies, other.Dependencies, dep => dep.Name, StringComparer.OrdinalIgnoreCase) &&
                    EqualityUtility.OrderedEquals(TargetFrameworks, other.TargetFrameworks, tfm => tfm.TargetAlias, StringComparer.OrdinalIgnoreCase) &&
                    EqualityUtility.EqualsWithNullCheck(RuntimeGraph, other.RuntimeGraph) &&
                    EqualityUtility.EqualsWithNullCheck(RestoreMetadata, other.RestoreMetadata);
@@ -144,7 +140,6 @@ namespace NuGet.ProjectModel
 
             return new PackageSpec(
                 targetFrameworks,
-                Dependencies?.ToList(),
                 RuntimeGraph?.Clone(),
                 RestoreSettings?.Clone()
                 )

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecOperations.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecOperations.cs
@@ -34,21 +34,6 @@ namespace NuGet.ProjectModel
             var range = dependency.VersionRange;
             var dependencyId = dependency.Id;
 
-            for (var i = 0; i < spec.Dependencies.Count; i++)
-            {
-                var existingDependency = spec.Dependencies[i];
-
-                bool updateVersionOverride = spec.RestoreMetadata?.CentralPackageVersionsEnabled == true && !existingDependency.VersionCentrallyManaged && existingDependency.VersionOverride is not null;
-
-                if (IsMatchingDependencyName(existingDependency, dependencyId))
-                {
-                    var libraryRange = new LibraryRange(existingDependency.LibraryRange) { VersionRange = range };
-                    spec.Dependencies[i] = new LibraryDependency(existingDependency) { LibraryRange = libraryRange, VersionOverride = updateVersionOverride ? range : null };
-
-                    foundExistingDependency = true;
-                }
-            }
-
             for (var i = 0; i < spec.TargetFrameworks.Count; i++)
             {
                 var targetFramework = spec.TargetFrameworks[i];
@@ -81,22 +66,13 @@ namespace NuGet.ProjectModel
 
             if (!foundExistingDependency)
             {
-                if (spec.RestoreMetadata?.ProjectStyle == ProjectStyle.PackageReference) // PackageReference does not use the `Dependencies` list in the PackageSpec.
+                for (var i = 0; i < spec.TargetFrameworks.Count; i++)
                 {
-                    for (var i = 0; i < spec.TargetFrameworks.Count; i++)
-                    {
-                        var framework = spec.TargetFrameworks[i];
-                        var newDependency = CreateDependency(dependencyId, range, spec.RestoreMetadata?.CentralPackageVersionsEnabled ?? false);
-
-                        var newDependencies = framework.Dependencies.Add(newDependency);
-                        spec.TargetFrameworks[i] = new TargetFrameworkInformation(framework) { Dependencies = newDependencies };
-                    }
-                }
-                else
-                {
+                    var framework = spec.TargetFrameworks[i];
                     var newDependency = CreateDependency(dependencyId, range, spec.RestoreMetadata?.CentralPackageVersionsEnabled ?? false);
 
-                    spec.Dependencies.Add(newDependency);
+                    var newDependencies = framework.Dependencies.Add(newDependency);
+                    spec.TargetFrameworks[i] = new TargetFrameworkInformation(framework) { Dependencies = newDependencies };
                 }
             }
         }
@@ -121,11 +97,6 @@ namespace NuGet.ProjectModel
 
         public static bool HasPackage(PackageSpec spec, string packageId)
         {
-            if (spec.Dependencies.Any(library => IsMatchingDependencyName(library, packageId)))
-            {
-                return true;
-            }
-
             if (spec.TargetFrameworks.Any(tf => tf.Dependencies.Any(library => IsMatchingDependencyName(library, packageId))))
             {
                 return true;
@@ -213,15 +184,6 @@ namespace NuGet.ProjectModel
         {
             if (spec == null) throw new ArgumentNullException(nameof(spec));
             if (packageId == null) throw new ArgumentNullException(nameof(packageId));
-
-            for (var i = spec.Dependencies.Count - 1; i >= 0; i--)
-            {
-                var dependency = spec.Dependencies[i];
-                if (IsMatchingDependencyName(dependency, packageId))
-                {
-                    spec.Dependencies.RemoveAt(i);
-                }
-            }
 
             for (var i = 0; i < spec.TargetFrameworks.Count; i++)
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -51,11 +51,6 @@ namespace NuGet.ProjectModel
 
             SetMSBuildMetadata(writer, packageSpec, environmentVariableReader);
 
-            if (packageSpec.Dependencies.Count > 0)
-            {
-                SetDependencies(writer, packageSpec.Dependencies);
-            }
-
             SetFrameworks(writer, packageSpec.TargetFrameworks, hashing);
 
             JsonRuntimeFormat.WriteRuntimeGraph(writer, packageSpec.RuntimeGraph);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -506,8 +506,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 var actualRestoreSpec = packageSpecs.Single();
                 SpecValidationUtility.ValidateProjectSpec(actualRestoreSpec);
-                //No top level dependencies
-                Assert.Equal(0, actualRestoreSpec.Dependencies.Count);
 
                 var actualDependency = actualRestoreSpec.TargetFrameworks.SingleOrDefault().Dependencies.Single();
                 Assert.NotNull(actualDependency);

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -90,20 +90,11 @@ namespace NuGet.Commands.FuncTest
                 Directory.CreateDirectory(Path.Combine(projectDir, "TestProject"));
                 var projectSpecPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var projectSpec = JsonPackageSpecReader.GetPackageSpec(BasicConfigWithNet46.ToString(), "TestProject", projectSpecPath);
-                projectSpec.Dependencies = new List<LibraryDependency>
-                {
-                    new LibraryDependency()
-                    {
-                        LibraryRange = new LibraryRange(
-                            "ReferencedProject",
-                            VersionRange.Parse("2.0.0-beta1"),
-                            LibraryDependencyTarget.Project)
-                    }
-                };
 
                 Directory.CreateDirectory(Path.Combine(projectDir, "ReferencedProject"));
                 var referenceSpecPath = Path.Combine(projectDir, "ReferencedProject", "project.json");
                 var referenceSpec = JsonPackageSpecReader.GetPackageSpec(BasicConfigWithNet46.ToString(), "ReferencedProject", referenceSpecPath);
+                projectSpec = projectSpec.WithTestProjectReference(referenceSpec);
                 referenceSpec.Version = new NuGetVersion("2.0.0-BETA1");
                 PackageSpecWriter.WriteToFile(referenceSpec, referenceSpecPath);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -89,11 +89,11 @@ namespace NuGet.Commands.FuncTest
             {
                 Directory.CreateDirectory(Path.Combine(projectDir, "TestProject"));
                 var projectSpecPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var projectSpec = JsonPackageSpecReader.GetPackageSpec(BasicConfigWithNet46.ToString(), "TestProject", projectSpecPath);
+                var projectSpec = JsonPackageSpecReader.GetPackageSpec(BasicConfigWithNet46.ToString(), "TestProject", projectSpecPath).WithTestRestoreMetadata();
 
                 Directory.CreateDirectory(Path.Combine(projectDir, "ReferencedProject"));
                 var referenceSpecPath = Path.Combine(projectDir, "ReferencedProject", "project.json");
-                var referenceSpec = JsonPackageSpecReader.GetPackageSpec(BasicConfigWithNet46.ToString(), "ReferencedProject", referenceSpecPath);
+                var referenceSpec = JsonPackageSpecReader.GetPackageSpec(BasicConfigWithNet46.ToString(), "ReferencedProject", referenceSpecPath).WithTestRestoreMetadata();
                 projectSpec = projectSpec.WithTestProjectReference(referenceSpec);
                 referenceSpec.Version = new NuGetVersion("2.0.0-BETA1");
                 PackageSpecWriter.WriteToFile(referenceSpec, referenceSpecPath);
@@ -1641,11 +1641,12 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_PopulatesProjectFileDependencyGroupsCorrectlyAsync()
         {
             const string project = @"{
-    ""dependencies"": {
-        ""Newtonsoft.Json"": ""6.0.4""
-    },
     ""frameworks"": {
-        ""net45"": {}
+        ""net45"": {
+            ""dependencies"": {
+                    ""Newtonsoft.Json"": ""6.0.4""
+            }
+        }
     },
     ""supports"": {
     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -1972,9 +1972,6 @@ namespace NuGet.Commands.Test
                     .OrderBy(s => s, StringComparer.Ordinal)));
 
                 // Dependency counts
-                Assert.Equal(0, project1Spec.Dependencies.Count);
-                Assert.Equal(0, project2Spec.Dependencies.Count);
-
                 Assert.Equal(1, project1Spec.GetTargetFramework(NuGetFramework.Parse("net46")).Dependencies.Length);
                 Assert.Equal(1, project1Spec.GetTargetFramework(NuGetFramework.Parse("netstandard1.6")).Dependencies.Length);
 
@@ -2123,7 +2120,6 @@ namespace NuGet.Commands.Test
                 var projectSpec = dgSpec.Projects.Single(e => e.Name == "a");
 
                 // Assert
-                Assert.Equal(0, projectSpec.Dependencies.Count);
                 Assert.Equal(1, dgSpec.Projects.Count);
                 Assert.Equal("y", string.Join("|", projectSpec.GetTargetFramework(NuGetFramework.Parse("net46")).Dependencies.Select(e => e.Name)));
                 Assert.Equal("z|y", string.Join("|", projectSpec.GetTargetFramework(NuGetFramework.Parse("netstandard1.6")).Dependencies.Select(e => e.Name)));
@@ -2297,8 +2293,8 @@ namespace NuGet.Commands.Test
                 var project1Spec = dgSpec.Projects.Single(e => e.Name == "a");
                 var project2Spec = dgSpec.Projects.Single(e => e.Name == "b");
 
-                var allDependencies1 = project1Spec.Dependencies.Concat(project1Spec.TargetFrameworks.Single().Dependencies).ToList();
-                var allDependencies2 = project2Spec.Dependencies.Concat(project2Spec.TargetFrameworks.Single().Dependencies).ToList();
+                var allDependencies1 = project1Spec.TargetFrameworks.Single().Dependencies;
+                var allDependencies2 = project2Spec.TargetFrameworks.Single().Dependencies;
                 var msbuildDependency = project1Spec.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Single();
 
                 // Assert
@@ -2311,7 +2307,7 @@ namespace NuGet.Commands.Test
                     .Select(e => e.FrameworkName.GetShortFolderName())
                     .OrderBy(s => s, StringComparer.Ordinal)));
 
-                Assert.Equal(0, allDependencies2.Count);
+                Assert.Equal(0, allDependencies2.Length);
             }
         }
 
@@ -2555,7 +2551,6 @@ namespace NuGet.Commands.Test
                 Assert.Equal("net46", string.Join("|", project1Spec.RestoreMetadata.OriginalTargetFrameworks));
                 Assert.Equal("net46", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.TargetAlias)));
                 Assert.Equal("x", project1Spec.GetTargetFramework(NuGetFramework.Parse("net46")).Dependencies.SingleOrDefault().Name);
-                Assert.Empty(project1Spec.Dependencies);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
@@ -441,7 +441,7 @@ namespace NuGet.Commands.Test
             spec.AddProject(project);
 
             // Act && Assert
-            AssertError(spec, "Property 'Dependencies' is not allowed");
+            AssertError(spec, "Property 'dependencies' is not allowed");
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
@@ -160,11 +160,6 @@ namespace NuGet.Commands.Test
                     ProjectUniqueName = "b"
                 });
 
-            spec.Projects.First().Dependencies.Add(new LibraryDependency()
-            {
-                LibraryRange = new LibraryRange("b", LibraryDependencyTarget.PackageProjectExternal)
-            });
-
             // Act && Assert no errors
             SpecValidationUtility.ValidateDependencySpec(spec);
         }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PackageSpecificWanringPropertiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PackageSpecificWanringPropertiesTests.cs
@@ -64,57 +64,6 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public void PackageSpecificWarningProperties_CreatesPackageSpecificWarningPropertiesWithUnconditionalDependencies()
-        {
-
-            // Arrange
-            var net45Framework = NuGetFramework.Parse("net45");
-            var netcoreappFramework = NuGetFramework.Parse("netcoreapp1.1");
-            var libraryId = "test_library";
-            var libraryVersion = "1.0.0";
-
-            var targetFrameworkInformation = new List<TargetFrameworkInformation>
-            {
-                new TargetFrameworkInformation()
-                {
-                    FrameworkName = net45Framework
-                },
-                new TargetFrameworkInformation()
-                {
-                    FrameworkName = netcoreappFramework
-                }
-            };
-
-            var packageSpec = new PackageSpec(targetFrameworkInformation)
-            {
-                Dependencies = new List<LibraryDependency>
-                {
-                    new LibraryDependency ()
-                    {
-                        LibraryRange = new LibraryRange
-                        {
-                            Name = libraryId,
-                            TypeConstraint = LibraryDependencyTarget.Package,
-                            VersionRange = VersionRange.Parse(libraryVersion)
-                        },
-                        NoWarn = [NuGetLogCode.NU1603, NuGetLogCode.NU1605]
-                    }
-                }
-            };
-
-            // Act
-            var warningProperties = PackageSpecificWarningProperties.CreatePackageSpecificWarningProperties(packageSpec);
-
-            // Assert
-            Assert.True(warningProperties.Contains(NuGetLogCode.NU1603, libraryId, net45Framework));
-            Assert.True(warningProperties.Contains(NuGetLogCode.NU1603, libraryId, netcoreappFramework));
-            Assert.True(warningProperties.Contains(NuGetLogCode.NU1605, libraryId, net45Framework));
-            Assert.True(warningProperties.Contains(NuGetLogCode.NU1605, libraryId, netcoreappFramework));
-            Assert.False(warningProperties.Contains(NuGetLogCode.NU1603, libraryId, NuGetFramework.Parse("random_framework")));
-            Assert.False(warningProperties.Contains(NuGetLogCode.NU1605, libraryId, NuGetFramework.Parse("random_framework")));
-        }
-
-        [Fact]
         public void PackageSpecificWarningProperties_CreatesPackageSpecificWarningPropertiesWithFrameworkConditionalDependencies()
         {
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/BuildIntegratedNuGetProjectTests.cs
@@ -56,7 +56,6 @@ namespace ProjectManagement.Test
                 Assert.Equal(projectTargetFramework, actual.TargetFrameworks[0].FrameworkName);
                 Assert.Empty(actual.TargetFrameworks[0].Imports);
 
-                Assert.Empty(actual.Dependencies);
                 Assert.Empty(actual.TargetFrameworks[0].Dependencies);
                 Assert.Empty(actual.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences));
             }
@@ -427,7 +426,6 @@ namespace ProjectManagement.Test
                 Assert.Equal(1, actual.TargetFrameworks[0].Imports.Length);
                 Assert.Equal(FallbackTargetFramework, actual.TargetFrameworks[0].Imports[0]);
 
-                Assert.Empty(actual.Dependencies);
                 Assert.Empty(actual.TargetFrameworks[0].Dependencies);
                 Assert.Empty(actual.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences));
             }
@@ -481,7 +479,6 @@ namespace ProjectManagement.Test
                 Assert.Equal(1, actual.TargetFrameworks[0].Imports.Length);
                 Assert.Equal(FallbackTargetFramework, actual.TargetFrameworks[0].Imports[0]);
 
-                Assert.Empty(actual.Dependencies);
                 Assert.Empty(actual.TargetFrameworks[0].Dependencies);
                 Assert.Empty(actual.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences));
             }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/MSBuildNuGetProjectTests.cs
@@ -60,7 +60,6 @@ namespace ProjectManagement.Test
                 Assert.Equal(projectTargetFramework, actual.TargetFrameworks[0].FrameworkName);
                 Assert.Empty(actual.TargetFrameworks[0].Imports);
 
-                Assert.Empty(actual.Dependencies);
                 Assert.Empty(actual.TargetFrameworks[0].Dependencies);
                 Assert.Empty(actual.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences));
             }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
@@ -140,14 +140,15 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""version"": ""1.0.0"",
-                                    ""target"": ""blah""
-                                }
-                            },
                             ""frameworks"": {
-                                ""net46"": {}
+                                ""net46"": {
+                                    ""dependencies"": {
+                                        ""packageA"": {
+                                            ""version"": ""1.0.0"",
+                                            ""target"": ""blah""
+                                        }
+                                    }
+                                }
                             }
                         }";
 
@@ -167,8 +168,7 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             Assert.NotNull(exception);
-            Assert.Equal("Invalid dependency target value 'blah'.", exception.Message);
-            Assert.EndsWith("project.json", exception.Path);
+            Assert.Equal("Error reading '' : Invalid dependency target value 'blah'.", exception.Message);
         }
 
         [Fact]
@@ -176,14 +176,15 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""version"": ""1.0.0"",
-                                    ""target"": ""winmd""
-                                }
-                            },
                             ""frameworks"": {
-                                ""net46"": {}
+                                ""net46"": {
+                                    ""dependencies"": {
+                                        ""packageA"": {
+                                            ""version"": ""1.0.0"",
+                                            ""target"": ""winmd""
+                                        }
+                                    }
+                                }
                             }
                         }";
 
@@ -203,8 +204,7 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             Assert.NotNull(exception);
-            Assert.Equal("Invalid dependency target value 'winmd'.", exception.Message);
-            Assert.EndsWith("project.json", exception.Path);
+            Assert.Equal("Error reading '' : Invalid dependency target value 'winmd'.", exception.Message);
         }
 
         [Fact]
@@ -212,14 +212,15 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""version"": ""1.0.0"",
-                                    ""target"": ""package,project""
-                                }
-                            },
                             ""frameworks"": {
-                                ""net46"": {}
+                                ""net46"": {
+                                    ""dependencies"": {
+                                        ""packageA"": {
+                                            ""version"": ""1.0.0"",
+                                            ""target"": ""package,project""
+                                        }
+                                    }
+                                }
                             }
                         }";
 
@@ -239,8 +240,7 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             Assert.NotNull(exception);
-            Assert.Equal("Invalid dependency target value 'package,project'.", exception.Message);
-            Assert.EndsWith("project.json", exception.Path);
+            Assert.Equal("Error reading '' : Invalid dependency target value 'package,project'.", exception.Message);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -20,7 +20,6 @@ using Xunit;
 namespace NuGet.ProjectModel.Test
 {
     [UseCulture("")] // Fix tests failing on systems with non-English locales
-    [Obsolete]
     public class JsonPackageSpecReaderTests
     {
         [Fact]
@@ -28,13 +27,14 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""type"": ""build""
-                                }
-                            },
                             ""frameworks"": {
-                                ""net46"": {}
+                                ""net46"": {
+                                  ""dependencies"": {
+                                        ""packageA"": {
+                                            ""type"": ""build""
+                                        }
+                                    }
+                                }
                             }
                         }";
 
@@ -59,20 +59,21 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                                  ""dependencies"": {
-                                        ""packageA"": {
-                                            ""target"": ""project""
-                                        }
-                                    },
                                     ""frameworks"": {
-                                        ""net46"": {}
+                                        ""net46"": {
+                                            ""dependencies"": {
+                                                ""packageA"": {
+                                                    ""target"": ""project""
+                                                }
+                                            }
+                                        }
                                     }
                                 }";
 
             // Act
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
             var spec = GetPackageSpec(json, "TestProject", "project.json", null);
-            var range = spec.Dependencies.Single().LibraryRange.VersionRange;
+            var range = spec.TargetFrameworks[0].Dependencies.Single().LibraryRange.VersionRange;
 
             // Assert
             Assert.Equal(VersionRange.All, range);
@@ -83,14 +84,15 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                                  ""dependencies"": {
-                                        ""packageA"": {
-                                            ""target"": ""package"",
-                                            ""version"": """"
-                                        }
-                                    },
                                     ""frameworks"": {
-                                        ""net46"": {}
+                                        ""net46"": {
+                                          ""dependencies"": {
+                                                ""packageA"": {
+                                                    ""target"": ""package"",
+                                                    ""version"": """"
+                                                }
+                                            }
+                                        }
                                     }
                                 }";
 
@@ -114,16 +116,17 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                                  ""dependencies"": {
-                                        ""packageA"": {
-                                            ""target"": ""package"",
-                                            ""version"": ""   ""
-                                        }
-                                    },
-                                    ""frameworks"": {
-                                        ""net46"": {}
+                        ""frameworks"": {
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageA"": {
+                                        ""target"": ""package"",
+                                        ""version"": ""   ""
                                     }
-                                }";
+                                }
+                              }
+                            }
+                        }";
 
             Exception exception = null;
 
@@ -167,6 +170,8 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
+                           ""frameworks"": {
+                             ""net46"": {
                                ""dependencies"": {
                                  ""redist"": {
                                    ""version"": ""1.0.0"",
@@ -174,13 +179,15 @@ namespace NuGet.ProjectModel.Test
                                    ""include"": ""analyzers""
                                  }
                                }
-                             }";
+                             }
+                            }
+                        }";
 
             // Act
             var actual = GetPackageSpec(json, "TestProject", "project.json", null);
 
             // Assert
-            var dep = actual.Dependencies.FirstOrDefault(d => d.Name.Equals("redist"));
+            var dep = actual.TargetFrameworks[0].Dependencies.FirstOrDefault(d => d.Name.Equals("redist"));
             Assert.NotNull(dep);
 
             var expected = LibraryIncludeFlags.Analyzers;
@@ -192,25 +199,26 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                              ""dependencies"": {
-                                    ""packageA"": {
-                                        ""target"": ""package"",
-                                        ""version"": ""1.0.0"",
-                                        ""noWarn"": [
-                                            ""NU1500"",
-                                            ""NU1107""
-                                          ]
-                                    }
-                                },
                                 ""frameworks"": {
-                                    ""net46"": {}
+                                    ""net46"": {
+                                        ""dependencies"": {
+                                            ""packageA"": {
+                                                ""target"": ""package"",
+                                                ""version"": ""1.0.0"",
+                                                ""noWarn"": [
+                                                    ""NU1500"",
+                                                    ""NU1107""
+                                                  ]
+                                            }
+                                        }
+                                    }
                                 },
                             }";
 
             var actual = GetPackageSpec(json, "TestProject", "project.json", null);
 
             // Assert
-            var dep = actual.Dependencies.FirstOrDefault(d => d.Name.Equals("packageA"));
+            var dep = actual.TargetFrameworks[0].Dependencies.FirstOrDefault(d => d.Name.Equals("packageA"));
             Assert.NotNull(dep);
             Assert.Equal(dep.NoWarn.Length, 2);
             Assert.Contains(NuGetLogCode.NU1500, dep.NoWarn);
@@ -222,24 +230,25 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                              ""dependencies"": {
-                                    ""packageA"": {
-                                        ""target"": ""package"",
-                                        ""version"": ""1.0.0"",
-                                        ""noWarn"": [
-                                            ""NU1500""
-                                          ]
-                                    }
-                                },
                                 ""frameworks"": {
-                                    ""net46"": {}
+                                    ""net46"": {
+                                        ""dependencies"": {
+                                            ""packageA"": {
+                                                ""target"": ""package"",
+                                                ""version"": ""1.0.0"",
+                                                ""noWarn"": [
+                                                    ""NU1500""
+                                                  ]
+                                            }
+                                        }
+                                    }
                                 },
                             }";
 
             var actual = GetPackageSpec(json, "TestProject", "project.json", null);
 
             // Assert
-            var dep = actual.Dependencies.FirstOrDefault(d => d.Name.Equals("packageA"));
+            var dep = actual.TargetFrameworks[0].Dependencies.FirstOrDefault(d => d.Name.Equals("packageA"));
             Assert.NotNull(dep);
             Assert.Equal(dep.NoWarn.Length, 1);
             Assert.Contains(NuGetLogCode.NU1500, dep.NoWarn);
@@ -251,23 +260,24 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                                  ""dependencies"": {
+                            ""frameworks"": {
+                                ""net46"": {
+                                    ""dependencies"": {
                                         ""packageA"": {
                                             ""target"": ""package"",
                                             ""version"": ""1.0.0"",
                                             ""noWarn"": [
                                               ]
                                         }
-                                    },
-                                    ""frameworks"": {
-                                        ""net46"": {}
-                                    },
-                                }";
+                                    }
+                                }
+                            },
+                        }";
 
             var actual = GetPackageSpec(json, "TestProject", "project.json", null);
 
             // Assert
-            var dep = actual.Dependencies.FirstOrDefault(d => d.Name.Equals("packageA"));
+            var dep = actual.TargetFrameworks[0].Dependencies.FirstOrDefault(d => d.Name.Equals("packageA"));
             Assert.NotNull(dep);
             Assert.Equal(dep.NoWarn.Length, 0);
         }
@@ -673,31 +683,12 @@ namespace NuGet.ProjectModel.Test
 
         [Fact]
 
-        public void GetPackageSpec_WhenDependenciesPropertyIsAbsent_ReturnsEmptyDependencies()
-        {
-            PackageSpec packageSpec = GetPackageSpec("{}");
-
-            Assert.Empty(packageSpec.Dependencies);
-        }
-
-        [Fact]
-
-        public void GetPackageSpec_WhenDependenciesValueIsNull_ReturnsEmptyDependencies()
-        {
-            PackageSpec packageSpec = GetPackageSpec("{\"dependencies\":null}");
-
-            Assert.Empty(packageSpec.Dependencies);
-        }
-
-        [Fact]
-
         public void GetPackageSpec_WhenDependenciesDependencyNameIsEmptyString_Throws()
         {
-            const string json = "{\"dependencies\":{\"\":{}}}";
+            const string json = "{\"frameworks\": {\"net472\": {\"dependencies\":{\"\":{}}}}}";
 
             FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
-            Assert.Equal("Unable to resolve dependency ''.", exception.Message);
-            Assert.Null(exception.InnerException);
+            Assert.Equal("Error reading '' : Unable to resolve dependency ''.", exception.Message);
         }
 
         [Fact]
@@ -708,7 +699,7 @@ namespace NuGet.ProjectModel.Test
                 name: "a",
                 new VersionRange(new NuGetVersion("1.2.3")),
                 LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference);
-            var json = $"{{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange.ToShortString()}\"}}}}";
+            var json = $"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange.ToShortString()}\"}}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -723,7 +714,7 @@ namespace NuGet.ProjectModel.Test
                 name: "a",
                 new VersionRange(new NuGetVersion("1.2.3"), includeMinVersion: true, new NuGetVersion("4.5.6"), includeMaxVersion: false),
                 LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference);
-            var json = $"{{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange}\"}}}}";
+            var json = $"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"{expectedResult.Name}\":\"{expectedResult.VersionRange}\"}}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -739,19 +730,18 @@ namespace NuGet.ProjectModel.Test
         [InlineData(LibraryDependencyTarget.PackageProjectExternal)]
         public void GetPackageSpec_WhenDependenciesDependencyTargetIsUnsupported_Throws(LibraryDependencyTarget target)
         {
-            var json = $"{{\"dependencies\":{{\"a\":{{\"version\":\"1.2.3\",\"target\":\"{target}\"}}}}}}";
+            var json = $"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"a\":{{\"version\":\"1.2.3\",\"target\":\"{target}\"}}}}}}}}}}";
 
             FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
 
-            Assert.Equal($"Invalid dependency target value '{target}'.", exception.Message);
-            Assert.Null(exception.InnerException);
+            Assert.Equal($"Error reading '' : Invalid dependency target value '{target}'.", exception.Message);
         }
 
         [Fact]
 
         public void GetPackageSpec_WhenDependenciesDependencyAutoreferencedPropertyIsAbsent_ReturnsFalseAutoreferenced()
         {
-            LibraryDependency dependency = GetDependency($"{{\"dependencies\":{{\"a\":{{\"target\":\"Project\"}}}}}}");
+            LibraryDependency dependency = GetDependency($"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"a\":{{\"target\":\"Project\"}}}}}}}}}}");
 
             Assert.False(dependency.AutoReferenced);
         }
@@ -761,7 +751,7 @@ namespace NuGet.ProjectModel.Test
         [InlineData(false)]
         public void GetPackageSpec_WhenDependenciesDependencyAutoreferencedValueIsBool_ReturnsBoolAutoreferenced(bool expectedValue)
         {
-            var json = $"{{\"dependencies\":{{\"a\":{{\"autoReferenced\":{expectedValue.ToString().ToLower()},\"target\":\"Project\"}}}}}}";
+            var json = $"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"a\":{{\"autoReferenced\":{expectedValue.ToString().ToLower()},\"target\":\"Project\"}}}}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -774,16 +764,17 @@ namespace NuGet.ProjectModel.Test
         [InlineData("suppressParent")]
         public void GetPackageSpec_WhenDependenciesDependencyValueIsArray_Throws(string propertyName)
         {
-            var json = $"{{\"dependencies\":{{\"a\":{{\"{propertyName}\":[\"b\"]}}}}}}";
+            var json = $"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"a\":{{\"{propertyName}\":[\"b\"]}}}}}}}}}}";
 
-            Assert.Throws<InvalidCastException>(() => GetPackageSpec(json));
+            var mainException = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
+            Assert.IsType<InvalidCastException>(mainException.InnerException);
         }
 
         [Fact]
 
         public void GetPackageSpec_WhenDependenciesDependencyIncludeAndExcludePropertiesAreAbsent_ReturnsAllIncludeType()
         {
-            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+            const string json = "{\"frameworks\": {\"net472\": {\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -797,7 +788,7 @@ namespace NuGet.ProjectModel.Test
             string value,
             LibraryIncludeFlags result)
         {
-            var json = $"{{\"dependencies\":{{\"a\":{{\"exclude\":{value},\"version\":\"1.0.0\"}}}}}}";
+            var json = $"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"a\":{{\"exclude\":{value},\"version\":\"1.0.0\"}}}}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -811,7 +802,7 @@ namespace NuGet.ProjectModel.Test
             string value,
             LibraryIncludeFlags expectedResult)
         {
-            var json = $"{{\"dependencies\":{{\"a\":{{\"include\":{value},\"version\":\"1.0.0\"}}}}}}";
+            var json = $"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"a\":{{\"include\":{value},\"version\":\"1.0.0\"}}}}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -822,7 +813,7 @@ namespace NuGet.ProjectModel.Test
 
         public void GetPackageSpec_WhenDependenciesDependencyIncludeValueOverridesTypeValue_ReturnsIncludeType()
         {
-            const string json = "{\"dependencies\":{\"a\":{\"include\":\"ContentFiles\",\"type\":\"BecomesNupkgDependency, SharedFramework\",\"version\":\"1.0.0\"}}}";
+            const string json = "{\"frameworks\": {\"net472\": {\"dependencies\":{\"a\":{\"include\":\"ContentFiles\",\"type\":\"BecomesNupkgDependency, SharedFramework\",\"version\":\"1.0.0\"}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -833,7 +824,7 @@ namespace NuGet.ProjectModel.Test
 
         public void GetPackageSpec_WhenDependenciesDependencySuppressParentValueOverridesTypeValue_ReturnsSuppressParent()
         {
-            const string json = "{\"dependencies\":{\"a\":{\"suppressParent\":\"ContentFiles\",\"type\":\"SharedFramework\",\"version\":\"1.0.0\"}}}";
+            const string json = "{\"frameworks\": {\"net472\": {\"dependencies\":{\"a\":{\"suppressParent\":\"ContentFiles\",\"type\":\"SharedFramework\",\"version\":\"1.0.0\"}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -844,7 +835,7 @@ namespace NuGet.ProjectModel.Test
 
         public void GetPackageSpec_WhenDependenciesDependencySuppressParentPropertyIsAbsent_ReturnsSuppressParent()
         {
-            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+            const string json = "{\"frameworks\": {\"net472\": {\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -859,29 +850,30 @@ namespace NuGet.ProjectModel.Test
             LibraryIncludeFlags expectedResult
             )
         {
-            var json = $"{{\"dependencies\":{{\"a\":{{\"suppressParent\":{value},\"version\":\"1.0.0\"}}}}}}";
+            var json = $"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"a\":{{\"suppressParent\":{value},\"version\":\"1.0.0\"}}}}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
             Assert.Equal(expectedResult, dependency.SuppressParent);
         }
 
+        // TODO NK - The whole Error reading, Error Reading thing is dumb.
         [Fact]
 
         public void GetPackageSpec_WhenDependenciesDependencyVersionValueIsInvalid_Throws()
         {
-            const string json = "{\"dependencies\":{\"a\":{\"version\":\"b\"}}}";
+            const string json = "{\"frameworks\": {\"net472\": {\"dependencies\":{\"a\":{\"version\":\"b\"}}}}}";
 
             FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
 
-            Assert.Equal("Error reading '' : 'b' is not a valid version string.", exception.Message);
+            Assert.Equal("Error reading '' : 'b' is not a valid version string.", exception.InnerException.Message);
         }
 
         [Fact]
 
         public void GetPackageSpec_WhenDependenciesDependencyTargetPropertyIsAbsent_ReturnsTarget()
         {
-            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+            const string json = "{\"frameworks\": {\"net472\": {\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -892,20 +884,20 @@ namespace NuGet.ProjectModel.Test
 
         public void GetPackageSpec_WhenDependenciesDependencyTargetValueIsPackageAndVersionPropertyIsAbsent_Throws()
         {
-            const string json = "{\"dependencies\":{\"a\":{\"target\":\"Package\"}}}";
+            const string json = "{\"frameworks\": {\"net472\": {\"dependencies\":{\"a\":{\"target\":\"Package\"}}}}}";
 
             FileFormatException exception = Assert.Throws<FileFormatException>(() => GetPackageSpec(json));
-            Assert.IsType<ArgumentException>(exception.InnerException);
-            Assert.Null(exception.InnerException.InnerException);
+            Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
+            Assert.Null(exception.InnerException.InnerException.InnerException);
 
-            Assert.Equal("Error reading '' : Package dependencies must specify a version range.", exception.Message);
+            Assert.Equal("Error reading '' : Package dependencies must specify a version range.", exception.InnerException.Message);
         }
 
         [Fact]
 
         public void GetPackageSpec_WhenDependenciesDependencyTargetValueIsProjectAndVersionPropertyIsAbsent_ReturnsAllVersionRange()
         {
-            LibraryDependency dependency = GetDependency("{\"dependencies\":{\"a\":{\"target\":\"Project\"}}}");
+            LibraryDependency dependency = GetDependency("{\"frameworks\": {\"net472\": {\"dependencies\":{\"a\":{\"target\":\"Project\"}}}}}");
 
             Assert.Equal(VersionRange.All, dependency.LibraryRange.VersionRange);
         }
@@ -914,7 +906,7 @@ namespace NuGet.ProjectModel.Test
 
         public void GetPackageSpec_WhenDependenciesDependencyNoWarnPropertyIsAbsent_ReturnsEmptyNoWarns()
         {
-            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+            const string json = "{\"frameworks\": {\"net472\": {\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -926,7 +918,7 @@ namespace NuGet.ProjectModel.Test
         public void GetPackageSpec_WhenDependenciesDependencyNoWarnValueIsValid_ReturnsNoWarns()
         {
             NuGetLogCode[] expectedResults = { NuGetLogCode.NU1000, NuGetLogCode.NU3000 };
-            var json = $"{{\"dependencies\":{{\"a\":{{\"noWarn\":[\"{expectedResults[0].ToString()}\",\"{expectedResults[1].ToString()}\"],\"version\":\"1.0.0\"}}}}}}";
+            var json = $"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"a\":{{\"noWarn\":[\"{expectedResults[0].ToString()}\",\"{expectedResults[1].ToString()}\"],\"version\":\"1.0.0\"}}}}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -940,7 +932,7 @@ namespace NuGet.ProjectModel.Test
 
         public void GetPackageSpec_WhenDependenciesDependencyGeneratePathPropertyPropertyIsAbsent_ReturnsFalseGeneratePathProperty()
         {
-            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+            const string json = "{\"frameworks\": {\"net472\": {\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -952,7 +944,7 @@ namespace NuGet.ProjectModel.Test
         [InlineData(false)]
         public void GetPackageSpec_WhenDependenciesDependencyGeneratePathPropertyValueIsValid_ReturnsGeneratePathProperty(bool expectedResult)
         {
-            var json = $"{{\"dependencies\":{{\"a\":{{\"generatePathProperty\":{expectedResult.ToString().ToLowerInvariant()},\"version\":\"1.0.0\"}}}}}}";
+            var json = $"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"a\":{{\"generatePathProperty\":{expectedResult.ToString().ToLowerInvariant()},\"version\":\"1.0.0\"}}}}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -963,7 +955,7 @@ namespace NuGet.ProjectModel.Test
 
         public void GetPackageSpec_WhenDependenciesDependencyTypePropertyIsAbsent_ReturnsDefaultTypeConstraint()
         {
-            const string json = "{\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}";
+            const string json = "{\"frameworks\": {\"net472\": {\"dependencies\":{\"a\":{\"version\":\"1.0.0\"}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -976,7 +968,7 @@ namespace NuGet.ProjectModel.Test
 
         public void GetPackageSpec_WhenDependenciesDependencyVersionCentrallyManagedPropertyIsAbsent_ReturnsFalseVersionCentrallyManaged()
         {
-            LibraryDependency dependency = GetDependency($"{{\"dependencies\":{{\"a\":{{\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}");
+            LibraryDependency dependency = GetDependency($"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"a\":{{\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}}}}}");
 
             Assert.False(dependency.VersionCentrallyManaged);
         }
@@ -986,7 +978,7 @@ namespace NuGet.ProjectModel.Test
         [InlineData(false)]
         public void GetPackageSpec_WhenDependenciesDependencyVersionCentrallyManagedValueIsBool_ReturnsBoolVersionCentrallyManaged(bool expectedValue)
         {
-            var json = $"{{\"dependencies\":{{\"a\":{{\"versionCentrallyManaged\":{expectedValue.ToString().ToLower()},\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}";
+            var json = $"{{\"frameworks\": {{\"net472\": {{\"dependencies\":{{\"a\":{{\"versionCentrallyManaged\":{expectedValue.ToString().ToLower()},\"target\":\"Package\",\"version\":\"1.0.0\"}}}}}}}}}}";
 
             LibraryDependency dependency = GetDependency(json);
 
@@ -3022,7 +3014,7 @@ namespace NuGet.ProjectModel.Test
         {
             PackageSpec packageSpec = GetPackageSpec(json);
 
-            return packageSpec.Dependencies.Single();
+            return packageSpec.TargetFrameworks.Single().Dependencies.Single();
         }
 
         private static TargetFrameworkInformation GetFramework(string json)

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecOperationsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecOperationsTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
@@ -14,39 +13,6 @@ namespace NuGet.ProjectModel.Test
 {
     public class PackageSpecOperationsTests
     {
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void AddOrUpdateDependency_WithNonPackageReferenceProjectStyle_AddsNewPackageDependencyToGenericDependencies(bool usePackageDependency)
-        {
-            // Arrange
-            var spec = new PackageSpec(new[]
-            {
-                new TargetFrameworkInformation
-                {
-                    FrameworkName = FrameworkConstants.CommonFrameworks.Net45
-                }
-            });
-            var identity = new PackageIdentity("NuGet.Versioning", new NuGetVersion("1.0.0"));
-            var packageDependency = new PackageDependency(identity.Id, new VersionRange(identity.Version));
-
-            // Act
-            if (usePackageDependency)
-            {
-                PackageSpecOperations.AddOrUpdateDependency(spec, packageDependency);
-            }
-            else
-            {
-                PackageSpecOperations.AddOrUpdateDependency(spec, identity);
-            }
-
-            // Assert
-            Assert.Equal(1, spec.Dependencies.Count);
-            Assert.Empty(spec.TargetFrameworks[0].Dependencies);
-            Assert.Equal(identity.Id, spec.Dependencies[0].LibraryRange.Name);
-            Assert.Equal(identity.Version, spec.Dependencies[0].LibraryRange.VersionRange.MinVersion);
-        }
-
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -81,49 +47,9 @@ namespace NuGet.ProjectModel.Test
             }
 
             // Assert
-            Assert.Empty(spec.Dependencies);
             Assert.Equal(1, spec.TargetFrameworks[0].Dependencies.Length);
             Assert.Equal(identity.Id, spec.TargetFrameworks[0].Dependencies[0].LibraryRange.Name);
             Assert.Equal(identity.Version, spec.TargetFrameworks[0].Dependencies[0].LibraryRange.VersionRange.MinVersion);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void AddOrUpdateDependency_WithExistingGenericPackageDependencies_UpdatesOnlyFrameworksWherePackageExists(bool usePackageDependency)
-        {
-            var dependency = new LibraryDependency
-            {
-                LibraryRange = new LibraryRange("NuGet.Versioning", new VersionRange(new NuGetVersion("1.0.0")), LibraryDependencyTarget.Package),
-            };
-
-            // Arrange
-            var spec = new PackageSpec(new[]
-            {
-                new TargetFrameworkInformation
-                {
-                    FrameworkName = FrameworkConstants.CommonFrameworks.Net45
-                }
-            });
-            spec.Dependencies.Add(dependency);
-            var identity = new PackageIdentity("NuGet.Versioning", new NuGetVersion("2.0.0"));
-            var packageDependency = new PackageDependency(identity.Id, new VersionRange(identity.Version));
-
-            // Act
-            if (usePackageDependency)
-            {
-                PackageSpecOperations.AddOrUpdateDependency(spec, packageDependency);
-            }
-            else
-            {
-                PackageSpecOperations.AddOrUpdateDependency(spec, identity);
-            }
-
-            // Assert
-            spec.Dependencies.Should().HaveCount(1);
-            spec.TargetFrameworks[0].Dependencies.Should().BeEmpty();
-            Assert.Equal(identity.Id, spec.Dependencies[0].LibraryRange.Name);
-            Assert.Equal(identity.Version, spec.Dependencies[0].LibraryRange.VersionRange.MinVersion);
         }
 
         [Theory]
@@ -164,7 +90,6 @@ namespace NuGet.ProjectModel.Test
             }
 
             // Assert
-            Assert.Empty(spec.Dependencies);
             Assert.Equal(1, spec.TargetFrameworks[0].Dependencies.Length);
             Assert.Equal(identity.Id, spec.TargetFrameworks[0].Dependencies[0].LibraryRange.Name);
             Assert.Equal(identity.Version, spec.TargetFrameworks[0].Dependencies[0].LibraryRange.VersionRange.MinVersion);
@@ -215,8 +140,6 @@ namespace NuGet.ProjectModel.Test
             }
 
             // Assert
-            Assert.Empty(spec.Dependencies);
-
             Assert.Equal(1, spec.TargetFrameworks[0].Dependencies.Length);
             Assert.Equal("nuget.versioning", spec.TargetFrameworks[0].Dependencies[0].LibraryRange.Name);
             Assert.Equal(
@@ -281,8 +204,6 @@ namespace NuGet.ProjectModel.Test
 
 
             // Assert
-            Assert.Empty(spec.Dependencies);
-
             Assert.Empty(spec.TargetFrameworks[0].Dependencies);
 
             Assert.Equal(1, spec.TargetFrameworks[1].Dependencies.Length);
@@ -342,8 +263,6 @@ namespace NuGet.ProjectModel.Test
             }
 
             // Assert
-            Assert.Empty(spec.Dependencies);
-
             Assert.Empty(spec.TargetFrameworks[0].Dependencies);
 
             Assert.Equal(1, spec.TargetFrameworks[1].Dependencies.Length);
@@ -464,8 +383,6 @@ namespace NuGet.ProjectModel.Test
             }
 
             // Assert
-            Assert.Empty(spec.Dependencies);
-
             Assert.Empty(spec.TargetFrameworks[0].Dependencies);
 
             Assert.Equal(1, spec.TargetFrameworks[1].Dependencies.Length);
@@ -506,21 +423,12 @@ namespace NuGet.ProjectModel.Test
                 FrameworkName = FrameworkConstants.CommonFrameworks.NetStandard16
             };
             var spec = new PackageSpec(new[] { frameworkA, frameworkB });
-            spec.Dependencies.Add(new LibraryDependency
-            {
-                LibraryRange = new LibraryRange
-                {
-                    Name = "NuGet.VERSIONING",
-                    VersionRange = new VersionRange(new NuGetVersion("0.7.0"))
-                }
-            });
             var id = "NuGet.Versioning";
 
             // Act
             PackageSpecOperations.RemoveDependency(spec, id);
 
             // Assert
-            Assert.Empty(spec.Dependencies);
             Assert.Empty(spec.TargetFrameworks[0].Dependencies);
             Assert.Empty(spec.TargetFrameworks[1].Dependencies);
         }
@@ -542,32 +450,6 @@ namespace NuGet.ProjectModel.Test
                 FrameworkName = FrameworkConstants.CommonFrameworks.Net45
             };
             var spec = new PackageSpec(new[] { framework });
-            var id = "NuGet.Versioning";
-
-            // Act
-            var actual = PackageSpecOperations.HasPackage(spec, id);
-
-            // Assert
-            Assert.True(actual);
-        }
-
-        [Fact]
-        public void HasPackage_ReturnsTrueWhenIdIsForAllFrameworks()
-        {
-            // Arrange
-            var framework = new TargetFrameworkInformation
-            {
-                FrameworkName = FrameworkConstants.CommonFrameworks.Net45
-            };
-            var spec = new PackageSpec(new[] { framework });
-            spec.Dependencies.Add(new LibraryDependency
-            {
-                LibraryRange = new LibraryRange
-                {
-                    Name = "nuget.versioning",
-                    VersionRange = new VersionRange(new NuGetVersion("0.9.0"))
-                }
-            });
             var id = "NuGet.Versioning";
 
             // Act

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
@@ -60,7 +60,7 @@ namespace NuGet.ProjectModel.Test
         [InlineData("ModifyRestoreMetadata", true)]
         [InlineData("ModifyVersion", true)]
         [InlineData("ModifyRuntimeGraph", true)]
-        //[InlineData("ModifyRestoreSettings", true)] = Not really included in the equals and hash code comparisons
+        [InlineData("ModifyRestoreSettings", false)]
         public void PackageSpecCloneTest(string methodName, bool validateJson)
         {
             // Arrange
@@ -81,17 +81,23 @@ namespace NuGet.ProjectModel.Test
             methodInfo.Invoke(null, new object[] { packageSpec });
 
             // Assert
-            Assert.NotEqual(packageSpec, clonedPackageSpec);
-
             if (validateJson)
             {
+                Assert.NotEqual(packageSpec, clonedPackageSpec);
+
                 originalJObject = packageSpec.ToJObject();
                 clonedJObject = clonedPackageSpec.ToJObject();
 
                 Assert.NotEqual(originalJObject.ToString(), clonedJObject.ToString());
             }
+            else
+            {
+                Assert.Equal(packageSpec, clonedPackageSpec);
+
+            }
 
             Assert.False(object.ReferenceEquals(packageSpec, clonedPackageSpec));
+
         }
 
         public class PackageSpecModify

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
@@ -59,7 +59,6 @@ namespace NuGet.ProjectModel.Test
         [InlineData("ModifyOriginalTargetFrameworkInformationEdit", true)]
         [InlineData("ModifyRestoreMetadata", true)]
         [InlineData("ModifyVersion", true)]
-        [InlineData("ModifyDependencies", true)]
         [InlineData("ModifyRuntimeGraph", true)]
         //[InlineData("ModifyRestoreSettings", true)] = Not really included in the equals and hash code comparisons
         public void PackageSpecCloneTest(string methodName, bool validateJson)

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
@@ -43,7 +42,6 @@ namespace NuGet.ProjectModel.Test
             packageSpec.FilePath = "FilePath";
             packageSpec.Name = "Name";
             packageSpec.Version = new NuGetVersion("1.0.0");
-            packageSpec.Dependencies = new List<LibraryDependency>() { CreateLibraryDependency(), CreateLibraryDependency() };
             packageSpec.RuntimeGraph = CreateRuntimeGraph();
             packageSpec.RestoreSettings = CreateProjectRestoreSettings();
             return packageSpec;
@@ -121,10 +119,6 @@ namespace NuGet.ProjectModel.Test
                 packageSpec.Version = new NuGetVersion("2.0.0");
             }
 
-            public static void ModifyDependencies(PackageSpec packageSpec)
-            {
-                packageSpec.Dependencies.Add(CreateLibraryDependency());
-            }
             public static void ModifyRuntimeGraph(PackageSpec packageSpec)
             {
                 packageSpec.RuntimeGraph.Supports["CompatibilityProfile"].RestoreContexts.Add(CreateFrameworkRuntimePair(rid: "win10-x64"));
@@ -728,46 +722,6 @@ namespace NuGet.ProjectModel.Test
             };
 
             leftSide.Should().Be(rightSide);
-        }
-
-        [Theory]
-        [InlineData("a", "a", true)]
-        [InlineData("b;a", "a;b", true)]
-        [InlineData("A;b", "a;B", true)]
-        [InlineData("a;b;c", "c;a;B", true)]
-        [InlineData("a;b;c;d", "c;a;b", false)]
-        public void PackageSpec_Equals_WithDependencies(string left, string right, bool expected)
-        {
-            var leftSide = new PackageSpec(new List<TargetFrameworkInformation>())
-            {
-                Dependencies = left.Split(';').Select(e =>
-                    new LibraryDependency()
-                    {
-                        LibraryRange = new LibraryRange(e, VersionRange.Parse("1.0.0"), LibraryDependencyTarget.Package)
-                    }
-                    )
-                .ToList()
-            };
-
-            var rightSide = new PackageSpec(new List<TargetFrameworkInformation>())
-            {
-                Dependencies = right.Split(';').Select(e =>
-                    new LibraryDependency()
-                    {
-                        LibraryRange = new LibraryRange(e, VersionRange.Parse("1.0.0"), LibraryDependencyTarget.Package)
-                    }
-                    )
-                .ToList()
-            };
-            if (expected)
-            {
-                leftSide.Should().Be(rightSide);
-            }
-            else
-            {
-                leftSide.Should().NotBe(rightSide);
-
-            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -27,12 +27,6 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                    ""dependencies"": {
-                        ""b"": {
-                            ""version"": ""[1.0.0, )"",
-                            ""autoReferenced"": true
-                        }
-                    },
                   ""frameworks"": {
                     ""net46"": {
                         ""dependencies"": {
@@ -97,14 +91,15 @@ namespace NuGet.ProjectModel.Test
             // Arrange
             var json = @"{
   ""version"": ""1.2.3"",
-  ""dependencies"": {
-    ""packageA"": {
-      ""suppressParent"": ""All"",
-      ""target"": ""Project""
-    }
-  },
   ""frameworks"": {
-    ""net46"": {}
+    ""net46"": {
+        ""dependencies"": {
+            ""packageA"": {
+                ""suppressParent"": ""All"",
+                ""target"": ""Project""
+            }
+        }
+    }
   }
 }";
             // Act & Assert
@@ -199,7 +194,7 @@ namespace NuGet.ProjectModel.Test
             var actualJson = GetJsonString(packageSpec);
 
             // Assert
-            Assert.Equal(expectedJson, actualJson);
+            actualJson.Should().Be(expectedJson);
         }
 
         [Fact]
@@ -211,7 +206,7 @@ namespace NuGet.ProjectModel.Test
             var actualJson = GetJsonString(packageSpec);
 
             // Assert
-            expectedJson.Should().Be(actualJson);
+            actualJson.Should().Be(expectedJson);
         }
 
         [Fact]
@@ -351,14 +346,6 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                    ""dependencies"": {
-                        ""b"": {
-                                ""version"": ""[1.0.0, )"",
-                        },
-                        ""a"": {
-                            ""version"": ""[1.0.0, )"",
-                        }
-                    },
                   ""frameworks"": {
                     ""net46"": {
                         ""dependencies"": {
@@ -386,10 +373,6 @@ namespace NuGet.ProjectModel.Test
                 }";
 
             var expectedJson = @"{
-                  ""dependencies"": {
-                    ""a"": ""[1.0.0, )"",
-                    ""b"": ""[1.0.0, )""
-                  },
                   ""frameworks"": {
                     ""net46"": {
                       ""dependencies"": {
@@ -420,11 +403,6 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                    ""dependencies"": {
-                        ""a"": {
-                                ""version"": ""1.0.0"",
-                        },
-                    },
                   ""frameworks"": {
                     ""net46"": {
                         ""dependencies"": {
@@ -440,9 +418,6 @@ namespace NuGet.ProjectModel.Test
                 }";
 
             var expectedJson = @"{
-                  ""dependencies"": {
-                    ""a"": ""[1.0.0, )""
-                  },
                   ""frameworks"": {
                     ""net46"": {
                       ""dependencies"": {
@@ -881,14 +856,14 @@ namespace NuGet.ProjectModel.Test
 
             packageSpec.TargetFrameworks.Add(new TargetFrameworkInformation()
             {
-                Dependencies = [],
+                Dependencies = [libraryDependency, libraryDependencyWithNoWarnGlobal],
                 FrameworkName = nugetFramework,
                 Imports = [nugetFramework],
             });
 
             packageSpec.TargetFrameworks.Add(new TargetFrameworkInformation()
             {
-                Dependencies = [libraryDependencyWithNoWarn],
+                Dependencies = [libraryDependencyWithNoWarn, libraryDependency, libraryDependencyWithNoWarnGlobal],
                 FrameworkName = nugetFrameworkWithNoWarn,
                 Imports = [nugetFrameworkWithNoWarn],
                 Warn = true

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -826,7 +826,6 @@ namespace NuGet.ProjectModel.Test
 
             var packageSpec = new PackageSpec()
             {
-                Dependencies = new List<LibraryDependency>() { libraryDependency, libraryDependencyWithNoWarnGlobal },
                 Name = "name",
                 FilePath = "filePath",
                 RestoreMetadata = new ProjectRestoreMetadata()

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJson.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJson.json
@@ -34,30 +34,44 @@
       }
     }
   },
-  "dependencies": {
-    "library": {
-      "include": "Build",
-      "target": "Package",
-      "version": "[1.2.3, )"
-    },
-    "libraryRangeWithNoWarnGlobal": {
-      "include": "Build",
-      "target": "Package",
-      "version": "[1.2.3, )",
-      "noWarn": [
-        "NU1500",
-        "NU1608"
-      ]
-    }
-  },
   "frameworks": {
     "frameworkidentifier123-frameworkprofile": {
+      "dependencies": {
+        "library": {
+          "include": "Build",
+          "target": "Package",
+          "version": "[1.2.3, )"
+        },
+        "libraryRangeWithNoWarnGlobal": {
+          "include": "Build",
+          "target": "Package",
+          "version": "[1.2.3, )",
+          "noWarn": [
+            "NU1500",
+            "NU1608"
+          ]
+        }
+      },
       "imports": [
         "frameworkidentifier123-frameworkprofile"
       ]
     },
     "frameworkidentifierwithnowarn125-frameworkprofilewithnowarn": {
       "dependencies": {
+        "library": {
+          "include": "Build",
+          "target": "Package",
+          "version": "[1.2.3, )"
+        },
+        "libraryRangeWithNoWarnGlobal": {
+          "include": "Build",
+          "target": "Package",
+          "version": "[1.2.3, )",
+          "noWarn": [
+            "NU1500",
+            "NU1608"
+          ]
+        },
         "libraryWithNoWarn": {
           "include": "Build",
           "target": "Package",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/nuget/home/issues/14446

## Description

Remove PackageSpec.Dependencies. 

This is unused in PackageReference. 
The clean-up allows us to keep slimming down the PackageSpec and simplify the restore implementation. 
This is just another step towards that.

Note that this change requires https://github.com/NuGet/Client.Engineering/issues/3200 to be done. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
