### PR TITLE
Use Fluent TextBox for Project PM UI Installed Version

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
@@ -53,22 +53,15 @@
       Visibility="{Binding IsInstalledVersionTopLevel, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
       Text="{x:Static local:Resources.Label_InstalledColon}" />
 
-    <Border
+    <shell_controls:TextBox
       Grid.Row="0"
       Grid.Column="2"
-      MinHeight="22"
-      BorderBrush="{DynamicResource {x:Static shell_styles:ShellColors.ControlStrokeDefaultBrushKey}}"
-      Visibility="{Binding IsInstalledVersionTopLevel, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
-      BorderThickness="1"
       VerticalAlignment="Center"
-      Margin="0,0,0,9">
-      <TextBox
-        Style="{DynamicResource SelectableTextBlockStyle}"
-        VerticalAlignment="Center"
-        AutomationProperties.LabeledBy="{Binding ElementName=_InstalledVersion}"
-        Margin="4,0,0,0"
-        Text="{Binding InstalledVersion, Converter={StaticResource VersionToStringConverter}, Mode=OneWay}" />
-    </Border>
+      IsReadOnly="true"
+      AutomationProperties.LabeledBy="{Binding ElementName=_InstalledVersion}"
+      Margin="0,0,0,9"
+      Text="{Binding InstalledVersion, Converter={StaticResource VersionToStringConverter}, Mode=OneWay}"
+      Visibility="{Binding IsInstalledVersionTopLevel, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
 
     <Button
       Grid.Row="0"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14466

## Description

The project-level PM UI had a custom Installed version text area. This PR updates it to a Fluent TextBox.

### Before this PR:
Installed textbox styling 
<img width="398" height="82" alt="image" src="https://github.com/user-attachments/assets/54481289-5566-4c3b-88cc-d225088bacb9" />

### After this PR:
Installed textbox styling 
<img width="431" height="86" alt="image" src="https://github.com/user-attachments/assets/a2c5d541-7a60-40a1-95af-e03535e1093f" />


I've tested that the textbox is still hiding when a Transitive package is selected. Note that Solution-level doesn't hide installed version for transitive packages only project-level

### Top-level package
<img width="925" height="306" alt="image" src="https://github.com/user-attachments/assets/ac7d3d1d-3232-46b6-a2f2-ff9760ff1610" />

### Transitive package
<img width="899" height="311" alt="image" src="https://github.com/user-attachments/assets/092a98c0-66c1-4859-923f-b7d17d5ce944" />


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ manually tested, see screenshots
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
