### PR TITLE
dotnet package update can update multiple packages in one command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Frameworks;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using static NuGet.CommandLine.XPlat.Commands.Package.Update.PackageUpdateCommandRunner;
@@ -60,11 +59,11 @@ internal interface IPackageUpdateIO
     /// is used by all target frameworks.
     /// </summary>
     /// <param name="updatedPackageSpec">The updated project specification containing target framework information.</param>
-    /// <param name="packageTfms">Target frameworks where the package is used.</param>
+    /// <param name="packageTfmAliases">Target frameworks where the package is used.</param>
     /// <param name="restorePreviewResult">The restore preview result containing resolved package information.</param>
     /// <param name="packageDependency">Package dependency information.</param>
     /// <param name="logger">Logger for the operation.</param>
-    void UpdatePackageReference(PackageSpec updatedPackageSpec, RestoreResult restorePreviewResult, List<NuGetFramework> packageTfms, PackageToUpdate packageDependency, ILogger logger);
+    void UpdatePackageReference(PackageSpec updatedPackageSpec, RestoreResult restorePreviewResult, List<string> packageTfmAliases, PackageToUpdate packageDependency, ILogger logger);
 
     /// <summary>
     /// An opaque type, to aid in testing, representing the result of a restore operation.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -7,14 +7,12 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.CommandLine.XPlat.Utility;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Credentials;
-using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
@@ -75,6 +73,10 @@ internal static class PackageUpdateCommandRunner
             return ExitCodes.Error;
         }
 
+        PackageSpec projectSpec = dgSpec.Projects.Count == 1
+            ? dgSpec.Projects[0]
+            : dgSpec.GetProjectSpec(dgSpec.Restore[0]);
+
         // 2. Find suitable version of package(s) to update
         // Source provider will be needed to find the package version and to restore, so create it here.
         logger.LogVerbose(Strings.PackageUpdate_FindingUpdateVersions);
@@ -92,14 +94,14 @@ internal static class PackageUpdateCommandRunner
 
         if (noPackagesSpecified)
         {
-            var allProjectPackages = GetAllPackagedReferencedByProject(dgSpec.Projects.Single());
+            var allProjectPackages = GetAllPackagesReferencedByProject(projectSpec);
             totalPackagesScanned = allProjectPackages.Count;
-            packagesToUpdateResult = await GetAllPackagesWithUpdatesAsync(dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
+            packagesToUpdateResult = await GetAllPackagesWithUpdatesAsync(projectSpec, versionChooser, settings, logger, cancellationToken);
         }
         else
         {
             totalPackagesScanned = args.Packages!.Count;
-            packagesToUpdateResult = await GetPackagesToUpdateAsync(args.Packages, dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
+            packagesToUpdateResult = await GetPackagesToUpdateAsync(args.Packages, projectSpec, versionChooser, settings, logger, cancellationToken);
         }
 
         if (packagesToUpdateResult.Count == 0)
@@ -138,10 +140,11 @@ internal static class PackageUpdateCommandRunner
         foreach (var packageResult in packagesToUpdateResult)
         {
             logger.LogInformation($"    " + Format.PackageUpdate_UpdatedMessage(packageResult.Package.Id, packageResult.Package.CurrentVersion.ToShortString(), packageResult.Package.NewVersion.ToShortString()));
-            packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageResult.Frameworks, packageResult.Package, logger);
+            packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageResult.TargetFrameworkAliases, packageResult.Package, logger);
             updatedCount++;
         }
 
+        // New line in between projects, or before the final summary.
         logger.LogInformation("");
 
         // 5. Commit restore if everything successful
@@ -206,13 +209,15 @@ internal static class PackageUpdateCommandRunner
             return new List<PackageUpdateResult>();
         }
 
-        var allProjectPackages = GetAllPackagedReferencedByProject(project);
+        var allProjectPackages = GetAllPackagesReferencedByProject(project);
         var packagesToUpdate = new List<PackageUpdateResult>();
 
         foreach (var packageId in allProjectPackages)
         {
             var packageToCheck = new Package { Id = packageId, VersionRange = null };
             var result = await GetSinglePackageToUpdateAsync(packageToCheck, project, versionChooser, settings, logger, suppressWarnings: true, cancellationToken);
+            // GetSinglePackageToUpdateAsync returns null if the package is already using the highest version.
+            // This is not an error when updating all packages in a project.
             if (result != null)
             {
                 packagesToUpdate.Add(result);
@@ -222,7 +227,7 @@ internal static class PackageUpdateCommandRunner
         return packagesToUpdate;
     }
 
-    private static HashSet<string> GetAllPackagedReferencedByProject(PackageSpec project)
+    private static HashSet<string> GetAllPackagesReferencedByProject(PackageSpec project)
     {
         var allPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -251,7 +256,7 @@ internal static class PackageUpdateCommandRunner
         CancellationToken cancellationToken)
     {
         VersionRange? existingVersion = null;
-        List<NuGetFramework>? frameworks = null;
+        List<string> frameworks = new();
 
         foreach (var tfm in project.TargetFrameworks)
         {
@@ -259,11 +264,7 @@ internal static class PackageUpdateCommandRunner
             {
                 if (string.Equals(package.Id, dependency.Name, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (frameworks is null)
-                    {
-                        frameworks = new List<NuGetFramework>();
-                    }
-                    frameworks.Add(tfm.FrameworkName);
+                    frameworks.Add(tfm.TargetAlias);
 
                     VersionRange tfmVersionRange;
                     if (project.RestoreMetadata.CentralPackageFloatingVersionsEnabled)
@@ -370,7 +371,7 @@ internal static class PackageUpdateCommandRunner
         return new PackageUpdateResult
         {
             Package = packageToUpdate,
-            Frameworks = frameworks!
+            TargetFrameworkAliases = frameworks!
         };
     }
 
@@ -400,7 +401,8 @@ internal static class PackageUpdateCommandRunner
     internal record PackageUpdateResult
     {
         public required PackageToUpdate Package { get; init; }
-        public required List<NuGetFramework> Frameworks { get; init; }
+
+        public required List<string> TargetFrameworkAliases { get; init; }
     }
 
     private static class Format

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -85,9 +85,23 @@ internal static class PackageUpdateCommandRunner
         CachingSourceProvider sourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings));
         using SourceCacheContext sourceCacheContext = new();
         var versionChooser = new VersionChooser(sourceProvider, settings, sourceCacheContext);
-        var packagesToUpdateResult = await GetPackagesToUpdateAsync(args.Packages, dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
 
         bool noPackagesSpecified = args.Packages is null || args.Packages.Count == 0;
+        int totalPackagesScanned = 0;
+        List<PackageUpdateResult> packagesToUpdateResult;
+
+        if (noPackagesSpecified)
+        {
+            var allProjectPackages = GetAllProjectPackages(dgSpec.Projects.Single());
+            totalPackagesScanned = allProjectPackages.Count;
+            packagesToUpdateResult = await GetAllPackagesWithUpdatesAsync(dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
+        }
+        else
+        {
+            totalPackagesScanned = args.Packages!.Count;
+            packagesToUpdateResult = await GetPackagesToUpdateAsync(args.Packages, dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
+        }
+
         if (packagesToUpdateResult.Count == 0)
         {
             if (noPackagesSpecified)
@@ -133,7 +147,7 @@ internal static class PackageUpdateCommandRunner
         // 5. Commit restore if everything successful
         await packageUpdateIO.CommitAsync(restorePreviewResult, CancellationToken.None);
 
-        int scannedCount = packagesToUpdateResult.Count;
+        int scannedCount = totalPackagesScanned;
         logger.LogMinimal(Format.PackageUpdate_FinalSummary(updatedCount, scannedCount), ConsoleColor.Green);
 
         return ExitCodes.Success;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -92,7 +92,7 @@ internal static class PackageUpdateCommandRunner
 
         if (noPackagesSpecified)
         {
-            var allProjectPackages = GetAllProjectPackages(dgSpec.Projects.Single());
+            var allProjectPackages = GetAllPackagedReferencedByProject(dgSpec.Projects.Single());
             totalPackagesScanned = allProjectPackages.Count;
             packagesToUpdateResult = await GetAllPackagesWithUpdatesAsync(dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
         }
@@ -206,7 +206,7 @@ internal static class PackageUpdateCommandRunner
             return new List<PackageUpdateResult>();
         }
 
-        var allProjectPackages = GetAllProjectPackages(project);
+        var allProjectPackages = GetAllPackagedReferencedByProject(project);
         var packagesToUpdate = new List<PackageUpdateResult>();
 
         foreach (var packageId in allProjectPackages)
@@ -222,7 +222,7 @@ internal static class PackageUpdateCommandRunner
         return packagesToUpdate;
     }
 
-    private static HashSet<string> GetAllProjectPackages(PackageSpec project)
+    private static HashSet<string> GetAllPackagedReferencedByProject(PackageSpec project)
     {
         var allPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -247,7 +247,7 @@ internal static class PackageUpdateCommandRunner
         IVersionChooser versionChooser,
         ISettings settings,
         ILoggerWithColor logger,
-         bool suppressWarnings,
+        bool suppressWarnings,
         CancellationToken cancellationToken)
     {
         VersionRange? existingVersion = null;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -85,17 +85,17 @@ internal static class PackageUpdateCommandRunner
         CachingSourceProvider sourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings));
         using SourceCacheContext sourceCacheContext = new();
         var versionChooser = new VersionChooser(sourceProvider, settings, sourceCacheContext);
-        (PackageToUpdate? packageToUpdate, List<NuGetFramework>? packageTfms) = await GetPackageToUpdateAsync(args.Packages, dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
+        var packagesToUpdateResult = await GetPackagesToUpdateAsync(args.Packages, dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
 
-        if (packageToUpdate is null)
+        if (!packagesToUpdateResult.Any())
         {
-            // GetPackagesToUpdateAsync is responsible for outputting an error message.
+            // GetPackagesToUpdateAsync is responsible for outputting error messages.
             return ExitCodes.Error;
         }
 
         // 3. Preview restore to validate changes
         logger.LogDebug(Strings.PackageUpdate_PreviewRestore);
-        var updatedDgSpec = GetUpdatedDependencyGraphSpec(dgSpec, packageToUpdate);
+        var updatedDgSpec = GetUpdatedDependencyGraphSpec(dgSpec, packagesToUpdateResult);
         var restorePreviewResult = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(updatedDgSpec, sourceCacheContext, logger, cancellationToken);
 
         if (!restorePreviewResult.Success)
@@ -107,23 +107,29 @@ internal static class PackageUpdateCommandRunner
         // 4. Update MSBuild files
         var projectName = Path.GetFileNameWithoutExtension(dgSpec.Projects[0].FilePath);
         logger.LogInformation($"  {projectName}:");
-        logger.LogInformation($"    " + Format.PackageUpdate_UpdatedMessage(packageToUpdate.Id, packageToUpdate.CurrentVersion.ToShortString(), packageToUpdate.NewVersion.ToShortString()));
-        logger.LogInformation("");
 
         var updatedPackageSpec = updatedDgSpec.Projects[0];
-        packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageTfms!, packageToUpdate, logger);
+        int updatedCount = 0;
+
+        foreach (var packageResult in packagesToUpdateResult)
+        {
+            logger.LogInformation($"    " + Format.PackageUpdate_UpdatedMessage(packageResult.Package.Id, packageResult.Package.CurrentVersion.ToShortString(), packageResult.Package.NewVersion.ToShortString()));
+            packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageResult.Frameworks, packageResult.Package, logger);
+            updatedCount++;
+        }
+
+        logger.LogInformation("");
 
         // 5. Commit restore if everything successful
         await packageUpdateIO.CommitAsync(restorePreviewResult, CancellationToken.None);
 
-        int updatedCount = 1;
-        int scannedCount = 1;
+        int scannedCount = packagesToUpdateResult.Count;
         logger.LogMinimal(Format.PackageUpdate_FinalSummary(updatedCount, scannedCount), ConsoleColor.Green);
 
         return ExitCodes.Success;
     }
 
-    internal static async Task<(PackageToUpdate?, List<NuGetFramework>?)> GetPackageToUpdateAsync(
+    internal static async Task<List<PackageUpdateResult>> GetPackagesToUpdateAsync(
         IReadOnlyList<Package> packages,
         PackageSpec project,
         IVersionChooser versionChooser,
@@ -134,26 +140,46 @@ internal static class PackageUpdateCommandRunner
         if (packages is null || packages.Count == 0)
         {
             logger.LogMinimal(Strings.Unsupported_UpgradeAllPackages, ConsoleColor.Red);
-            return (null, null);
-        }
-
-        if (packages.Count > 1)
-        {
-            logger.LogMinimal(Strings.Unsupported_MoreThanOnePackage, ConsoleColor.Red);
-            return (null, null);
+            return new List<PackageUpdateResult>();
         }
 
         var sourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
         if (sourceMapping.IsEnabled)
         {
             logger.LogMinimal(Strings.Unsupported_PackageSourceMapping, ConsoleColor.Red);
-            return (null, null);
+            return new List<PackageUpdateResult>();
         }
 
-        var package = packages.Single();
+        var packagesToUpdate = new List<PackageUpdateResult>();
+        bool hasErrors = false;
 
+        foreach (var package in packages)
+        {
+            var result = await GetSinglePackageToUpdateAsync(package, project, versionChooser, settings, logger, cancellationToken);
+            if (result != null)
+            {
+                packagesToUpdate.Add(result);
+            }
+            else
+            {
+                hasErrors = true;
+            }
+        }
+
+        return hasErrors ? new List<PackageUpdateResult>() : packagesToUpdate;
+    }
+
+    private static async Task<PackageUpdateResult?> GetSinglePackageToUpdateAsync(
+        Package package,
+        PackageSpec project,
+        IVersionChooser versionChooser,
+        ISettings settings,
+        ILoggerWithColor logger,
+        CancellationToken cancellationToken)
+    {
         VersionRange? existingVersion = null;
         List<NuGetFramework>? frameworks = null;
+
         foreach (var tfm in project.TargetFrameworks)
         {
             foreach (var dependency in tfm.Dependencies)
@@ -176,7 +202,7 @@ internal static class PackageUpdateCommandRunner
                             logger.LogMinimal(
                                 Messages.Error_CouldNotFindPackageVersionForCpmPackage(package.Id),
                                 ConsoleColor.Red);
-                            return (null, null);
+                            return null;
                         }
                         tfmVersionRange = centralVersion.VersionRange;
                     }
@@ -196,7 +222,7 @@ internal static class PackageUpdateCommandRunner
                             logger.LogMinimal(
                                 Messages.Unsupported_UpdatePackageWithDifferentPerTfmVersions(package.Id, project.FilePath),
                                 ConsoleColor.Red);
-                            return (null, null);
+                            return null;
                         }
                     }
                 }
@@ -206,7 +232,7 @@ internal static class PackageUpdateCommandRunner
         if (existingVersion is null)
         {
             logger.LogMinimal(Messages.Error_PackageNotReferenced(package.Id, project.FilePath), ConsoleColor.Red);
-            return (null, null);
+            return null;
         }
 
         VersionRange newVersion;
@@ -228,13 +254,13 @@ internal static class PackageUpdateCommandRunner
             if (highestVersion is null)
             {
                 logger.LogMinimal(Messages.Error_NoVersionsAvailable(package.Id), ConsoleColor.Red);
-                return (null, null);
+                return null;
             }
 
             if (existingVersion.MinVersion == highestVersion)
             {
-                logger.LogMinimal(Messages.Warning_AlreadyHighestVersion(package.Id, highestVersion.OriginalVersion, project.FilePath), ConsoleColor.Red);
-                return (null, null);
+                logger.LogMinimal(Messages.Warning_AlreadyHighestVersion(package.Id, highestVersion.OriginalVersion, project.FilePath), ConsoleColor.Yellow);
+                return null;
             }
 
             newVersion = new VersionRange(highestVersion);
@@ -244,8 +270,8 @@ internal static class PackageUpdateCommandRunner
             newVersion = package.VersionRange;
             if (newVersion == existingVersion)
             {
-                logger.LogMinimal(Messages.Warning_AlreadyUsingSameVersion(package.Id, newVersion.OriginalString), ConsoleColor.Red);
-                return (null, null);
+                logger.LogMinimal(Messages.Warning_AlreadyUsingSameVersion(package.Id, newVersion.OriginalString), ConsoleColor.Yellow);
+                return null;
             }
         }
 
@@ -256,14 +282,22 @@ internal static class PackageUpdateCommandRunner
             NewVersion = newVersion
         };
 
-        return (packageToUpdate, frameworks);
+        return new PackageUpdateResult
+        {
+            Package = packageToUpdate,
+            Frameworks = frameworks!
+        };
     }
 
-    private static DependencyGraphSpec GetUpdatedDependencyGraphSpec(DependencyGraphSpec currentDgSpec, PackageToUpdate packageToUpdate)
+    private static DependencyGraphSpec GetUpdatedDependencyGraphSpec(DependencyGraphSpec currentDgSpec, List<PackageUpdateResult> packagesToUpdate)
     {
         var updatedPackageSpec = currentDgSpec.Projects[0].Clone();
-        PackageDependency packageDependency = new PackageDependency(packageToUpdate.Id, packageToUpdate.NewVersion);
-        PackageSpecOperations.AddOrUpdateDependency(updatedPackageSpec, packageDependency);
+
+        foreach (var packageResult in packagesToUpdate)
+        {
+            PackageDependency packageDependency = new PackageDependency(packageResult.Package.Id, packageResult.Package.NewVersion);
+            PackageSpecOperations.AddOrUpdateDependency(updatedPackageSpec, packageDependency);
+        }
 
         var updatedDgSpec = currentDgSpec.WithReplacedSpec(updatedPackageSpec).WithoutRestores();
         updatedDgSpec.AddRestore(updatedPackageSpec.RestoreMetadata.ProjectUniqueName);
@@ -276,6 +310,12 @@ internal static class PackageUpdateCommandRunner
         public required string Id { get; init; }
         public required VersionRange CurrentVersion { get; init; }
         public required VersionRange NewVersion { get; init; }
+    }
+
+    internal record PackageUpdateResult
+    {
+        public required PackageToUpdate Package { get; init; }
+        public required List<NuGetFramework> Frameworks { get; init; }
     }
 
     private static class Format

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -87,10 +87,20 @@ internal static class PackageUpdateCommandRunner
         var versionChooser = new VersionChooser(sourceProvider, settings, sourceCacheContext);
         var packagesToUpdateResult = await GetPackagesToUpdateAsync(args.Packages, dgSpec.Projects.Single(), versionChooser, settings, logger, cancellationToken);
 
-        if (!packagesToUpdateResult.Any())
+        bool noPackagesSpecified = args.Packages is null || args.Packages.Count == 0;
+        if (packagesToUpdateResult.Count == 0)
         {
-            // GetPackagesToUpdateAsync is responsible for outputting error messages.
-            return ExitCodes.Error;
+            if (noPackagesSpecified)
+            {
+                // When no packages are specified and all packages are already up to date, return exit code 2
+                logger.LogMinimal("All packages are already up to date.", ConsoleColor.Green);
+                return ExitCodes.NoPackagesNeedUpdating;
+            }
+            else
+            {
+                // GetPackagesToUpdateAsync is responsible for outputting error messages.
+                return ExitCodes.Error;
+            }
         }
 
         // 3. Preview restore to validate changes
@@ -139,8 +149,7 @@ internal static class PackageUpdateCommandRunner
     {
         if (packages is null || packages.Count == 0)
         {
-            logger.LogMinimal(Strings.Unsupported_UpgradeAllPackages, ConsoleColor.Red);
-            return new List<PackageUpdateResult>();
+            return await GetAllPackagesWithUpdatesAsync(project, versionChooser, settings, logger, cancellationToken);
         }
 
         var sourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
@@ -155,7 +164,7 @@ internal static class PackageUpdateCommandRunner
 
         foreach (var package in packages)
         {
-            var result = await GetSinglePackageToUpdateAsync(package, project, versionChooser, settings, logger, cancellationToken);
+            var result = await GetSinglePackageToUpdateAsync(package, project, versionChooser, settings, logger, suppressWarnings: false, cancellationToken);
             if (result != null)
             {
                 packagesToUpdate.Add(result);
@@ -169,12 +178,62 @@ internal static class PackageUpdateCommandRunner
         return hasErrors ? new List<PackageUpdateResult>() : packagesToUpdate;
     }
 
+    private static async Task<List<PackageUpdateResult>> GetAllPackagesWithUpdatesAsync(
+        PackageSpec project,
+        IVersionChooser versionChooser,
+        ISettings settings,
+        ILoggerWithColor logger,
+        CancellationToken cancellationToken)
+    {
+        var sourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+        if (sourceMapping.IsEnabled)
+        {
+            logger.LogMinimal(Strings.Unsupported_PackageSourceMapping, ConsoleColor.Red);
+            return new List<PackageUpdateResult>();
+        }
+
+        var allProjectPackages = GetAllProjectPackages(project);
+        var packagesToUpdate = new List<PackageUpdateResult>();
+
+        foreach (var packageId in allProjectPackages)
+        {
+            var packageToCheck = new Package { Id = packageId, VersionRange = null };
+            var result = await GetSinglePackageToUpdateAsync(packageToCheck, project, versionChooser, settings, logger, suppressWarnings: true, cancellationToken);
+            if (result != null)
+            {
+                packagesToUpdate.Add(result);
+            }
+        }
+
+        return packagesToUpdate;
+    }
+
+    private static HashSet<string> GetAllProjectPackages(PackageSpec project)
+    {
+        var allPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var tfm in project.TargetFrameworks)
+        {
+            foreach (var dependency in tfm.Dependencies)
+            {
+                // Skip auto-referenced packages and packages without explicit names
+                if (!string.IsNullOrEmpty(dependency.Name) && !dependency.AutoReferenced)
+                {
+                    allPackageIds.Add(dependency.Name);
+                }
+            }
+        }
+
+        return allPackageIds;
+    }
+
     private static async Task<PackageUpdateResult?> GetSinglePackageToUpdateAsync(
         Package package,
         PackageSpec project,
         IVersionChooser versionChooser,
         ISettings settings,
         ILoggerWithColor logger,
+         bool suppressWarnings,
         CancellationToken cancellationToken)
     {
         VersionRange? existingVersion = null;
@@ -231,7 +290,10 @@ internal static class PackageUpdateCommandRunner
 
         if (existingVersion is null)
         {
-            logger.LogMinimal(Messages.Error_PackageNotReferenced(package.Id, project.FilePath), ConsoleColor.Red);
+            if (!suppressWarnings)
+            {
+                logger.LogMinimal(Messages.Error_PackageNotReferenced(package.Id, project.FilePath), ConsoleColor.Red);
+            }
             return null;
         }
 
@@ -253,13 +315,19 @@ internal static class PackageUpdateCommandRunner
 
             if (highestVersion is null)
             {
-                logger.LogMinimal(Messages.Error_NoVersionsAvailable(package.Id), ConsoleColor.Red);
+                if (!suppressWarnings)
+                {
+                    logger.LogMinimal(Messages.Error_NoVersionsAvailable(package.Id), ConsoleColor.Red);
+                }
                 return null;
             }
 
             if (existingVersion.MinVersion == highestVersion)
             {
-                logger.LogMinimal(Messages.Warning_AlreadyHighestVersion(package.Id, highestVersion.OriginalVersion, project.FilePath), ConsoleColor.Yellow);
+                if (!suppressWarnings)
+                {
+                    logger.LogMinimal(Messages.Warning_AlreadyHighestVersion(package.Id, highestVersion.OriginalVersion, project.FilePath), ConsoleColor.Yellow);
+                }
                 return null;
             }
 
@@ -270,7 +338,10 @@ internal static class PackageUpdateCommandRunner
             newVersion = package.VersionRange;
             if (newVersion == existingVersion)
             {
-                logger.LogMinimal(Messages.Warning_AlreadyUsingSameVersion(package.Id, newVersion.OriginalString), ConsoleColor.Yellow);
+                if (!suppressWarnings)
+                {
+                    logger.LogMinimal(Messages.Warning_AlreadyUsingSameVersion(package.Id, newVersion.OriginalString), ConsoleColor.Yellow);
+                }
                 return null;
             }
         }
@@ -334,5 +405,15 @@ internal static class PackageUpdateCommandRunner
         {
             return string.Format(CultureInfo.CurrentCulture, Strings.PackageUpdate_FinalSummary, updatedCount, scannedCount);
         }
+    }
+
+    // These exit codes are documented, so consider changing them or adding new ones a breaking change.
+    private static class ExitCodes
+    {
+        public const int Success = 0;
+        // System.CommandLine returns 1 on parse ererors, so even if this const isn't used, the value 1 is still returned.
+        public const int InvalidArgs = 1;
+        public const int NoPackagesNeedUpdating = 2;
+        public const int Error = 3;
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -138,9 +138,16 @@ internal class PackageUpdateIO : IPackageUpdateIO
         await RestoreRunner.CommitAsync(((RestoreResult)restorePreviewResult).RestoreResultPair, CancellationToken.None);
     }
 
-    public void UpdatePackageReference(PackageSpec updatedPackageSpec, IPackageUpdateIO.RestoreResult restorePreviewResult, List<NuGetFramework> packageTfms, PackageToUpdate packageToUpdate, ILogger logger)
+    public void UpdatePackageReference(PackageSpec updatedPackageSpec, IPackageUpdateIO.RestoreResult restorePreviewResult, List<string> packageTfmAliases, PackageToUpdate packageToUpdate, ILogger logger)
     {
         PackageDependency packageDependency = new PackageDependency(packageToUpdate.Id, packageToUpdate.NewVersion);
+
+        List<NuGetFramework> packageTfms = new List<NuGetFramework>(packageTfmAliases.Count);
+        foreach (var alias in packageTfmAliases)
+        {
+            var targetFramework = updatedPackageSpec.TargetFrameworks.Single(tfm => tfm.TargetAlias == alias);
+            packageTfms.Add(targetFramework.FrameworkName);
+        }
 
         if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms,
             packageDependency.Id,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -1572,6 +1572,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to All packages are already up to date..
+        /// </summary>
+        internal static string PackageUpdate_AllPackagesAlreadyUpToDate {
+            get {
+                return ResourceManager.GetString("PackageUpdate_AllPackagesAlreadyUpToDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Updated {0} packages in {1} scanned packages..
         /// </summary>
         internal static string PackageUpdate_FinalSummary {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.CommandLine.XPlat {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -2319,15 +2319,6 @@ namespace NuGet.CommandLine.XPlat {
         internal static string TrustSyncCommandDescription {
             get {
                 return ResourceManager.GetString("TrustSyncCommandDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unsupported: Updating more than one package is not yet supported.
-        /// </summary>
-        internal static string Unsupported_MoreThanOnePackage {
-            get {
-                return ResourceManager.GetString("Unsupported_MoreThanOnePackage", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -1071,5 +1071,8 @@ Do not translate "PackageVersion"</comment>
   </data>
   <data name="AllowInsecureConnections_Description" xml:space="preserve">
     <value>Allows pushing to HTTP sources (insecure).</value>
+  </data>
+  <data name="PackageUpdate_AllPackagesAlreadyUpToDate" xml:space="preserve">
+    <value>All packages are already up to date.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -988,9 +988,6 @@ NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set 'allo
   <data name="PackageUpdate_PreviewRestoreFailed" xml:space="preserve">
     <value>Preview restore with updated packages was not successful. Force mode is not yet available.</value>
   </data>
-  <data name="Unsupported_MoreThanOnePackage" xml:space="preserve">
-    <value>Unsupported: Updating more than one package is not yet supported</value>
-  </data>
   <data name="Unsupported_PackageSourceMapping" xml:space="preserve">
     <value>Unsupported: Projects using Package Source Mapping are not yet supported</value>
   </data>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
@@ -886,6 +886,11 @@ Další informace najdete tady: https://docs.nuget.org/docs/reference/command-li
         <target state="translated">Cesta k souboru projektu nebo řešení nebo k adresáři</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
@@ -1252,11 +1252,6 @@ Hledání porovnává řetězce bez rozlišování malých a velkých písmen po
         <target state="translated">Jméno existující důvěryhodné podepisující osoby, která se má odebrat.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">Nepodporováno: Aktualizace více než jednoho balíčku se zatím nepodporuje.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">Nepodporované: Projekty používající mapování zdroje balíčku se zatím nepodporují.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
@@ -886,6 +886,11 @@ Weitere Informationen finden Sie unter: https://docs.nuget.org/docs/reference/co
         <target state="translated">Pfad zu einer Projekt- oder Projektmappendatei oder einem Verzeichnis</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
@@ -1252,11 +1252,6 @@ Bei der Suche handelt es sich um einen ungültigen Zeichenfolgenvergleich mit de
         <target state="translated">Der Name des vorhandenen vertrauenswürdigen Signaturgebers, der entfernt werden soll.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">Nicht unterstützt: Das Aktualisieren mehrerer Pakete wird noch nicht unterstützt.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">Nicht unterstützt: Projekte, die die Paketquellzuordnung verwenden, werden noch nicht unterstützt.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
@@ -1252,11 +1252,6 @@ La búsqueda es una comparación de cadenas que no diferencia mayúsculas de min
         <target state="translated">Nombre del firmante de confianza existente que se va a quitar.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">No compatible: Aún no se admite la actualización de más de un paquete</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">No compatible: Aún no se admiten los proyectos que usan la asignación de origen de paquetes</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
@@ -886,6 +886,11 @@ Para obtener más información, visite https://docs.nuget.org/docs/reference/com
         <target state="translated">Ruta de acceso a un archivo de proyecto o solución, o a un directorio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
@@ -886,6 +886,11 @@ Pour plus d'informations, visitez https://docs.nuget.org/docs/reference/command-
         <target state="translated">Chemin d’accès à un fichier de projet ou de solution, ou à un répertoire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
@@ -1252,11 +1252,6 @@ La recherche est une comparaison de chaînes qui ne respecte pas la casse à l�
         <target state="translated">Nom du signataire approuvé existant à supprimer.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">Non pris en charge : La mise à jour de plusieurs packages n’est pas encore prise en charge</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">Non pris en charge : Les projets qui utilisent le mappage des sources de package ne sont pas encore pris en charge</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
@@ -886,6 +886,11 @@ Per altre informazioni, vedere https://docs.nuget.org/docs/reference/command-lin
         <target state="translated">Percorso di un progetto, un file di soluzione o una directory.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
@@ -1252,11 +1252,6 @@ La ricerca viene eseguita in un confronto di stringhe senza distinzione tra maiu
         <target state="translated">Nome del firmatario attendibile esistente da rimuovere.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">Non supportato: l'aggiornamento di più pacchetti non è ancora supportato</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">Non supportato: i progetti che usano il mapping dell'origine pacchetto non sono ancora supportati</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
@@ -1252,11 +1252,6 @@ The search is a case-insensitive string comparison using the supplied value, whi
         <target state="translated">削除する既存の信頼された署名者の名前。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">サポートされていません: 複数のパッケージの更新はまだサポートされていません</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">サポートされていません: パッケージ ソース マッピングを使用するプロジェクトはまだサポートされていません</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
@@ -886,6 +886,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">プロジェクトまたはソリューション ファイル、またはディレクトリへのパス。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
@@ -886,6 +886,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">프로젝트, 솔루션 파일 또는 디렉터리의 경로입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
@@ -1253,11 +1253,6 @@ The search is a case-insensitive string comparison using the supplied value, whi
         <target state="translated">제거할 기존 신뢰할 수 있는 서명자의 이름입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">지원되지 않음: 둘 이상의 패키지 업데이트는 아직 지원되지 않음</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">지원되지 않음: 패키지 원본 매핑을 사용하는 프로젝트는 아직 지원되지 않음</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
@@ -1252,11 +1252,6 @@ Wyszukiwanie polega na porównywaniu łańcuchów bez rozróżniania wielkości 
         <target state="translated">Imię istniejącej osoby podpisującej do usunięcia.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">Nieobsługiwane: aktualizowanie więcej niż jednego pakietu nie jest jeszcze obsługiwane</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">Nieobsługiwane: projekty korzystające z mapowania źródła pakietów nie są jeszcze obsługiwane</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
@@ -886,6 +886,11 @@ Aby uzyskać więcej informacji, odwiedź stronę https://docs.nuget.org/docs/re
         <target state="translated">Ścieżka do pliku projektu lub rozwiązania albo katalogu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
@@ -1252,11 +1252,6 @@ A pesquisa é uma comparação de cadeia de caracteres que não faz distinção 
         <target state="translated">O nome do signatário confiável existente a ser removido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">Sem suporte: ainda não há suporte para a atualização de mais de um pacote</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">Sem suporte: ainda não há suporte para projetos que usam o Mapeamento de Origem do Pacote</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
@@ -886,6 +886,11 @@ Para obter mais informações, acesse https://docs.nuget.org/docs/reference/comm
         <target state="translated">Caminho para um projeto ou arquivo de solução ou um diretório.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
@@ -886,6 +886,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">Путь к проекту, файлу решения или каталогу.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
@@ -1252,11 +1252,6 @@ The search is a case-insensitive string comparison using the supplied value, whi
         <target state="translated">Имя существующего доверенного подписывающего лица, которое нужно удалить.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">Не поддерживается: обновление более чем одного пакета пока не поддерживается</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">Не поддерживается: проекты, использующие сопоставление источников пакетов, пока не поддерживаются</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
@@ -886,6 +886,11 @@ Daha fazla bilgi için bkz. https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">Bir proje veya çözüm dosyasına ya da dizine giden yol.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
@@ -1252,11 +1252,6 @@ Arama, sağlanan değeri kullanan büyük/küçük harfe duyarsız bir dize kar�
         <target state="translated">Kaldırılacak mevcut güvenilen imzalayanın adı.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">Desteklenmiyor: Birden fazla paketin güncelleştirilmesi henüz desteklenmiyor</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">Desteklenmiyor: Paket Kaynağı Eşlemesi özelliğini kullanan projeler henüz desteklenmiyor</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
@@ -886,6 +886,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">项目或解决方案文件或目录的路径。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
@@ -1252,11 +1252,6 @@ The search is a case-insensitive string comparison using the supplied value, whi
         <target state="translated">要删除的现有受信任签名人的名称。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">不支持: 尚不支持更新多个包</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">不支持: 尚不支持使用包源映射的项目</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
@@ -886,6 +886,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">專案、解決方案檔案或目錄的路徑。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageUpdate_AllPackagesAlreadyUpToDate">
+        <source>All packages are already up to date.</source>
+        <target state="new">All packages are already up to date.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageUpdate_FinalSummary">
         <source>Updated {0} packages in {1} scanned packages.</source>
         <target state="new">Updated {0} packages in {1} scanned packages.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
@@ -1252,11 +1252,6 @@ The search is a case-insensitive string comparison using the supplied value, whi
         <target state="translated">要移除之現有信任簽署者的名稱。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Unsupported_MoreThanOnePackage">
-        <source>Unsupported: Updating more than one package is not yet supported</source>
-        <target state="translated">不支援: 尚不支援更新多個套件</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Unsupported_PackageSourceMapping">
         <source>Unsupported: Projects using Package Source Mapping are not yet supported</source>
         <target state="translated">不支援: 尚不支援使用套件來源對應的專案</target>

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -53,7 +54,7 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var (packageToUpdate, _) = await PackageUpdateCommandRunner.GetPackageToUpdateAsync(
+        var packagesToUpdate = await PackageUpdateCommandRunner.GetPackagesToUpdateAsync(
             [package],
             packageSpec,
             versionChooser.Object,
@@ -62,6 +63,8 @@ public class GetPackageToUpdateTests
             CancellationToken.None);
 
         // Assert
+        packagesToUpdate.Should().HaveCount(1);
+        var packageToUpdate = packagesToUpdate.First().Package;
         packageToUpdate.Should().NotBeNull();
         packageToUpdate.Id.Should().Be("Contoso.Utils");
         packageToUpdate.CurrentVersion.ToString().Should().Be("[1.0.0, )");
@@ -95,7 +98,7 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var (packageToUpdate, _) = await PackageUpdateCommandRunner.GetPackageToUpdateAsync(
+        var packagesToUpdate = await PackageUpdateCommandRunner.GetPackagesToUpdateAsync(
             [package],
             packageSpec,
             versionChooser.Object,
@@ -104,6 +107,8 @@ public class GetPackageToUpdateTests
             CancellationToken.None);
 
         // Assert
+        packagesToUpdate.Should().HaveCount(1);
+        var packageToUpdate = packagesToUpdate.First().Package;
         packageToUpdate.Should().NotBeNull();
         packageToUpdate.Id.Should().Be("Contoso.Utils");
         packageToUpdate.CurrentVersion.ToString().Should().Be("[1.0.0, )");
@@ -132,7 +137,7 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var (packageToUpdate, _) = await PackageUpdateCommandRunner.GetPackageToUpdateAsync(
+        var packagesToUpdate = await PackageUpdateCommandRunner.GetPackagesToUpdateAsync(
             [package],
             packageSpec,
             versionChooser.Object,
@@ -141,6 +146,8 @@ public class GetPackageToUpdateTests
             CancellationToken.None);
 
         // Assert
+        packagesToUpdate.Should().HaveCount(1);
+        var packageToUpdate = packagesToUpdate.First().Package;
         packageToUpdate.Should().NotBeNull();
         packageToUpdate.Id.Should().Be("Contoso.Utils");
         packageToUpdate.CurrentVersion.ToString().Should().Be("[1.0.0, )");
@@ -172,7 +179,7 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var (packageToUpdate, _) = await PackageUpdateCommandRunner.GetPackageToUpdateAsync(
+        var packagesToUpdate = await PackageUpdateCommandRunner.GetPackagesToUpdateAsync(
             [package],
             packageSpec,
             versionChooser.Object,
@@ -181,12 +188,12 @@ public class GetPackageToUpdateTests
             CancellationToken.None);
 
         // Assert
-        packageToUpdate.Should().BeNull();
+        packagesToUpdate.Should().BeEmpty();
         logger.Invocations.Count.Should().BeGreaterThan(0);
     }
 
     [Fact]
-    public async Task RequestPackageNotReferencedByProject_ReturnsNullAndLogsError()
+    public async Task RequestPackageNotReferencedByProject_ReturnsEmptyAndLogsError()
     {
         // Arrange
         Pkg package = new()
@@ -207,7 +214,7 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var (packageToUpdate, frameworks) = await PackageUpdateCommandRunner.GetPackageToUpdateAsync(
+        var packagesToUpdate = await PackageUpdateCommandRunner.GetPackagesToUpdateAsync(
             [package],
             packageSpec,
             versionChooser.Object,
@@ -216,8 +223,7 @@ public class GetPackageToUpdateTests
             CancellationToken.None);
 
         // Assert
-        packageToUpdate.Should().BeNull();
-        frameworks.Should().BeNull();
+        packagesToUpdate.Should().BeEmpty();
 
         // Verify that an error was logged
         logger.Verify(
@@ -225,5 +231,99 @@ public class GetPackageToUpdateTests
                 It.Is<string>(message => message.Contains("NotReferenced.Package") && message.Contains("not referenced")),
                 It.IsAny<ConsoleColor>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task RequestMultiplePackages_GetsAllRequested()
+    {
+        // Arrange
+        Pkg package1 = new()
+        {
+            Id = "Contoso.Utils",
+            VersionRange = new VersionRange(new NuGetVersion("1.2.3"))
+        };
+
+        Pkg package2 = new()
+        {
+            Id = "Fabrikam.Tools",
+            VersionRange = null // Should get latest version
+        };
+
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Contoso.Utils", [new("Version", "1.0.0")])
+                   .WithItem("PackageReference", "Fabrikam.Tools", [new("Version", "2.0.0")]);
+        })
+            .Build();
+
+        var versionChooser = new Mock<IVersionChooser>(MockBehavior.Strict);
+        versionChooser
+            .Setup(v => v.GetLatestVersionAsync("Fabrikam.Tools", It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("2.1.0"));
+
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act
+        var packagesToUpdate = await PackageUpdateCommandRunner.GetPackagesToUpdateAsync(
+            [package1, package2],
+            packageSpec,
+            versionChooser.Object,
+            NullSettings.Instance,
+            logger.Object,
+            CancellationToken.None);
+
+        // Assert
+        packagesToUpdate.Should().HaveCount(2);
+
+        var contosoUpdate = packagesToUpdate.First(p => p.Package.Id == "Contoso.Utils");
+        contosoUpdate.Package.CurrentVersion.ToString().Should().Be("[1.0.0, )");
+        contosoUpdate.Package.NewVersion.ToString().Should().Be("[1.2.3, )");
+
+        var fabrikamUpdate = packagesToUpdate.First(p => p.Package.Id == "Fabrikam.Tools");
+        fabrikamUpdate.Package.CurrentVersion.ToString().Should().Be("[2.0.0, )");
+        fabrikamUpdate.Package.NewVersion.ToString().Should().Be("[2.1.0, )");
+
+        logger.Invocations.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RequestMultiplePackagesWithOneError_ReturnsEmpty()
+    {
+        // Arrange
+        Pkg package1 = new()
+        {
+            Id = "Contoso.Utils",
+            VersionRange = new VersionRange(new NuGetVersion("1.2.3"))
+        };
+
+        Pkg package2 = new()
+        {
+            Id = "NotReferenced.Package",
+            VersionRange = new VersionRange(new NuGetVersion("1.0.0"))
+        };
+
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Contoso.Utils", [new("Version", "1.0.0")]);
+        })
+            .Build();
+
+        var versionChooser = new Mock<IVersionChooser>(MockBehavior.Strict);
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act
+        var packagesToUpdate = await PackageUpdateCommandRunner.GetPackagesToUpdateAsync(
+            [package1, package2],
+            packageSpec,
+            versionChooser.Object,
+            NullSettings.Instance,
+            logger.Object,
+            CancellationToken.None);
+
+        // Assert
+        packagesToUpdate.Should().BeEmpty();
+        logger.Invocations.Count.Should().BeGreaterThan(0);
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
@@ -326,4 +326,127 @@ public class GetPackageToUpdateTests
         packagesToUpdate.Should().BeEmpty();
         logger.Invocations.Count.Should().BeGreaterThan(0);
     }
+
+    [Fact]
+    public async Task NoPackagesProvided_BothPackagesHaveUpdates_UpdatesBothPackages()
+    {
+        // Arrange
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Test.Package1", [new("Version", "1.0.0")])
+                   .WithItem("PackageReference", "Test.Package2", [new("Version", "2.0.0")]);
+        })
+            .Build();
+
+        var versionChooser = new Mock<IVersionChooser>(MockBehavior.Strict);
+        versionChooser
+            .Setup(v => v.GetLatestVersionAsync("Test.Package1", It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("1.2.3"));
+        versionChooser
+            .Setup(v => v.GetLatestVersionAsync("Test.Package2", It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("2.1.0"));
+
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act - Pass empty list to trigger "update all packages" behavior
+        var packagesToUpdate = await PackageUpdateCommandRunner.GetPackagesToUpdateAsync(
+            [],
+            packageSpec,
+            versionChooser.Object,
+            NullSettings.Instance,
+            logger.Object,
+            CancellationToken.None);
+
+        // Assert
+        packagesToUpdate.Should().HaveCount(2);
+
+        var package1Update = packagesToUpdate.First(p => p.Package.Id == "Test.Package1");
+        package1Update.Package.CurrentVersion.ToString().Should().Be("[1.0.0, )");
+        package1Update.Package.NewVersion.ToString().Should().Be("[1.2.3, )");
+
+        var package2Update = packagesToUpdate.First(p => p.Package.Id == "Test.Package2");
+        package2Update.Package.CurrentVersion.ToString().Should().Be("[2.0.0, )");
+        package2Update.Package.NewVersion.ToString().Should().Be("[2.1.0, )");
+
+        logger.Invocations.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NoPackagesProvided_OnePackageAlreadyLatest_UpdatesOnlyOutdatedPackage()
+    {
+        // Arrange
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Test.Package1", [new("Version", "1.0.0")])
+                   .WithItem("PackageReference", "Test.Package2", [new("Version", "2.1.0")]);
+        })
+            .Build();
+
+        var versionChooser = new Mock<IVersionChooser>(MockBehavior.Strict);
+        versionChooser
+            .Setup(v => v.GetLatestVersionAsync("Test.Package1", It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("1.2.3"));
+        versionChooser
+            .Setup(v => v.GetLatestVersionAsync("Test.Package2", It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("2.1.0")); // Same as current version
+
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act - Pass empty list to trigger "update all packages" behavior
+        var packagesToUpdate = await PackageUpdateCommandRunner.GetPackagesToUpdateAsync(
+            [],
+            packageSpec,
+            versionChooser.Object,
+            NullSettings.Instance,
+            logger.Object,
+            CancellationToken.None);
+
+        // Assert
+        packagesToUpdate.Should().HaveCount(1);
+
+        var packageUpdate = packagesToUpdate.First();
+        packageUpdate.Package.Id.Should().Be("Test.Package1");
+        packageUpdate.Package.CurrentVersion.ToString().Should().Be("[1.0.0, )");
+        packageUpdate.Package.NewVersion.ToString().Should().Be("[1.2.3, )");
+
+        logger.Invocations.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NoPackagesProvided_AllPackagesUpToDate_ReturnsEmptyList()
+    {
+        // Arrange
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Test.Package1", [new("Version", "1.2.3")])
+                   .WithItem("PackageReference", "Test.Package2", [new("Version", "2.1.0")]);
+        })
+            .Build();
+
+        var versionChooser = new Mock<IVersionChooser>(MockBehavior.Strict);
+        versionChooser
+            .Setup(v => v.GetLatestVersionAsync("Test.Package1", It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("1.2.3")); // Same as current version
+        versionChooser
+            .Setup(v => v.GetLatestVersionAsync("Test.Package2", It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("2.1.0")); // Same as current version
+
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act - Pass empty list to trigger "update all packages" behavior
+        var packagesToUpdate = await PackageUpdateCommandRunner.GetPackagesToUpdateAsync(
+            [],
+            packageSpec,
+            versionChooser.Object,
+            NullSettings.Instance,
+            logger.Object,
+            CancellationToken.None);
+
+        // Assert
+        packagesToUpdate.Should().BeEmpty();
+        logger.Invocations.Count.Should().Be(0);
+    }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/MultiProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/MultiProjectTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.ProjectModel;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update.PackageUpdateCommandRunnerTests;
+
+using Pkg = XPlat.Commands.Package.Update.Package;
+
+public class MultiProjectTests
+{
+    [Fact]
+    public async Task ProjectWithP2PReference_SinglePackage_UpdatesCorrectPackageVersion()
+    {
+        // Arrange
+        var solutionDirectory = RuntimeEnvironmentHelper.IsWindows
+            ? @"S:\path\to\repo\src"
+            : @"/path/to/repo/src";
+        var project1Path = Path.Combine(solutionDirectory, "Project1", "Project1.csproj");
+        var project1 = new TestPackageSpecFactory(project1Path, builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Test.Package", [new("Version", "1.0.0")])
+                   .WithItem("ProjectReference", @"..\Project2\Project2.csproj", []);
+        }).Build();
+
+        var project2Path = Path.Combine(solutionDirectory, "Project2", "Project2.csproj");
+        var project2 = new TestPackageSpecFactory(project2Path, builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0");
+        }).Build();
+
+        DependencyGraphSpec dgSpec = new DependencyGraphSpec();
+        dgSpec.AddProject(project1);
+        dgSpec.AddProject(project2);
+        dgSpec.AddRestore(project1Path);
+
+        var packagesToUpdate = new List<Pkg>
+        {
+            new Pkg { Id = "Test.Package", VersionRange = new VersionRange(new NuGetVersion("1.2.3")) }
+        };
+
+        TestData testData = InitTest(project1Path, packagesToUpdate, dgSpec);
+
+        // Act
+        int exitCode = await RunCommand(testData, CancellationToken.None);
+
+        // Assert
+        exitCode.Should().Be(0);
+
+        // Updated project1, but not project2
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.Is<PackageSpec>(p => p.FilePath == project1Path),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package" && p.NewVersion.ToString() == "[1.2.3, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.Is<PackageSpec>(p => p.FilePath == project2Path),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
+            It.IsAny<ILogger>()),
+            Times.Never);
+
+        // preview restore must have both projects, but only project1 for restore
+        testData.IoMock.Verify(x => x.PreviewUpdatePackageReferenceAsync(
+            It.Is<DependencyGraphSpec>(d => d.Projects.Count == 2 && d.Restore.Count == 1 && d.Restore[0] == project1Path),
+            It.IsAny<SourceCacheContext>(),
+            It.IsAny<ILogger>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        testData.LoggerMock.Verify(x => x.LogMinimal(
+            It.Is<string>(s => s.Contains(string.Format(Strings.PackageUpdate_FinalSummary, 1, 1))),
+            It.IsAny<ConsoleColor>()),
+            Times.Once);
+    }
+
+    private TestData InitTest(string updateTarget, IReadOnlyList<Pkg> packagesToUpdate, DependencyGraphSpec dgSpec, bool restoreSuccessful = true)
+    {
+        var commandArgs = new PackageUpdateArgs
+        {
+            Project = updateTarget,
+            Packages = packagesToUpdate,
+            Interactive = false,
+            LogLevel = LogLevel.Information
+        };
+
+        var loggerMock = new Mock<ILoggerWithColor>();
+        ILoggerWithColor logger = loggerMock.Object;
+
+        var restoreResultMock = new Mock<IPackageUpdateIO.RestoreResult>();
+        restoreResultMock.SetupGet(x => x.Success).Returns(restoreSuccessful);
+        var restoreResult = restoreResultMock.Object;
+
+        var ioMock = new Mock<IPackageUpdateIO>();
+
+        ioMock.Setup(x => x.LoadSettings(It.IsAny<string>()))
+            .Returns(NullSettings.Instance);
+
+        ioMock.Setup(x => x.GetDependencyGraphSpec(commandArgs.Project)).Returns(dgSpec);
+
+        ioMock.Setup(x => x.PreviewUpdatePackageReferenceAsync(
+            It.IsAny<DependencyGraphSpec>(),
+            It.IsAny<SourceCacheContext>(),
+            It.IsAny<ILogger>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(restoreResult);
+
+        ioMock.Setup(x => x.UpdatePackageReference(
+            It.IsAny<PackageSpec>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
+            It.IsAny<ILogger>()));
+
+        ioMock.Setup(x => x.CommitAsync(
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var testData = new TestData
+        {
+            CommandArgs = commandArgs,
+            IoMock = ioMock,
+            LoggerMock = loggerMock
+        };
+        return testData;
+    }
+
+    private Task<int> RunCommand(TestData testData, CancellationToken cancellationToken)
+    {
+        return PackageUpdateCommandRunner.Run(
+            testData.CommandArgs,
+            testData.LoggerMock.Object,
+            testData.IoMock.Object,
+            cancellationToken);
+    }
+
+    record TestData
+    {
+        public required PackageUpdateArgs CommandArgs { get; init; }
+        public required Mock<IPackageUpdateIO> IoMock { get; init; }
+        public required Mock<ILoggerWithColor> LoggerMock { get; init; }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,6 +54,11 @@ public class SingleProjectTests
             It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package" && p.NewVersion.ToString() == "[1.2.3, )"),
             It.IsAny<ILogger>()),
             Times.Once);
+
+        testData.LoggerMock.Verify(x => x.LogMinimal(
+            It.Is<string>(s => s.Contains(string.Format(Strings.PackageUpdate_FinalSummary, 1, 1))),
+            It.IsAny<ConsoleColor>()),
+            Times.Once);
     }
 
     [Fact]
@@ -94,6 +100,11 @@ public class SingleProjectTests
             It.IsAny<List<NuGetFramework>>(),
             It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package2" && p.NewVersion.ToString() == "[2.1.0, )"),
             It.IsAny<ILogger>()),
+            Times.Once);
+
+        testData.LoggerMock.Verify(x => x.LogMinimal(
+            It.Is<string>(s => s.Contains(string.Format(Strings.PackageUpdate_FinalSummary, 2, 2))),
+            It.IsAny<ConsoleColor>()),
             Times.Once);
     }
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -11,7 +11,6 @@ using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Package.Update;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Frameworks;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -50,7 +49,7 @@ public class SingleProjectTests
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
-            It.IsAny<List<NuGetFramework>>(),
+            It.IsAny<List<string>>(),
             It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package" && p.NewVersion.ToString() == "[1.2.3, )"),
             It.IsAny<ILogger>()),
             Times.Once);
@@ -89,7 +88,7 @@ public class SingleProjectTests
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
-            It.IsAny<List<NuGetFramework>>(),
+            It.IsAny<List<string>>(),
             It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package1" && p.NewVersion.ToString() == "[1.2.3, )"),
             It.IsAny<ILogger>()),
             Times.Once);
@@ -97,7 +96,7 @@ public class SingleProjectTests
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
-            It.IsAny<List<NuGetFramework>>(),
+            It.IsAny<List<string>>(),
             It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package2" && p.NewVersion.ToString() == "[2.1.0, )"),
             It.IsAny<ILogger>()),
             Times.Once);
@@ -143,7 +142,54 @@ public class SingleProjectTests
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
-            It.IsAny<List<NuGetFramework>>(),
+            It.IsAny<List<string>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Contoso.Polyfill" && p.NewVersion.ToString() == "[1.2.3, )"),
+            It.IsAny<ILogger>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task MultiTargetingWithTfmAliases_SinglePackage_UpdatesExpectedPackage()
+    {
+        // Arrange
+        var packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFrameworks", "dev;experimental");
+        })
+            .WithInnerBuild(builder =>
+            {
+                builder
+                .WithProperty("TargetFramework", "dev")
+                .WithProperty("TargetFrameworkIdentifier", ".NETCoreApp")
+                .WithProperty("TargetFrameworkVersion", "v8.0")
+                .WithProperty("TargetFrameworkMoniker", ".NETCoreApp,Version=v8.0")
+                .WithItem("PackageReference", "Contoso.Polyfill", [new("Version", "1.0.0")]);
+            })
+            .WithInnerBuild(builder =>
+            {
+                builder
+                .WithProperty("TargetFramework", "experimental")
+                .WithProperty("TargetFrameworkIdentifier", ".NETCoreApp")
+                .WithProperty("TargetFrameworkVersion", "v9.0")
+                .WithProperty("TargetFrameworkMoniker", ".NETCoreApp,Version=v9.0");
+            }).Build();
+
+        var packagesToUpdate = new List<Pkg>
+        {
+            new Pkg { Id = "Contoso.Polyfill", VersionRange = new VersionRange(new NuGetVersion("1.2.3")) }
+        };
+
+        TestData testData = InitTest(packagesToUpdate, packageSpec);
+
+        // Act
+        int exitCode = await RunCommand(testData, CancellationToken.None);
+
+        // Assert
+        exitCode.Should().Be(0);
+
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.IsAny<PackageSpec>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.Is<List<string>>(p => p.Count == 1 && p[0] == "dev"),
             It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Contoso.Polyfill" && p.NewVersion.ToString() == "[1.2.3, )"),
             It.IsAny<ILogger>()), Times.Once);
     }
@@ -178,7 +224,7 @@ public class SingleProjectTests
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
-            It.IsAny<List<NuGetFramework>>(),
+            It.IsAny<List<string>>(),
             It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
             It.IsAny<ILogger>()), Times.Never);
     }
@@ -213,7 +259,7 @@ public class SingleProjectTests
         testData.IoMock.Verify(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
-            It.IsAny<List<NuGetFramework>>(),
+            It.IsAny<List<string>>(),
             It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
             It.IsAny<ILogger>()), Times.Never);
     }
@@ -291,7 +337,7 @@ public class SingleProjectTests
         ioMock.Setup(x => x.UpdatePackageReference(
             It.IsAny<PackageSpec>(),
             It.IsAny<IPackageUpdateIO.RestoreResult>(),
-            It.IsAny<List<NuGetFramework>>(),
+            It.IsAny<List<string>>(),
             It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
             It.IsAny<ILogger>()));
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -56,6 +56,48 @@ public class SingleProjectTests
     }
 
     [Fact]
+    public async Task SingleTarget_MultiplePackages_UpdatesBothPackages()
+    {
+        // Arrange
+        var packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Test.Package1", [new("Version", "1.0.0")])
+                   .WithItem("PackageReference", "Test.Package2", [new("Version", "2.0.0")]);
+        }).Build();
+
+        var packagesToUpdate = new List<Pkg>
+        {
+            new Pkg { Id = "Test.Package1", VersionRange = new VersionRange(new NuGetVersion("1.2.3")) },
+            new Pkg { Id = "Test.Package2", VersionRange = new VersionRange(new NuGetVersion("2.1.0")) }
+        };
+
+        TestData testData = InitTest(packagesToUpdate, packageSpec);
+
+        // Act
+        int exitCode = await RunCommand(testData, CancellationToken.None);
+
+        // Assert
+        exitCode.Should().Be(0);
+
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.IsAny<PackageSpec>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<NuGetFramework>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package1" && p.NewVersion.ToString() == "[1.2.3, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.IsAny<PackageSpec>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<NuGetFramework>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package2" && p.NewVersion.ToString() == "[2.1.0, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task MultiTargetingWithConditionalPackage_SinglePackage_UpdatesExpectedPackage()
     {
         // Arrange

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -156,7 +156,7 @@ public class SingleProjectTests
         int exitCode = await RunCommand(testData, CancellationToken.None);
 
         // Assert
-        exitCode.Should().Be(ExitCodes.Error);
+        exitCode.Should().Be(3);
 
         testData.IoMock.Verify(x => x.PreviewUpdatePackageReferenceAsync(
             It.IsAny<DependencyGraphSpec>(),
@@ -191,7 +191,7 @@ public class SingleProjectTests
         int exitCode = await RunCommand(testData, CancellationToken.None);
 
         // Assert
-        exitCode.Should().Be(ExitCodes.Error);
+        exitCode.Should().Be(3);
 
         testData.IoMock.Verify(x => x.PreviewUpdatePackageReferenceAsync(
             It.IsAny<DependencyGraphSpec>(),
@@ -238,9 +238,8 @@ public class SingleProjectTests
         int exitCode = await RunCommand(testData, CancellationToken.None);
 
         // Assert
-        exitCode.Should().Be(ExitCodes.Error);
+        exitCode.Should().Be(3);
     }
-
 
     private TestData InitTest(IReadOnlyList<Pkg> packagesToUpdate, PackageSpec project, bool restoreSuccessful = true)
     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14308

## Description

As per [the feature spec](https://github.com/NuGet/Home/blob/dev/accepted/2024/package-update-command.md), `dotnet package update` can be provided with zero, or multiple packages. When no packages are provided, it tries to update all packages in the project to the latest version. When multiple packages are provided, it just tries to update those packages.

One thing to call out is the feature spec gives specific error code information for different scenarios.  Since these error codes are specific to the package update command, it gets its own `ExitCodes` constants, rather than using the shared constants that other command use. To be honest, beyond basic "zero is success and 1 is input parser error", other exit codes will often be command specific, so I'm not sure a shared exit code set of constants makes a lot of sense.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14354
