### PR TITLE
Build.ps1 should have inner-loop defaults

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ NuGet members may contribute directly to the main remote.
 
 ### Notable `build.ps1` switches
 
-- `-RunUnitTest` - skips running unit tests.
+- `-RunUnitTests` - Runs unit tests after building.
 - `-Clean` - cleans build artifacts without deleting files that configure.ps1 creates.
 
 > Reveal all script parameters and switches by running

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,11 +79,11 @@ NuGet members may contribute directly to the main remote.
 
 1. Build with
 
-    `.\build.ps1 -SkipUnitTest`
+    `.\build.ps1`
 
    Or Build and Unit test with
 
-   `.\build.ps1`
+   `.\build.ps1 -RunUnitTests`
 
     > Note: You have to to run .\configure.ps1 and .\build.ps1 at least once in order for your build to succeed.
 
@@ -104,8 +104,8 @@ NuGet members may contribute directly to the main remote.
 
 ### Notable `build.ps1` switches
 
-- `-SkipUnitTest` - skips running unit tests.
-- `-Fast` - runs minimal incremental build. Skips end-to-end packaging step.
+- `-RunUnitTest` - skips running unit tests.
+- `-Clean` - cleans build artifacts without deleting files that configure.ps1 creates.
 
 > Reveal all script parameters and switches by running
   Get-Help .\build.ps1 -detailed

--- a/build.ps1
+++ b/build.ps1
@@ -11,8 +11,8 @@ Release label to use for package and assemblies versioning (zlocal by default)
 .PARAMETER BuildNumber
 Build number to use for package and assemblies versioning (auto-generated if not provided)
 
-.PARAMETER Fast
-Runs minimal incremental build. Skips end-to-end packaging step.
+.PARAMETER Clean
+Cleans output artifacts before building
 
 .PARAMETER CI
 Indicates the build script is invoked from CI
@@ -22,6 +22,12 @@ Indicates whether to create the end to end package.
 
 .PARAMETER SkipDelaySigning
 Indicates whether to skip strong name signing.  By default assemblies will be delay signed and require strong name validation exclusions.
+
+.PARAMETER RunUnitTests
+Indicates whether to run unit tests after building
+
+.PARAMETER Pack
+Creates NuGet's packages after building
 
 .EXAMPLE
 .\build.ps1
@@ -46,15 +52,16 @@ param (
     [Alias('n')]
     [int]$BuildNumber,
     [Alias('su')]
-    [switch]$SkipUnitTest,
+    [switch]$RunUnitTest,
     [Alias('f')]
-    [switch]$Fast,
+    [switch]$Clean,
     [switch]$CI,
     [switch]$PackageEndToEnd,
     [switch]$SkipDelaySigning,
     [switch]$Binlog,
     [switch]$IncludeApex,
-    [switch]$UpdateXlf
+    [switch]$UpdateXlf,
+    [switch]$Pack
 )
 
 . "$PSScriptRoot\build\common.ps1"
@@ -85,16 +92,20 @@ Invoke-BuildStep 'Cleaning artifacts' {
     Clear-Artifacts
     Clear-Nupkgs
 } `
--skip:$Fast `
+-skip:(-not $Clean) `
 -ev +BuildErrors
 
-if ($SkipUnitTest) {
-    $VSTarget = "BuildVS;Pack";
-    $VSMessage = "Running Build"
-}
-else {
+if ($RunUnitTest) {
     $VSTarget = "RunVS";
     $VSMessage = "Running Build, Pack, Core unit tests, and Unit tests";
+}
+else {
+    if ($Pack) {
+        $VSTarget = "BuildVS;Pack";
+    } else {
+        $VSTarget = "BuildVS";
+    }
+    $VSMessage = "Running Build"
 }
 
 $MSBuildExe = Get-MSBuildExe

--- a/build.ps1
+++ b/build.ps1
@@ -52,7 +52,7 @@ param (
     [Alias('n')]
     [int]$BuildNumber,
     [Alias('su')]
-    [switch]$RunUnitTest,
+    [switch]$RunUnitTests,
     [Alias('f')]
     [switch]$Clean,
     [switch]$CI,
@@ -95,7 +95,7 @@ Invoke-BuildStep 'Cleaning artifacts' {
 -skip:(-not $Clean) `
 -ev +BuildErrors
 
-if ($RunUnitTest) {
+if ($RunUnitTests) {
     $VSTarget = "RunVS";
     $VSMessage = "Running Build, Pack, Core unit tests, and Unit tests";
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14453

## Description

As the linked issue says, VSCode's GitHub Copilot in agent mode can run `.\build.ps1` in order to test if changes compile successfully.  It doesn't know to use `-Fast -SkipUnitTest` to make it faster, so optimize the inner-loop by making `.\build.ps1` compile only by default.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
