### PR TITLE
Update publish tasks to use latest version of Microsoft.DotNet.Build.Feed

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.3.1" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.DataAI.NuGetRecommender.Contracts" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.20528.5" />
+    <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25401.1" />
     <PackageVersion Include="Microsoft.DotNet.Maestro.Tasks" Version="1.1.0-beta.24415.2" />
     <PackageVersion Include="Microsoft.DotNet.XliffTasks" Version="10.0.0-beta.25260.104" />
     <PackageVersion Include="Microsoft.DotNet.SignTool" Version="10.0.0-beta.25367.5" />

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -13,9 +13,8 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" />
   </ItemGroup>
 
-  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.Feed.PushToAzureDevOpsArtifacts" AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Feed)\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll" />
-  <UsingTask TaskName="Microsoft.DotNet.Maestro.Tasks.PushMetadataToBuildAssetRegistry" AssemblyFile="$(PkgMicrosoft_DotNet_Maestro_Tasks)\tools\net6.0\Microsoft.DotNet.Maestro.Tasks.dll" />
-
+  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.Feed.PushToBuildStorage" AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Feed)\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll" />
+  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.Feed.PublishBuildToMaestro" AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Feed)\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll" />
 
   <Target Name="PublishToBuildAssetRegistry">
     <PropertyGroup>
@@ -28,7 +27,7 @@
     <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
 
     <ItemGroup>
-      <ItemsToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.nupkg" />
+      <ItemsToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.nupkg" Kind="Package" />
       <ItemsToPush Remove="$(NuGetClientNupkgsDirectoryPath)/NuGet.Packaging.Core.*" />
     </ItemGroup>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug
Fixes: https://github.com/dotnet/arcade-services/issues/5062

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

## Description
Latest version of Microsoft.DotNet.Build.Feed contains a retry to publishing tasks, this PR updates the package and also addresses a breaking change for a renamed task.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[] Added tests~
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
