### PR TITLE
Account for project and package reference with the same name when adding a package reference

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
@@ -7,9 +7,10 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
+using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
-using static NuGet.CommandLine.XPlat.Commands.Package.Update.PackageUpdateCommandRunner;
+using NuGet.Versioning;
 
 namespace NuGet.CommandLine.XPlat.Commands.Package.Update;
 
@@ -60,11 +61,10 @@ internal interface IPackageUpdateIO
     /// is used by all target frameworks.
     /// </summary>
     /// <param name="updatedPackageSpec">The updated project specification containing target framework information.</param>
-    /// <param name="restorePreviewResult">The restore preview result containing resolved package information.</param>
     /// <param name="packageTfms">Target frameworks where the package is used.</param>
     /// <param name="packageDependency">Package dependency information.</param>
-    /// <param name="logger">Logger for the operation.</param>
-    void UpdatePackageReference(PackageSpec updatedPackageSpec, RestoreResult restorePreviewResult, List<NuGetFramework> packageTfms, PackageToUpdate packageDependency, ILogger logger);
+    /// <param name="resolvedVersion">The resolved package version.</param>
+    void UpdatePackageReference(PackageSpec updatedPackageSpec, PackageDependency packageDependency, List<NuGetFramework> packageTfms, NuGetVersion resolvedVersion);
 
     /// <summary>
     /// An opaque type, to aid in testing, representing the result of a restore operation.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
@@ -63,7 +63,8 @@ internal interface IPackageUpdateIO
     /// <param name="restorePreviewResult">The restore preview result containing resolved package information.</param>
     /// <param name="packageTfms">Target frameworks where the package is used.</param>
     /// <param name="packageDependency">Package dependency information.</param>
-    void UpdatePackageReference(PackageSpec updatedPackageSpec, RestoreResult restorePreviewResult, List<NuGetFramework> packageTfms, PackageToUpdate packageDependency);
+    /// <param name="logger">Logger for the operation.</param>
+    void UpdatePackageReference(PackageSpec updatedPackageSpec, RestoreResult restorePreviewResult, List<NuGetFramework> packageTfms, PackageToUpdate packageDependency, ILogger logger);
 
     /// <summary>
     /// An opaque type, to aid in testing, representing the result of a restore operation.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
@@ -7,10 +7,9 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
-using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
-using NuGet.Versioning;
+using static NuGet.CommandLine.XPlat.Commands.Package.Update.PackageUpdateCommandRunner;
 
 namespace NuGet.CommandLine.XPlat.Commands.Package.Update;
 
@@ -62,9 +61,10 @@ internal interface IPackageUpdateIO
     /// </summary>
     /// <param name="updatedPackageSpec">The updated project specification containing target framework information.</param>
     /// <param name="packageTfms">Target frameworks where the package is used.</param>
+    /// <param name="restorePreviewResult">The restore preview result containing resolved package information.</param>
     /// <param name="packageDependency">Package dependency information.</param>
-    /// <param name="resolvedVersion">The resolved package version.</param>
-    void UpdatePackageReference(PackageSpec updatedPackageSpec, PackageDependency packageDependency, List<NuGetFramework> packageTfms, NuGetVersion resolvedVersion);
+    /// <param name="logger">Logger for the operation.</param>
+    void UpdatePackageReference(PackageSpec updatedPackageSpec, RestoreResult restorePreviewResult, List<NuGetFramework> packageTfms, PackageToUpdate packageDependency, ILogger logger);
 
     /// <summary>
     /// An opaque type, to aid in testing, representing the result of a restore operation.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -111,7 +111,7 @@ internal static class PackageUpdateCommandRunner
         logger.LogInformation("");
 
         var updatedPackageSpec = updatedDgSpec.Projects[0];
-        packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageTfms!, packageToUpdate);
+        packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageTfms!, packageToUpdate, logger);
 
         // 5. Commit restore if everything successful
         await packageUpdateIO.CommitAsync(restorePreviewResult, CancellationToken.None);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -111,7 +111,6 @@ internal static class PackageUpdateCommandRunner
         logger.LogInformation("");
 
         var updatedPackageSpec = updatedDgSpec.Projects[0];
-
         packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageTfms!, packageToUpdate, logger);
 
         // 5. Commit restore if everything successful

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -98,12 +98,6 @@ internal static class PackageUpdateCommandRunner
         var updatedDgSpec = GetUpdatedDependencyGraphSpec(dgSpec, packageToUpdate);
         var restorePreviewResult = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(updatedDgSpec, sourceCacheContext, logger, cancellationToken);
 
-        if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms, packageToUpdate.Id, ((PackageUpdateIO.RestoreResult)restorePreviewResult).RestoreResultPair.Result, logger, out NuGetVersion resolvedVersion))
-        {
-            return ExitCodes.Error;
-        }
-
-
         if (!restorePreviewResult.Success)
         {
             logger.LogMinimal(Strings.PackageUpdate_PreviewRestoreFailed, ConsoleColor.Red);
@@ -118,8 +112,7 @@ internal static class PackageUpdateCommandRunner
 
         var updatedPackageSpec = updatedDgSpec.Projects[0];
 
-        PackageDependency packageDependency = new PackageDependency(packageToUpdate.Id, packageToUpdate.NewVersion);
-        packageUpdateIO.UpdatePackageReference(updatedPackageSpec, packageDependency, packageTfms!, resolvedVersion);
+        packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageTfms!, packageToUpdate, logger);
 
         // 5. Commit restore if everything successful
         await packageUpdateIO.CommitAsync(restorePreviewResult, CancellationToken.None);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -96,7 +96,13 @@ internal static class PackageUpdateCommandRunner
         // 3. Preview restore to validate changes
         logger.LogDebug(Strings.PackageUpdate_PreviewRestore);
         var updatedDgSpec = GetUpdatedDependencyGraphSpec(dgSpec, packageToUpdate);
-        var restorePreviewResult = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(updatedDgSpec, sourceCacheContext, logger, cancellationToken);
+        IPackageUpdateIO.RestoreResult restorePreviewResult = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(updatedDgSpec, sourceCacheContext, logger, cancellationToken);
+
+        if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms, packageToUpdate.Id, ((PackageUpdateIO.RestoreResult)restorePreviewResult).RestoreResultPair, logger, out NuGetVersion resolvedVersion))
+        {
+            return ExitCodes.Error;
+        }
+
 
         if (!restorePreviewResult.Success)
         {
@@ -111,7 +117,9 @@ internal static class PackageUpdateCommandRunner
         logger.LogInformation("");
 
         var updatedPackageSpec = updatedDgSpec.Projects[0];
-        packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageTfms!, packageToUpdate, logger);
+
+        PackageDependency packageDependency = new PackageDependency(packageToUpdate.Id, packageToUpdate.NewVersion);
+        packageUpdateIO.UpdatePackageReference(updatedPackageSpec, packageDependency, packageTfms!, resolvedVersion);
 
         // 5. Commit restore if everything successful
         await packageUpdateIO.CommitAsync(restorePreviewResult, CancellationToken.None);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -96,9 +96,9 @@ internal static class PackageUpdateCommandRunner
         // 3. Preview restore to validate changes
         logger.LogDebug(Strings.PackageUpdate_PreviewRestore);
         var updatedDgSpec = GetUpdatedDependencyGraphSpec(dgSpec, packageToUpdate);
-        IPackageUpdateIO.RestoreResult restorePreviewResult = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(updatedDgSpec, sourceCacheContext, logger, cancellationToken);
+        var restorePreviewResult = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(updatedDgSpec, sourceCacheContext, logger, cancellationToken);
 
-        if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms, packageToUpdate.Id, ((PackageUpdateIO.RestoreResult)restorePreviewResult).RestoreResultPair, logger, out NuGetVersion resolvedVersion))
+        if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms, packageToUpdate.Id, ((PackageUpdateIO.RestoreResult)restorePreviewResult).RestoreResultPair.Result, logger, out NuGetVersion resolvedVersion))
         {
             return ExitCodes.Error;
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -16,7 +16,6 @@ using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
-using static NuGet.CommandLine.XPlat.Commands.Package.Update.PackageUpdateCommandRunner;
 
 namespace NuGet.CommandLine.XPlat.Commands.Package.Update;
 
@@ -138,15 +137,8 @@ internal class PackageUpdateIO : IPackageUpdateIO
         await RestoreRunner.CommitAsync(((RestoreResult)restorePreviewResult).RestoreResultPair, CancellationToken.None);
     }
 
-    public void UpdatePackageReference(PackageSpec updatedPackageSpec, IPackageUpdateIO.RestoreResult restorePreviewResult, List<NuGetFramework> packageTfms, PackageToUpdate packageToUpdate, ILogger logger)
+    public void UpdatePackageReference(PackageSpec updatedPackageSpec, PackageDependency packageDependency, List<NuGetFramework> packageTfms, NuGetVersion resolvedVersion)
     {
-        PackageDependency packageDependency = new PackageDependency(packageToUpdate.Id, packageToUpdate.NewVersion);
-
-        if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms, packageDependency, ((RestoreResult)restorePreviewResult).RestoreResultPair, logger, out NuGetVersion resolvedVersion))
-        {
-            return;
-        }
-
         // Generate the LibraryDependency using the same logic as AddPackageReferenceCommandRunner
         var libraryDependency = AddPackageReferenceCommandRunner.GenerateLibraryDependency(
             updatedPackageSpec,
@@ -170,7 +162,7 @@ internal class PackageUpdateIO : IPackageUpdateIO
         }
     }
 
-    private class RestoreResult : IPackageUpdateIO.RestoreResult
+    internal class RestoreResult : IPackageUpdateIO.RestoreResult
     {
         internal required RestoreResultPair RestoreResultPair { get; init; }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -144,10 +144,11 @@ internal class PackageUpdateIO : IPackageUpdateIO
 
         if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms,
             packageDependency.Id,
-            ((RestoreResult)restorePreviewResult).RestoreResultPair.Result, NullLogger.Instance, out NuGetVersion resolvedVersion))
+            ((RestoreResult)restorePreviewResult).RestoreResultPair.Result, logger, out NuGetVersion resolvedVersion))
         {
             return;
         }
+
         // Generate the LibraryDependency using the same logic as AddPackageReferenceCommandRunner
         var libraryDependency = AddPackageReferenceCommandRunner.GenerateLibraryDependency(
             updatedPackageSpec,
@@ -171,7 +172,7 @@ internal class PackageUpdateIO : IPackageUpdateIO
         }
     }
 
-    internal class RestoreResult : IPackageUpdateIO.RestoreResult
+    private class RestoreResult : IPackageUpdateIO.RestoreResult
     {
         internal required RestoreResultPair RestoreResultPair { get; init; }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -16,6 +16,7 @@ using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using static NuGet.CommandLine.XPlat.Commands.Package.Update.PackageUpdateCommandRunner;
 
 namespace NuGet.CommandLine.XPlat.Commands.Package.Update;
 
@@ -137,8 +138,16 @@ internal class PackageUpdateIO : IPackageUpdateIO
         await RestoreRunner.CommitAsync(((RestoreResult)restorePreviewResult).RestoreResultPair, CancellationToken.None);
     }
 
-    public void UpdatePackageReference(PackageSpec updatedPackageSpec, PackageDependency packageDependency, List<NuGetFramework> packageTfms, NuGetVersion resolvedVersion)
+    public void UpdatePackageReference(PackageSpec updatedPackageSpec, IPackageUpdateIO.RestoreResult restorePreviewResult, List<NuGetFramework> packageTfms, PackageToUpdate packageToUpdate, ILogger logger)
     {
+        PackageDependency packageDependency = new PackageDependency(packageToUpdate.Id, packageToUpdate.NewVersion);
+
+        if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms,
+            packageDependency.Id,
+            ((RestoreResult)restorePreviewResult).RestoreResultPair.Result, NullLogger.Instance, out NuGetVersion resolvedVersion))
+        {
+            return;
+        }
         // Generate the LibraryDependency using the same logic as AddPackageReferenceCommandRunner
         var libraryDependency = AddPackageReferenceCommandRunner.GenerateLibraryDependency(
             updatedPackageSpec,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -147,7 +147,8 @@ internal class PackageUpdateIO : IPackageUpdateIO
             customPackagesPath: null,
             ((RestoreResult)restorePreviewResult).RestoreResultPair,
             packageTfms,
-            packageDependency);
+            packageDependency,
+            NullLogger.Instance);
 
         // Determine whether to add package reference conditionally or unconditionally
         if (packageTfms.Count == updatedPackageSpec.TargetFrameworks.Count)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.CommandLine.XPlat.Utility;
@@ -15,6 +16,7 @@ using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 using static NuGet.CommandLine.XPlat.Commands.Package.Update.PackageUpdateCommandRunner;
 
 namespace NuGet.CommandLine.XPlat.Commands.Package.Update;
@@ -141,14 +143,17 @@ internal class PackageUpdateIO : IPackageUpdateIO
     {
         PackageDependency packageDependency = new PackageDependency(packageToUpdate.Id, packageToUpdate.NewVersion);
 
+        if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms, packageDependency, ((RestoreResult)restorePreviewResult).RestoreResultPair, NullLogger.Instance, out NuGetVersion resolvedVersion))
+        {
+            return;
+        }
+
         // Generate the LibraryDependency using the same logic as AddPackageReferenceCommandRunner
         var libraryDependency = AddPackageReferenceCommandRunner.GenerateLibraryDependency(
             updatedPackageSpec,
             customPackagesPath: null,
-            ((RestoreResult)restorePreviewResult).RestoreResultPair,
-            packageTfms,
             packageDependency,
-            NullLogger.Instance);
+            resolvedVersion);
 
         // Determine whether to add package reference conditionally or unconditionally
         if (packageTfms.Count == updatedPackageSpec.TargetFrameworks.Count)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.CommandLine.XPlat.Utility;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -138,11 +138,11 @@ internal class PackageUpdateIO : IPackageUpdateIO
         await RestoreRunner.CommitAsync(((RestoreResult)restorePreviewResult).RestoreResultPair, CancellationToken.None);
     }
 
-    public void UpdatePackageReference(PackageSpec updatedPackageSpec, IPackageUpdateIO.RestoreResult restorePreviewResult, List<NuGetFramework> packageTfms, PackageToUpdate packageToUpdate)
+    public void UpdatePackageReference(PackageSpec updatedPackageSpec, IPackageUpdateIO.RestoreResult restorePreviewResult, List<NuGetFramework> packageTfms, PackageToUpdate packageToUpdate, ILogger logger)
     {
         PackageDependency packageDependency = new PackageDependency(packageToUpdate.Id, packageToUpdate.NewVersion);
 
-        if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms, packageDependency, ((RestoreResult)restorePreviewResult).RestoreResultPair, NullLogger.Instance, out NuGetVersion resolvedVersion))
+        if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms, packageDependency, ((RestoreResult)restorePreviewResult).RestoreResultPair, logger, out NuGetVersion resolvedVersion))
         {
             return;
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -213,7 +213,6 @@ namespace NuGet.CommandLine.XPlat
                 compatibleFrameworks.IntersectWith(userSpecifiedFrameworkSet);
             }
 
-            // 5. Write to Project
             if (compatibleFrameworks.Count == 0)
             {
                 // Package is compatible with none of the project TFMs
@@ -226,15 +225,18 @@ namespace NuGet.CommandLine.XPlat
 
                 return 1;
             }
+
+            // 5. Write to Project
+
+            if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency.Id, restorePreviewResult.Result, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
+            {
+                return 1;
+            }
+
             // Ignore the graphs with RID
-            else if (compatibleFrameworks.Count ==
+            if (compatibleFrameworks.Count ==
                      restorePreviewResult.Result.CompatibilityCheckResults.Count(r => string.IsNullOrEmpty(r.Graph.RuntimeIdentifier)))
             {
-                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency.Id, restorePreviewResult.Result, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
-                {
-                    return 1;
-                }
-
                 // Package is compatible with all the project TFMs
                 // Add an unconditional package reference to the project
                 packageReferenceArgs.Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
@@ -249,11 +251,6 @@ namespace NuGet.CommandLine.XPlat
             }
             else
             {
-                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency.Id, restorePreviewResult.Result, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
-                {
-                    return 1;
-                }
-
                 // Package is compatible with some of the project TFMs
                 // Add conditional package references to the project for the compatible TFMs
                 packageReferenceArgs.Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -230,7 +230,7 @@ namespace NuGet.CommandLine.XPlat
             else if (compatibleFrameworks.Count ==
                      restorePreviewResult.Result.CompatibilityCheckResults.Count(r => string.IsNullOrEmpty(r.Graph.RuntimeIdentifier)))
             {
-                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency, restorePreviewResult, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
+                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency.Id, restorePreviewResult, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
                 {
                     return 1;
                 }
@@ -249,7 +249,7 @@ namespace NuGet.CommandLine.XPlat
             }
             else
             {
-                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency, restorePreviewResult, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
+                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency.Id, restorePreviewResult, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
                 {
                     return 1;
                 }
@@ -280,16 +280,16 @@ namespace NuGet.CommandLine.XPlat
             return 0;
         }
 
-        internal static bool TryFindResolvedVersion(List<NuGetFramework> userSpecifiedFrameworks, PackageDependency packageDependency, RestoreResultPair restorePreviewResult, ILogger logger, out NuGetVersion resolvedVersion)
+        internal static bool TryFindResolvedVersion(List<NuGetFramework> userSpecifiedFrameworks, string packageId, RestoreResultPair restorePreviewResult, ILogger logger, out NuGetVersion resolvedVersion)
         {
             // get the package resolved version from restore preview result
-            (LibraryType libraryType, resolvedVersion) = GetPackageVersionFromRestoreResult(restorePreviewResult, packageDependency.Id, userSpecifiedFrameworks);
+            (LibraryType libraryType, resolvedVersion) = GetPackageVersionFromRestoreResult(restorePreviewResult, packageId, userSpecifiedFrameworks);
 
             if (libraryType == LibraryType.Unresolved)
             {
                 logger.LogError(string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_AddPkgUnresolved,
-                    packageDependency.Id));
+                    packageId));
                 return false;
             }
 
@@ -299,7 +299,7 @@ namespace NuGet.CommandLine.XPlat
                 // If the package is a project or external project, we cannot add it as a package reference.
                 logger.LogError(string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_AddPkgProjectReference,
-                    packageDependency.Id));
+                    packageId));
                 return false;
             }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -230,7 +230,7 @@ namespace NuGet.CommandLine.XPlat
             else if (compatibleFrameworks.Count ==
                      restorePreviewResult.Result.CompatibilityCheckResults.Count(r => string.IsNullOrEmpty(r.Graph.RuntimeIdentifier)))
             {
-                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency.Id, restorePreviewResult, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
+                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency.Id, restorePreviewResult.Result, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
                 {
                     return 1;
                 }
@@ -249,7 +249,7 @@ namespace NuGet.CommandLine.XPlat
             }
             else
             {
-                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency.Id, restorePreviewResult, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
+                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency.Id, restorePreviewResult.Result, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
                 {
                     return 1;
                 }
@@ -280,10 +280,10 @@ namespace NuGet.CommandLine.XPlat
             return 0;
         }
 
-        internal static bool TryFindResolvedVersion(List<NuGetFramework> userSpecifiedFrameworks, string packageId, RestoreResultPair restorePreviewResult, ILogger logger, out NuGetVersion resolvedVersion)
+        internal static bool TryFindResolvedVersion(List<NuGetFramework> userSpecifiedFrameworks, string packageId, RestoreResult restoreResult, ILogger logger, out NuGetVersion resolvedVersion)
         {
             // get the package resolved version from restore preview result
-            (LibraryType libraryType, resolvedVersion) = GetPackageVersionFromRestoreResult(restorePreviewResult, packageId, userSpecifiedFrameworks);
+            (LibraryType libraryType, resolvedVersion) = GetPackageVersionFromRestoreResult(restoreResult, packageId, userSpecifiedFrameworks);
 
             if (libraryType == LibraryType.Unresolved)
             {
@@ -454,13 +454,12 @@ namespace NuGet.CommandLine.XPlat
             return spec;
         }
 
-        internal static (LibraryType, NuGetVersion) GetPackageVersionFromRestoreResult(RestoreResultPair restorePreviewResult,
+        internal static (LibraryType, NuGetVersion) GetPackageVersionFromRestoreResult(RestoreResult restoreResult,
             string packageId,
             List<NuGetFramework> userSpecifiedFrameworks)
         {
             // Get the restore graphs from the restore result
-            var restoreGraphs = restorePreviewResult
-                .Result
+            var restoreGraphs = restoreResult
                 .RestoreGraphs;
 
             if (userSpecifiedFrameworks.Count > 1)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -238,7 +238,7 @@ namespace NuGet.CommandLine.XPlat
                     packageReferenceArgs.ProjectPath));
 
                 // generate a library dependency with all the metadata like Include, Exlude and SuppressParent
-                var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs.PackageDirectory, restorePreviewResult, userSpecifiedFrameworks, packageDependency);
+                var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs.PackageDirectory, restorePreviewResult, userSpecifiedFrameworks, packageDependency, packageReferenceArgs.Logger);
 
                 msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency, packageReferenceArgs.NoVersion);
             }
@@ -256,7 +256,7 @@ namespace NuGet.CommandLine.XPlat
                     .Where(originalFramework => originalFramework != null);
 
                 // generate a library dependency with all the metadata like Include, Exlude and SuppressParent
-                var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs.PackageDirectory, restorePreviewResult, userSpecifiedFrameworks, packageDependency);
+                var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs.PackageDirectory, restorePreviewResult, userSpecifiedFrameworks, packageDependency, packageReferenceArgs.Logger);
 
                 msBuild.AddPackageReferencePerTFM(packageReferenceArgs.ProjectPath,
                     libraryDependency,
@@ -282,30 +282,36 @@ namespace NuGet.CommandLine.XPlat
             return await AddPackageCommandUtility.GetLatestVersionFromSourcesAsync(sources, logger, packageId, prerelease, CancellationToken.None);
         }
 
+        /// <summary>
+        /// Returns the library dependency for the package reference to be added if appropriate. May return null if the package is not compatible with the project or if it is a project reference.
+        /// </summary>
         internal static LibraryDependency GenerateLibraryDependency(
             PackageSpec project,
             string customPackagesPath,
             RestoreResultPair restorePreviewResult,
             List<NuGetFramework> userSpecifiedFrameworks,
-            PackageDependency packageDependency)
+            PackageDependency packageDependency,
+            ILogger logger)
         {
             // get the package resolved version from restore preview result
             (LibraryType libraryType, NuGetVersion resolvedVersion) = GetPackageVersionFromRestoreResult(restorePreviewResult, packageDependency.Id, userSpecifiedFrameworks);
 
             if (libraryType == LibraryType.Unresolved)
             {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
+                logger.LogError(string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_AddPkgUnresolved,
                     packageDependency.Id));
+                return null;
             }
 
             if (libraryType == LibraryType.Project ||
                libraryType == LibraryType.ExternalProject)
             {
                 // If the package is a project or external project, we cannot add it as a package reference.
-                throw new CommandException(string.Format(CultureInfo.CurrentCulture,
+                logger.LogError(string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_AddPkgProjectReference,
                     packageDependency.Id));
+                return null;
             }
 
             // correct package version to write in project file

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -230,6 +230,11 @@ namespace NuGet.CommandLine.XPlat
             else if (compatibleFrameworks.Count ==
                      restorePreviewResult.Result.CompatibilityCheckResults.Count(r => string.IsNullOrEmpty(r.Graph.RuntimeIdentifier)))
             {
+                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency, restorePreviewResult, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
+                {
+                    return 1;
+                }
+
                 // Package is compatible with all the project TFMs
                 // Add an unconditional package reference to the project
                 packageReferenceArgs.Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
@@ -237,13 +242,18 @@ namespace NuGet.CommandLine.XPlat
                     packageReferenceArgs.PackageId,
                     packageReferenceArgs.ProjectPath));
 
-                // generate a library dependency with all the metadata like Include, Exlude and SuppressParent
-                var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs.PackageDirectory, restorePreviewResult, userSpecifiedFrameworks, packageDependency, packageReferenceArgs.Logger);
+                // generate a library dependency with all the metadata like Include, Exclude and SuppressParent
+                var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs.PackageDirectory, packageDependency, resolvedVersion);
 
                 msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency, packageReferenceArgs.NoVersion);
             }
             else
             {
+                if (!TryFindResolvedVersion(userSpecifiedFrameworks, packageDependency, restorePreviewResult, packageReferenceArgs.Logger, out NuGetVersion resolvedVersion))
+                {
+                    return 1;
+                }
+
                 // Package is compatible with some of the project TFMs
                 // Add conditional package references to the project for the compatible TFMs
                 packageReferenceArgs.Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
@@ -256,7 +266,7 @@ namespace NuGet.CommandLine.XPlat
                     .Where(originalFramework => originalFramework != null);
 
                 // generate a library dependency with all the metadata like Include, Exlude and SuppressParent
-                var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs.PackageDirectory, restorePreviewResult, userSpecifiedFrameworks, packageDependency, packageReferenceArgs.Logger);
+                var libraryDependency = GenerateLibraryDependency(updatedPackageSpec, packageReferenceArgs.PackageDirectory, packageDependency, resolvedVersion);
 
                 msBuild.AddPackageReferencePerTFM(packageReferenceArgs.ProjectPath,
                     libraryDependency,
@@ -268,6 +278,32 @@ namespace NuGet.CommandLine.XPlat
             await RestoreRunner.CommitAsync(restorePreviewResult, CancellationToken.None);
 
             return 0;
+        }
+
+        internal static bool TryFindResolvedVersion(List<NuGetFramework> userSpecifiedFrameworks, PackageDependency packageDependency, RestoreResultPair restorePreviewResult, ILogger logger, out NuGetVersion resolvedVersion)
+        {
+            // get the package resolved version from restore preview result
+            (LibraryType libraryType, resolvedVersion) = GetPackageVersionFromRestoreResult(restorePreviewResult, packageDependency.Id, userSpecifiedFrameworks);
+
+            if (libraryType == LibraryType.Unresolved)
+            {
+                logger.LogError(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Error_AddPkgUnresolved,
+                    packageDependency.Id));
+                return false;
+            }
+
+            if (libraryType == LibraryType.Project ||
+               libraryType == LibraryType.ExternalProject)
+            {
+                // If the package is a project or external project, we cannot add it as a package reference.
+                logger.LogError(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Error_AddPkgProjectReference,
+                    packageDependency.Id));
+                return false;
+            }
+
+            return true;
         }
 
         internal static string GetAliasForFramework(PackageSpec spec, NuGetFramework framework)
@@ -288,32 +324,9 @@ namespace NuGet.CommandLine.XPlat
         internal static LibraryDependency GenerateLibraryDependency(
             PackageSpec project,
             string customPackagesPath,
-            RestoreResultPair restorePreviewResult,
-            List<NuGetFramework> userSpecifiedFrameworks,
             PackageDependency packageDependency,
-            ILogger logger)
+            NuGetVersion resolvedVersion)
         {
-            // get the package resolved version from restore preview result
-            (LibraryType libraryType, NuGetVersion resolvedVersion) = GetPackageVersionFromRestoreResult(restorePreviewResult, packageDependency.Id, userSpecifiedFrameworks);
-
-            if (libraryType == LibraryType.Unresolved)
-            {
-                logger.LogError(string.Format(CultureInfo.CurrentCulture,
-                    Strings.Error_AddPkgUnresolved,
-                    packageDependency.Id));
-                return null;
-            }
-
-            if (libraryType == LibraryType.Project ||
-               libraryType == LibraryType.ExternalProject)
-            {
-                // If the package is a project or external project, we cannot add it as a package reference.
-                logger.LogError(string.Format(CultureInfo.CurrentCulture,
-                    Strings.Error_AddPkgProjectReference,
-                    packageDependency.Id));
-                return null;
-            }
-
             // correct package version to write in project file
             var version = packageDependency.VersionRange;
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -441,7 +441,7 @@ namespace NuGet.CommandLine.XPlat
             return spec;
         }
 
-        private static (LibraryType, NuGetVersion) GetPackageVersionFromRestoreResult(RestoreResultPair restorePreviewResult,
+        internal static (LibraryType, NuGetVersion) GetPackageVersionFromRestoreResult(RestoreResultPair restorePreviewResult,
             string packageId,
             List<NuGetFramework> userSpecifiedFrameworks)
         {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -454,7 +454,7 @@ namespace NuGet.CommandLine.XPlat
             return spec;
         }
 
-        internal static (LibraryType, NuGetVersion) GetPackageVersionFromRestoreResult(RestoreResult restoreResult,
+        private static (LibraryType, NuGetVersion) GetPackageVersionFromRestoreResult(RestoreResult restoreResult,
             string packageId,
             List<NuGetFramework> userSpecifiedFrameworks)
         {
@@ -485,7 +485,7 @@ namespace NuGet.CommandLine.XPlat
                     var firstMatchingEntry = matchingPackageEntries
                         .First();
 
-                    // If we have found that the project is select, then we return null.
+                    // If we have found that the project is selected, then we return null.
                     if (firstMatchingEntry.Key.Type == LibraryType.Project ||
                         firstMatchingEntry.Key.Type == LibraryType.ExternalProject)
                     {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -290,7 +290,23 @@ namespace NuGet.CommandLine.XPlat
             PackageDependency packageDependency)
         {
             // get the package resolved version from restore preview result
-            var resolvedVersion = GetPackageVersionFromRestoreResult(restorePreviewResult, packageDependency.Id, userSpecifiedFrameworks);
+            (LibraryType libraryType, NuGetVersion resolvedVersion) = GetPackageVersionFromRestoreResult(restorePreviewResult, packageDependency.Id, userSpecifiedFrameworks);
+
+            if (libraryType == LibraryType.Unresolved)
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Error_AddPkgUnresolved,
+                    packageDependency.Id));
+            }
+
+            if (libraryType == LibraryType.Project ||
+               libraryType == LibraryType.ExternalProject)
+            {
+                // If the package is a project or external project, we cannot add it as a package reference.
+                throw new CommandException(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Error_AddPkgProjectReference,
+                    packageDependency.Id));
+            }
 
             // correct package version to write in project file
             var version = packageDependency.VersionRange;
@@ -419,7 +435,7 @@ namespace NuGet.CommandLine.XPlat
             return spec;
         }
 
-        private static NuGetVersion GetPackageVersionFromRestoreResult(RestoreResultPair restorePreviewResult,
+        private static (LibraryType, NuGetVersion) GetPackageVersionFromRestoreResult(RestoreResultPair restorePreviewResult,
             string packageId,
             List<NuGetFramework> userSpecifiedFrameworks)
         {
@@ -448,13 +464,23 @@ namespace NuGet.CommandLine.XPlat
 
                 if (matchingPackageEntries.Any())
                 {
-                    return matchingPackageEntries
-                        .First()
+                    var firstMatchingEntry = matchingPackageEntries
+                        .First();
+
+                    // If we have found that the project is select, then we return null.
+                    if (firstMatchingEntry.Key.Type == LibraryType.Project ||
+                        firstMatchingEntry.Key.Type == LibraryType.ExternalProject)
+                    {
+                        return (firstMatchingEntry.Key.Type, null);
+                    }
+
+                    return (firstMatchingEntry.Key.Type, firstMatchingEntry
                         .Key
-                        .Version;
+                        .Version);
                 }
             }
-            return null;
+
+            return (LibraryType.Unresolved, null);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.CommandLine.XPlat {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -498,6 +498,24 @@ namespace NuGet.CommandLine.XPlat {
         internal static string Error_AddPkgIncompatibleWithAllFrameworks {
             get {
                 return ResourceManager.GetString("Error_AddPkgIncompatibleWithAllFrameworks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error while adding a PackageReference for &apos;{0}&apos;. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect..
+        /// </summary>
+        internal static string Error_AddPkgProjectReference {
+            get {
+                return ResourceManager.GetString("Error_AddPkgProjectReference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find a resolved package for &apos;{0}&apos;. This is a tooling error. Please file an issue at https://github.com/NuGet/Home..
+        /// </summary>
+        internal static string Error_AddPkgUnresolved {
+            get {
+                return ResourceManager.GetString("Error_AddPkgUnresolved", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -502,7 +502,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error while adding a PackageReference for &apos;{0}&apos;. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect..
+        ///   Looks up a localized string similar to Failed to add a PackageReference for &apos;{0}&apos;. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project..
         /// </summary>
         internal static string Error_AddPkgProjectReference {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -1064,4 +1064,12 @@ Do not translate "PackageVersion"</comment>
     <comment>{0}: Number of packages updated
 {1}: Package checked for updated versions</comment>
   </data>
+  <data name="Error_AddPkgUnresolved" xml:space="preserve">
+    <value>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</value>
+    <comment>{0} Package Id</comment>
+  </data>
+  <data name="Error_AddPkgProjectReference" xml:space="preserve">
+    <value>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</value>
+    <comment>{0} - PackageId</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -1069,7 +1069,7 @@ Do not translate "PackageVersion"</comment>
     <comment>{0} Package Id</comment>
   </data>
   <data name="Error_AddPkgProjectReference" xml:space="preserve">
-    <value>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</value>
+    <value>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</value>
     <comment>{0} - PackageId</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">Položka VersionOverride pro balíček {0} by neměla být prázdná.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">VersionOverride für das Paket „{0}“ darf nicht leer sein.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">VersionOverride para el paquete "{0}" no debe estar vacío.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">VersionOverride pour le package « {0} » ne doit pas être vide.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">VersionOverride per il pacchetto '{0}' non deve essere vuoto.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">パッケージ '{0}' の VersionOverride を空にすることはできません。</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">패키지 '{0}'의 VersionOverride는 비워 둘 수 없습니다.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">Element VersionOverride dla pakietu „{0}” nie powinien być pusty.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">VersionOverride para o pacote "{0}" não deve estar vazio.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">Параметр VersionOverride для пакета "{0}" не должен быть пустым.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">'{0}' paketi için VersionOverride boş olmamalıdır.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">包 "{0}" 的 VersionOverride 不应为空。</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
@@ -239,6 +239,16 @@
 {1} - all / user specified
 {2} - Project Path</note>
       </trans-unit>
+      <trans-unit id="Error_AddPkgProjectReference">
+        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
+        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <note>{0} - PackageId</note>
+      </trans-unit>
+      <trans-unit id="Error_AddPkgUnresolved">
+        <source>Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</source>
+        <target state="new">Unable to find a resolved package for '{0}'. This is a tooling error. Please file an issue at https://github.com/NuGet/Home.</target>
+        <note>{0} Package Id</note>
+      </trans-unit>
       <trans-unit id="Error_AddPkg_CentralPackageVersions_EmptyVersionOverride">
         <source>VersionOverride for package '{0}' should not be empty.</source>
         <target state="translated">封裝 '{0}' 的 VersionOverride 不應為空白。</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
@@ -240,8 +240,8 @@
 {2} - Project Path</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgProjectReference">
-        <source>Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</source>
-        <target state="new">Error while adding a PackageReference for '{0}'. There a project sharing the same name that is preferred and as such adding the PackageReference would have no effect.</target>
+        <source>Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</source>
+        <target state="new">Failed to add a PackageReference for '{0}'. A ProjectReference with the same name already exists and a package with the same name cannot be added to the project.</target>
         <note>{0} - PackageId</note>
       </trans-unit>
       <trans-unit id="Error_AddPkgUnresolved">

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1402,7 +1402,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public async Task AddPkg_WithPackageReferenceMatchingExistingProject_Succeeds()
+        public async Task AddPkg_WithPackageReferenceMatchingExistingProject_ErrorsWithInformationMessage()
         {
             using var pathContext = new SimpleTestPathContext();
             var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
@@ -1422,13 +1422,10 @@ namespace NuGet.XPlat.FuncTest
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act
-            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-            var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
-            var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
-
-            // Assert
-            Assert.Equal(1, result);
-            Assert.Null(itemGroup);
+            var exception = await Assert.ThrowsAsync<CommandException>(async () => await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger)));
+            exception.Message.Should().Contain(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Error_AddPkgProjectReference,
+                    packageX.Id));
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1411,6 +1411,11 @@ namespace NuGet.XPlat.FuncTest
             projectA.AddProjectToAllFrameworks(projectB);
             projectA.Save();
 
+            // Generate Package
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageX);
             var logger = new TestCommandOutputLogger(_testOutputHelper);
 
             var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: projectB);
@@ -1424,7 +1429,34 @@ namespace NuGet.XPlat.FuncTest
             // Assert
             Assert.Equal(1, result);
             Assert.Null(itemGroup);
-            logger.ErrorMessages.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task AddPkg_WithPackageReferenceMatchingExistingTransitiveProject_Succeeds()
+        {
+            using var pathContext = new SimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+            var packageX = XPlatTestUtils.CreatePackage(packageVersion: "2.0.0");
+            var projectB = XPlatTestUtils.CreateProject("projectB", pathContext, "net46");
+            var projectC = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
+            projectA.AddProjectToAllFrameworks(projectB);
+            projectB.AddProjectToAllFrameworks(projectC);
+            projectA.Save();
+            projectB.Save();
+
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: [projectB, projectC]);
+            var commandRunner = new AddPackageReferenceCommandRunner();
+
+            // Act
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+            var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
+
+            // Assert
+            Assert.Equal(1, result);
+            Assert.Null(itemGroup);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1422,7 +1422,7 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: projectB);
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
@@ -1434,9 +1434,6 @@ namespace NuGet.XPlat.FuncTest
                 Assert.Equal(1, result);
                 Assert.Null(itemGroup);
                 logger.ErrorMessages.Should().BeEmpty();
-
-                //Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "2.0.0"));
-                //Assert.True(XPlatTestUtils.ValidateAssetsFile(projectA, packageX.Id));
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -263,7 +265,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
                 // Assert
@@ -309,7 +311,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
                 Assert.Equal(0, result);
@@ -403,7 +405,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
                 // Assert
@@ -450,7 +452,7 @@ namespace NuGet.XPlat.FuncTest
                 var logger = new TestCommandOutputLogger(_testOutputHelper);
 
                 // Verify that the package reference exists before removing.
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot, packageType: PackageType.DotnetCliTool);
 
                 Assert.NotNull(itemGroup);
@@ -461,7 +463,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
                 // Assert
@@ -504,7 +506,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // If noRestore is set, then we do not perform compatibility check.
                 // The added package reference will be unconditional
@@ -551,7 +553,7 @@ namespace NuGet.XPlat.FuncTest
                 projectA.Save();
 
                 // Verify that the package reference exists before removing.
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot, packageType: PackageType.DotnetCliTool);
                 var logger = new TestCommandOutputLogger(_testOutputHelper);
 
@@ -563,7 +565,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
                 // Assert
@@ -596,7 +598,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
                 Assert.Equal(0, result);
@@ -637,7 +639,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, commonFramework);
 
                 // Assert
@@ -686,7 +688,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, commonFramework);
 
                 // Assert
@@ -747,7 +749,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
 
                 // Assert
                 Assert.Equal(0, result);
@@ -804,9 +806,11 @@ namespace NuGet.XPlat.FuncTest
                 Assert.Equal(sources[0], customSourcePath);
 
                 var ridlessTarget = projectA.AssetsFile.Targets.Single(e => string.IsNullOrEmpty(e.RuntimeIdentifier));
-                ridlessTarget.Libraries.Should().Contain(e => e.Type == "package" && e.Name == packageX);
-                // Should resolve to highest available version.
-                ridlessTarget.Libraries.Should().Contain(e => e.Version.Equals(packageX_V2.Version));
+                ridlessTarget.Libraries.Should().HaveCount(1);
+                ridlessTarget.Libraries[0].Type.Should().Be("package");
+                ridlessTarget.Libraries[0].Name.Should().Be(packageX);
+                // Should resolve to highest available version
+                ridlessTarget.Libraries[0].Version.Should().Be(packageX_V2.Version);
             }
         }
 
@@ -889,9 +893,12 @@ namespace NuGet.XPlat.FuncTest
                 Assert.Equal(sources[0], customSourcePath);
 
                 var ridlessTarget = projectA.AssetsFile.Targets.Single(e => string.IsNullOrEmpty(e.RuntimeIdentifier));
-                ridlessTarget.Libraries.Should().Contain(e => e.Type == "package" && e.Name == packageX);
+
+                ridlessTarget.Libraries.Should().HaveCount(1);
+                ridlessTarget.Libraries[0].Type.Should().Be("package");
+                ridlessTarget.Libraries[0].Name.Should().Be(packageX);
                 // Should resolve to specified version.
-                ridlessTarget.Libraries.Should().Contain(e => e.Version.Equals(packageX_V1.Version));
+                ridlessTarget.Libraries[0].Version.Should().Be(packageX_V1.Version);
             }
         }
 
@@ -982,7 +989,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, commonFramework);
 
                 // Assert
@@ -1023,7 +1030,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
                 Assert.Equal(1, result);
@@ -1054,7 +1061,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
                 Assert.Equal(1, result);
@@ -1092,13 +1099,11 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, msbuild);
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
-
                 packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageY.Id, packageY.Version, projectA);
 
                 // Act
                 result = await commandRunner.ExecuteCommand(packageArgs, msbuild);
-                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
                 Assert.Equal(0, result);
@@ -1157,13 +1162,13 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageY.Id, packageY.Version, projectA);
 
                 // Act
                 result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
-                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, commonFramework);
 
                 // Assert
@@ -1200,7 +1205,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
                 // Assert
@@ -1247,7 +1252,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Create a package ref with the old version
                 var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 //Preconditions
                 Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packages[0].Id, userInputVersionOld));
@@ -1261,7 +1266,7 @@ namespace NuGet.XPlat.FuncTest
                 // Act
                 // Create a package ref with the new version
                 result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
-                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
                 // Verify that the only package reference is with the new version
@@ -1314,7 +1319,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Create a package ref with old version
                 var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 //Preconditions
                 Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packages[0].Id, userInputVersionOld));
@@ -1327,7 +1332,7 @@ namespace NuGet.XPlat.FuncTest
                 // Act
                 // Create a package ref with new version
                 result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
-                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
                 // Verify that the only package reference is with the new version
@@ -1360,7 +1365,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
                 Assert.Equal(0, result);
@@ -1392,7 +1397,7 @@ namespace NuGet.XPlat.FuncTest
 
             // Act
             var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-            var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+            var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
             // Assert
             Assert.Equal(0, result);
@@ -1454,7 +1459,7 @@ namespace NuGet.XPlat.FuncTest
 
             // Act
             var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-            var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+            var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
             var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
             // Assert

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1418,7 +1418,7 @@ namespace NuGet.XPlat.FuncTest
                 packageX);
             var logger = new TestCommandOutputLogger(_testOutputHelper);
 
-            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: projectX);
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, dependentProjects: projectX);
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act
@@ -1449,7 +1449,7 @@ namespace NuGet.XPlat.FuncTest
                 packageX);
             var logger = new TestCommandOutputLogger(_testOutputHelper);
 
-            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: [projectB, projectX]);
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, dependentProjects: [projectB, projectX]);
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1404,37 +1404,27 @@ namespace NuGet.XPlat.FuncTest
         [Fact]
         public async Task AddPkg_WithPackageReferenceMatchingExistingProject_Succeeds()
         {
-            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+            var packageX = XPlatTestUtils.CreatePackage(packageVersion: "2.0.0");
+            var projectB = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
+            projectA.AddProjectToAllFrameworks(projectB);
+            projectA.Save();
 
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
-                var packageX = XPlatTestUtils.CreatePackage(packageVersion: "2.0.0");
-                var projectB = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
-                projectA.AddProjectToAllFrameworks(projectB);
-                projectA.Save();
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
 
-                var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: projectB);
+            var commandRunner = new AddPackageReferenceCommandRunner();
 
-                // Generate Package
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    PackageSaveMode.Defaultv3,
-                    packageX);
+            // Act
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+            var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: projectB);
-                var commandRunner = new AddPackageReferenceCommandRunner();
-
-                // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
-
-                // Assert
-                Assert.Equal(1, result);
-                Assert.Null(itemGroup);
-                logger.ErrorMessages.Should().BeEmpty();
-            }
+            // Assert
+            Assert.Equal(1, result);
+            Assert.Null(itemGroup);
+            logger.ErrorMessages.Should().BeEmpty();
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1407,8 +1407,8 @@ namespace NuGet.XPlat.FuncTest
             using var pathContext = new SimpleTestPathContext();
             var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
             var packageX = XPlatTestUtils.CreatePackage(packageVersion: "2.0.0");
-            var projectB = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
-            projectA.AddProjectToAllFrameworks(projectB);
+            var projectX = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
+            projectA.AddProjectToAllFrameworks(projectX);
             projectA.Save();
 
             // Generate Package
@@ -1418,32 +1418,38 @@ namespace NuGet.XPlat.FuncTest
                 packageX);
             var logger = new TestCommandOutputLogger(_testOutputHelper);
 
-            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: projectB);
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: projectX);
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act
-            var exception = await Assert.ThrowsAsync<CommandException>(async () => await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger)));
-            exception.Message.Should().Contain(string.Format(CultureInfo.CurrentCulture,
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            result.Should().Be(1);
+            logger.ErrorMessages.Should().Contain(string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_AddPkgProjectReference,
                     packageX.Id));
         }
 
         [Fact]
-        public async Task AddPkg_WithPackageReferenceMatchingExistingTransitiveProject_Succeeds()
+        public async Task AddPkg_WithPackageReferenceMatchingExistingTransitiveProject_AddsPackageReference()
         {
             using var pathContext = new SimpleTestPathContext();
             var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
-            var packageX = XPlatTestUtils.CreatePackage(packageVersion: "2.0.0");
+            var packageX = XPlatTestUtils.CreatePackage(packageVersion: "0.1.0");
             var projectB = XPlatTestUtils.CreateProject("projectB", pathContext, "net46");
-            var projectC = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
+            var projectX = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
             projectA.AddProjectToAllFrameworks(projectB);
-            projectB.AddProjectToAllFrameworks(projectC);
+            projectB.AddProjectToAllFrameworks(projectX);
             projectA.Save();
             projectB.Save();
 
+            // Generate Package
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageX);
             var logger = new TestCommandOutputLogger(_testOutputHelper);
 
-            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: [projectB, projectC]);
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA, projects: [projectB, projectX]);
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act
@@ -1452,8 +1458,11 @@ namespace NuGet.XPlat.FuncTest
             var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
             // Assert
-            Assert.Equal(1, result);
-            Assert.Null(itemGroup);
+            Assert.Equal(0, result);
+            Assert.NotNull(itemGroup);
+
+            Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, packageX.Version));
+            Assert.True(XPlatTestUtils.ValidateAssetsFile(projectA, packageX.Id));
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1400,5 +1400,44 @@ namespace NuGet.XPlat.FuncTest
             // Since user did not specify a version, the package reference will contain the resolved version
             Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packageX.Id, "1.0.0", stringComparison: StringComparison.Ordinal));
         }
+
+        [Fact]
+        public async Task AddPkg_WithPackageReferenceMatchingExistingProject_Succeeds()
+        {
+            // Arrange
+
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var packageX = XPlatTestUtils.CreatePackage(packageVersion: "2.0.0");
+                var projectB = XPlatTestUtils.CreateProject(packageX.Id, pathContext, "net46");
+                projectA.AddProjectToAllFrameworks(projectB);
+                projectA.Save();
+
+                var logger = new TestCommandOutputLogger(_testOutputHelper);
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA);
+                var commandRunner = new AddPackageReferenceCommandRunner();
+
+                // Act
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
+
+                // Assert
+                Assert.Equal(1, result);
+                Assert.Null(itemGroup);
+                logger.ErrorMessages.Should().BeEmpty();
+
+                //Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "2.0.0"));
+                //Assert.True(XPlatTestUtils.ValidateAssetsFile(projectA, packageX.Id));
+            }
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -215,12 +215,12 @@ namespace NuGet.XPlat.FuncTest
             };
         }
 
-        internal static PackageReferenceArgs GetPackageReferenceArgs(TestCommandOutputLogger logger, string packageId, string packageVersion, SimpleTestProjectContext project, string frameworks = "", string packageDirectory = "", string sources = "", bool noRestore = false, bool noVersion = false, bool prerelease = false)
+        internal static PackageReferenceArgs GetPackageReferenceArgs(TestCommandOutputLogger logger, string packageId, string packageVersion, SimpleTestProjectContext project, string frameworks = "", string packageDirectory = "", string sources = "", bool noRestore = false, bool noVersion = false, bool prerelease = false, params SimpleTestProjectContext[] projects)
         {
             var dgFilePath = string.Empty;
             if (!noRestore)
             {
-                dgFilePath = CreateDGFileForProject(project);
+                dgFilePath = CreateDGFileForProject(project, projects);
             }
             return new PackageReferenceArgs(project.ProjectPath, logger)
             {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -346,7 +346,7 @@ namespace NuGet.XPlat.FuncTest
             }
 
             return itemGroups
-                .First(i => i.Descendants(referenceType).Any() &&
+                .FirstOrDefault(i => i.Descendants(referenceType).Any() &&
                             i.FirstAttribute == null);
         }
 
@@ -364,12 +364,16 @@ namespace NuGet.XPlat.FuncTest
                 Directory.EnumerateFiles(Path.Combine(packageDirectoryPath, package.Id.ToLower(), package.Version.ToLower())).Any();
         }
 
-        public static string CreateDGFileForProject(SimpleTestProjectContext project)
+        public static string CreateDGFileForProject(SimpleTestProjectContext project, params SimpleTestProjectContext[] projectRefs)
         {
             var dgSpec = new DependencyGraphSpec();
             var dgFilePath = Path.Combine(Directory.GetParent(project.ProjectPath).FullName, "temp.dg");
             dgSpec.AddRestore(project.ProjectName);
             dgSpec.AddProject(project.PackageSpec);
+            foreach (var projectRef in projectRefs)
+            {
+                dgSpec.AddProject(projectRef.PackageSpec);
+            }
             dgSpec.Save(dgFilePath);
             return dgFilePath;
         }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -8,8 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using NuGet.CommandLine.XPlat;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -21,56 +21,6 @@ namespace NuGet.XPlat.FuncTest
 {
     public static class XPlatTestUtils
     {
-        /// <summary>
-        /// Add a dependency to project.json.
-        /// </summary>
-        public static void AddDependency(JObject json, string id, string version)
-        {
-            var deps = (JObject)json["dependencies"];
-
-            deps.Add(new JProperty(id, version));
-        }
-
-        /// <summary>
-        /// Basic netcoreapp1.0 config
-        /// </summary>
-        public static JObject BasicConfigNetCoreApp
-        {
-            get
-            {
-                var json = new JObject();
-
-                var frameworks = new JObject
-                {
-                    ["netcoreapp1.0"] = new JObject()
-                };
-
-                json["dependencies"] = new JObject();
-
-                json["frameworks"] = frameworks;
-
-                return json;
-            }
-        }
-
-        /// <summary>
-        /// Write a json file to disk.
-        /// </summary>
-        public static void WriteJson(JObject json, string outputPath)
-        {
-            Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
-
-            using (var fs = File.Open(outputPath, FileMode.CreateNew))
-            using (var sw = new StreamWriter(fs))
-            using (var writer = new JsonTextWriter(sw))
-            {
-                writer.Formatting = Newtonsoft.Json.Formatting.Indented;
-
-                var serializer = new JsonSerializer();
-                serializer.Serialize(writer, json);
-            }
-        }
-
         /// <summary>
         /// Copies test sources configuration to a test folder
         /// </summary>
@@ -86,7 +36,7 @@ namespace NuGet.XPlat.FuncTest
 
         private const string ProtocolConfigFileName = "NuGet.Protocol.FuncTest.config";
 
-        public static string ReadApiKey(string feedName)
+        public static string? ReadApiKey(string feedName)
         {
             var testSettingsFolder = TestSources.GetConfigFileRoot();
             var protocolConfigPath = Path.Combine(testSettingsFolder, ProtocolConfigFileName);
@@ -95,7 +45,7 @@ namespace NuGet.XPlat.FuncTest
             using (Stream configStream = File.OpenRead(protocolConfigPath))
             {
                 var doc = XDocument.Load(XmlReader.Create(configStream));
-                var element = doc.Root.Element(feedName);
+                var element = doc.Root?.Element(feedName);
 
                 return element?.Element("ApiKey")?.Value;
             }
@@ -140,7 +90,7 @@ namespace NuGet.XPlat.FuncTest
             SimpleTestPathContext pathContext,
             SimpleTestPackageContext package,
             string projectFrameworks,
-            string packageFramework = null)
+            string? packageFramework = null)
         {
             var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
                     projectName: projectName,
@@ -180,8 +130,8 @@ namespace NuGet.XPlat.FuncTest
 
         public static SimpleTestPackageContext CreatePackage(string packageId = "packageX",
             string packageVersion = "1.0.0",
-            string frameworkString = null,
-            PackageType packageType = null,
+            string? frameworkString = null,
+            PackageType? packageType = null,
             bool developmentDependency = false)
         {
             var package = new SimpleTestPackageContext()
@@ -263,12 +213,12 @@ namespace NuGet.XPlat.FuncTest
 
         // Assert Helper Methods
 
-        public static bool ValidateReference(XElement root, string packageId, string version, PackageType packageType = null, bool developmentDependency = false, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
+        public static bool ValidateReference(XElement root, string packageId, string version, PackageType? packageType = null, bool developmentDependency = false, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
         {
 
             var packageReferences = root
                     .Descendants(GetReferenceType(packageType))
-                    .Where(d => d.FirstAttribute.Value.Equals(packageId, stringComparison));
+                    .Where(d => StringComparer.FromComparison(stringComparison).Equals(d.FirstAttribute?.Value, packageId));
 
             if (packageReferences.Count() != 1)
             {
@@ -317,16 +267,16 @@ namespace NuGet.XPlat.FuncTest
             return project.AssetsFile.Targets.Any(t => t.Libraries.Any(library => string.Equals(library.Name, packageId, StringComparison.OrdinalIgnoreCase)));
         }
 
-        public static bool ValidateNoReference(XElement root, string packageId, PackageType packageType = null)
+        public static bool ValidateNoReference(XElement root, string packageId, PackageType? packageType = null)
         {
             var packageReferences = root
                     .Descendants(GetReferenceType(packageType))
-                    .Where(d => d.FirstAttribute.Value.Equals(packageId, StringComparison.OrdinalIgnoreCase));
+                    .Where(d => StringComparer.OrdinalIgnoreCase.Equals(d.FirstAttribute?.Value, packageId));
 
             return !(packageReferences.Any());
         }
 
-        public static XElement GetItemGroupForFramework(XElement root, string framework, PackageType packageType = null)
+        public static XElement GetItemGroupForFramework(XElement root, string framework, PackageType? packageType = null)
         {
             var itemGroups = root.Descendants("ItemGroup");
             return itemGroups
@@ -336,7 +286,7 @@ namespace NuGet.XPlat.FuncTest
                             i.FirstAttribute.Value.Trim().Equals(GetTargetFrameworkCondition(framework), StringComparison.OrdinalIgnoreCase));
         }
 
-        public static XElement GetItemGroupForAllFrameworks(XElement root, PackageType packageType = null)
+        public static XElement? GetItemGroupForAllFrameworks(XElement root, PackageType? packageType = null)
         {
             var itemGroups = root.Descendants("ItemGroup");
             var referenceType = GetReferenceType(packageType);
@@ -367,7 +317,7 @@ namespace NuGet.XPlat.FuncTest
         public static string CreateDGFileForProject(SimpleTestProjectContext project, params SimpleTestProjectContext[] projectRefs)
         {
             var dgSpec = new DependencyGraphSpec();
-            var dgFilePath = Path.Combine(Directory.GetParent(project.ProjectPath).FullName, "temp.dg");
+            var dgFilePath = Path.Combine(Directory.GetParent(project.ProjectPath)!.FullName, "temp.dg");
             dgSpec.AddRestore(project.ProjectName);
             dgSpec.AddProject(project.PackageSpec);
             foreach (var projectRef in projectRefs)
@@ -416,7 +366,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
-        public static string GetReferenceType(PackageType packageType)
+        public static string GetReferenceType(PackageType? packageType)
         {
             var referenceType = "PackageReference";
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -215,12 +215,12 @@ namespace NuGet.XPlat.FuncTest
             };
         }
 
-        internal static PackageReferenceArgs GetPackageReferenceArgs(TestCommandOutputLogger logger, string packageId, string packageVersion, SimpleTestProjectContext project, string frameworks = "", string packageDirectory = "", string sources = "", bool noRestore = false, bool noVersion = false, bool prerelease = false, params SimpleTestProjectContext[] projects)
+        internal static PackageReferenceArgs GetPackageReferenceArgs(TestCommandOutputLogger logger, string packageId, string packageVersion, SimpleTestProjectContext project, string frameworks = "", string packageDirectory = "", string sources = "", bool noRestore = false, bool noVersion = false, bool prerelease = false, params SimpleTestProjectContext[] dependentProjects)
         {
             var dgFilePath = string.Empty;
             if (!noRestore)
             {
-                dgFilePath = CreateDGFileForProject(project, projects);
+                dgFilePath = CreateDGFileForProject(project, dependentProjects);
             }
             return new PackageReferenceArgs(project.ProjectPath, logger)
             {

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -50,7 +50,8 @@ public class SingleProjectTests
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package" && p.NewVersion.ToString() == "[1.2.3, )")), Times.Once);
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package" && p.NewVersion.ToString() == "[1.2.3, )"),
+            It.IsAny<ILogger>()), Times.Once);
     }
 
     [Fact]
@@ -89,7 +90,8 @@ public class SingleProjectTests
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Contoso.Polyfill" && p.NewVersion.ToString() == "[1.2.3, )")), Times.Once);
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Contoso.Polyfill" && p.NewVersion.ToString() == "[1.2.3, )"),
+            It.IsAny<ILogger>()), Times.Once);
     }
 
     [Fact]
@@ -123,7 +125,8 @@ public class SingleProjectTests
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>()), Times.Never);
+            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
+            It.IsAny<ILogger>()), Times.Never);
     }
 
     [Fact]
@@ -157,7 +160,8 @@ public class SingleProjectTests
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>()), Times.Never);
+            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
+            It.IsAny<ILogger>()), Times.Never);
     }
 
     [Fact]
@@ -235,7 +239,8 @@ public class SingleProjectTests
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>()));
+            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
+            It.IsAny<ILogger>()));
 
         ioMock.Setup(x => x.CommitAsync(
             It.IsAny<IPackageUpdateIO.RestoreResult>(),

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -11,6 +11,7 @@ using NuGet.CommandLine.XPlat.Commands.Package.Update;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
+using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -48,10 +49,9 @@ public class SingleProjectTests
 
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
-            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.Is<PackageDependency>(p => p.Id == "Test.Package" && p.VersionRange.ToString() == "[1.2.3, )"),
             It.IsAny<List<NuGetFramework>>(),
-            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package" && p.NewVersion.ToString() == "[1.2.3, )"),
-            It.IsAny<ILogger>()), Times.Once);
+            It.IsAny<NuGetVersion>()), Times.Once);
     }
 
     [Fact]
@@ -88,10 +88,9 @@ public class SingleProjectTests
 
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
-            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.Is<PackageDependency>(p => p.Id == "Contoso.Polyfill" && p.VersionRange.ToString() == "[1.2.3, )"),
             It.IsAny<List<NuGetFramework>>(),
-            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Contoso.Polyfill" && p.NewVersion.ToString() == "[1.2.3, )"),
-            It.IsAny<ILogger>()), Times.Once);
+            It.IsAny<NuGetVersion>()), Times.Once);
     }
 
     [Fact]
@@ -123,10 +122,9 @@ public class SingleProjectTests
 
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
-            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<PackageDependency>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
-            It.IsAny<ILogger>()), Times.Never);
+            It.IsAny<NuGetVersion>()), Times.Never);
     }
 
     [Fact]
@@ -158,10 +156,9 @@ public class SingleProjectTests
 
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
-            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<PackageDependency>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
-            It.IsAny<ILogger>()), Times.Never);
+            It.IsAny<NuGetVersion>()), Times.Never);
     }
 
     [Fact]
@@ -237,10 +234,9 @@ public class SingleProjectTests
 
         ioMock.Setup(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
-            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<PackageDependency>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
-            It.IsAny<ILogger>()));
+            It.IsAny<NuGetVersion>()));
 
         ioMock.Setup(x => x.CommitAsync(
             It.IsAny<IPackageUpdateIO.RestoreResult>(),

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -11,7 +11,6 @@ using NuGet.CommandLine.XPlat.Commands.Package.Update;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
-using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -49,9 +48,11 @@ public class SingleProjectTests
 
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
-            It.Is<PackageDependency>(p => p.Id == "Test.Package" && p.VersionRange.ToString() == "[1.2.3, )"),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.IsAny<NuGetVersion>()), Times.Once);
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package" && p.NewVersion.ToString() == "[1.2.3, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
     }
 
     [Fact]
@@ -88,9 +89,10 @@ public class SingleProjectTests
 
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
-            It.Is<PackageDependency>(p => p.Id == "Contoso.Polyfill" && p.VersionRange.ToString() == "[1.2.3, )"),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.IsAny<NuGetVersion>()), Times.Once);
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Contoso.Polyfill" && p.NewVersion.ToString() == "[1.2.3, )"),
+            It.IsAny<ILogger>()), Times.Once);
     }
 
     [Fact]
@@ -122,9 +124,10 @@ public class SingleProjectTests
 
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
-            It.IsAny<PackageDependency>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.IsAny<NuGetVersion>()), Times.Never);
+            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
+            It.IsAny<ILogger>()), Times.Never);
     }
 
     [Fact]
@@ -156,9 +159,10 @@ public class SingleProjectTests
 
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
-            It.IsAny<PackageDependency>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.IsAny<NuGetVersion>()), Times.Never);
+            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
+            It.IsAny<ILogger>()), Times.Never);
     }
 
     [Fact]
@@ -234,9 +238,10 @@ public class SingleProjectTests
 
         ioMock.Setup(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
-            It.IsAny<PackageDependency>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
             It.IsAny<List<NuGetFramework>>(),
-            It.IsAny<NuGetVersion>()));
+            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
+            It.IsAny<ILogger>()));
 
         ioMock.Setup(x => x.CommitAsync(
             It.IsAny<IPackageUpdateIO.RestoreResult>(),

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -263,7 +263,17 @@ namespace NuGet.Test.Utility
                 _packageSpec.RestoreMetadata.OutputPath = ProjectExtensionsPath;
                 _packageSpec.RestoreMetadata.OriginalTargetFrameworks = _packageSpec.TargetFrameworks.Select(e => e.TargetAlias).ToList();
                 _packageSpec.RestoreMetadata.TargetFrameworks = Frameworks
-                    .Select(f => new ProjectRestoreMetadataFrameworkInfo(f.Framework))
+                    .Select(f => new ProjectRestoreMetadataFrameworkInfo(f.Framework)
+                    {
+                        ProjectReferences = f.ProjectReferences.Select(p => new ProjectRestoreReference()
+                        {
+                            ProjectUniqueName = p.ProjectName,
+                            ProjectPath = p.ProjectPath,
+                            ExcludeAssets = LibraryIncludeFlagUtils.GetFlags(MSBuildStringUtility.Split(p.ExcludeAssets)),
+                            IncludeAssets = LibraryIncludeFlagUtils.GetFlags(MSBuildStringUtility.Split(p.IncludeAssets)),
+                            PrivateAssets = LibraryIncludeFlagUtils.GetFlags(MSBuildStringUtility.Split(p.PrivateAssets))
+                        }).ToList(),
+                    })
                     .ToList();
                 _packageSpec.RestoreMetadata.Sources = Sources?.ToList();
                 _packageSpec.RestoreMetadata.PackagesPath = GlobalPackagesFolder;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/8543

## Description

When you attempt to add a package that shares the same id with a pre-existing project reference, the `dotnet add package` command fails with the a null ref because https://github.com/NuGet/NuGet.Client/blob/04410842ba4e3f4182c39c8a5284951105e57c32/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs#L293 returns the wrong version and then nuspecFile is empty: https://github.com/NuGet/NuGet.Client/blob/04410842ba4e3f4182c39c8a5284951105e57c32/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs#L315. 

We need to account for the fact that we're *finding* the project here and not the package. 

While restore is successful (restore just handles the deduplication), there's no point in adding a reference that leads to nothing. AFter all the package may not have been restored anyways.

Note that this scenario cannot realistically happen in update (despite them using nearly the same code), because update only works on packages already in the project.
Either way, we log it, so people would file an issue if it were ever a problem.

The add package command numbering comments were also incorrect, so I fixed that up and fixed some of the if/else conditions to make it flow better.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
