### PR TITLE
Use System.Text.Json source generator with NuGet.Protocol

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
@@ -36,18 +36,6 @@ namespace NuGet.Protocol
 
         internal static readonly JsonSerializer JsonObjectSerializer = JsonSerializer.Create(ObjectSerializationSettings);
 
-        internal static readonly System.Text.Json.JsonSerializerOptions JsonSerializerOptions = CreateJsonSerializerOptions();
-
-        private static System.Text.Json.JsonSerializerOptions CreateJsonSerializerOptions()
-        {
-            var options = new System.Text.Json.JsonSerializerOptions()
-            {
-                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
-            };
-            options.Converters.Add(new VersionRangeStjConverter());
-            return options;
-        }
-
         /// <summary>
         /// Serialize object to the JSON.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -20,6 +20,7 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Events;
+using NuGet.Protocol.Utility;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol
@@ -579,7 +580,7 @@ namespace NuGet.Protocol
 
         private static async Task<HashSet<NuGetVersion>> ConsumeFlatContainerIndexAsync(Stream stream, string id, string baseUri, CancellationToken token)
         {
-            var json = await JsonSerializer.DeserializeAsync<FlatContainerVersionList>(stream, cancellationToken: token);
+            var json = await JsonSerializer.DeserializeAsync(stream, JsonContext.Default.FlatContainerVersionList, cancellationToken: token);
 
             var result =
 #if NETSTANDARD
@@ -606,7 +607,7 @@ namespace NuGet.Protocol
             return contentUri;
         }
 
-        record struct FlatContainerVersionList
+        internal record struct FlatContainerVersionList
         {
             [JsonPropertyName("versions")]
             public List<string>? Versions { get; set; }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/VulnerabilityInfoResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/VulnerabilityInfoResourceV3.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
+using NuGet.Protocol.Utility;
 
 namespace NuGet.Protocol.Resources
 {
@@ -47,7 +48,8 @@ namespace NuGet.Protocol.Resources
                 vulnFiles = await httpSourceResource.HttpSource.GetAsync(request,
                     async result =>
                     {
-                        var parsed = await JsonSerializer.DeserializeAsync<IReadOnlyList<V3VulnerabilityIndexEntry>>(result.Stream, JsonExtensions.JsonSerializerOptions);
+                        IReadOnlyList<V3VulnerabilityIndexEntry>? parsed =
+                            await JsonSerializer.DeserializeAsync(result.Stream, JsonContext.Default.VulnerabilityIndex);
                         return parsed;
                     },
                     log,
@@ -98,7 +100,8 @@ namespace NuGet.Protocol.Resources
                 data = await httpSourceResource.HttpSource.GetAsync(request,
                     async result =>
                     {
-                        var parsed = await JsonSerializer.DeserializeAsync<CaseInsensitiveDictionary<IReadOnlyList<PackageVulnerabilityInfo>>>(result.Stream, JsonExtensions.JsonSerializerOptions);
+                        CaseInsensitiveDictionary<IReadOnlyList<PackageVulnerabilityInfo>>? parsed =
+                            await JsonSerializer.DeserializeAsync(result.Stream, JsonContext.Default.VulnerabilityPage);
                         return parsed;
                     },
                     logger,

--- a/src/NuGet.Core/NuGet.Protocol/Utility/JsonContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/JsonContext.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using NuGet.Protocol.Converters;
+using NuGet.Protocol.Model;
+
+namespace NuGet.Protocol.Utility
+{
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
+    [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+        GenerationMode = JsonSourceGenerationMode.Metadata,
+        Converters = [typeof(VersionRangeStjConverter)])]
+#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
+    [JsonSerializable(typeof(HttpFileSystemBasedFindPackageByIdResource.FlatContainerVersionList))]
+    [JsonSerializable(typeof(IReadOnlyList<V3VulnerabilityIndexEntry>), TypeInfoPropertyName = "VulnerabilityIndex")]
+    [JsonSerializable(typeof(CaseInsensitiveDictionary<IReadOnlyList<PackageVulnerabilityInfo>>), TypeInfoPropertyName = "VulnerabilityPage")]
+    internal partial class JsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionRangeStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionRangeStjConverterTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Text.Json;
 using FluentAssertions;
+using NuGet.Protocol.Utility;
 using NuGet.Versioning;
 using Xunit;
 
@@ -21,7 +22,7 @@ namespace NuGet.Protocol.Tests.Converters
             const string json = $"\"{range}\"";
 
             // Act
-            var actual = JsonSerializer.Deserialize<VersionRange>(json, JsonExtensions.JsonSerializerOptions);
+            VersionRange? actual = JsonSerializer.Deserialize(json, JsonContext.Default.VersionRange);
 
             // Assert
             actual.Should().NotBeNull();
@@ -31,14 +32,14 @@ namespace NuGet.Protocol.Tests.Converters
         [Fact]
         public void Deserialize_InvalidString_ThrowsException()
         {
-            Assert.Throws<ArgumentException>(() => JsonSerializer.Deserialize<VersionRange>("\"not a range\"", JsonExtensions.JsonSerializerOptions));
+            Assert.Throws<ArgumentException>(() => JsonSerializer.Deserialize<VersionRange>("\"not a range\"", JsonContext.Default.VersionRange));
         }
 
         [Fact]
         public void Deserialize_Null_ReturnsNull()
         {
             // Act
-            var actual = JsonSerializer.Deserialize<VersionRange>("null", JsonExtensions.JsonSerializerOptions);
+            var actual = JsonSerializer.Deserialize<VersionRange>("null");
 
             // Assert
             actual.Should().BeNull();
@@ -52,7 +53,7 @@ namespace NuGet.Protocol.Tests.Converters
             var range = VersionRange.Parse(rangeString);
 
             // Act
-            var actual = JsonSerializer.Serialize(range, JsonExtensions.JsonSerializerOptions);
+            var actual = JsonSerializer.Serialize(range, JsonContext.Default.VersionRange);
 
             // Assert
             const string expected = $"\"{rangeString}\"";
@@ -66,8 +67,8 @@ namespace NuGet.Protocol.Tests.Converters
             var range = VersionRange.Parse("[1.0.0, 2.0.0)");
 
             // Act
-            var json = JsonSerializer.Serialize(range, JsonExtensions.JsonSerializerOptions);
-            var actual = JsonSerializer.Deserialize<VersionRange>(json, JsonExtensions.JsonSerializerOptions);
+            var json = JsonSerializer.Serialize(range, JsonContext.Default.VersionRange);
+            var actual = JsonSerializer.Deserialize<VersionRange>(json, JsonContext.Default.VersionRange);
 
             // Assert
             actual.Should().BeEquivalentTo(range);
@@ -80,8 +81,9 @@ namespace NuGet.Protocol.Tests.Converters
             var json = "\"[1.0.0, 2.0.0)\"";
 
             // Act
-            var versionRange = JsonSerializer.Deserialize<VersionRange>(json, JsonExtensions.JsonSerializerOptions);
-            var actual = JsonSerializer.Serialize(versionRange, JsonExtensions.JsonSerializerOptions);
+            var versionRange = JsonSerializer.Deserialize<VersionRange>(json, JsonContext.Default.VersionRange);
+            versionRange.Should().NotBeNull();
+            var actual = JsonSerializer.Serialize(versionRange, JsonContext.Default.VersionRange);
 
             // Assert
             actual.Should().Be(json);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14470

## Description

Change NuGet.Protocol from using reflection based JSON deserialization, to using System.Text.Json's source generator.

Note that this does not make NuGet.Protocol AoT ready, as NuGet uses reflection directly still in MetadataReferenceCache: 
https://github.com/NuGet/NuGet.Client/blob/cc84846ef5d8739d6ffe2b0f8c3856239a1c4dbd/src/NuGet.Core/NuGet.Protocol/Utility/MetadataReferenceCache.cs#L99-L100

https://github.com/NuGet/NuGet.Client/blob/cc84846ef5d8739d6ffe2b0f8c3856239a1c4dbd/src/NuGet.Core/NuGet.Protocol/Utility/MetadataReferenceCache.cs#L111-L112

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~  As described by https://github.com/NuGet/Home/issues/14408, it should be sufficient to set `IsAotCompatible` to have the compiler warn us when code isn't AoT compatible. However, we can't do that for NuGet.Protocol yet because it's still using reflection.
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
