### PR TITLE
Handle floating range comparison properly when picking which package is greater

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1028,9 +1028,7 @@ namespace NuGet.Commands
                     VersionRange chosenVersionRange = chosenResolvedItem.LibraryDependency.LibraryRange.VersionRange ?? VersionRange.All;
 
                     // The chosen item should be evicted or the current item has a greater version, determine if the current item should be chosen instead
-                    var isGreaterThanOrEqualTo = RemoteDependencyWalker.IsGreaterThanOrEqualTo(chosenVersionRange, currentVersionRange);
-
-                    if (evictOnTypeConstraint || !isGreaterThanOrEqualTo)
+                    if (evictOnTypeConstraint || !RemoteDependencyWalker.IsGreaterThanOrEqualTo(chosenVersionRange, currentVersionRange))
                     {
                         if (chosenResolvedItem.LibraryDependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentDependencyGraphItem.LibraryDependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
                         {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1028,9 +1028,9 @@ namespace NuGet.Commands
                     VersionRange chosenVersionRange = chosenResolvedItem.LibraryDependency.LibraryRange.VersionRange ?? VersionRange.All;
 
                     // The chosen item should be evicted or the current item has a greater version, determine if the current item should be chosen instead
-                    var isGreaterThanOrEqualTo = RemoteDependencyWalker.IsGreaterThanOrEqualTo(currentVersionRange, chosenVersionRange);
+                    var isGreaterThanOrEqualTo = RemoteDependencyWalker.IsGreaterThanOrEqualTo(chosenVersionRange, currentVersionRange);
 
-                    if (evictOnTypeConstraint || isGreaterThanOrEqualTo)
+                    if (evictOnTypeConstraint || !isGreaterThanOrEqualTo)
                     {
                         if (chosenResolvedItem.LibraryDependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentDependencyGraphItem.LibraryDependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
                         {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1028,7 +1028,9 @@ namespace NuGet.Commands
                     VersionRange chosenVersionRange = chosenResolvedItem.LibraryDependency.LibraryRange.VersionRange ?? VersionRange.All;
 
                     // The chosen item should be evicted or the current item has a greater version, determine if the current item should be chosen instead
-                    if (evictOnTypeConstraint || !RemoteDependencyWalker.IsGreaterThanOrEqualTo(chosenVersionRange, currentVersionRange))
+                    var isGreaterThanOrEqualTo = RemoteDependencyWalker.IsGreaterThanOrEqualTo(currentVersionRange, chosenVersionRange);
+
+                    if (evictOnTypeConstraint || !isGreaterThanOrEqualTo)
                     {
                         if (chosenResolvedItem.LibraryDependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentDependencyGraphItem.LibraryDependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
                         {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1030,7 +1030,7 @@ namespace NuGet.Commands
                     // The chosen item should be evicted or the current item has a greater version, determine if the current item should be chosen instead
                     var isGreaterThanOrEqualTo = RemoteDependencyWalker.IsGreaterThanOrEqualTo(currentVersionRange, chosenVersionRange);
 
-                    if (evictOnTypeConstraint || !isGreaterThanOrEqualTo)
+                    if (evictOnTypeConstraint || isGreaterThanOrEqualTo)
                     {
                         if (chosenResolvedItem.LibraryDependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package) && currentDependencyGraphItem.LibraryDependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package))
                         {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -508,7 +508,7 @@ namespace NuGet.DependencyResolver
                                 return true;
                             }
 
-                            return nearRelease.Length < farRelease.Length;
+                            return nearRelease.Length > farRelease.Length;
                         }
                         return true;
                     }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -407,6 +407,8 @@ namespace NuGet.DependencyResolver
 
         // Verifies if minimum version specification for nearVersion is greater than the
         // minimum version specification for farVersion
+        // Floating ranges are considered greater than the equivalent non-floating ranges.
+        // When floating ranges are compared, the shorter one is considered greater, since it matches more.
         public static bool IsGreaterThanOrEqualTo(VersionRange nearVersion, VersionRange farVersion)
         {
             if (!nearVersion.HasLowerBound)
@@ -498,6 +500,10 @@ namespace NuGet.DependencyResolver
                         {
                             return false;
                         }
+                        // When ranges are equivalent in everything but release label length, the shorter is considered greater.
+                        // When comparing versions, the longer one is considered newer, but with 2 floating ranges,
+                        // the shorter one will match everything the longer one does.
+                        // If there's no version satisfying the longer range, then the operation will fail at a later point.
                         return nearRelease.Length <= farRelease.Length;
                     }
                     else

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -490,15 +490,15 @@ namespace NuGet.DependencyResolver
 
                     if (compareResult == 0)
                     {
-                        //if (nearVersion.IsFloating && !farVersion.IsFloating)
-                        //{
-                        //    return true;
-                        //}
+                        if (nearVersion.IsFloating && !farVersion.IsFloating)
+                        {
+                            return true;
+                        }
 
-                        //if (!nearVersion.IsFloating && farVersion.IsFloating)
-                        //{
-                        //    return false;
-                        //}
+                        if (!nearVersion.IsFloating && farVersion.IsFloating)
+                        {
+                            return false;
+                        }
 
                         //if (nearVersion.IsFloating && farVersion.IsFloating)
                         //{
@@ -508,7 +508,7 @@ namespace NuGet.DependencyResolver
                         //        return true;
                         //    }
 
-                        //    return nearRelease.Length > farRelease.Length;
+                        //    //return nearRelease.Length > farRelease.Length;
                         //}
                         return true;
                     }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -487,8 +487,7 @@ namespace NuGet.DependencyResolver
                     {
                         return true;
                     }
-
-                    if (compareResult == 0)
+                    else if (compareResult == 0)
                     {
                         if (nearVersion.IsFloating && !farVersion.IsFloating)
                         {
@@ -500,19 +499,12 @@ namespace NuGet.DependencyResolver
                             return false;
                         }
 
-                        //if (nearVersion.IsFloating && farVersion.IsFloating)
-                        //{
-                        //    var max = Math.Max(nearRelease.Length, farRelease.Length);
-                        //    if (max == lengthToCompare)
-                        //    {
-                        //        return true;
-                        //    }
-
-                        //    //return nearRelease.Length > farRelease.Length;
-                        //}
                         return true;
                     }
-                    return false;
+                    else
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -489,6 +489,11 @@ namespace NuGet.DependencyResolver
                         {
                             return true;
                         }
+
+                        if (!nearVersion.IsFloating && farVersion.IsFloating)
+                        {
+                            return false;
+                        }
                     }
                     return compared;
                 }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -498,8 +498,7 @@ namespace NuGet.DependencyResolver
                         {
                             return false;
                         }
-
-                        return true;
+                        return nearRelease.Length <= farRelease.Length;
                     }
                     else
                     {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -491,11 +491,12 @@ namespace NuGet.DependencyResolver
                     }
                     else if (compareResult == 0)
                     {
+                        // When 2 ranges are equivalent, but one is floating and the other is not, the floating one is greater.
                         if (nearVersion.IsFloating && !farVersion.IsFloating)
                         {
                             return true;
                         }
-
+                        // When 2 ranges are equivalent, but one is floating and the other is not, the floating one is greater.
                         if (!nearVersion.IsFloating && farVersion.IsFloating)
                         {
                             return false;

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -490,26 +490,26 @@ namespace NuGet.DependencyResolver
 
                     if (compareResult == 0)
                     {
-                        if (nearVersion.IsFloating && !farVersion.IsFloating)
-                        {
-                            return true;
-                        }
+                        //if (nearVersion.IsFloating && !farVersion.IsFloating)
+                        //{
+                        //    return true;
+                        //}
 
-                        if (!nearVersion.IsFloating && farVersion.IsFloating)
-                        {
-                            return false;
-                        }
+                        //if (!nearVersion.IsFloating && farVersion.IsFloating)
+                        //{
+                        //    return false;
+                        //}
 
-                        if (nearVersion.IsFloating && farVersion.IsFloating)
-                        {
-                            var max = Math.Max(nearRelease.Length, farRelease.Length);
-                            if (max == lengthToCompare)
-                            {
-                                return true;
-                            }
+                        //if (nearVersion.IsFloating && farVersion.IsFloating)
+                        //{
+                        //    var max = Math.Max(nearRelease.Length, farRelease.Length);
+                        //    if (max == lengthToCompare)
+                        //    {
+                        //        return true;
+                        //    }
 
-                            return nearRelease.Length > farRelease.Length;
-                        }
+                        //    return nearRelease.Length > farRelease.Length;
+                        //}
                         return true;
                     }
                     return false;

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -479,9 +479,18 @@ namespace NuGet.DependencyResolver
                 {
                     var lengthToCompare = Math.Min(nearRelease.Length, farRelease.Length);
 
-                    return StringComparer.OrdinalIgnoreCase.Compare(
+                    var compared = StringComparer.OrdinalIgnoreCase.Compare(
                         nearRelease.Substring(0, lengthToCompare),
                         farRelease.Substring(0, lengthToCompare)) >= 0;
+
+                    if (compared)
+                    {
+                        if (nearVersion.IsFloating && !farVersion.IsFloating)
+                        {
+                            return true;
+                        }
+                    }
+                    return compared;
                 }
             }
 

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -479,11 +479,16 @@ namespace NuGet.DependencyResolver
                 {
                     var lengthToCompare = Math.Min(nearRelease.Length, farRelease.Length);
 
-                    var compared = StringComparer.OrdinalIgnoreCase.Compare(
+                    int compareResult = StringComparer.OrdinalIgnoreCase.Compare(
                         nearRelease.Substring(0, lengthToCompare),
-                        farRelease.Substring(0, lengthToCompare)) >= 0;
+                        farRelease.Substring(0, lengthToCompare));
 
-                    if (compared)
+                    if (compareResult > 0)
+                    {
+                        return true;
+                    }
+
+                    if (compareResult == 0)
                     {
                         if (nearVersion.IsFloating && !farVersion.IsFloating)
                         {
@@ -494,8 +499,20 @@ namespace NuGet.DependencyResolver
                         {
                             return false;
                         }
+
+                        if (nearVersion.IsFloating && farVersion.IsFloating)
+                        {
+                            var max = Math.Max(nearRelease.Length, farRelease.Length);
+                            if (max == lengthToCompare)
+                            {
+                                return true;
+                            }
+
+                            return nearRelease.Length < farRelease.Length;
+                        }
+                        return true;
                     }
-                    return compared;
+                    return false;
                 }
             }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -2156,8 +2156,8 @@ namespace NuGet.Commands.FuncTest
         }";
             // Setup project
             var project1 = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net472");
-            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
-            var project3 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project3", pathContext.SolutionRoot, spec3);
+            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec3);
+            var project3 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project3", pathContext.SolutionRoot, spec2);
             project1 = project1.WithTestProjectReference(project2);
             project1 = project1.WithTestProjectReference(project3);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -2107,6 +2107,73 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // P1 -> P2 -> A 2.0.0-alpha*
+        // P1 -> P2 -> A 2.0.0-alphabeta*
+        [Fact]
+        public async Task RestoreCommand_WithMultiplePrereleaseTransitiveVersionWithFullyMatchedReleaseLabel_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                new SimpleTestPackageContext("a", "1.0.0"),
+                new SimpleTestPackageContext("a", "2.0.0-alpha.1"),
+                new SimpleTestPackageContext("a", "2.0.0-alpha.2"),
+                new SimpleTestPackageContext("a", "2.0.0-alphabeta.1"),
+                new SimpleTestPackageContext("a", "2.0.0-alphabeta.2")
+                );
+
+            // Setup project
+
+
+            var spec2 = @"
+        {
+            ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                    ""a"": {
+                        ""version"": ""2.0.0-alpha*"",
+                        ""target"": ""Package"",
+                    },
+                }
+            }
+            }
+        }";
+
+            var spec3 = @"
+        {
+            ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                    ""a"": {
+                        ""version"": ""2.0.0-alphabeta*"",
+                        ""target"": ""Package"",
+                    },
+                }
+            }
+            }
+        }";
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net472");
+            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
+            var project3 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project3", pathContext.SolutionRoot, spec3);
+            project1 = project1.WithTestProjectReference(project2);
+            project1 = project1.WithTestProjectReference(project3);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2, project3);
+            result.Success.Should().BeTrue();
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0-alphabeta.2"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
         // P1 -> P2 -> B 2.0.0-preview.*
         // P1 -> B 2.0.0-preview.2 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -2122,7 +2122,8 @@ namespace NuGet.Commands.FuncTest
                 new SimpleTestPackageContext("a", "2.0.0-alpha.1"),
                 new SimpleTestPackageContext("a", "2.0.0-alpha.2"),
                 new SimpleTestPackageContext("a", "2.0.0-alphabeta.1"),
-                new SimpleTestPackageContext("a", "2.0.0-alphabeta.2")
+                new SimpleTestPackageContext("a", "2.0.0-alphabeta.2"),
+                new SimpleTestPackageContext("a", "2.0.0-alphagamma.2")
                 );
 
             // Setup project
@@ -2170,7 +2171,7 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets.Should().HaveCount(1);
             result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
             result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
-            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0-alphabeta.2"));
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0-alphagamma.2"));
             result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project0");
             result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -2108,7 +2108,7 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
-        // P1 -> P2 -> A 2.0.0-alpha*
+        // P1 -> P2 -> P4 -> A 2.0.0-alpha*
         // P1 -> P3 -> A 2.0.0-alphabeta*
         [Fact]
         public async Task RestoreCommand_WithMultiplePrereleaseTransitiveVersionWithFullyMatchedReleaseLabel_VerifiesEquivalency()
@@ -2127,9 +2127,7 @@ namespace NuGet.Commands.FuncTest
                 );
 
             // Setup project
-
-
-            var spec2 = @"
+            var spec3 = @"
         {
             ""frameworks"": {
             ""net472"": {
@@ -2143,7 +2141,7 @@ namespace NuGet.Commands.FuncTest
             }
         }";
 
-            var spec3 = @"
+            var spec4 = @"
         {
             ""frameworks"": {
             ""net472"": {
@@ -2158,25 +2156,25 @@ namespace NuGet.Commands.FuncTest
         }";
             // Setup project
             var project1 = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net472");
-            var project4 = ProjectTestHelpers.GetPackageSpec("Project0", pathContext.SolutionRoot, framework: "net472");
-            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec3);
-            var project3 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project3", pathContext.SolutionRoot, spec2);
+            var project2 = ProjectTestHelpers.GetPackageSpec("Project2", pathContext.SolutionRoot, framework: "net472");
+            var project3 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project3", pathContext.SolutionRoot, spec3);
+            var project4 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project4", pathContext.SolutionRoot, spec4);
             project1 = project1.WithTestProjectReference(project2);
-            project1 = project1.WithTestProjectReference(project4);
-            project4 = project4.WithTestProjectReference(project3);
+            project1 = project1.WithTestProjectReference(project3);
+            project2 = project2.WithTestProjectReference(project4);
 
             // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2, project3, project4);
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project3, project4, project2);
             result.Success.Should().BeTrue(string.Join(Environment.NewLine, result.LogMessages.Select(e => e.Message)));
             result.LockFile.Targets.Should().HaveCount(1);
             result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
             result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
             result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0-alphagamma.2"));
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project0");
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
             result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("Project3");
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("Project4");
             result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -2108,7 +2109,7 @@ namespace NuGet.Commands.FuncTest
         }
 
         // P1 -> P2 -> A 2.0.0-alpha*
-        // P1 -> P2 -> A 2.0.0-alphabeta*
+        // P1 -> P3 -> A 2.0.0-alphabeta*
         [Fact]
         public async Task RestoreCommand_WithMultiplePrereleaseTransitiveVersionWithFullyMatchedReleaseLabel_VerifiesEquivalency()
         {
@@ -2156,22 +2157,26 @@ namespace NuGet.Commands.FuncTest
         }";
             // Setup project
             var project1 = ProjectTestHelpers.GetPackageSpec("Project1", pathContext.SolutionRoot, framework: "net472");
+            var project4 = ProjectTestHelpers.GetPackageSpec("Project0", pathContext.SolutionRoot, framework: "net472");
             var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec3);
             var project3 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project3", pathContext.SolutionRoot, spec2);
             project1 = project1.WithTestProjectReference(project2);
-            project1 = project1.WithTestProjectReference(project3);
+            project1 = project1.WithTestProjectReference(project4);
+            project4 = project4.WithTestProjectReference(project3);
 
             // Act & Assert
-            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2, project3);
-            result.Success.Should().BeTrue();
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2, project3, project4);
+            result.Success.Should().BeTrue(string.Join(Environment.NewLine, result.LogMessages.Select(e => e.Message)));
             result.LockFile.Targets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(4);
             result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
             result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("2.0.0-alphabeta.2"));
-            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project0");
             result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
-            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project3");
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[3].Name.Should().Be("Project3");
+            result.LockFile.Targets[0].Libraries[3].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
         // P1 -> P2 -> B 2.0.0-preview.*

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -2107,6 +2107,74 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // P1 -> P2 -> B 2.0.0-preview.*
+        // P1 -> B 2.0.0-preview.2 
+        [Fact]
+        public async Task RestoreCommand_WithDirectVersionAndWithPrereleaseTransitiveVersion_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            var versionRange = VersionRange.Parse("2.0.0-preview.*");
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                new SimpleTestPackageContext("a", "1.0.0"),
+                new SimpleTestPackageContext("b", "2.0.0-preview.1"),
+                new SimpleTestPackageContext("b", "2.0.0-preview.2"),
+                new SimpleTestPackageContext("b", "2.0.0-preview.3")
+                );
+
+            // Setup project
+            var spec1 = @"
+        {
+            ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                    ""a"": {
+                        ""version"": ""[1.0.0,)"",
+                        ""target"": ""Package"",
+                    },
+                    ""b"": {
+                        ""version"": ""[2.0.0-preview.2,)"",
+                        ""target"": ""Package"",
+                    },
+                }
+            }
+            }
+        }";
+
+            var spec2 = @"
+        {
+            ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                    ""b"": {
+                        ""version"": """ + versionRange.ToString() + @""",
+                        ""target"": ""Package"",
+                    },
+                }
+            }
+            }
+        }";
+
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
+            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
+            project1 = project1.WithTestProjectReference(project2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2);
+            result.Success.Should().BeTrue();
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0-preview.2"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
 
         // Project1 -> Project3 -> (project) ProjectAndPackage 1.0.0 -> Project4 -> PackageB 2.0.0
         //          -> packageA 1.0.0 -> PackageB 1.0.0

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -2041,6 +2041,73 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        // P1 -> P2 -> B 2.0.0-preview.*
+        // P1 -> A -> B 2.0.0-preview.1
+        [Fact]
+        public async Task RestoreCommand_WithPrereleaseTransitiveVersionWithFullyMatchedReleaseLabel_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            var versionRange = VersionRange.Parse("2.0.0-preview.*");
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Dependencies = [new SimpleTestPackageContext("b", "2.0.0-preview.1")],
+                },
+                new SimpleTestPackageContext("b", "2.0.0-preview.2")
+                );
+
+            // Setup project
+            var spec1 = @"
+        {
+            ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                    ""a"": {
+                        ""version"": ""[1.0.0,)"",
+                        ""target"": ""Package"",
+                    },
+                }
+            }
+            }
+        }";
+
+            var spec2 = @"
+        {
+            ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                    ""b"": {
+                        ""version"": """ + versionRange.ToString() + @""",
+                        ""target"": ""Package"",
+                    },
+                }
+            }
+            }
+        }";
+
+            // Setup project
+            var project1 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, spec1);
+            var project2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, spec2);
+            project1 = project1.WithTestProjectReference(project2);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, project1, project2);
+            result.Success.Should().BeTrue();
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("a");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("b");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0-preview.2"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
+
         // Project1 -> Project3 -> (project) ProjectAndPackage 1.0.0 -> Project4 -> PackageB 2.0.0
         //          -> packageA 1.0.0 -> PackageB 1.0.0
         //                            -> ProjectAndPackage 2.0.0

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -815,7 +815,7 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("3.1.0-beta-234", "3.2.0-*")]
         [InlineData("3.0.0-*", "3.1.0-beta-234")]
         [InlineData("6.8.0", "*-*")]
-        //[InlineData("3.0.0-preview.1", "3.0.0-preview.*")] // TODO: https://github.com/NuGet/Home/issues/13833
+        [InlineData("3.0.0-preview.1", "3.0.0-preview.*")]
         [InlineData("3.0.1", "3.0.*")]
         [InlineData("3.0.1", "*-preview.*")]
         [InlineData("3.0.1", "3.*-preview.*")]

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -761,13 +761,11 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("3.1.2-beta-*", "3.1.2-alpha-*")]
         [InlineData("3.1.*", "3.1.2-alpha-*")]
         [InlineData("*", "3.1.2-alpha-*")]
-        [InlineData("*", "*")]
         [InlineData("1.*", "1.1.*")]
         [InlineData("1.*", "1.3.*")]
         [InlineData("1.8.*", "1.8.3.*")]
         [InlineData("1.8.3.5*", "1.8.3.4-*")]
         [InlineData("1.8.3.*", "1.8.3.4-*")]
-        [InlineData("1.8.3.4-alphabeta-*", "1.8.3.4-alpha*")]
         [InlineData("1.8.5.4-alpha-*", "1.8.3.4-gamma*")]
         [InlineData("1.8.3.6-alpha-*", "1.8.3.4-gamma*")]
         [InlineData("1.8.3-*", "1.8.3-alpha*")]
@@ -790,9 +788,11 @@ namespace NuGet.DependencyResolver.Tests
 
             // Act
             var isGreater = RemoteDependencyWalker.IsGreaterThanOrEqualTo(leftVersion, rightVersion);
+            var isSmaller = RemoteDependencyWalker.IsGreaterThanOrEqualTo(rightVersion, leftVersion);
 
             // Assert
             Assert.True(isGreater);
+            Assert.False(isSmaller);
         }
 
         [Theory]
@@ -820,6 +820,7 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("3.0.1", "3.0.1.*-preview.*")]
         [InlineData("99.*", "*-*")]
         [InlineData("*-preview.*", "*-*")]
+        [InlineData("1.8.3.4-alphabeta-*", "1.8.3.4-alpha*")]
         public void IsGreaterThanEqualTo_ReturnsFalse_IfRightVersionIsLargerThanLeft(string leftVersionString, string rightVersionString)
         {
             // Arrange
@@ -828,9 +829,11 @@ namespace NuGet.DependencyResolver.Tests
 
             // Act
             var isGreater = RemoteDependencyWalker.IsGreaterThanOrEqualTo(leftVersion, rightVersion);
+            var isSmaller = RemoteDependencyWalker.IsGreaterThanOrEqualTo(rightVersion, leftVersion);
 
             // Assert
             Assert.False(isGreater);
+            Assert.True(isSmaller);
         }
 
         // When ranges are equivalent in everything but release label length, they're considered equivalent.
@@ -842,7 +845,6 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("3.0", "3.0")]
         [InlineData("3.0", "3.0.0")]
         [InlineData("1.8.3-*", "1.8.3-*")]
-        [InlineData("1.8.3.4-alpha*", "1.8.3.4-alphabeta-*")]
         public void IsGreaterThanEqualTo_ReturnsTrue_IfRightVersionAndLeftVersionAreEquivalent(string leftVersionString, string rightVersionString)
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -821,7 +821,6 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("3.0.1", "3.*-preview.*")]
         [InlineData("3.0.1", "3.0.*-preview.*")]
         [InlineData("3.0.1", "3.0.1.*-preview.*")]
-        [InlineData("1.8.3.4-alpha*", "1.8.3.4-alphabeta-*")]
         public void IsGreaterThanEqualTo_ReturnsFalse_IfRightVersionIsLargerThanLeft(string leftVersionString, string rightVersionString)
         {
             // Arrange
@@ -833,6 +832,24 @@ namespace NuGet.DependencyResolver.Tests
 
             // Assert
             Assert.False(isGreater);
+        }
+
+        // When ranges are equivalent in everything but release length, they're considered equivalent.
+        [Theory]
+        [InlineData("1.8.3.4-alpha*", "1.8.3.4-alphabeta-*")]
+        public void IsGreaterThanEqualTo_ReturnsTrue_IfRightVersionAndLeftVersionAreEquivalent(string leftVersionString, string rightVersionString)
+        {
+            // Arrange
+            var leftVersion = VersionRange.Parse(leftVersionString);
+            var rightVersion = VersionRange.Parse(rightVersionString);
+
+            // Act
+            var left = RemoteDependencyWalker.IsGreaterThanOrEqualTo(leftVersion, rightVersion);
+            var right = RemoteDependencyWalker.IsGreaterThanOrEqualTo(leftVersion, rightVersion);
+
+            // Assert
+            Assert.True(left);
+            Assert.True(right);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -752,8 +752,6 @@ namespace NuGet.DependencyResolver.Tests
         }
 
         [Theory]
-        [InlineData("3.0", "3.0")]
-        [InlineData("3.0", "3.0.0")]
         [InlineData("3.1", "3.0.0")]
         [InlineData("3.1.2", "3.1.1")]
         [InlineData("3.1.2-beta", "3.1.2-alpha")]
@@ -773,7 +771,6 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("1.8.5.4-alpha-*", "1.8.3.4-gamma*")]
         [InlineData("1.8.3.6-alpha-*", "1.8.3.4-gamma*")]
         [InlineData("1.8.3-*", "1.8.3-alpha*")]
-        [InlineData("1.8.3-*", "1.8.3-*")]
         [InlineData("1.8.4-*", "1.8.3-*")]
         [InlineData("2.8.1-*", "1.8.3-*")]
         [InlineData("3.2.0-*", "3.1.0-beta-234")]
@@ -821,6 +818,8 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("3.0.1", "3.*-preview.*")]
         [InlineData("3.0.1", "3.0.*-preview.*")]
         [InlineData("3.0.1", "3.0.1.*-preview.*")]
+        [InlineData("99.*", "*-*")]
+        [InlineData("*-preview.*", "*-*")]
         public void IsGreaterThanEqualTo_ReturnsFalse_IfRightVersionIsLargerThanLeft(string leftVersionString, string rightVersionString)
         {
             // Arrange
@@ -839,6 +838,10 @@ namespace NuGet.DependencyResolver.Tests
         // If there's no package that matches the longer range, the longer range won't be satisfied and restore would fail
         // Which range we encounter first is not important.
         [Theory]
+        [InlineData("*", "*")]
+        [InlineData("3.0", "3.0")]
+        [InlineData("3.0", "3.0.0")]
+        [InlineData("1.8.3-*", "1.8.3-*")]
         [InlineData("1.8.3.4-alpha*", "1.8.3.4-alphabeta-*")]
         public void IsGreaterThanEqualTo_ReturnsTrue_IfRightVersionAndLeftVersionAreEquivalent(string leftVersionString, string rightVersionString)
         {
@@ -848,7 +851,7 @@ namespace NuGet.DependencyResolver.Tests
 
             // Act
             var left = RemoteDependencyWalker.IsGreaterThanOrEqualTo(leftVersion, rightVersion);
-            var right = RemoteDependencyWalker.IsGreaterThanOrEqualTo(leftVersion, rightVersion);
+            var right = RemoteDependencyWalker.IsGreaterThanOrEqualTo(rightVersion, leftVersion);
 
             // Assert
             Assert.True(left);

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -780,6 +780,7 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("3.*-preview.*", "3.0.1")]
         [InlineData("3.0.*-preview.*", "3.0.1")]
         [InlineData("3.0.1.*-preview.*", "3.0.1")]
+        [InlineData("1.8.3.4-alpha3", "1.8.3.4-alpha.*")]
         public void IsGreaterThanEqualTo_ReturnsTrue_IfRightVersionIsSmallerThanLeft(string leftVersionString, string rightVersionString)
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -836,10 +836,6 @@ namespace NuGet.DependencyResolver.Tests
             Assert.True(isSmaller);
         }
 
-        // When ranges are equivalent in everything but release label length, they're considered equivalent.
-        // The longer range is greater, and everything that matches the longer range, matches the shorter range.
-        // If there's no package that matches the longer range, the longer range won't be satisfied and restore would fail
-        // Which range we encounter first is not important.
         [Theory]
         [InlineData("*", "*")]
         [InlineData("3.0", "3.0")]

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -834,7 +834,10 @@ namespace NuGet.DependencyResolver.Tests
             Assert.False(isGreater);
         }
 
-        // When ranges are equivalent in everything but release length, they're considered equivalent.
+        // When ranges are equivalent in everything but release label length, they're considered equivalent.
+        // The longer range is greater, and everything that matches the longer range, matches the shorter range.
+        // If there's no package that matches the longer range, the longer range won't be satisfied and restore would fail
+        // Which range we encounter first is not important.
         [Theory]
         [InlineData("1.8.3.4-alpha*", "1.8.3.4-alphabeta-*")]
         public void IsGreaterThanEqualTo_ReturnsTrue_IfRightVersionAndLeftVersionAreEquivalent(string leftVersionString, string rightVersionString)

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -821,7 +821,7 @@ namespace NuGet.DependencyResolver.Tests
         [InlineData("3.0.1", "3.*-preview.*")]
         [InlineData("3.0.1", "3.0.*-preview.*")]
         [InlineData("3.0.1", "3.0.1.*-preview.*")]
-
+        [InlineData("1.8.3.4-alpha*", "1.8.3.4-alphabeta-*")]
         public void IsGreaterThanEqualTo_ReturnsFalse_IfRightVersionIsLargerThanLeft(string leftVersionString, string rightVersionString)
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13833

## Description

When we'd have 2 transitive ranges, where one is floating, we'd often not choose the greater, or rather floating range.
For example, prior to this change, whichever would come along first among 2.0.0-preview.1 and 2.0.0-preview.* would win, but in practice, we want the higher version (as the old resolver does). 
In this change, when a version matches completely, we always pick the floating version.
There's also a change in this PR, previous when "1.8.3.4-alphabeta-*" and "1.8.3.4-alpha*" were compared, the first one was chosen as greater due to the range being greater, but in reality, while `1.8.3.4-alphabeta` is greater than 1.8.3.4-alpha, the floating range of the second one will match everything the longer one does, so in this makes it makes more sense to have the shorter be greater. 

There's some potential risk that this causes issues in the old resolver (since it uses the method slightly differently), the comparison testing didn't show any issues. Note that this only really comes into effect where there's multiple floating ranges for the same package and since floating ranges are only possible in projects, it means 2 projects in the same repo need to be using a different floating range and the chances of that are really low, so the risk is in a low probability scenario.
We also develop for the new algorithm first and it's enabled by default, so prioritizing that is more important.

Finally in the IsGreaterThanOrEqualTo tests, I added more explicit tests for whenever it's supposed to be greater, vs equal, vs smaller by adding the reverse comparison as well. 
It makes the tests cleaner.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
