### PR TITLE
Pruning is enable only when a project targets/multi-targets .NET 10

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -252,7 +252,8 @@ namespace NuGet.SolutionRestoreManager
 
         /// <summary>
         /// The result will contain CLEAR and no sources specified in RestoreSources if the clear keyword is in it.
-        /// If there are additional sources specified, the value AdditionalValue will be set in the result and then all the additional sources will follow        /// </summary>
+        /// If there are additional sources specified, the value AdditionalValue will be set in the result and then all the additional sources will follow
+        /// </summary>
         internal static IEnumerable<string> GetRestoreSources(IReadOnlyList<IVsTargetFrameworkInfo4> values)
         {
             string? propertyValue = GetSingleNonEvaluatedPropertyOrNull(values, ProjectBuildProperties.RestoreSources, e => e);
@@ -272,7 +273,8 @@ namespace NuGet.SolutionRestoreManager
 
         /// <summary>
         /// The restoreEnablePackagePruning will contain CLEAR and no sources specified in RestoreFallbackFolders if the clear keyword is in it.
-        /// If there are additional fallback folders specified, the value AdditionalValue will be set in the restoreEnablePackagePruning and then all the additional fallback folders will follow        /// </summary>
+        /// If there are additional fallback folders specified, the value AdditionalValue will be set in the restoreEnablePackagePruning and then all the additional fallback folders will follow
+        /// </summary>
         internal static IEnumerable<string> GetRestoreFallbackFolders(IReadOnlyList<IVsTargetFrameworkInfo4> tfms)
         {
             var value = GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.RestoreFallbackFolders, e => e);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -272,8 +272,8 @@ namespace NuGet.SolutionRestoreManager
         }
 
         /// <summary>
-        /// The restoreEnablePackagePruning will contain CLEAR and no sources specified in RestoreFallbackFolders if the clear keyword is in it.
-        /// If there are additional fallback folders specified, the value AdditionalValue will be set in the restoreEnablePackagePruning and then all the additional fallback folders will follow
+        /// The result will contain CLEAR and no sources specified in RestoreFallbackFolders if the clear keyword is in it.
+        /// If there are additional fallback folders specified, the value AdditionalValue will be set in the result and then all the additional fallback folders will follow
         /// </summary>
         internal static IEnumerable<string> GetRestoreFallbackFolders(IReadOnlyList<IVsTargetFrameworkInfo4> tfms)
         {
@@ -336,7 +336,7 @@ namespace NuGet.SolutionRestoreManager
             return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.RestoreUseLegacyDependencyResolver, MSBuildStringUtility.IsTrue);
         }
 
-        internal static bool GetIsPruningEnabledGlobally(IReadOnlyList<IVsTargetFrameworkInfo4> tfms)
+        internal static bool IsPruningEnabledGlobally(IReadOnlyList<IVsTargetFrameworkInfo4> tfms)
         {
             foreach (var value in GetNonEvaluatedPropertyOrNull(tfms, "_RestorePackagePruningDefault", s => s))
             {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -91,7 +91,7 @@ namespace NuGet.SolutionRestoreManager
         }
 
         internal static TargetFrameworkInformation ToTargetFrameworkInformation(
-            IVsTargetFrameworkInfo4 targetFrameworkInfo, bool cpvmEnabled, string projectFullPath)
+            IVsTargetFrameworkInfo4 targetFrameworkInfo, bool cpvmEnabled, bool isPruningEnabledGlobally, string projectFullPath)
         {
             var frameworkName = GetTargetFramework(targetFrameworkInfo.Properties, projectFullPath);
 
@@ -105,7 +105,8 @@ namespace NuGet.SolutionRestoreManager
                 ? MSBuildStringUtility.Split(atfString).Select(NuGetFramework.Parse).ToList()
                 : null;
 
-            bool isPackagePruningEnabled = MSBuildStringUtility.IsTrue(GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.RestoreEnablePackagePruning));
+            bool? restoreEnablePackagePruning = MSBuildStringUtility.GetBooleanOrNull(GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.RestoreEnablePackagePruning));
+            bool isPackagePruningEnabled = restoreEnablePackagePruning == null ? isPruningEnabledGlobally : restoreEnablePackagePruning == true;
 
             // Get fallback properties
             (frameworkName, var imports, var assetTargetFallback, var warn) = AssetTargetFallbackUtility.GetFallbackFrameworkInformation(frameworkName, ptf, atf);
@@ -251,8 +252,7 @@ namespace NuGet.SolutionRestoreManager
 
         /// <summary>
         /// The result will contain CLEAR and no sources specified in RestoreSources if the clear keyword is in it.
-        /// If there are additional sources specified, the value AdditionalValue will be set in the result and then all the additional sources will follow
-        /// </summary>
+        /// If there are additional sources specified, the value AdditionalValue will be set in the result and then all the additional sources will follow        /// </summary>
         internal static IEnumerable<string> GetRestoreSources(IReadOnlyList<IVsTargetFrameworkInfo4> values)
         {
             string? propertyValue = GetSingleNonEvaluatedPropertyOrNull(values, ProjectBuildProperties.RestoreSources, e => e);
@@ -271,9 +271,8 @@ namespace NuGet.SolutionRestoreManager
         }
 
         /// <summary>
-        /// The result will contain CLEAR and no sources specified in RestoreFallbackFolders if the clear keyword is in it.
-        /// If there are additional fallback folders specified, the value AdditionalValue will be set in the result and then all the additional fallback folders will follow
-        /// </summary>
+        /// The restoreEnablePackagePruning will contain CLEAR and no sources specified in RestoreFallbackFolders if the clear keyword is in it.
+        /// If there are additional fallback folders specified, the value AdditionalValue will be set in the restoreEnablePackagePruning and then all the additional fallback folders will follow        /// </summary>
         internal static IEnumerable<string> GetRestoreFallbackFolders(IReadOnlyList<IVsTargetFrameworkInfo4> tfms)
         {
             var value = GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.RestoreFallbackFolders, e => e);
@@ -333,6 +332,21 @@ namespace NuGet.SolutionRestoreManager
         internal static bool GetUseLegacyDependencyResolver(IReadOnlyList<IVsTargetFrameworkInfo4> tfms)
         {
             return GetSingleNonEvaluatedPropertyOrNull(tfms, ProjectBuildProperties.RestoreUseLegacyDependencyResolver, MSBuildStringUtility.IsTrue);
+        }
+
+        internal static bool GetIsPruningEnabledGlobally(IReadOnlyList<IVsTargetFrameworkInfo4> tfms)
+        {
+            foreach (var value in GetNonEvaluatedPropertyOrNull(tfms, "_RestorePackagePruningDefault", s => s))
+            {
+                if (value is not null)
+                {
+                    if (MSBuildStringUtility.IsTrue(value))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         internal static RestoreAuditProperties? GetRestoreAuditProperties(IReadOnlyList<IVsTargetFrameworkInfo4> tfms)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -340,12 +340,9 @@ namespace NuGet.SolutionRestoreManager
         {
             foreach (var value in GetNonEvaluatedPropertyOrNull(tfms, "_RestorePackagePruningDefault", s => s))
             {
-                if (value is not null)
+                if (value is not null && MSBuildStringUtility.IsTrue(value))
                 {
-                    if (MSBuildStringUtility.IsTrue(value))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
             return false;

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -319,7 +319,7 @@ namespace NuGet.SolutionRestoreManager
             var targetFrameworks = projectRestoreInfo.TargetFrameworks;
 
             var cpvmEnabled = VSNominationUtilities.IsCentralPackageVersionManagementEnabled(targetFrameworks);
-            var isPruningEnabledGlobally = VSNominationUtilities.GetIsPruningEnabledGlobally(targetFrameworks);
+            var isPruningEnabledGlobally = VSNominationUtilities.IsPruningEnabledGlobally(targetFrameworks);
 
             TargetFrameworkInformation[] tfis = new TargetFrameworkInformation[targetFrameworks.Count];
             for (int i = 0; i < targetFrameworks.Count; i++)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -319,12 +319,13 @@ namespace NuGet.SolutionRestoreManager
             var targetFrameworks = projectRestoreInfo.TargetFrameworks;
 
             var cpvmEnabled = VSNominationUtilities.IsCentralPackageVersionManagementEnabled(targetFrameworks);
+            var isPruningEnabledGlobally = VSNominationUtilities.GetIsPruningEnabledGlobally(targetFrameworks);
 
             TargetFrameworkInformation[] tfis = new TargetFrameworkInformation[targetFrameworks.Count];
             for (int i = 0; i < targetFrameworks.Count; i++)
             {
                 IVsTargetFrameworkInfo4 targetFrameworkInfo = targetFrameworks[i];
-                TargetFrameworkInformation tfi = VSNominationUtilities.ToTargetFrameworkInformation(targetFrameworkInfo, cpvmEnabled, projectNames.FullName);
+                TargetFrameworkInformation tfi = VSNominationUtilities.ToTargetFrameworkInformation(targetFrameworkInfo, cpvmEnabled, isPruningEnabledGlobally, projectNames.FullName);
                 tfis[i] = tfi;
             }
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -702,6 +702,7 @@ namespace NuGet.Build.Tasks.Console
         /// </summary>
         /// <param name="projectInnerNodes">An <see cref="IReadOnlyDictionary{NuGetFramework,ProjectInstance} "/> containing the projects by their target framework.</param>
         /// <param name="isCpvmEnabled">A flag that is true if the Central Package Management was enabled.</param>
+        /// <param name="isPruningEnabledGlobally">A flag that tells us the default for pruning, if the pruning property is not set.</param>
         /// <returns>A <see cref="List{TargetFrameworkInformation}" /> containing the target framework information for the specified project.</returns>
         internal static List<TargetFrameworkInformation> GetTargetFrameworkInfos(IReadOnlyDictionary<string, IMSBuildProject> projectInnerNodes, bool isCpvmEnabled, bool isPruningEnabledGlobally)
         {

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -1077,7 +1077,7 @@ namespace NuGet.Build.Tasks.Console
             }
         }
 
-        private static bool GetPackagePruningDefault(IEnumerable<IMSBuildProject> innerBuilds)
+        internal static bool GetPackagePruningDefault(IEnumerable<IMSBuildProject> innerBuilds)
         {
             foreach (var item in innerBuilds.NoAllocEnumerate())
             {

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -703,7 +703,7 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="projectInnerNodes">An <see cref="IReadOnlyDictionary{NuGetFramework,ProjectInstance} "/> containing the projects by their target framework.</param>
         /// <param name="isCpvmEnabled">A flag that is true if the Central Package Management was enabled.</param>
         /// <returns>A <see cref="List{TargetFrameworkInformation}" /> containing the target framework information for the specified project.</returns>
-        internal static List<TargetFrameworkInformation> GetTargetFrameworkInfos(IReadOnlyDictionary<string, IMSBuildProject> projectInnerNodes, bool isCpvmEnabled)
+        internal static List<TargetFrameworkInformation> GetTargetFrameworkInfos(IReadOnlyDictionary<string, IMSBuildProject> projectInnerNodes, bool isCpvmEnabled, bool isPruningEnabledGlobally)
         {
             var targetFrameworkInfos = new List<TargetFrameworkInformation>(projectInnerNodes.Count);
 
@@ -735,7 +735,10 @@ namespace NuGet.Build.Tasks.Console
                 }
 
                 var dependencies = GetPackageReferences(msBuildProjectInstance, isCpvmEnabled, centralPackageVersions);
-                var prunedReferences = msBuildProjectInstance.IsPropertyTrue("RestoreEnablePackagePruning") ? GetPrunePackageReferences(msBuildProjectInstance) : [];
+
+                bool? restoreEnablePackagePruning = MSBuildStringUtility.GetBooleanOrNull(msBuildProjectInstance.GetProperty("RestoreEnablePackagePruning"));
+                bool isPackagePruningEnabled = restoreEnablePackagePruning == null ? isPruningEnabledGlobally : restoreEnablePackagePruning == true;
+                var prunedReferences = isPackagePruningEnabled ? GetPrunePackageReferences(msBuildProjectInstance) : [];
 
                 var targetFrameworkInformation = new TargetFrameworkInformation()
                 {
@@ -992,9 +995,10 @@ namespace NuGet.Build.Tasks.Console
 
             (bool isCentralPackageManagementEnabled, bool isCentralPackageVersionOverrideDisabled, bool isCentralPackageTransitivePinningEnabled, bool isCentralPackageFloatingVersionsEnabled) = MSBuildRestoreUtility.GetCentralPackageManagementSettings(project, projectStyle);
 
+            bool isPruningEnabledGlobally = GetPackagePruningDefault(projectsByTargetFramework.Values);
             RestoreAuditProperties auditProperties = MSBuildRestoreUtility.GetRestoreAuditProperties(project, projectsByTargetFramework.Values, GetAuditSuppressions(project));
 
-            List<TargetFrameworkInformation> targetFrameworkInfos = GetTargetFrameworkInfos(projectsByTargetFramework, isCentralPackageManagementEnabled);
+            List<TargetFrameworkInformation> targetFrameworkInfos = GetTargetFrameworkInfos(projectsByTargetFramework, isCentralPackageManagementEnabled, isPruningEnabledGlobally);
 
             List<IMSBuildProject> innerNodes = projectsByTargetFramework.Values.ToList();
 
@@ -1071,6 +1075,18 @@ namespace NuGet.Build.Tasks.Console
 
                 return (projectStyleResult.ProjectStyle, projectStyleResult.PackagesConfigFilePath);
             }
+        }
+
+        private static bool GetPackagePruningDefault(IEnumerable<IMSBuildProject> innerBuilds)
+        {
+            foreach (var item in innerBuilds.NoAllocEnumerate())
+            {
+                if (item.IsPropertyTrue("_RestorePackagePruningDefault"))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private static HashSet<string> GetAuditSuppressions(IMSBuildProject project)

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -39,6 +39,10 @@
     <None Include="app.manifest" />
   </ItemGroup>
 
+  <ItemGroup Label="NuGet Shared">
+    <Compile Include="$(SharedDirectory)\NoAllocEnumerateExtensions.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <Content Include="..\NuGet.Build.Tasks\NuGet.RestoreEx.targets">
       <Link>%(Filename)%(Extension)</Link>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -1205,6 +1205,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RuntimeIdentifierGraphPath>$(RuntimeIdentifierGraphPath)</RuntimeIdentifierGraphPath>
         <WindowsTargetPlatformMinVersion>$(WindowsTargetPlatformMinVersion)</WindowsTargetPlatformMinVersion>
         <RestoreEnablePackagePruning>$(RestoreEnablePackagePruning)</RestoreEnablePackagePruning>
+        <_RestorePackagePruningDefault>$(_RestorePackagePruningDefault)</_RestorePackagePruningDefault>
         <NuGetAuditMode>$(NuGetAuditMode)</NuGetAuditMode>
       </_RestoreGraphEntry>
     </ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -90,8 +90,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                     AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
                     AND '$(SdkAnalysisLevel)' != ''
                     AND $([MSBuild]::VersionGreaterThanOrEquals('$(SdkAnalysisLevel)', '10.0.100'))
-                    AND (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0')))
-                        OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '2.0'))))"
+                    AND ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0')))"
                     >true</RestoreEnablePackagePruning>
     <RestoreEnablePackagePruning Condition="$(RestoreEnablePackagePruning) == '' AND '$(TargetFrameworks)' == ''">false</RestoreEnablePackagePruning>
     <_RestorePackagePruningDefault Condition="'$(UsingMicrosoftNETSdk)' == 'true'

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -81,15 +81,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup>
-    <RestoreEnablePackagePruning Condition="'$(RestoreEnablePackagePruning)' == ''
-                    AND '$(UsingMicrosoftNETSdk)' == 'true'
+    <_RestorePackagePruningDefault Condition="'$(UsingMicrosoftNETSdk)' == 'true'
                     AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
                     AND '$(SdkAnalysisLevel)' != ''
                     AND $([MSBuild]::VersionGreaterThanOrEquals('$(SdkAnalysisLevel)', '10.0.100'))
-                    AND (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0')))
-                        OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '2.0'))))"
-                    >true</RestoreEnablePackagePruning>
-    <RestoreEnablePackagePruning Condition="$(RestoreEnablePackagePruning) == '' ">false</RestoreEnablePackagePruning>
+                    AND ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0')))"
+                    >true</_RestorePackagePruningDefault>
+    <_RestorePackagePruningDefault Condition="'$(_RestorePackagePruningDefault)' == ''">false</_RestorePackagePruningDefault>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -80,7 +80,20 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
   </PropertyGroup>
 
+  <!-- Package pruning is enabled for all projects targeting .NET 10 or greater, including multi-targeted projects. -->
   <PropertyGroup>
+    <!-- We only set the RestoreEnablePackagePruning default for single TFM projects. 
+    For multi-targeted projects that requires knowing the other inner builds, so we rely on _RestorePackagePruningDefault. -->
+    <RestoreEnablePackagePruning Condition="'$(RestoreEnablePackagePruning)' == ''
+                    AND '$(UsingMicrosoftNETSdk)' == 'true'
+                    AND '$(TargetFrameworks)' == ''
+                    AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
+                    AND '$(SdkAnalysisLevel)' != ''
+                    AND $([MSBuild]::VersionGreaterThanOrEquals('$(SdkAnalysisLevel)', '10.0.100'))
+                    AND (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0')))
+                        OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '2.0'))))"
+                    >true</RestoreEnablePackagePruning>
+    <RestoreEnablePackagePruning Condition="$(RestoreEnablePackagePruning) == '' AND '$(TargetFrameworks)' == ''">false</RestoreEnablePackagePruning>
     <_RestorePackagePruningDefault Condition="'$(UsingMicrosoftNETSdk)' == 'true'
                     AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
                     AND '$(SdkAnalysisLevel)' != ''

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -724,12 +724,21 @@ namespace NuGet.Commands
                 prunePackageReferences.Add(targetFramework.TargetAlias, new Dictionary<string, PrunePackageReference>(StringComparer.OrdinalIgnoreCase));
             }
 
-            foreach (var item in GetItemByType(items, "TargetFrameworkInformation"))
+            List<IMSBuildItem> tfiItems = GetItemByType(items, "TargetFrameworkInformation").ToList();
+            bool isPruningEnabledGlobally = false;
+            foreach (var item in tfiItems)
+            {
+                isPruningEnabledGlobally |= IsPropertyTrue(item, "_RestorePackagePruningDefault");
+            }
+
+            foreach (var item in tfiItems)
             {
                 var tfm = item.GetProperty("TargetFramework") ?? string.Empty;
 
-                bool enabled = IsPropertyTrue(item, "RestoreEnablePackagePruning");
-                isPruningEnabled[tfm] = enabled;
+                bool? restoreEnablePackagePruning = MSBuildStringUtility.GetBooleanOrNull(item.GetProperty("RestoreEnablePackagePruning"));
+                bool isPackagePruningEnabled = restoreEnablePackagePruning == null ? isPruningEnabledGlobally : restoreEnablePackagePruning == true;
+
+                isPruningEnabled[tfm] = isPackagePruningEnabled;
             }
 
             foreach (var item in GetItemByType(items, "PrunePackageReference"))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -724,14 +724,18 @@ namespace NuGet.Commands
                 prunePackageReferences.Add(targetFramework.TargetAlias, new Dictionary<string, PrunePackageReference>(StringComparer.OrdinalIgnoreCase));
             }
 
-            List<IMSBuildItem> tfiItems = GetItemByType(items, "TargetFrameworkInformation").ToList();
+            List<IMSBuildItem> targetFrameworkInfos = GetItemByType(items, "TargetFrameworkInformation").ToList();
             bool isPruningEnabledGlobally = false;
-            foreach (var item in tfiItems)
+            foreach (var item in targetFrameworkInfos)
             {
-                isPruningEnabledGlobally |= IsPropertyTrue(item, "_RestorePackagePruningDefault");
+                if (IsPropertyTrue(item, "_RestorePackagePruningDefault"))
+                {
+                    isPruningEnabledGlobally = true;
+                    break;
+                }
             }
 
-            foreach (var item in tfiItems)
+            foreach (var item in targetFrameworkInfos)
             {
                 var tfm = item.GetProperty("TargetFramework") ?? string.Empty;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
@@ -105,7 +105,6 @@ namespace NuGet.Commands.Restore.Utility
 
             RestoreAuditProperties? auditProperties = GetRestoreAuditProperties(project);
             bool isPruningEnabledGlobally = GetPackagePruningDefault(project);
-
             List<TargetFrameworkInformation> targetFrameworkInfos = GetTargetFrameworkInfos(project, isCentralPackageManagementEnabled, isPruningEnabledGlobally);
 
             ProjectRestoreMetadata restoreMetadata;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
@@ -104,8 +104,9 @@ namespace NuGet.Commands.Restore.Utility
                 GetCentralPackageManagementSettings(outerBuild, projectStyle);
 
             RestoreAuditProperties? auditProperties = GetRestoreAuditProperties(project);
+            bool isPruningEnabledGlobally = GetPackagePruningDefault(project);
 
-            List<TargetFrameworkInformation> targetFrameworkInfos = GetTargetFrameworkInfos(project, isCentralPackageManagementEnabled);
+            List<TargetFrameworkInformation> targetFrameworkInfos = GetTargetFrameworkInfos(project, isCentralPackageManagementEnabled, isPruningEnabledGlobally);
 
             ProjectRestoreMetadata restoreMetadata;
 
@@ -188,7 +189,7 @@ namespace NuGet.Commands.Restore.Utility
         /// <param name="project">An <see cref="IReadOnlyDictionary{NuGetFramework,ProjectInstance} "/> containing the projects by their target framework.</param>
         /// <param name="isCpvmEnabled">A flag that is true if the Central Package Management was enabled.</param>
         /// <returns>A <see cref="List{TargetFrameworkInformation}" /> containing the target framework information for the specified project.</returns>
-        internal static List<TargetFrameworkInformation> GetTargetFrameworkInfos(IProject project, bool isCpvmEnabled)
+        internal static List<TargetFrameworkInformation> GetTargetFrameworkInfos(IProject project, bool isCpvmEnabled, bool isPruningEnabledGlobally)
         {
             var targetFrameworkInfos = new List<TargetFrameworkInformation>(project.TargetFrameworks.Count);
 
@@ -220,7 +221,11 @@ namespace NuGet.Commands.Restore.Utility
                 }
 
                 var dependencies = GetPackageReferences(msBuildProjectInstance, isCpvmEnabled, centralPackageVersions);
-                var prunedReferences = msBuildProjectInstance.IsPropertyTrue("RestoreEnablePackagePruning") ? GetPrunePackageReferences(msBuildProjectInstance) : [];
+
+                bool? restoreEnablePackagePruning = MSBuildStringUtility.GetBooleanOrNull(msBuildProjectInstance.GetProperty("RestoreEnablePackagePruning"));
+                bool isPackagePruningEnabled = restoreEnablePackagePruning == null ? isPruningEnabledGlobally : restoreEnablePackagePruning == true;
+
+                var prunedReferences = isPackagePruningEnabled ? GetPrunePackageReferences(msBuildProjectInstance) : [];
 
                 var targetFrameworkInformation = new TargetFrameworkInformation()
                 {
@@ -241,6 +246,18 @@ namespace NuGet.Commands.Restore.Utility
             }
 
             return targetFrameworkInfos;
+        }
+
+        private static bool GetPackagePruningDefault(IProject project)
+        {
+            foreach (var item in project.TargetFrameworks.NoAllocEnumerate())
+            {
+                if (item.Value.IsPropertyTrue("_RestorePackagePruningDefault"))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private static RestoreAuditProperties? GetRestoreAuditProperties(IProject project)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
@@ -187,6 +187,7 @@ namespace NuGet.Commands.Restore.Utility
         /// </summary>
         /// <param name="project">An <see cref="IReadOnlyDictionary{NuGetFramework,ProjectInstance} "/> containing the projects by their target framework.</param>
         /// <param name="isCpvmEnabled">A flag that is true if the Central Package Management was enabled.</param>
+        /// <param name="isPruningEnabledGlobally">A flag that tells us the default for pruning, if the pruning property is not set.</param>
         /// <returns>A <see cref="List{TargetFrameworkInformation}" /> containing the target framework information for the specified project.</returns>
         internal static List<TargetFrameworkInformation> GetTargetFrameworkInfos(IProject project, bool isCpvmEnabled, bool isPruningEnabledGlobally)
         {

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -63,5 +63,6 @@ namespace NuGet.ProjectManagement
         public const string UsingMicrosoftNETSdk = nameof(UsingMicrosoftNETSdk);
         public const string RestoreUseLegacyDependencyResolver = nameof(RestoreUseLegacyDependencyResolver);
         public const string RestoreEnablePackagePruning = nameof(RestoreEnablePackagePruning);
+        public const string RestorePackagePruningDefault = "_" + nameof(RestorePackagePruningDefault);
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~const NuGet.ProjectManagement.ProjectBuildProperties.RestorePackagePruningDefault = "_RestorePackagePruningDefault" -> string

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VSNominationUtilitiesTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VSNominationUtilitiesTests.cs
@@ -484,5 +484,34 @@ namespace NuGet.SolutionRestoreManager.Test
             //Assert
             Assert.Equal(expected, actual);
         }
+
+        [Theory]
+        [MemberData(nameof(IsPruningEnabledGlobally))]
+        public void IsPruningEnabledGlobally_WithVariousInputs_ReturnsExpectedResult(string[] members, bool expected)
+        {
+            // Arrange
+            var builder = new TestProjectRestoreInfoBuilder();
+
+            for (int i = 0; i < members.Length; i++)
+            {
+                builder = builder.WithTargetFrameworkInfo($"net{i + 1}.0", builder =>
+                {
+                    builder
+                    .WithProperty(ProjectBuildProperties.RestorePackagePruningDefault, members[i]);
+                });
+            }
+            var projectRestoreInfo = builder.Build();
+
+            // Act & Assert
+            VSNominationUtilities.IsPruningEnabledGlobally(projectRestoreInfo.TargetFrameworks).Should().Be(expected);
+        }
+
+        public static readonly List<object[]> IsPruningEnabledGlobally
+            = new List<object[]>
+            {
+                    new object[] { new string[] { "true", "false" }, true },
+                    new object[] { new string[] { "true", "" }, true },
+                    new object[] { new string[] { "", "", "false" }, false },
+            };
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3195,12 +3195,12 @@ EndGlobal";
         }
 
         [Theory]
-        [InlineData("false", "'$(TargetFramework)' == 'netstandard2.1'", true)]
-        [InlineData("false", "'$(TargetFramework)' == 'netstandard2.1'", false)]
-        public async Task DotnetRestore_WithMultiTargetedProjectAndRestoreEnablePackagePruning_CanConditionallyDisablePruning(string restoreEnablePackagePruning, string condition, bool useStaticGraphRestore)
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DotnetRestore_WithMultiTargetedProjectAndRestoreEnablePackagePruning_CanConditionallyDisablePruning(bool useStaticGraphRestore)
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
-            LockFile assetsFile = await DotnetRestore_MultiTargetedProjectWithRestoreEnablePackagePruning(pathContext, restoreEnablePackagePruning, condition, useStaticGraphRestore);
+            LockFile assetsFile = await DotnetRestore_MultiTargetedProjectWithRestoreEnablePackagePruning(pathContext, "false", "'$(TargetFramework)' == 'netstandard2.1'", useStaticGraphRestore);
 
             assetsFile.PackageSpec.TargetFrameworks[0].PackagesToPrune.Should().NotBeEmpty();
             var firstTarget = assetsFile.GetTarget(assetsFile.PackageSpec.TargetFrameworks[0].TargetAlias, string.Empty);
@@ -3214,12 +3214,12 @@ EndGlobal";
         }
 
         [Theory]
-        [InlineData("false", null, true)]
-        [InlineData("false", null, false)]
-        public async Task DotnetRestore_WithMultiTargetedProjectAndRestoreEnablePackagePruning_CanDisablePruningForAll(string restoreEnablePackagePruning, string condition, bool useStaticGraphRestore)
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DotnetRestore_WithMultiTargetedProjectAndRestoreEnablePackagePruning_CanDisablePruningForAll(bool useStaticGraphRestore)
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
-            LockFile assetsFile = await DotnetRestore_MultiTargetedProjectWithRestoreEnablePackagePruning(pathContext, restoreEnablePackagePruning, condition, useStaticGraphRestore);
+            LockFile assetsFile = await DotnetRestore_MultiTargetedProjectWithRestoreEnablePackagePruning(pathContext, "false", null, useStaticGraphRestore);
 
             assetsFile.PackageSpec.TargetFrameworks[0].PackagesToPrune.Should().BeEmpty();
             var firstTarget = assetsFile.GetTarget(assetsFile.PackageSpec.TargetFrameworks[0].TargetAlias, string.Empty);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3013,11 +3013,6 @@ EndGlobal";
         public async Task DotnetRestore_WithCoreFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning, bool useStaticGraphRestore)
         {
             string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
-            await DotnetRestore_WithFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(sdkAnalysisLevel, restoreEnablePackagePruning, tfm, useStaticGraphRestore);
-        }
-
-        private async Task DotnetRestore_WithFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning, string tfm, bool useStaticGraphRestore)
-        {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
             var projectName = "ClassLibrary1";
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -3072,11 +3067,6 @@ EndGlobal";
         public async Task DotnetRestore_WithCoreFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_DisablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning)
         {
             string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
-            await DotnetRestore_WithFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_DisablesPruning(sdkAnalysisLevel, restoreEnablePackagePruning, tfm);
-        }
-
-        private async Task DotnetRestore_WithFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_DisablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning, string tfm)
-        {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
             var projectName = "ClassLibrary1";
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3119,10 +3119,10 @@ EndGlobal";
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task DotnetRestore_WithMultiTargetedProjectAndPrunePackageReference_EnablesForAllFrameworks(bool useStaticGraphRestore)
+        public async Task DotnetRestore_WithMultiTargetedProjectAndSDKAnalysisLevel_EnablesForAllFrameworks(bool useStaticGraphRestore)
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
-            LockFile assetsFile = await DotnetRestore_WithMultiTargetedProject_Setup(pathContext, "10.0.100", useStaticGraphRestore);
+            LockFile assetsFile = await DotnetRestore_MultiTargetedProjectWithSDKAnalysisLevel(pathContext, "10.0.100", useStaticGraphRestore);
 
             assetsFile.PackageSpec.TargetFrameworks[0].PackagesToPrune.Should().NotBeEmpty();
             assetsFile.Targets[0].Libraries.Should().Contain(e => e.Name.Equals("X"));
@@ -3136,10 +3136,10 @@ EndGlobal";
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task DotnetRestore_WithMultiTargetedProjectAndPrunePackageReference_DisablesForAllFrameworks(bool useStaticGraphRestore)
+        public async Task DotnetRestore_WithMultiTargetedProjectAndSDKAnalysisLevel_DisablesForAllFrameworks(bool useStaticGraphRestore)
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
-            LockFile assetsFile = await DotnetRestore_WithMultiTargetedProject_Setup(pathContext, "9.0.100", useStaticGraphRestore);
+            LockFile assetsFile = await DotnetRestore_MultiTargetedProjectWithSDKAnalysisLevel(pathContext, "9.0.100", useStaticGraphRestore);
 
             assetsFile.PackageSpec.TargetFrameworks[0].PackagesToPrune.Should().BeEmpty();
             assetsFile.Targets[0].Libraries.Should().Contain(e => e.Name.Equals("X"));
@@ -3150,7 +3150,7 @@ EndGlobal";
             assetsFile.Targets[1].Libraries.Should().Contain(e => e.Name.Equals("Y"));
         }
 
-        private async Task<LockFile> DotnetRestore_WithMultiTargetedProject_Setup(SimpleTestPathContext pathContext, string sdkAnalysisLevel, bool useStaticGraphRestore)
+        private async Task<LockFile> DotnetRestore_MultiTargetedProjectWithSDKAnalysisLevel(SimpleTestPathContext pathContext, string sdkAnalysisLevel, bool useStaticGraphRestore)
         {
             string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
             var projectName = "ClassLibrary1";
@@ -3165,10 +3165,91 @@ EndGlobal";
                 var xml = XDocument.Load(stream);
                 ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"{tfm};netstandard2.1");
                 ProjectFileUtils.AddProperty(xml, "SdkAnalysisLevel", sdkAnalysisLevel);
-                //if (!string.IsNullOrEmpty(restoreEnablePackagePruning))
-                //{
-                //    ProjectFileUtils.AddProperty(xml, "RestoreEnablePackagePruning", restoreEnablePackagePruning);
-                //}
+
+                ProjectFileUtils.AddItem(
+                    xml,
+                    "PackageReference",
+                    "X",
+                    string.Empty,
+                    [],
+                    new Dictionary<string, string>() { { "Version", "1.0.0" } });
+
+                ProjectFileUtils.AddItem(
+                    xml,
+                    "PrunePackageReference",
+                    "Y",
+                    string.Empty,
+                    [],
+                    new Dictionary<string, string>() { { "Version", "2.0.0" } });
+
+                ProjectFileUtils.WriteXmlToFile(xml, stream);
+            }
+
+            var result = _dotnetFixture.RunDotnetExpectSuccess(workingDirectory, $"restore {projectFile} {(useStaticGraphRestore ? " /p:RestoreUseStaticGraphEvaluation=true" : string.Empty)}", testOutputHelper: _testOutputHelper);
+            result.AllOutput.Should().NotContain("Warning");
+            string assetsFilePath = Path.Combine(workingDirectory, "obj", LockFileFormat.AssetsFileName);
+            LockFile assetsFile = new LockFileFormat().Read(assetsFilePath);
+            assetsFile.Targets.Should().HaveCount(2);
+            assetsFile.PackageSpec.TargetFrameworks.Should().HaveCount(2);
+            return assetsFile;
+        }
+
+        [Theory]
+        [InlineData("false", "'$(TargetFramework)' == 'netstandard2.1'", true)]
+        [InlineData("false", "'$(TargetFramework)' == 'netstandard2.1'", false)]
+        public async Task DotnetRestore_WithMultiTargetedProjectAndRestoreEnablePackagePruning_CanConditionallyDisablePruning(string restoreEnablePackagePruning, string condition, bool useStaticGraphRestore)
+        {
+            using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
+            LockFile assetsFile = await DotnetRestore_MultiTargetedProjectWithRestoreEnablePackagePruning(pathContext, restoreEnablePackagePruning, condition, useStaticGraphRestore);
+
+            assetsFile.PackageSpec.TargetFrameworks[0].PackagesToPrune.Should().NotBeEmpty();
+            var firstTarget = assetsFile.GetTarget(assetsFile.PackageSpec.TargetFrameworks[0].TargetAlias, string.Empty);
+            firstTarget.Libraries.Should().Contain(e => e.Name.Equals("X"));
+            firstTarget.Libraries.Should().NotContain(e => e.Name.Equals("Y"));
+
+            assetsFile.PackageSpec.TargetFrameworks[1].PackagesToPrune.Should().BeEmpty();
+            var secondTarget = assetsFile.GetTarget(assetsFile.PackageSpec.TargetFrameworks[1].TargetAlias, string.Empty);
+            secondTarget.Libraries.Should().Contain(e => e.Name.Equals("X"));
+            secondTarget.Libraries.Should().Contain(e => e.Name.Equals("Y"));
+        }
+
+        [Theory]
+        [InlineData("false", null, true)]
+        [InlineData("false", null, false)]
+        public async Task DotnetRestore_WithMultiTargetedProjectAndRestoreEnablePackagePruning_CanDisablePruningForAll(string restoreEnablePackagePruning, string condition, bool useStaticGraphRestore)
+        {
+            using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
+            LockFile assetsFile = await DotnetRestore_MultiTargetedProjectWithRestoreEnablePackagePruning(pathContext, restoreEnablePackagePruning, condition, useStaticGraphRestore);
+
+            assetsFile.PackageSpec.TargetFrameworks[0].PackagesToPrune.Should().BeEmpty();
+            var firstTarget = assetsFile.GetTarget(assetsFile.PackageSpec.TargetFrameworks[0].TargetAlias, string.Empty);
+            firstTarget.Libraries.Should().Contain(e => e.Name.Equals("X"));
+            firstTarget.Libraries.Should().Contain(e => e.Name.Equals("Y"));
+
+            assetsFile.PackageSpec.TargetFrameworks[1].PackagesToPrune.Should().BeEmpty();
+            var secondTarget = assetsFile.GetTarget(assetsFile.PackageSpec.TargetFrameworks[1].TargetAlias, string.Empty);
+            secondTarget.Libraries.Should().Contain(e => e.Name.Equals("X"));
+            secondTarget.Libraries.Should().Contain(e => e.Name.Equals("Y"));
+        }
+
+        private async Task<LockFile> DotnetRestore_MultiTargetedProjectWithRestoreEnablePackagePruning(SimpleTestPathContext pathContext, string restoreEnablePackagePruning, string condition, bool useStaticGraphRestore)
+        {
+            string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+            var projectName = "ClassLibrary1";
+            var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
+            var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, new SimpleTestPackageContext("X", "1.0.0") { Dependencies = [new SimpleTestPackageContext("Y", "1.0.0")] });
+
+            _dotnetFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib -f netstandard2.1", testOutputHelper: _testOutputHelper);
+
+            using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
+            {
+                var xml = XDocument.Load(stream);
+                ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"{tfm};netstandard2.1");
+                if (!string.IsNullOrEmpty(restoreEnablePackagePruning))
+                {
+                    ProjectFileUtils.AddProperty(xml, "RestoreEnablePackagePruning", restoreEnablePackagePruning, condition);
+                }
                 ProjectFileUtils.AddItem(
                     xml,
                     "PackageReference",

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3006,23 +3006,17 @@ EndGlobal";
         }
 
         [Theory]
-        [InlineData("10.0.100", null, "netstandard2.1")]
-        [InlineData("9.0.100", "true", "netstandard2.1")]
-        public async Task DotnetRestore_WithNETStandardFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning, string tfm)
-        {
-            await DotnetRestore_WithFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(sdkAnalysisLevel, restoreEnablePackagePruning, tfm);
-        }
-
-        [Theory]
-        [InlineData("10.0.100", null)]
-        [InlineData("9.0.100", "true")]
-        public async Task DotnetRestore_WithCoreFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning)
+        [InlineData("10.0.100", null, true)]
+        [InlineData("9.0.100", "true", true)]
+        [InlineData("10.0.100", null, false)]
+        [InlineData("9.0.100", "true", false)]
+        public async Task DotnetRestore_WithCoreFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning, bool useStaticGraphRestore)
         {
             string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
-            await DotnetRestore_WithFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(sdkAnalysisLevel, restoreEnablePackagePruning, tfm);
+            await DotnetRestore_WithFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(sdkAnalysisLevel, restoreEnablePackagePruning, tfm, useStaticGraphRestore);
         }
 
-        private async Task DotnetRestore_WithFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning, string tfm)
+        private async Task DotnetRestore_WithFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning, string tfm, bool useStaticGraphRestore)
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
             var projectName = "ClassLibrary1";
@@ -3060,7 +3054,7 @@ EndGlobal";
                 ProjectFileUtils.WriteXmlToFile(xml, stream);
             }
 
-            var result = _dotnetFixture.RunDotnetExpectSuccess(workingDirectory, $"restore {projectFile}", testOutputHelper: _testOutputHelper);
+            var result = _dotnetFixture.RunDotnetExpectSuccess(workingDirectory, $"restore {projectFile} {(useStaticGraphRestore ? " /p:RestoreUseStaticGraphEvaluation=true" : string.Empty)}", testOutputHelper: _testOutputHelper);
             result.AllOutput.Should().NotContain("Warning");
             string assetsFilePath = Path.Combine(workingDirectory, "obj", LockFileFormat.AssetsFileName);
             LockFile assetsFile = new LockFileFormat().Read(assetsFilePath);
@@ -3068,18 +3062,8 @@ EndGlobal";
             assetsFile.PackageSpec.TargetFrameworks.Should().HaveCount(1);
             assetsFile.PackageSpec.TargetFrameworks[0].TargetAlias.Should().Be(tfm);
             assetsFile.PackageSpec.TargetFrameworks[0].PackagesToPrune.Should().NotBeEmpty();
-
-            // netstandard2.1
             assetsFile.Targets[0].Libraries.Should().Contain(e => e.Name.Equals("X"));
             assetsFile.Targets[0].Libraries.Should().NotContain(e => e.Name.Equals("Y"));
-        }
-
-        [Theory]
-        [InlineData("9.0.100", null, "netstandard2.1")]
-        [InlineData("10.0.100", "false", "netstandard2.1")]
-        public async Task DotnetRestore_WithNETStandard_SDKAnalysisLevelAndRestoreEnablePackagePruning_DisablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning, string tfm)
-        {
-            await DotnetRestore_WithFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_DisablesPruning(sdkAnalysisLevel, restoreEnablePackagePruning, tfm);
         }
 
         [Theory]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3010,7 +3010,7 @@ EndGlobal";
         [InlineData("9.0.100", "true", true)]
         [InlineData("10.0.100", null, false)]
         [InlineData("9.0.100", "true", false)]
-        public async Task DotnetRestore_WithCoreFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning, bool useStaticGraphRestore)
+        public async Task DotnetRestore_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning, bool useStaticGraphRestore)
         {
             string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
@@ -3064,7 +3064,7 @@ EndGlobal";
         [Theory]
         [InlineData("9.0.100", null)]
         [InlineData("10.0.100", "false")]
-        public async Task DotnetRestore_WithCoreFramework_SDKAnalysisLevelAndRestoreEnablePackagePruning_DisablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning)
+        public async Task DotnetRestore_SDKAnalysisLevelAndRestoreEnablePackagePruning_DisablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning)
         {
             string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
@@ -3114,6 +3114,87 @@ EndGlobal";
             assetsFile.PackageSpec.TargetFrameworks[0].PackagesToPrune.Should().BeEmpty();
             assetsFile.Targets[0].Libraries.Should().Contain(e => e.Name.Equals("X"));
             assetsFile.Targets[0].Libraries.Should().Contain(e => e.Name.Equals("Y"));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DotnetRestore_WithMultiTargetedProjectAndPrunePackageReference_EnablesForAllFrameworks(bool useStaticGraphRestore)
+        {
+            using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
+            LockFile assetsFile = await DotnetRestore_WithMultiTargetedProject_Setup(pathContext, "10.0.100", useStaticGraphRestore);
+
+            assetsFile.PackageSpec.TargetFrameworks[0].PackagesToPrune.Should().NotBeEmpty();
+            assetsFile.Targets[0].Libraries.Should().Contain(e => e.Name.Equals("X"));
+            assetsFile.Targets[0].Libraries.Should().NotContain(e => e.Name.Equals("Y"));
+
+            assetsFile.PackageSpec.TargetFrameworks[1].PackagesToPrune.Should().NotBeEmpty();
+            assetsFile.Targets[1].Libraries.Should().Contain(e => e.Name.Equals("X"));
+            assetsFile.Targets[1].Libraries.Should().NotContain(e => e.Name.Equals("Y"));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DotnetRestore_WithMultiTargetedProjectAndPrunePackageReference_DisablesForAllFrameworks(bool useStaticGraphRestore)
+        {
+            using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
+            LockFile assetsFile = await DotnetRestore_WithMultiTargetedProject_Setup(pathContext, "9.0.100", useStaticGraphRestore);
+
+            assetsFile.PackageSpec.TargetFrameworks[0].PackagesToPrune.Should().BeEmpty();
+            assetsFile.Targets[0].Libraries.Should().Contain(e => e.Name.Equals("X"));
+            assetsFile.Targets[0].Libraries.Should().Contain(e => e.Name.Equals("Y"));
+
+            assetsFile.PackageSpec.TargetFrameworks[1].PackagesToPrune.Should().BeEmpty();
+            assetsFile.Targets[1].Libraries.Should().Contain(e => e.Name.Equals("X"));
+            assetsFile.Targets[1].Libraries.Should().Contain(e => e.Name.Equals("Y"));
+        }
+
+        private async Task<LockFile> DotnetRestore_WithMultiTargetedProject_Setup(SimpleTestPathContext pathContext, string sdkAnalysisLevel, bool useStaticGraphRestore)
+        {
+            string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+            var projectName = "ClassLibrary1";
+            var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
+            var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, new SimpleTestPackageContext("X", "1.0.0") { Dependencies = [new SimpleTestPackageContext("Y", "1.0.0")] });
+
+            _dotnetFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib -f netstandard2.1", testOutputHelper: _testOutputHelper);
+
+            using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
+            {
+                var xml = XDocument.Load(stream);
+                ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"{tfm};netstandard2.1");
+                ProjectFileUtils.AddProperty(xml, "SdkAnalysisLevel", sdkAnalysisLevel);
+                //if (!string.IsNullOrEmpty(restoreEnablePackagePruning))
+                //{
+                //    ProjectFileUtils.AddProperty(xml, "RestoreEnablePackagePruning", restoreEnablePackagePruning);
+                //}
+                ProjectFileUtils.AddItem(
+                    xml,
+                    "PackageReference",
+                    "X",
+                    string.Empty,
+                    [],
+                    new Dictionary<string, string>() { { "Version", "1.0.0" } });
+
+                ProjectFileUtils.AddItem(
+                    xml,
+                    "PrunePackageReference",
+                    "Y",
+                    string.Empty,
+                    [],
+                    new Dictionary<string, string>() { { "Version", "2.0.0" } });
+
+                ProjectFileUtils.WriteXmlToFile(xml, stream);
+            }
+
+            var result = _dotnetFixture.RunDotnetExpectSuccess(workingDirectory, $"restore {projectFile} {(useStaticGraphRestore ? " /p:RestoreUseStaticGraphEvaluation=true" : string.Empty)}", testOutputHelper: _testOutputHelper);
+            result.AllOutput.Should().NotContain("Warning");
+            string assetsFilePath = Path.Combine(workingDirectory, "obj", LockFileFormat.AssetsFileName);
+            LockFile assetsFile = new LockFileFormat().Read(assetsFilePath);
+            assetsFile.Targets.Should().HaveCount(2);
+            assetsFile.PackageSpec.TargetFrameworks.Should().HaveCount(2);
+            return assetsFile;
         }
 
         [Theory]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -6325,7 +6325,7 @@ namespace ClassLibrary
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task DotnetPack_WithMultiTargetedProject_WhenDirectPackageIsPartiallyPrunable_DoesNotIncludeAsADependency()
+        public async Task DotnetPack_WithMultiTargetedProject_WhenDirectPackageIsPartiallyPrunable_IncludesAsADependency()
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
             var tfm = "net472;netstandard2.1";
@@ -6389,8 +6389,9 @@ namespace ClassLibrary
             dependencyGroups[0].TargetFramework.Should().Be(NuGetFramework.Parse("net472"));
             dependencyGroups[0].Packages.Should().HaveCount(1);
             dependencyGroups[0].Packages.Single().Id.Should().Be("Z");
-            dependencyGroups[1].Packages.Should().HaveCount(1);
-            dependencyGroups[1].Packages.Single().Id.Should().Be("Z");
+            dependencyGroups[1].Packages.Should().HaveCount(2);
+            dependencyGroups[1].Packages.First().Id.Should().Be("X");
+            dependencyGroups[1].Packages.Last().Id.Should().Be("Z");
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetPropertyDefaultsTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetPropertyDefaultsTests.cs
@@ -56,8 +56,8 @@ namespace Msbuild.Integration.Test
         [Theory]
         // .NET (Core) SDK 10.0
         [InlineData("10.0.100", "net10.0", "true")]
-        [InlineData("10.0.100", "net9.0", "true")]
-        [InlineData("10.0.100", "net8.0", "true")]
+        [InlineData("10.0.100", "net9.0", "false")]
+        [InlineData("10.0.100", "net8.0", "false")]
         [InlineData("10.0.100", "net7.0", "false")]
         [InlineData("10.0.100", "net6.0", "false")]
         [InlineData("10.0.100", "net5.0", "false")]
@@ -69,8 +69,8 @@ namespace Msbuild.Integration.Test
         [InlineData("10.0.100", "netcoreapp1.1", "false")]
         [InlineData("10.0.100", "netcoreapp1.0", "false")]
         // .NET Standard SDK 10.0
-        [InlineData("10.0.100", "netstandard2.1", "true")]
-        [InlineData("10.0.100", "netstandard2.0", "true")]
+        [InlineData("10.0.100", "netstandard2.1", "false")]
+        [InlineData("10.0.100", "netstandard2.0", "false")]
         [InlineData("10.0.100", "netstandard1.6", "false")]
         // .NET Framework SDK 10.0
         [InlineData("10.0.100", "net48", "false")]
@@ -91,7 +91,7 @@ namespace Msbuild.Integration.Test
             var projectFilePath = Path.Combine(testDirectory, "my.proj");
             File.WriteAllText(projectFilePath, projectText);
 
-            string args = $"{projectFilePath} -getProperty:RestoreEnablePackagePruning";
+            string args = $"{projectFilePath} -getProperty:_RestorePackagePruningDefault";
             if (!string.IsNullOrEmpty(SdkAnalysisLevel)) args += $" -p:SdkAnalysisLevel={SdkAnalysisLevel}";
 
             var framework = NuGetFramework.Parse(targetFramework);

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetPropertyDefaultsTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetPropertyDefaultsTests.cs
@@ -80,7 +80,61 @@ namespace Msbuild.Integration.Test
         [InlineData("9.0.100", "net8.0", "false")]
         [InlineData("9.0.100", "netstandard2.1", "false")]
         [InlineData("9.0.100", "netstandard2.0", "false")]
-        public void PackagePruningDefaults(string SdkAnalysisLevel, string targetFramework, string expected)
+        public void PackagePruningDefaults_RestoreEnablePackagePruning(string SdkAnalysisLevel, string targetFramework, string expected)
+        {
+            // Arrange
+            using var testDirectory = TestDirectory.Create();
+
+            string projectText = @"<Project>
+    <Import Project=""$(NuGetRestoreTargets)"" />
+</Project>";
+            var projectFilePath = Path.Combine(testDirectory, "my.proj");
+            File.WriteAllText(projectFilePath, projectText);
+
+            string args = $"{projectFilePath} -getProperty:RestoreEnablePackagePruning";
+            if (!string.IsNullOrEmpty(SdkAnalysisLevel)) args += $" -p:SdkAnalysisLevel={SdkAnalysisLevel}";
+
+            var framework = NuGetFramework.Parse(targetFramework);
+            args += $" -p:TargetFrameworkIdentifier={framework.Framework}";
+            args += $" -p:TargetFrameworkVersion={framework.Version}";
+            args += $" -p:UsingMicrosoftNETSdk=true";
+
+            // Act
+            var result = _fixture.RunMsBuild(testDirectory, args);
+            var resultText = result.Output.Trim();
+
+            // Assert
+            resultText.Should().Be(expected);
+        }
+
+        [Theory]
+        // .NET (Core) SDK 10.0
+        [InlineData("10.0.100", "net10.0", "true")]
+        [InlineData("10.0.100", "net9.0", "false")]
+        [InlineData("10.0.100", "net8.0", "false")]
+        [InlineData("10.0.100", "net7.0", "false")]
+        [InlineData("10.0.100", "net6.0", "false")]
+        [InlineData("10.0.100", "net5.0", "false")]
+        [InlineData("10.0.100", "netcoreapp3.1", "false")]
+        [InlineData("10.0.100", "netcoreapp3.0", "false")]
+        [InlineData("10.0.100", "netcoreapp2.2", "false")]
+        [InlineData("10.0.100", "netcoreapp2.1", "false")]
+        [InlineData("10.0.100", "netcoreapp2.0", "false")]
+        [InlineData("10.0.100", "netcoreapp1.1", "false")]
+        [InlineData("10.0.100", "netcoreapp1.0", "false")]
+        // .NET Standard SDK 10.0
+        [InlineData("10.0.100", "netstandard2.1", "false")]
+        [InlineData("10.0.100", "netstandard2.0", "false")]
+        [InlineData("10.0.100", "netstandard1.6", "false")]
+        // .NET Framework SDK 10.0
+        [InlineData("10.0.100", "net48", "false")]
+        // SDK 10.0
+        [InlineData("9.0.100", "net10.0", "false")]
+        [InlineData("9.0.100", "net9.0", "false")]
+        [InlineData("9.0.100", "net8.0", "false")]
+        [InlineData("9.0.100", "netstandard2.1", "false")]
+        [InlineData("9.0.100", "netstandard2.0", "false")]
+        public void PackagePruningDefaults__RestorePackagePruningDefault(string SdkAnalysisLevel, string targetFramework, string expected)
         {
             // Arrange
             using var testDirectory = TestDirectory.Create();

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -1284,5 +1284,84 @@ namespace NuGet.Build.Tasks.Console.Test
             net471PackagesToPrune[0].Value.Name.Should().Be("x");
             net471PackagesToPrune[0].Value.VersionRange.Should().Be(VersionRange.Parse("(, 1.0.0]"));
         }
+
+        [Theory]
+        [MemberData(nameof(IsPruningEnabledGlobally))]
+        public void GetPackagePruningDefault(string[] members, bool expected)
+        {
+            // Arrange
+            string net471 = "net471";
+            string net472 = "net472";
+            string net47 = "net47";
+
+            members.Should().HaveCount(3);
+
+            var innerNodes = new Dictionary<string, IMSBuildProject>
+            {
+                [net472] = new MockMSBuildProject("Project",
+                    new Dictionary<string, string>
+                    {
+                        { "ManagePackageVersionsCentrally", "true"},
+                        { "TargetFramework", "net472" },
+                        { "TargetFrameworkIdentifier", ".NETFramework" },
+                        { "TargetFrameworkVersion", "v4.7.2" },
+                        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
+                        { "_RestorePackagePruningDefault", members[0] },
+                    },
+                    new Dictionary<string, IList<IMSBuildItem>>
+                    {
+                        ["PrunePackageReference"] = new List<IMSBuildItem>
+                        {
+                            new MSBuildItem("x", new Dictionary<string, string> { ["Version"] = "1.0.0"}),
+                            new MSBuildItem("y", new Dictionary<string, string> { ["Version"] = "5.0.0"}),
+                        }
+                    }),
+                [net471] = new MockMSBuildProject("Project",
+                    new Dictionary<string, string>
+                    {
+                        { "TargetFramework", "net471" },
+                        { "TargetFrameworkIdentifier", ".NETFramework" },
+                        { "TargetFrameworkVersion", "v4.7.1" },
+                        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.1" },
+                        { "_RestorePackagePruningDefault", members[1] },
+                    },
+                    new Dictionary<string, IList<IMSBuildItem>>
+                    {
+                        ["PrunePackageReference"] = new List<IMSBuildItem>
+                        {
+                            new MSBuildItem("x", new Dictionary<string, string> { ["Version"] = "1.0.0"}),
+                        }
+                    }),
+                [net47] = new MockMSBuildProject("Project",
+                    new Dictionary<string, string>
+                    {
+                        { "TargetFramework", "net47" },
+                        { "TargetFrameworkIdentifier", ".NETFramework" },
+                        { "TargetFrameworkVersion", "v4.7.0" },
+                        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.0" },
+                        { "_RestorePackagePruningDefault", members[2] },
+                    },
+                    new Dictionary<string, IList<IMSBuildItem>>
+                    {
+                        ["PrunePackageReference"] = new List<IMSBuildItem>
+                        {
+                            new MSBuildItem("x", new Dictionary<string, string> { ["Version"] = "1.0.0"}),
+                        }
+                    })
+            };
+
+            var result = MSBuildStaticGraphRestore.GetPackagePruningDefault(innerNodes.Values);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        public static readonly List<object[]> IsPruningEnabledGlobally
+            = new List<object[]>
+            {
+                    new object[] { new string[] { "true", "false", "false" }, true },
+                    new object[] { new string[] { "true", "", "false" }, true },
+                    new object[] { new string[] { "", "", "false" }, false },
+            };
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -1286,15 +1286,15 @@ namespace NuGet.Build.Tasks.Console.Test
         }
 
         [Theory]
-        [MemberData(nameof(IsPruningEnabledGlobally))]
-        public void GetPackagePruningDefault(string[] members, bool expected)
+        [InlineData("true", "false", "false", true)]
+        [InlineData("true", "", "false", true)]
+        [InlineData("", "", "false", false)]
+        public void GetPackagePruningDefault(string firstDefault, string secondDefault, string thirdDefault, bool expected)
         {
             // Arrange
             string net471 = "net471";
             string net472 = "net472";
             string net47 = "net47";
-
-            members.Should().HaveCount(3);
 
             var innerNodes = new Dictionary<string, IMSBuildProject>
             {
@@ -1306,7 +1306,7 @@ namespace NuGet.Build.Tasks.Console.Test
                         { "TargetFrameworkIdentifier", ".NETFramework" },
                         { "TargetFrameworkVersion", "v4.7.2" },
                         { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
-                        { "_RestorePackagePruningDefault", members[0] },
+                        { "_RestorePackagePruningDefault", firstDefault },
                     },
                     new Dictionary<string, IList<IMSBuildItem>>
                     {
@@ -1323,7 +1323,7 @@ namespace NuGet.Build.Tasks.Console.Test
                         { "TargetFrameworkIdentifier", ".NETFramework" },
                         { "TargetFrameworkVersion", "v4.7.1" },
                         { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.1" },
-                        { "_RestorePackagePruningDefault", members[1] },
+                        { "_RestorePackagePruningDefault", secondDefault },
                     },
                     new Dictionary<string, IList<IMSBuildItem>>
                     {
@@ -1339,7 +1339,7 @@ namespace NuGet.Build.Tasks.Console.Test
                         { "TargetFrameworkIdentifier", ".NETFramework" },
                         { "TargetFrameworkVersion", "v4.7.0" },
                         { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.0" },
-                        { "_RestorePackagePruningDefault", members[2] },
+                        { "_RestorePackagePruningDefault", thirdDefault },
                     },
                     new Dictionary<string, IList<IMSBuildItem>>
                     {
@@ -1355,13 +1355,5 @@ namespace NuGet.Build.Tasks.Console.Test
             // Assert
             result.Should().Be(expected);
         }
-
-        public static readonly List<object[]> IsPruningEnabledGlobally
-            = new List<object[]>
-            {
-                    new object[] { new string[] { "true", "false", "false" }, true },
-                    new object[] { new string[] { "true", "", "false" }, true },
-                    new object[] { new string[] { "", "", "false" }, false },
-            };
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -922,7 +922,7 @@ namespace NuGet.Build.Tasks.Console.Test
                     }),
             };
 
-            var targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: true);
+            var targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: true, isPruningEnabledGlobally: false);
 
             // Assert
             Assert.Equal(4, targetFrameworkInfos.Count);
@@ -1000,7 +1000,8 @@ namespace NuGet.Build.Tasks.Console.Test
                     new Dictionary<string, IMSBuildProject>() {
                         { string.Empty, project }
                     },
-                    isCpvmEnabled: false);
+                    isCpvmEnabled: false,
+                    isPruningEnabledGlobally: false);
 
             // Assert
             targetFrameworkInfos.Should().HaveCount(1);
@@ -1069,7 +1070,7 @@ namespace NuGet.Build.Tasks.Console.Test
             };
 
             // Act
-            List<TargetFrameworkInformation> targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: false);
+            List<TargetFrameworkInformation> targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: false, isPruningEnabledGlobally: false);
 
             // Assert
             targetFrameworkInfos.Should().HaveCount(2);
@@ -1156,7 +1157,7 @@ namespace NuGet.Build.Tasks.Console.Test
                     })
             };
 
-            var targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: false);
+            var targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: false, isPruningEnabledGlobally: false);
 
             // Assert
             targetFrameworkInfos.Should().HaveCount(3);
@@ -1210,7 +1211,7 @@ namespace NuGet.Build.Tasks.Console.Test
                     })
             };
             // Act & Assert
-            var exception = Assert.Throws<ArgumentException>(() => MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: false));
+            var exception = Assert.Throws<ArgumentException>(() => MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: false, isPruningEnabledGlobally: false));
             exception.Message.Should().Contain("PrunePackageReference");
         }
 
@@ -1261,7 +1262,7 @@ namespace NuGet.Build.Tasks.Console.Test
                     })
             };
 
-            var targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: false);
+            var targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: false, isPruningEnabledGlobally: false);
 
             // Assert
             targetFrameworkInfos.Should().HaveCount(2);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -428,7 +428,6 @@ namespace NuGet.PackageManagement.Test
                     foreach (var restoreSummary in noOpRestoreSummaries)
                     {
                         Assert.True(restoreSummary.NoOpRestore);
-                        restoreSummary.NoOpRestore
                     }
                 }
             }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -428,6 +428,7 @@ namespace NuGet.PackageManagement.Test
                     foreach (var restoreSummary in noOpRestoreSummaries)
                     {
                         Assert.True(restoreSummary.NoOpRestore);
+                        restoreSummary.NoOpRestore
                     }
                 }
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/nuget/home/issues/14345

## Description

In https://github.com/nuget/home/issues/14345 and https://github.com/NuGet/Home/pull/14442, we decide to enable pruning for projects multi targeting .NET 10. 

Given that this is a inner build feature, it's a bit trickier.
To do this, we introduce a new property that tells us about the default (which is an 'OR' of all properties). 

The consequence of this is that REstoreEnablePackagePruning is not longer the canonical value for pruning being enabled. 

This means the .NET SDK targets can't really depend on `REstoreEnablePackagePruning` being `true`. 
We are going to set the condition in single targeted projects, but in multi targeted ones, we'll read the extra condition. 

That means the SDK will need to change to something.
It's a minor perf hit, but the alternative is moving the enabled logic to the .NET SDK and running an extra build that basically 'ORs' these values.

cc @dsplaisted

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
