### PR TITLE
Update Xlf on Build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,6 @@
 
   <PropertyGroup>
     <UsingToolXliff>true</UsingToolXliff>
-    <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
+    <UpdateXlfOnBuild Condition="'$(CI)' != 'true'">true</UpdateXlfOnBuild>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,5 +15,6 @@
 
   <PropertyGroup>
     <UsingToolXliff>true</UsingToolXliff>
+    <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

I wes getting build errors when updating res files. 
```
error : 'xlf\Strings.cs.xlf' is out-of-date with 'Strings.resx'. Run `msbuild /t:UpdateXlf` to update .xlf files or set UpdateXlfOnBuild=true to update them on every build, but note that it is strongly discouraged to set UpdateXlfOnBuild=true in official/CI build environments as they should not modify source code during the build. 
```
I had to run the msbuild target UpdateXlf to update them.

Adding it to the properties would make sure the XLIFF localization files will be updated to match resource files automatically on each build.

Doc notes: https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.XliffTasks/README.md#updating-xlf-files

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
