### PR TITLE
Build .NET Frameworks TFMs on non-Windows

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -368,6 +368,7 @@
     </PropertyGroup>
     <PropertyGroup>
       <DotNetTestAdditionalArgs Condition="'$(SYSTEM_DEBUG)' == 'true' And '$(BINLOG_DIRECTORY)' != ''">--diag &quot;$(BINLOG_DIRECTORY)\vstest.log&quot;</DotNetTestAdditionalArgs>
+      <SkipDesktopAssemblies Condition="'$(SkipDesktopAssemblies)' == '' and '$(OS)' != 'Windows_NT'">true</SkipDesktopAssemblies>
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(SkipDesktopAssemblies)' != 'true' ">

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -18,7 +18,7 @@
     <!-- Target frameworks for class libraries-->
     <TargetFrameworksLibrary>$(NetStandardVersion)</TargetFrameworksLibrary>
     <TargetFrameworksLibrary Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NETCoreTargetFramework);$(TargetFrameworksLibrary)</TargetFrameworksLibrary>
-    <TargetFrameworksLibrary Condition="'$(IsXPlat)' != 'true' And '$(DotNetBuildSourceOnly)' != 'true'">$(NETFXTargetFramework);$(TargetFrameworksLibrary)</TargetFrameworksLibrary>
+    <TargetFrameworksLibrary Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(NETFXTargetFramework);$(TargetFrameworksLibrary)</TargetFrameworksLibrary>
 
     <!-- Target frameworks for class libraries which require signing APIs which need to target NET 5.0 -->
     <TargetFrameworksLibraryForSigning>$(TargetFrameworksLibrary)</TargetFrameworksLibraryForSigning>
@@ -26,12 +26,11 @@
 
     <!-- Target framework for runnable apps -->
     <TargetFrameworksExe>$(NETCoreTargetFramework)</TargetFrameworksExe>
-    <TargetFrameworksExe Condition="'$(IsXPlat)' != 'true' And '$(DotNetBuildSourceOnly)' != 'true'">$(NETFXTargetFramework);$(TargetFrameworksExe)</TargetFrameworksExe>
+    <TargetFrameworksExe Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(NETFXTargetFramework);$(TargetFrameworksExe)</TargetFrameworksExe>
 
     <!-- Target frameworks for unit tests -->
     <TargetFrameworksUnitTest>$(NETCoreTargetFramework)</TargetFrameworksUnitTest>
-    <TargetFrameworksUnitTest Condition="'$(IsXPlat)' != 'true' And '$(DotNetBuildSourceOnly)' != 'true'">$(NETFXTargetFramework);$(TargetFrameworksUnitTest)</TargetFrameworksUnitTest>
-
+    <TargetFrameworksUnitTest Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(NETFXTargetFramework);$(TargetFrameworksUnitTest)</TargetFrameworksUnitTest>
   </PropertyGroup>
 
   <!-- Common -->


### PR DESCRIPTION
The VMR builds nuget-client on non-Windows platforms. The produced packages are currently different to the Windows ones due to .NET Frameworks TFMs getting filtered out. This causes an issue when .NET Frameworks apps use the NuGet packages and are built on Unix. An error showed up due to this in dotnet/sdk.

Unblocks https://github.com/dotnet/dotnet/pull/1734

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
