### PR TITLE
Update .editorconfig for event naming rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -137,7 +137,7 @@ dotnet_naming_rule.static_fields_rule.style = pascal_case_style
 ; Naming rule: Private members must be camel-cased and prefixed with underscore
 dotnet_naming_style.private_member_style.capitalization = camel_case
 dotnet_naming_style.private_member_style.required_prefix = _
-dotnet_naming_symbols.private_field_symbols.applicable_kinds = field,event
+dotnet_naming_symbols.private_field_symbols.applicable_kinds = field
 dotnet_naming_symbols.private_field_symbols.applicable_accessibilities = private,protected,internal
 dotnet_naming_rule.private_field_rule.severity = warning
 dotnet_naming_rule.private_field_rule.symbols  = private_field_symbols


### PR DESCRIPTION
## Description
For some reason we currently require event names to be prefixed with an underscore.  Event names should be Pascal case and not have a prefix

<img width="956" height="424" alt="image" src="https://github.com/user-attachments/assets/740f6f63-1b83-4818-a274-c430fc24654c" />


## PR Checklist

- [x] Meaningful title, helpful description and ~~a linked NuGet/Home issue~~
- [ ] ~~Added tests~~
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
