### PR TITLE
Use real signing in official build

### DIFF
--- a/build/sign.proj
+++ b/build/sign.proj
@@ -22,7 +22,9 @@
 
     <PropertyGroup>
       <DryRunSigning Condition="'$(DryRunSigning)' == ''">true</DryRunSigning>
-      <TestSigning>true</TestSigning>
+      <TestSigning>false</TestSigning>
+      <TestSigning Condition="'$(DotNetSignType)' == 'test'">true</TestSigning>
+
       <SigningTempDirectory Condition="'$(SigningTempDirectory)' == ''">$(ArtifactTempDirectory)</SigningTempDirectory>
       <SigningLogDirectory Condition="'$(SigningLogDirectory)' == ''">$(ArtifactTempDirectory)</SigningLogDirectory>
 

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -7,6 +7,9 @@ parameters:
   displayName: Run unit tests
   type: boolean
   default: true
+- name: SigningType
+  displayName: Type of signing to use
+  type: string
 
 steps:
 - task: PowerShell@1
@@ -199,7 +202,7 @@ steps:
   inputs:
     solution: "build\\sign.proj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore /p:DryRunSigning=false /p:SigningLogDirectory=$(Build.StagingDirectory)\\binlog /binarylogger:$(Build.StagingDirectory)\\binlog\\15.Sign.binlog"
+    msbuildArguments: "/restore /p:DryRunSigning=false /p:DotNetSignType=$(SigningType) /p:SigningLogDirectory=$(Build.StagingDirectory)\\binlog /binarylogger:$(Build.StagingDirectory)\\binlog\\15.Sign.binlog"
 
 - task: NuGetToolInstaller@1
   displayName: Use NuGet 6.x

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -238,6 +238,7 @@ stages:
         BuildRTM: false
         NuGetLocalizationType: ${{ parameters.NuGetLocalizationType }}
         RunUnitTests: ${{ parameters.RunUnitTestsOnWindows }}
+        SigningType: ${{ parameters.SigningType }}
 
 - stage: Build_For_Publishing
   displayName: Build NuGet published to nuget.org
@@ -301,6 +302,7 @@ stages:
         BuildRTM: true
         NuGetLocalizationType: Full
         RunUnitTests: ${{ parameters.RunUnitTestsOnWindows }}
+        SigningType: ${{ parameters.SigningType }}
 
   - job: Validate_Publishing_Artifacts
     condition: "and(succeeded(), ne(variables['RunBuildForPublishing'], 'false'))"


### PR DESCRIPTION
This was causing a hang, I think due to mismatch of the sign type between signtool and the MB signing plugin.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

Signing hanging in official pipeline.

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
