### PR TITLE
Remove SDKAnalysisLevel check for NU1510 and NU1511

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
@@ -175,10 +175,7 @@ namespace NuGet.Commands
 
                 if (!isPackage)
                 {
-                    if (isRootProject && enablePruningWarnings && SdkAnalysisLevelMinimums.IsEnabled(
-                        projectRestoreMetadata.SdkAnalysisLevel,
-                        projectRestoreMetadata.UsingMicrosoftNETSdk,
-                        SdkAnalysisLevelMinimums.V10_0_100))
+                    if (isRootProject && enablePruningWarnings)
                     {
                         logger.Log(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1511, string.Format(CultureInfo.CurrentCulture, Strings.Error_RestorePruningProjectReference, dependency.Name), dependency.Name,
                             targetGraphName));

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -841,12 +841,7 @@ namespace NuGet.Commands
 
         internal static void AnalyzePruningResults(PackageSpec project, TelemetryEvent telemetryEvent, ILogger logger)
         {
-            bool enablePruningWarnings =
-                SdkAnalysisLevelMinimums.IsEnabled(
-                    project.RestoreMetadata.SdkAnalysisLevel,
-                    project.RestoreMetadata.UsingMicrosoftNETSdk,
-                    SdkAnalysisLevelMinimums.V10_0_100) &&
-                HasFrameworkNewerThanNET10(project);
+            bool enablePruningWarnings = HasFrameworkNewerThanNET10(project);
 
             Dictionary<string, List<string>> prunedDirectPackages = GetPrunableDirectPackages(project);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Progress: https://github.com/nuget/home/issues/14126 

## Description

Pruning warnings are only enabled .NET 10 TFM, and as such the SDKAnalysisLevel checks are redundant.
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. - https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#sdkanalysislevel already contains a list of settings. 
