### PR TITLE
remove redundant string alloc in GetTempFilePath

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
@@ -21,7 +21,7 @@ namespace NuGet.Common
         /// </summary>
         public static string GetTempFilePath(string directory)
         {
-            var fileName = $"{Guid.NewGuid()}.tmp".ToLowerInvariant();
+            var fileName = $"{Guid.NewGuid()}.tmp";
 
             return Path.GetFullPath(Path.Combine(directory, fileName));
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

guid tostring returns lower case by default. so ToLowerInvariant is functionally a no-op, but it also allocates a new string

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
