### PR TITLE
Remove pre-signtool signtarget deps

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -24,7 +24,6 @@
 
   <PropertyGroup Condition="'$(Shipping)' == 'true'">
     <GetSymbolsToIndexDependsOn Condition="'$(GetSymbolsToIndexDependsOn)' == ''">GetSymbolsToIndexDefault</GetSymbolsToIndexDependsOn>
-    <SignTargetsForRealSigning Condition="'$(SignTargetsForRealSigning)' == ''">GetBuildOutputWithSigningMetadata</SignTargetsForRealSigning>
     <SymbolTargetsToGetPdbs Condition="'$(SymbolTargetsToGetPdbs)' == ''">GetDebugSymbolsProjectOutput</SymbolTargetsToGetPdbs>
   </PropertyGroup>
 
@@ -143,7 +142,7 @@
   <Target Name="GetSymbolsToIndexDefault" DependsOnTargets="GetTargetFrameworkSet" Returns="@(SymbolFilesToIndex)" Condition=" '$(Shipping)' == 'true' ">
     <MSBuild
       Projects="$(MSBuildProjectFullPath)"
-      Targets="$(SignTargetsForRealSigning);$(SymbolTargetsToGetPdbs)"
+      Targets="$(SymbolTargetsToGetPdbs)"
       Properties="TargetFramework=%(ProjectTargetFrameworkEntries.Identity);
                   BuildProjectReferences=false;">
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

Build error:

```
##[error]src\NuGet.Clients\NuGet.Console\NuGet.Console.csproj(0,0): Error MSB4057: The target "GetBuildOutputWithSigningMetadata" does not exist in the project.
D:\a\_work\1\s\src\NuGet.Clients\NuGet.Console\NuGet.Console.csproj : error MSB4057: The target "GetBuildOutputWithSigningMetadata" does not exist in the project.
```

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

Fixes: Remove dependency on non-existent target.

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
