### PR TITLE
Migrate BuildIntegratedNuGetProjectTests from project.json to PackageReference

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -79,7 +79,7 @@ namespace NuGet.Test
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, package);
 
                 var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
-                var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+                var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
                 var nuGetPackageManager = new NuGetPackageManager(
@@ -200,7 +200,7 @@ namespace NuGet.Test
 
             try
             {
-                var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+                var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -343,7 +343,7 @@ namespace NuGet.Test
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageContext);
             string projectName = "project1";
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -404,7 +404,7 @@ namespace NuGet.Test
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, package);
                 var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
 
-                var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+                var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -459,7 +459,7 @@ namespace NuGet.Test
             using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
-                var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -521,7 +521,7 @@ namespace NuGet.Test
             using var pathContext = new SimpleTestPathContext();
             using var testSolutionManager = new TestSolutionManager(pathContext);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -583,7 +583,7 @@ namespace NuGet.Test
 
             var lockFiles = new List<string>();
 
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
@@ -656,7 +656,7 @@ namespace NuGet.Test
             using var pathContext = new SimpleTestPathContext();
             using var testSolutionManager = new TestSolutionManager(pathContext);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -710,7 +710,7 @@ namespace NuGet.Test
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, versioning105, versioning107);
 
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -772,7 +772,7 @@ namespace NuGet.Test
             var latestPackage = new PackageIdentity(nugetVersioningId, NuGetVersion.Parse("10.5.0"));
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, originalInstalledPackage, latestPackage);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -861,7 +861,7 @@ namespace NuGet.Test
                 incompatibleLatestPackage);
 
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -965,7 +965,7 @@ namespace NuGet.Test
             var originalPackage2 = new PackageIdentity(packageId2, NuGetVersion.Parse("3.5.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -1066,7 +1066,7 @@ namespace NuGet.Test
             var originalPackage = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("3.5.0"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -1149,18 +1149,6 @@ namespace NuGet.Test
             actionsSecondUpdate.Count().Should().Be(0);
         }
 
-        private ISettings PopulateSettingsWithSources(SourceRepositoryProvider sourceRepositoryProvider, TestDirectory settingsDirectory)
-        {
-            var settings = new Settings(settingsDirectory);
-
-            foreach (var source in sourceRepositoryProvider.GetRepositories())
-            {
-                settings.AddOrUpdate(ConfigurationConstants.PackageSources, source.PackageSource.AsSourceItem());
-            }
-
-            return settings;
-        }
-
         [Fact]
         public async Task UpdatePackageToExactVersion()
         {
@@ -1171,7 +1159,7 @@ namespace NuGet.Test
             using var pathContext = new SimpleTestPathContext();
             using var testSolutionManager = new TestSolutionManager(pathContext);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -1236,7 +1224,7 @@ namespace NuGet.Test
             using var pathContext = new SimpleTestPathContext();
             using var testSolutionManager = new TestSolutionManager(pathContext);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -1344,7 +1332,7 @@ namespace NuGet.Test
             using var pathContext = new SimpleTestPathContext();
             using var testSolutionManager = new TestSolutionManager(pathContext);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -1405,7 +1393,7 @@ namespace NuGet.Test
             using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
-                var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -1454,7 +1442,7 @@ namespace NuGet.Test
             using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
-                var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -1510,7 +1498,7 @@ namespace NuGet.Test
             using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
-                var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
                 var deleteOnRestartManager = new TestDeleteOnRestartManager();
                 var nuGetPackageManager = new NuGetPackageManager(
                     sourceRepositoryProvider,
@@ -1569,7 +1557,7 @@ namespace NuGet.Test
             using var pathContext = new SimpleTestPathContext();
             using var testSolutionManager = new TestSolutionManager(pathContext);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -1650,7 +1638,7 @@ namespace NuGet.Test
             packageContext.Dependencies.Add(dependencyPackageContext);
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageContext, dependencyPackageContext);
 
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(sourceRepositoryProvider, testSettings, testSolutionManager, deleteOnRestartManager);
 
@@ -1703,7 +1691,7 @@ namespace NuGet.Test
             var packageIdentity = new PackageIdentity("nuget.core", NuGetVersion.Parse("2.8.3"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var testDeleteManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(sourceRepositoryProvider, testSettings, testSolutionManager, testDeleteManager);
 
@@ -1754,7 +1742,7 @@ namespace NuGet.Test
             var updateIdentity = new PackageIdentity("nuget.core", NuGetVersion.Parse("2.8.5"));
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
 
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var deleteOnRestartManager = new TestDeleteOnRestartManager();
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
@@ -1813,7 +1801,7 @@ namespace NuGet.Test
                     new PackageSource(pathContext.PackageSource)
                 });
 
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var token = CancellationToken.None;
             var resolutionContext = new ResolutionContext(DependencyBehavior.Lowest, includePrelease: true, includeUnlisted: true, versionConstraints: VersionConstraints.None);
             var testNuGetProjectContext = new TestNuGetProjectContext();
@@ -1885,7 +1873,7 @@ namespace NuGet.Test
             using (var testSolutionManager = new TestSolutionManager())
             using (var randomProjectFolderPath = TestDirectory.Create())
             {
-                var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
+                var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, randomProjectFolderPath);
                 var token = CancellationToken.None;
                 var resolutionContext = new ResolutionContext(DependencyBehavior.Lowest, includePrelease: true, includeUnlisted: true, versionConstraints: VersionConstraints.None);
                 var testNuGetProjectContext = new TestNuGetProjectContext();

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -395,83 +395,89 @@ namespace NuGet.PackageManagement.Test
             }
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
+        [Fact]
         public async Task BuildIntegratedNuGetProject_IsRestoreRequiredWithNoChanges()
         {
             // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            using var solutionManager = new TestSolutionManager(pathContext);
+
             var projectName = "testproj";
-            using (var packagesFolder = TestDirectory.Create())
-            using (var rootFolder = TestDirectory.Create())
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
+            projectFolder.Create();
+
+            var testLogger = new TestLogger();
+
+            var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.7");
+            nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
+            var sourceRepository = CreateGPFSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
+            var sources = sourceRepositoryProvider.GetRepositories();
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+
+            // Create a PackageSpec for the PackageReference project.
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(
+                testSettings,
+                projectName,
+                pathContext.SolutionRoot,
+                framework: "uap10.0");
+
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency("NuGet.Versioning", VersionRange.Parse("1.0.*")));
+
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                projectFullPath: Path.GetDirectoryName(packageSpec.FilePath),
+                projectName);
+
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
+
+            solutionManager.NuGetProjects.Add(buildIntegratedProject);
+
+            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+            var providersCache = new RestoreCommandProvidersCache();
+            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
+
+            var mutatingRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
+
+            foreach (var restoreSummary in mutatingRestoreSummaries)
             {
-                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
-                projectFolder.Create();
-                var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
-                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
+                Assert.False(restoreSummary.NoOpRestore);
+                Assert.Equal(1, restoreSummary.InstallCount);
+                Assert.True(restoreSummary.Success, "Restore should succeed for floating version");
+            }
 
-                BuildIntegrationTestUtility.CreateConfigJson(projectConfig.FullName);
+            var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
 
-                var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
-
-                JsonConfigUtility.AddDependency(json, new NuGet.Packaging.Core.PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7")));
-
-                using (var writer = new StreamWriter(projectConfig.FullName))
-                {
-                    writer.Write(json.ToString());
-                }
-
-                var sources = new List<SourceRepository>
-                {
-                    Repository.Factory.GetVisualStudio("https://www.nuget.org/api/v2/")
-                };
-
-                var projectTargetFramework = NuGetFramework.Parse("uap10.0");
-                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
-                var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);
-
-                var effectiveGlobalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(NullSettings.Instance);
-
-                using (var solutionManager = new TestSolutionManager())
-                {
-                    solutionManager.NuGetProjects.Add(project);
-
-                    var testLogger = new TestLogger();
-                    var settings = new Settings(rootFolder);
-                    settings.AddOrUpdate(ConfigurationConstants.Config, new AddItem("globalPackagesFolder", packagesFolder));
-
-                    var providersCache = new RestoreCommandProvidersCache();
-                    var restoreContext = new DependencyGraphCacheContext(testLogger, settings);
-
-                    await DependencyGraphRestoreUtility.RestoreAsync(
-                        solutionManager,
-                        await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                        restoreContext,
-                        providersCache,
-                        (c) => { },
-                        sources,
-                        Guid.Empty,
-                        false,
-                        true,
-                        testLogger,
-                        CancellationToken.None);
-
-                    var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
-                        solutionManager,
-                        await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                        restoreContext,
-                        providersCache,
-                        (c) => { },
-                        sources,
-                        Guid.Empty,
-                        false,
-                        true,
-                        testLogger,
-                        CancellationToken.None);
-
-                    foreach (var restoreSummary in noOpRestoreSummaries)
-                    {
-                        Assert.True(restoreSummary.NoOpRestore);
-                    }
-                }
+            foreach (var restoreSummary in noOpRestoreSummaries)
+            {
+                Assert.True(restoreSummary.NoOpRestore);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -33,14 +33,13 @@ namespace NuGet.PackageManagement.Test
             using var solutionManager = new TestSolutionManager(pathContext);
 
             var projectName = "testproj";
-
-            var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
-            projectFolder.Create();
-            var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
             var versioning107 = new PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7"));
 
             var sources = new List<SourceRepository> { };
             var testLogger = new TestLogger();
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+            var packageContext = new SimpleTestPackageContext(packageIdentity);
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageContext);
             var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
             var settings = Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config");
             var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -571,10 +571,9 @@ namespace NuGet.PackageManagement.Test
             nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.FallbackFolder, nuGetVersioningPackageContext);
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(solutionManager.GlobalPackagesFolder, nuGetVersioningPackageContext);
             var fallbackFolderSourceRepository = CreateMockSourceRepository(pathContext.FallbackFolder);
             var globalPackagesFolderSourceRepository = CreateMockSourceRepository(solutionManager.GlobalPackagesFolder);
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider([fallbackFolderSourceRepository.PackageSource, globalPackagesFolderSourceRepository.PackageSource]);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(fallbackFolderSourceRepository.PackageSource);
             var sources = sourceRepositoryProvider.GetRepositories();
             var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -19,7 +19,6 @@ using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
-using NuGet.Protocol.VisualStudio;
 using NuGet.Test;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -482,75 +481,92 @@ namespace NuGet.PackageManagement.Test
             }
         }
 
-        [Fact(Skip = "Add nuget.config to bring in fallback folders")]
-        public async Task BuildIntegratedNuGetProject_IsRestoreRequiredWithNoChangesFallbackFolder()
+        [Fact]
+        public async Task BuildIntegratedNuGetProject_IsRestoreRequiredWithNoChanges_FallbackFolder()
         {
             // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            using var solutionManager = new TestSolutionManager(pathContext);
+
             var projectName = "testproj";
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
+            projectFolder.Create();
 
-            using (var globalFolder = TestDirectory.Create())
-            using (var fallbackFolder = TestDirectory.Create())
-            using (var rootFolder = TestDirectory.Create())
-            {
-                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
-                projectFolder.Create();
-                var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
-                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
+            var testLogger = new TestLogger();
 
-                BuildIntegrationTestUtility.CreateConfigJson(projectConfig.FullName);
+            var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.7");
+            nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
-                var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.FallbackFolder, nuGetVersioningPackageContext);
+            var fallbackFolderSourceRepository = CreateMockSourceRepository(pathContext.FallbackFolder);
+            var globalPackagesFolderSourceRepository = CreateMockSourceRepository(solutionManager.GlobalPackagesFolder);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(fallbackFolderSourceRepository.PackageSource);
+            var sources = sourceRepositoryProvider.GetRepositories();
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
-                JsonConfigUtility.AddDependency(json, new NuGet.Packaging.Core.PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7")));
+            // Create a PackageSpec for the PackageReference project.
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(
+                testSettings,
+                projectName,
+                pathContext.SolutionRoot,
+                framework: "uap10.0");
 
-                using (var writer = new StreamWriter(projectConfig.FullName))
-                {
-                    writer.Write(json.ToString());
-                }
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency("NuGet.Versioning", VersionRange.Parse("1.0.*")));
 
-                var sources = new List<SourceRepository>
-                {
-                    Repository.Factory.GetVisualStudio("https://www.nuget.org/api/v2/")
-                };
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            testNuGetProjectContext.TestExecutionContext = new TestExecutionContext(nuGetVersioningPackageContext.Identity);
 
-                var projectTargetFramework = NuGetFramework.Parse("uap10.0");
-                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
-                var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                projectFullPath: Path.GetDirectoryName(packageSpec.FilePath),
+                projectName);
 
-                // Restore to the fallback folder
-                using (var solutionManager = new TestSolutionManager())
-                {
-                    solutionManager.NuGetProjects.Add(project);
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
 
-                    var testLogger = new TestLogger();
+            solutionManager.NuGetProjects.Add(buildIntegratedProject);
 
-                    var restoreContext = new DependencyGraphCacheContext(testLogger, NullSettings.Instance);
+            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+            var providersCache = new RestoreCommandProvidersCache();
+            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
 
-                    await DependencyGraphRestoreUtility.RestoreAsync(
-                        solutionManager,
-                        await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                        restoreContext,
-                        new RestoreCommandProvidersCache(),
-                        (c) => { },
-                        sources,
-                        Guid.Empty,
-                        false,
-                        true,
-                        testLogger,
-                        CancellationToken.None);
+            // Restore to the global & fallback folders.
+            var firstRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
 
-                    var packageFolders = new List<string> { globalFolder, fallbackFolder };
+            firstRestoreSummaries.Should().HaveCount(1);
+            var firstRestoreSummary = firstRestoreSummaries[0];
+            firstRestoreSummary.NoOpRestore.Should().BeFalse();
+            firstRestoreSummary.Success.Should().BeTrue();
 
-                    // Act
-                    //var actual = await project.IsRestoreRequired(
-                    //    packageFolders.Select(p => new VersionFolderPathResolver(p)),
-                    //    new HashSet<PackageIdentity>(),
-                    //    restoreContext);
+            var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
 
-                    // Assert
-                    //Assert.False(actual);
-                }
-            }
+            noOpRestoreSummaries.Should().HaveCount(1);
+            var secondRestoreSummary = noOpRestoreSummaries[0];
+            secondRestoreSummary.NoOpRestore.Should().BeTrue();
+            secondRestoreSummary.Success.Should().BeTrue();
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using Newtonsoft.Json.Linq;
 using NuGet.Commands;
+using NuGet.Commands.Test;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging;
@@ -16,6 +18,7 @@ using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.VisualStudio;
+using NuGet.Test;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Test.Utility;
@@ -25,6 +28,16 @@ namespace NuGet.PackageManagement.Test
 {
     public class BuildIntegratedNuGetProjectTests
     {
+        private static SourceRepository CreateGPFSourceRepository(string gpfPath)
+        {
+            PackageSource gpfPackageSource = new(gpfPath);
+
+            var mockSourceRepository = new Mock<SourceRepository>(gpfPackageSource, new List<INuGetResourceProvider>());
+            mockSourceRepository.SetupGet(m => m.PackageSource).Returns(gpfPackageSource);
+
+            return mockSourceRepository.Object;
+        }
+
         [Fact]
         public async Task BuildIntegratedNuGetProject_IsRestoreRequiredChangedSha512()
         {
@@ -32,21 +45,40 @@ namespace NuGet.PackageManagement.Test
             using var pathContext = new SimpleTestPathContext();
             using var solutionManager = new TestSolutionManager(pathContext);
 
-            var projectName = "testproj";
-            var versioning107 = new PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7"));
-
-            var sources = new List<SourceRepository> { };
             var testLogger = new TestLogger();
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-            var packageContext = new SimpleTestPackageContext(packageIdentity);
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, packageContext);
-            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
-            var settings = Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config");
-            var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);
+            var projectName = "testproj";
 
-            solutionManager.NuGetProjects.Add(project);
+            var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.7");
+            nuGetVersioningPackageContext.AddFile("lib/net452/NuGet.Versioning.dll");
 
-            var restoreContext = new DependencyGraphCacheContext(testLogger, settings);
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.UserPackagesFolder, nuGetVersioningPackageContext);
+            var sourceRepository = CreateGPFSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
+            var sources = sourceRepositoryProvider.GetRepositories();
+
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+
+            // Create a PackageSpec for the PackageReference project.
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(
+                testSettings,
+                projectName,
+                pathContext.SolutionRoot,
+                framework: "net452");
+
+            var projectTargetFramework = NuGetFramework.Parse("net452");
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            testNuGetProjectContext.TestExecutionContext = new TestExecutionContext(nuGetVersioningPackageContext.Identity);
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                projectFullPath: Path.GetDirectoryName(packageSpec.FilePath),
+                projectName);
+
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
+
+            solutionManager.NuGetProjects.Add(buildIntegratedProject);
+
+            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
             var providersCache = new RestoreCommandProvidersCache();
             var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
 
@@ -82,7 +114,7 @@ namespace NuGet.PackageManagement.Test
                 Assert.True(restoreSummary.NoOpRestore);
             }
 
-            var resolver = new VersionFolderPathResolver(solutionManager.GlobalPackagesFolder);
+            var resolver = new VersionFolderPathResolver(pathContext.UserPackagesFolder);
             var hashPath = resolver.GetHashPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
             var nupkgMetadataPath = resolver.GetNupkgMetadataPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -25,97 +25,88 @@ namespace NuGet.PackageManagement.Test
 {
     public class BuildIntegratedNuGetProjectTests
     {
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
+        [Fact]
         public async Task BuildIntegratedNuGetProject_IsRestoreRequiredChangedSha512()
         {
             // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            using var solutionManager = new TestSolutionManager(pathContext);
+
             var projectName = "testproj";
 
-            using (var solutionManager = new TestSolutionManager())
+            var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
+            projectFolder.Create();
+            var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
+            var versioning107 = new PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7"));
+
+            var sources = new List<SourceRepository> { };
+            var testLogger = new TestLogger();
+            var testSettings = PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var settings = Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config");
+            var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);
+
+            solutionManager.NuGetProjects.Add(project);
+
+            var restoreContext = new DependencyGraphCacheContext(testLogger, settings);
+            var providersCache = new RestoreCommandProvidersCache();
+            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
+
+            await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                dgSpec1,
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
+
+            var dgSpec2 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
+            var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                dgSpec2,
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
+
+            foreach (var restoreSummary in noOpRestoreSummaries)
             {
-                var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
-                projectFolder.Create();
-                var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
-                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
+                Assert.True(restoreSummary.NoOpRestore);
+            }
 
-                BuildIntegrationTestUtility.CreateConfigJson(projectConfig.FullName);
-                var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
+            var resolver = new VersionFolderPathResolver(solutionManager.GlobalPackagesFolder);
+            var hashPath = resolver.GetHashPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
+            var nupkgMetadataPath = resolver.GetNupkgMetadataPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
 
-                JsonConfigUtility.AddDependency(json, new PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7")));
+            File.Delete(hashPath);
+            File.Delete(nupkgMetadataPath);
 
-                using (var writer = new StreamWriter(projectConfig.FullName))
-                {
-                    writer.Write(json.ToString());
-                }
+            var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                new RestoreCommandProvidersCache(),
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
 
-                var sources = new List<SourceRepository> { };
-                var testLogger = new TestLogger();
-                var settings = Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config");
-                var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);
-
-                solutionManager.NuGetProjects.Add(project);
-
-                var restoreContext = new DependencyGraphCacheContext(testLogger, settings);
-                var providersCache = new RestoreCommandProvidersCache();
-                var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
-
-                await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    dgSpec1,
-                    restoreContext,
-                    providersCache,
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    testLogger,
-                    CancellationToken.None);
-
-                var dgSpec2 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
-                var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    dgSpec2,
-                    restoreContext,
-                    providersCache,
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    testLogger,
-                    CancellationToken.None);
-
-                foreach (var restoreSummary in noOpRestoreSummaries)
-                {
-                    Assert.True(restoreSummary.NoOpRestore);
-                }
-
-                var resolver = new VersionFolderPathResolver(solutionManager.GlobalPackagesFolder);
-                var hashPath = resolver.GetHashPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
-                var nupkgMetadataPath = resolver.GetNupkgMetadataPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
-
-                File.Delete(hashPath);
-                File.Delete(nupkgMetadataPath);
-
-                var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                    restoreContext,
-                    new RestoreCommandProvidersCache(),
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    testLogger,
-                    CancellationToken.None);
-
-                foreach (var restoreSummary in restoreSummaries)
-                {
-                    Assert.True(restoreSummary.Success);
-                    Assert.False(restoreSummary.NoOpRestore);
-                }
+            foreach (var restoreSummary in restoreSummaries)
+            {
+                Assert.True(restoreSummary.Success);
+                Assert.False(restoreSummary.NoOpRestore);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -218,7 +218,6 @@ namespace NuGet.PackageManagement.Test
             var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
             projectFolder.Create();
 
-            //var sources = new List<SourceRepository> { };
             var testLogger = new TestLogger();
 
             var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.7");
@@ -310,81 +309,85 @@ namespace NuGet.PackageManagement.Test
             }
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
+        [Fact]
         public async Task BuildIntegratedNuGetProject_IsRestoreNotRequiredWithFloatingVersion()
         {
             // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            using var solutionManager = new TestSolutionManager(pathContext);
+
             var projectName = "testproj";
-            using (var packagesFolder = TestDirectory.Create())
-            using (var rootFolder = TestDirectory.Create())
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
+            projectFolder.Create();
+
+            var testLogger = new TestLogger();
+
+            //project3.AddPackageToAllFrameworks(new SimpleTestPackageContext("packageE", "1.0.*"));
+            var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.7");
+            nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
+            var sourceRepository = CreateGPFSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
+            var sources = sourceRepositoryProvider.GetRepositories();
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+
+            // Create a PackageSpec for the PackageReference project.
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(
+                testSettings,
+                projectName,
+                pathContext.SolutionRoot,
+                framework: "uap10.0");
+
+            //PackageIdentity floatingVersionPackage = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("1.0.*"));
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency("NuGet.Versioning", VersionRange.Parse("1.0.*")));
+
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            //testNuGetProjectContext.TestExecutionContext = new TestExecutionContext(floatingVersionPackage);
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                projectFullPath: Path.GetDirectoryName(packageSpec.FilePath),
+                projectName);
+
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
+
+            solutionManager.NuGetProjects.Add(buildIntegratedProject);
+
+            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+            var providersCache = new RestoreCommandProvidersCache();
+            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
+
+            await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
+
+            var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
+
+            foreach (var restoreSummary in noOpRestoreSummaries)
             {
-                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
-                projectFolder.Create();
-                var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
-                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
-
-                BuildIntegrationTestUtility.CreateConfigJson(projectConfig.FullName);
-
-                var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
-
-                json.Add("dependencies", JObject.Parse("{ \"nuget.versioning\": \"1.0.*\" }"));
-
-                using (var writer = new StreamWriter(projectConfig.FullName))
-                {
-                    writer.Write(json.ToString());
-                }
-
-                var sources = new List<SourceRepository>
-                {
-                    Repository.Factory.GetVisualStudio("https://www.nuget.org/api/v2/")
-                };
-
-                var projectTargetFramework = NuGetFramework.Parse("uap10.0");
-                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
-                var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);
-
-                var testLogger = new TestLogger();
-                var settings = new Settings(rootFolder);
-                settings.AddOrUpdate(ConfigurationConstants.Config, new AddItem("globalPackagesFolder", packagesFolder));
-
-                using (var solutionManager = new TestSolutionManager())
-                {
-                    solutionManager.NuGetProjects.Add(project);
-
-                    var restoreContext = new DependencyGraphCacheContext(testLogger, settings);
-                    var providersCache = new RestoreCommandProvidersCache();
-
-                    await DependencyGraphRestoreUtility.RestoreAsync(
-                        solutionManager,
-                        await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                        restoreContext,
-                        providersCache,
-                        (c) => { },
-                        sources,
-                        Guid.Empty,
-                        false,
-                        true,
-                        testLogger,
-                        CancellationToken.None);
-
-                    var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
-                        solutionManager,
-                        await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                        restoreContext,
-                        providersCache,
-                        (c) => { },
-                        sources,
-                        Guid.Empty,
-                        false,
-                        true,
-                        testLogger,
-                        CancellationToken.None);
-
-                    foreach (var restoreSummary in noOpRestoreSummaries)
-                    {
-                        Assert.True(restoreSummary.NoOpRestore);
-                    }
-                }
+                Assert.True(restoreSummary.NoOpRestore);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -206,96 +206,107 @@ namespace NuGet.PackageManagement.Test
             }
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
+        [Fact]
         public async Task BuildIntegratedNuGetProject_IsRestoreRequiredMissingPackage()
         {
             // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            using var solutionManager = new TestSolutionManager(pathContext);
+
             var projectName = "testproj";
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
+            projectFolder.Create();
 
-            using (var solutionManager = new TestSolutionManager())
+            //var sources = new List<SourceRepository> { };
+            var testLogger = new TestLogger();
+
+            var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.7");
+            nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
+            var sourceRepository = CreateGPFSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
+            var sources = sourceRepositoryProvider.GetRepositories();
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+
+            // Create a PackageSpec for the PackageReference project.
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(
+                testSettings,
+                projectName,
+                pathContext.SolutionRoot,
+                framework: "uap10.0");
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, nuGetVersioningPackageContext.Identity);
+
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            testNuGetProjectContext.TestExecutionContext = new TestExecutionContext(nuGetVersioningPackageContext.Identity);
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                projectFullPath: Path.GetDirectoryName(packageSpec.FilePath),
+                projectName);
+
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
+
+            solutionManager.NuGetProjects.Add(buildIntegratedProject);
+
+            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+            var providersCache = new RestoreCommandProvidersCache();
+            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
+
+            await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
+
+            var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
+
+            foreach (var restoreSummary in noOpRestoreSummaries)
             {
-                var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
-                projectFolder.Create();
-                var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
-                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
+                Assert.True(restoreSummary.NoOpRestore);
+            }
 
-                BuildIntegrationTestUtility.CreateConfigJson(projectConfig.FullName);
+            var resolver = new VersionFolderPathResolver(solutionManager.GlobalPackagesFolder);
+            var pathToDelete = resolver.GetInstallPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
 
-                var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
+            TestFileSystemUtility.DeleteRandomTestFolder(pathToDelete);
 
-                JsonConfigUtility.AddDependency(json, new NuGet.Packaging.Core.PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7")));
+            var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                new RestoreCommandProvidersCache(),
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
 
-                using (var writer = new StreamWriter(projectConfig.FullName))
-                {
-                    writer.Write(json.ToString());
-                }
-
-                var sources = new List<SourceRepository> { };
-
-                var projectTargetFramework = NuGetFramework.Parse("uap10.0");
-                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
-                var project = new ProjectJsonNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName);
-                solutionManager.NuGetProjects.Add(project);
-
-                var testLogger = new TestLogger();
-                var settings = Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config");
-                var restoreContext = new DependencyGraphCacheContext(testLogger, settings);
-                var providersCache = new RestoreCommandProvidersCache();
-
-                await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                    restoreContext,
-                    providersCache,
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    testLogger,
-                    CancellationToken.None);
-
-                var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                    restoreContext,
-                    providersCache,
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    testLogger,
-                    CancellationToken.None);
-
-                foreach (var restoreSummary in noOpRestoreSummaries)
-                {
-                    Assert.True(restoreSummary.NoOpRestore);
-                }
-
-                var resolver = new VersionFolderPathResolver(solutionManager.GlobalPackagesFolder);
-                var pathToDelete = resolver.GetInstallPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
-
-                TestFileSystemUtility.DeleteRandomTestFolder(pathToDelete);
-
-                var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
-                    solutionManager,
-                    await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
-                    restoreContext,
-                    new RestoreCommandProvidersCache(),
-                    (c) => { },
-                    sources,
-                    Guid.Empty,
-                    false,
-                    true,
-                    testLogger,
-                    CancellationToken.None);
-
-                foreach (var restoreSummary in restoreSummaries)
-                {
-                    Assert.True(restoreSummary.Success);
-                    Assert.False(restoreSummary.NoOpRestore);
-                }
+            foreach (var restoreSummary in restoreSummaries)
+            {
+                Assert.True(restoreSummary.Success);
+                Assert.False(restoreSummary.NoOpRestore);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -323,7 +323,6 @@ namespace NuGet.PackageManagement.Test
 
             var testLogger = new TestLogger();
 
-            //project3.AddPackageToAllFrameworks(new SimpleTestPackageContext("packageE", "1.0.*"));
             var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.7");
             nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
@@ -340,11 +339,9 @@ namespace NuGet.PackageManagement.Test
                 pathContext.SolutionRoot,
                 framework: "uap10.0");
 
-            //PackageIdentity floatingVersionPackage = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("1.0.*"));
             PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency("NuGet.Versioning", VersionRange.Parse("1.0.*")));
 
             var testNuGetProjectContext = new TestNuGetProjectContext();
-            //testNuGetProjectContext.TestExecutionContext = new TestExecutionContext(floatingVersionPackage);
             var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
                 projectTargetFramework,
                 testNuGetProjectContext,
@@ -359,7 +356,7 @@ namespace NuGet.PackageManagement.Test
             var providersCache = new RestoreCommandProvidersCache();
             var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
 
-            await DependencyGraphRestoreUtility.RestoreAsync(
+            var mutatingRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                 solutionManager,
                 await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
                 restoreContext,
@@ -371,6 +368,13 @@ namespace NuGet.PackageManagement.Test
                 true,
                 testLogger,
                 CancellationToken.None);
+
+            foreach (var restoreSummary in mutatingRestoreSummaries)
+            {
+                Assert.False(restoreSummary.NoOpRestore);
+                Assert.Equal(1, restoreSummary.InstallCount);
+                Assert.True(restoreSummary.Success, "Restore should succeed for floating version");
+            }
 
             var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                 solutionManager,

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -16,6 +16,7 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
+using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.VisualStudio;
 using NuGet.Test;
@@ -51,7 +52,7 @@ namespace NuGet.PackageManagement.Test
             var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.7");
             nuGetVersioningPackageContext.AddFile("lib/net452/NuGet.Versioning.dll");
 
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.UserPackagesFolder, nuGetVersioningPackageContext);
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
             var sourceRepository = CreateGPFSourceRepository(pathContext.UserPackagesFolder);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
             var sources = sourceRepositoryProvider.GetRepositories();
@@ -64,6 +65,7 @@ namespace NuGet.PackageManagement.Test
                 projectName,
                 pathContext.SolutionRoot,
                 framework: "net452");
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, nuGetVersioningPackageContext.Identity);
 
             var projectTargetFramework = NuGetFramework.Parse("net452");
             var testNuGetProjectContext = new TestNuGetProjectContext();

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NuGet.Commands;
@@ -29,12 +30,12 @@ namespace NuGet.PackageManagement.Test
 {
     public class BuildIntegratedNuGetProjectTests
     {
-        private static SourceRepository CreateGPFSourceRepository(string gpfPath)
+        private static SourceRepository CreateMockSourceRepository(string sourcePath)
         {
-            PackageSource gpfPackageSource = new(gpfPath);
+            PackageSource packageSource = new(sourcePath);
 
-            var mockSourceRepository = new Mock<SourceRepository>(gpfPackageSource, new List<INuGetResourceProvider>());
-            mockSourceRepository.SetupGet(m => m.PackageSource).Returns(gpfPackageSource);
+            var mockSourceRepository = new Mock<SourceRepository>(packageSource, new List<INuGetResourceProvider>());
+            mockSourceRepository.SetupGet(m => m.PackageSource).Returns(packageSource);
 
             return mockSourceRepository.Object;
         }
@@ -53,7 +54,7 @@ namespace NuGet.PackageManagement.Test
             nuGetVersioningPackageContext.AddFile("lib/net452/NuGet.Versioning.dll");
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
-            var sourceRepository = CreateGPFSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepository = CreateMockSourceRepository(pathContext.UserPackagesFolder);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
             var sources = sourceRepositoryProvider.GetRepositories();
 
@@ -224,7 +225,7 @@ namespace NuGet.PackageManagement.Test
             nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
-            var sourceRepository = CreateGPFSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepository = CreateMockSourceRepository(pathContext.UserPackagesFolder);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
             var sources = sourceRepositoryProvider.GetRepositories();
             var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
@@ -327,7 +328,7 @@ namespace NuGet.PackageManagement.Test
             nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
-            var sourceRepository = CreateGPFSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepository = CreateMockSourceRepository(pathContext.UserPackagesFolder);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
             var sources = sourceRepositoryProvider.GetRepositories();
             var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
@@ -413,7 +414,7 @@ namespace NuGet.PackageManagement.Test
             nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
-            var sourceRepository = CreateGPFSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepository = CreateMockSourceRepository(pathContext.UserPackagesFolder);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
             var sources = sourceRepositoryProvider.GetRepositories();
             var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
@@ -552,74 +553,99 @@ namespace NuGet.PackageManagement.Test
             }
         }
 
-        [Fact(Skip = "Add nuget.config to bring in fallback folders")]
-        public void BuildIntegratedNuGetProject_IsRestoreRequiredWithNoChangesFallbackFolderIgnoresOtherHashes()
+        [Fact]
+        public async Task BuildIntegratedNuGetProject_IsRestoreRequiredWithNoChanges_FallbackFolderIgnoresOtherHashesAsync()
         {
             // Arrange
-            //var projectName = "testproj";
+            using var pathContext = new SimpleTestPathContext();
+            using var solutionManager = new TestSolutionManager(pathContext);
 
-            //using (var globalFolder = TestDirectory.Create())
-            //using (var fallbackFolder = TestDirectory.Create())
-            //using (var rootFolder = TestDirectory.Create())
-            //{
-            //    var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
-            //    projectFolder.Create();
-            //    var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
-            //    var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
+            var projectName = "testproj";
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
+            projectFolder.Create();
 
-            //    BuildIntegrationTestUtility.CreateConfigJson(projectConfig.FullName);
+            var testLogger = new TestLogger();
 
-            //    var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
+            var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.7");
+            nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
-            //    JsonConfigUtility.AddDependency(json, new PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7")));
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.FallbackFolder, nuGetVersioningPackageContext);
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(solutionManager.GlobalPackagesFolder, nuGetVersioningPackageContext);
+            var fallbackFolderSourceRepository = CreateMockSourceRepository(pathContext.FallbackFolder);
+            var globalPackagesFolderSourceRepository = CreateMockSourceRepository(solutionManager.GlobalPackagesFolder);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider([fallbackFolderSourceRepository.PackageSource, globalPackagesFolderSourceRepository.PackageSource]);
+            var sources = sourceRepositoryProvider.GetRepositories();
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
-            //    using (var writer = new StreamWriter(projectConfig.FullName))
-            //    {
-            //        writer.Write(json.ToString());
-            //    }
+            // Create a PackageSpec for the PackageReference project.
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(
+                testSettings,
+                projectName,
+                pathContext.SolutionRoot,
+                framework: "uap10.0");
 
-            //    var sources = new List<SourceRepository>
-            //    {
-            //        Repository.Factory.GetVisualStudio("https://www.nuget.org/api/v2/")
-            //    };
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency("NuGet.Versioning", VersionRange.Parse("1.0.*")));
 
-            //    var projectTargetFramework = NuGetFramework.Parse("uap10.0");
-            //    var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
-            //    var project = new ProjectJsonBuildIntegratedNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName, msBuildNuGetProjectSystem);
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            testNuGetProjectContext.TestExecutionContext = new TestExecutionContext(nuGetVersioningPackageContext.Identity);
 
-            //    // Restore to the fallback folder
-            //    var result = await BuildIntegratedRestoreUtility.RestoreAsync(project,
-            //        BuildIntegrationTestUtility.GetExternalProjectReferenceContext(),
-            //        sources,
-            //        fallbackFolder,
-            //        Enumerable.Empty<string>(),
-            //        CancellationToken.None);
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                projectFullPath: Path.GetDirectoryName(packageSpec.FilePath),
+                projectName);
 
-            //    // Restore to global folder
-            //    result = await BuildIntegratedRestoreUtility.RestoreAsync(project,
-            //        BuildIntegrationTestUtility.GetExternalProjectReferenceContext(),
-            //        sources,
-            //        globalFolder,
-            //        Enumerable.Empty<string>(),
-            //        CancellationToken.None);
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
 
-            //    var resolver = new VersionFolderPathResolver(fallbackFolder);
-            //    var hashPath = resolver.GetHashPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
-            //    File.WriteAllText(hashPath, "AA00F==");
+            solutionManager.NuGetProjects.Add(buildIntegratedProject);
 
-            //    var packageFolders = new List<string>() { globalFolder, fallbackFolder };
+            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+            var providersCache = new RestoreCommandProvidersCache();
+            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
 
-            //    var context = BuildIntegrationTestUtility.GetExternalProjectReferenceContext();
+            // Restore to the global & fallback folders.
+            var firstRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
 
-            //    // Act
-            //    var actual = project.IsRestoreRequired(
-            //        packageFolders.Select(p => new VersionFolderPathResolver(p)),
-            //        new HashSet<PackageIdentity>(),
-            //        context);
+            firstRestoreSummaries.Should().HaveCount(1);
+            var firstRestoreSummary = firstRestoreSummaries[0];
+            firstRestoreSummary.NoOpRestore.Should().BeFalse();
+            firstRestoreSummary.Success.Should().BeTrue();
 
-            //    // Assert
-            //    Assert.False(actual);
-            //}
+            // Modify the package's hash in the Fallback Folder
+            string fallbackFolder = fallbackFolderSourceRepository.PackageSource.Source;
+            var resolver = new VersionFolderPathResolver(fallbackFolder);
+            var hashPath = resolver.GetHashPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
+            File.WriteAllText(hashPath, "AA00F==");
+
+            var noOpRestoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
+                solutionManager,
+                await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext),
+                restoreContext,
+                providersCache,
+                (c) => { },
+                sources,
+                Guid.Empty,
+                false,
+                true,
+                testLogger,
+                CancellationToken.None);
+
+            noOpRestoreSummaries.Should().HaveCount(1);
+            var secondRestoreSummary = noOpRestoreSummaries[0];
+            secondRestoreSummary.NoOpRestore.Should().BeTrue();
+            secondRestoreSummary.Success.Should().BeTrue();
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/SourceRepository/TestSourceRepositoryUtility.cs
+++ b/test/TestUtilities/Test.Utility/SourceRepository/TestSourceRepositoryUtility.cs
@@ -79,6 +79,18 @@ namespace Test.Utility
             var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider, thisUtility.ResourceProviders);
             return sourceRepositoryProvider;
         }
+
+        public static ISettings PopulateSettingsWithSources(SourceRepositoryProvider sourceRepositoryProvider, TestDirectory settingsDirectory)
+        {
+            var settings = new Settings(settingsDirectory);
+
+            foreach (var source in sourceRepositoryProvider.GetRepositories())
+            {
+                settings.AddOrUpdate(ConfigurationConstants.PackageSources, source.PackageSource.AsSourceItem());
+            }
+
+            return settings;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Part of: https://github.com/NuGet/Home/issues/10212

## Description

This refactors all remaining BuildIntegratedNuGetProjectTests  to use PackageReference. 
- BuildIntegratedNuGetProject_IsRestoreRequiredChangedSha512
- BuildIntegratedNuGetProject_IsRestoreRequiredMissingPackage
- BuildIntegratedNuGetProject_IsRestoreNotRequiredWithFloatingVersion
- BuildIntegratedNuGetProject_IsRestoreRequiredWithNoChanges

Un-skipped 2 tests that were never completed for use with project.json, so we now have these for PackageReference Fallback Folder test coverage:
- BuildIntegratedNuGetProject_IsRestoreRequiredWithNoChanges_FallbackFolder
- BuildIntegratedNuGetProject_IsRestoreRequiredWithNoChanges_FallbackFolderIgnoresOtherHashesAsync


### Other changes
Refactored `PopulateSettingsWithSources` from another test file into a `TestSourceRepositoryUtility` to be shared with the tests changed in this PR.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
