### PR TITLE
Set Fluent UI style on PM UI SearchControl

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -10,10 +10,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Documents;
 using System.Windows.Input;
 using Microsoft;
+using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text.Editor;
@@ -31,6 +32,7 @@ using NuGet.Versioning;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Internal.Contracts;
 using NuGet.VisualStudio.Telemetry;
+using Hyperlink = System.Windows.Documents.Hyperlink;
 using Resx = NuGet.PackageManagement.UI;
 using Task = System.Threading.Tasks.Task;
 
@@ -71,6 +73,14 @@ namespace NuGet.PackageManagement.UI
         private INuGetPackageFileService _nugetPackageFileService;
         private bool _isReadmeTabEnabled;
 
+        private SearchControl SearchControl
+        {
+            get
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+                return ((IVsWindowSearchHostPrivate)_windowSearchHost).SearchControl as SearchControl;
+            }
+        }
 
         private PackageManagerInstalledTabData _installedTabTelemetryData;
 
@@ -132,6 +142,11 @@ namespace NuGet.PackageManagement.UI
                 _windowSearchHost = _windowSearchHostFactory.CreateWindowSearchHost(_topPanel.SearchControlParent);
                 _windowSearchHost.SetupSearch(this);
                 _windowSearchHost.IsVisible = true;
+
+                if (SearchControl is SearchControl searchControl)
+                {
+                    searchControl.SetResourceReference(FrameworkElement.StyleProperty, SearchControl.ToolBarStyleKey);
+                }
             }
 
             AddRestoreBar();

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -145,6 +145,7 @@ namespace NuGet.PackageManagement.UI
 
                 if (SearchControl is SearchControl searchControl)
                 {
+                    // Use Fluent UI style for the search control.
                     searchControl.SetResourceReference(FrameworkElement.StyleProperty, SearchControl.ToolBarStyleKey);
                 }
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14469

## Description

Updates Search Control to use Fluent Styling for both Solution-level and Project-level NuGet Package Manager in Visual Studio.

- Obtain a reference to the injected Search Control and set the Fluent Styles by using the Toolbar style.
This approach was suggested by the IDE Experience team.

- The VSSDK analyzer requires throwing if not on the UI thread. We shouldn't have any need to access SearchControl off of the main thread, anyway.

- The Screen Reader announcement is unchanged. If any screen-reader bugs arise within the search control going forward, we'll want to work with the IDE Experience team.

### Search Control - before & after

- Similar to the Fluent ComboBoxes, the Search Control MRU results list has more height and a "pill" on the left of the selected item to more clearly indicate which item is focused on or selected.

- _Subtle change_: Focusing in the search control no longer immediately hides the Watermarked Text `(Search Ctrl+L)`. This text remains visible until a character is typed.


<img width="690" height="216" alt="image" src="https://github.com/user-attachments/assets/c62234d9-5f8e-4a09-b28b-487e365d5eb8" />

### Loading search results - before & after

- Search progress is similar, with a different color on the indeterminate progress bar.
- The Stop Search button is now a red square.

<img width="1166" height="262" alt="image" src="https://github.com/user-attachments/assets/f6765050-5e13-4a62-a39d-66a871f5857c" />

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ Manually tested
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
