### PR TITLE
Migrate NuGetPackageManagerTelemetryTests from project.json to PackageReference

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
-using Newtonsoft.Json.Linq;
 using NuGet.Commands;
 using NuGet.Commands.Test;
 using NuGet.Common;
@@ -164,10 +163,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
 
 
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task PreviewInstallPackage_VersionNotInRange_RaiseTelemetryEventsWithErrorCodeNU1102(bool projectSetupForError)
+        [Fact]
+        public async Task PreviewInstallPackage_VersionNotInRange_RaiseTelemetryEventsWithErrorCodeNU1102()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
@@ -213,15 +210,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                 pathContext.SolutionRoot,
                 framework: "uap10.0");
 
-            if (projectSetupForError)
-            {
-                PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency("NuGet.Versioning", VersionRange.Parse("99.0.0")));
-            }
-            else
-            {
-                PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency("NuGet.Versioning", VersionRange.Parse("1.0.0")));
-            }
-
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency("NuGet.Versioning", VersionRange.Parse("99.0.0")));
 
             var testNuGetProjectContext = new TestNuGetProjectContext();
             var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
@@ -256,10 +245,13 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             telemetryEvents.Count(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName).Should().Be(1);
 
             telemetryEvents.Where(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName).Should().Contain(p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName);
+
+            string expectedLogCode = NuGetLogCode.NU1102.ToString();
             telemetryEvents
                 .Where(p => p.Name == "ProjectRestoreInformation")
-                .ElementAt(1)["ErrorCodes"].ToString()
-                .Should().Contain(NuGetLogCode.NU1102.ToString());
+                .ElementAt(1)["ErrorCodes"].Should().NotBeNull()
+                .And.Subject.ToString().Should().NotBeNull()
+                .And.Subject.Should().Be(expectedLogCode);
 
             List<KeyValuePair<string, object>> projectFilePaths = telemetryEvents
                 .Where(p => p.Name == "ProjectRestoreInformation")
@@ -274,7 +266,6 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             singlePath.Should().Be(msBuildNuGetProjectSystem.ProjectFullPath);
         }
 
-        //TODO: Fixes: https://github.com/NuGet/Home/issues/10093
         [Fact]
         public async Task PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithWarningCode()
         {
@@ -384,75 +375,6 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             string singleFilePath = projectFilePaths.Distinct().Should().ContainSingle().Subject.Value.ToString();
             string singlePath = Path.GetDirectoryName(singleFilePath);
             singlePath.Should().Be(msBuildNuGetProjectSystem.ProjectFullPath);
-        }
-
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
-        public async Task PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithDupedWarningCodes()
-        {
-            // Arrange
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
-
-            // set up telemetry service
-            var telemetrySession = new Mock<ITelemetrySession>();
-
-            var telemetryEvents = new ConcurrentQueue<TelemetryEvent>();
-            telemetrySession
-                .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
-                .Callback<TelemetryEvent>(x => telemetryEvents.Enqueue(x));
-
-            var nugetProjectContext = new TestNuGetProjectContext();
-            var telemetryService = new TestNuGetVSTelemetryService(telemetrySession.Object, _logger);
-            TelemetryActivity.NuGetTelemetryService = telemetryService;
-
-            // Create Package Manager
-            using (var solutionManager = new TestSolutionManager())
-            {
-                var nuGetPackageManager = new NuGetPackageManager(
-                    sourceRepositoryProvider,
-                    Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config"),
-                    solutionManager,
-                    new TestDeleteOnRestartManager());
-
-                var json = new JObject
-                {
-                    ["dependencies"] = new JObject()
-                    {
-                        new JProperty("NuGet.Frameworks", "4.6.9")
-                    },
-                    ["frameworks"] = new JObject
-                    {
-                        ["net46"] = new JObject()
-                    }
-                };
-
-                var buildIntegratedProject = solutionManager.AddBuildIntegratedProject(json: json);
-
-                // Act
-                var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("4.6.9"));
-
-                await nuGetPackageManager.PreviewInstallPackageAsync(
-                    buildIntegratedProject,
-                    target,
-                    new ResolutionContext(),
-                    nugetProjectContext,
-                    sourceRepositoryProvider.GetRepositories(),
-                    sourceRepositoryProvider.GetRepositories(),
-                    CancellationToken.None);
-
-                // Assert
-                Assert.Equal(7, telemetryEvents.Count);
-                Assert.Equal(2, telemetryEvents.Count(p => p.Name == "ProjectRestoreInformation"));
-                Assert.Equal(1, telemetryEvents.Count(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName));
-
-                Assert.Contains(telemetryEvents.Where(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName), p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName);
-
-                Assert.True((string)telemetryEvents
-                    .Last(p => p.Name == "ProjectRestoreInformation")["WarningCodes"] == NuGetLogCode.NU1603.ToString());
-
-                var projectFilePaths = telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").SelectMany(x => x.GetPiiData()).Where(x => x.Key == "ProjectFilePath");
-                Assert.Equal(2, projectFilePaths.Count());
-                Assert.True(projectFilePaths.All(p => p.Value is string y && File.Exists(y) && (y.EndsWith(".csproj") || y.EndsWith("project.json") || y.EndsWith("proj"))));
-            }
         }
 
         [Fact]
@@ -576,11 +498,16 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             }
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]
+        [Fact]
         public async Task ExecuteNuGetProjectActions_BuildIntegrated_RaiseTelemetryEvents()
         {
             // Arrange
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+            using var pathContext = new SimpleTestPathContext();
+            using var solutionManager = new TestSolutionManager(pathContext);
+
+            var projectName = "testproj";
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
 
             // set up telemetry service
             var telemetrySession = new Mock<ITelemetrySession>();
@@ -594,58 +521,78 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             var telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
-            using (var settingsdir = TestDirectory.Create())
-            using (var testSolutionManager = new TestSolutionManager())
-            {
-                var settings = Settings.LoadSpecificSettings(testSolutionManager.SolutionDirectory, "NuGet.Config");
-                foreach (var source in sourceRepositoryProvider.GetRepositories())
-                {
-                    settings.AddOrUpdate(ConfigurationConstants.PackageSources, source.PackageSource.AsSourceItem());
-                }
+            var testLogger = new TestLogger();
 
-                var token = CancellationToken.None;
-                var deleteOnRestartManager = new TestDeleteOnRestartManager();
-                var nuGetPackageManager = new NuGetPackageManager(
-                    sourceRepositoryProvider,
-                    settings,
-                    testSolutionManager,
-                    deleteOnRestartManager);
+            var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.0");
+            nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
-                var installationCompatibility = new Mock<IInstallationCompatibility>();
-                nuGetPackageManager.InstallationCompatibility = installationCompatibility.Object;
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
+            var sourceRepository = CreateMockSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
+            var sources = sourceRepositoryProvider.GetRepositories();
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
-                var buildIntegratedProject = testSolutionManager.AddBuildIntegratedProject();
+            var nuGetPackageManager = new NuGetPackageManager(
+                sourceRepositoryProvider,
+                NullSettings.Instance,
+                solutionManager,
+                new TestDeleteOnRestartManager());
 
-                var packageIdentity = _packageWithDependents[0];
+            // Create a PackageSpec for the PackageReference project.
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(
+                testSettings,
+                projectName,
+                pathContext.SolutionRoot,
+                framework: "uap10.0");
 
-                var projectActions = new List<NuGetProjectAction>();
-                projectActions.Add(
-                    NuGetProjectAction.CreateInstallProjectAction(
-                        packageIdentity,
-                        sourceRepositoryProvider.GetRepositories().First(),
-                        buildIntegratedProject));
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                projectFullPath: Path.GetDirectoryName(packageSpec.FilePath),
+                projectName);
 
-                // Act
-                await nuGetPackageManager.ExecuteNuGetProjectActionsAsync(
-                    new List<NuGetProject>() { buildIntegratedProject },
-                    projectActions,
-                    nugetProjectContext,
-                    NullSourceCacheContext.Instance,
-                    token);
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
 
-                // Assert
-                Assert.Equal(24, telemetryEvents.Count);
+            solutionManager.NuGetProjects.Add(buildIntegratedProject);
 
-                Assert.Equal(2, telemetryEvents.Count(p => p.Name == "ProjectRestoreInformation"));
-                Assert.Equal(2, telemetryEvents.Count(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName));
+            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+            var providersCache = new RestoreCommandProvidersCache();
+            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
 
-                Assert.Contains(telemetryEvents.Where(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName), p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName);
-                Assert.Contains(telemetryEvents.Where(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName), p => (string)p["SubStepName"] == TelemetryConstants.ExecuteActionStepName);
+            // Act
+            var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("1.0.0"));
 
-                var projectFilePaths = telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").SelectMany(x => x.GetPiiData()).Where(x => x.Key == "ProjectFilePath");
-                Assert.Equal(2, projectFilePaths.Count());
-                Assert.True(projectFilePaths.All(p => p.Value is string y && File.Exists(y) && (y.EndsWith(".csproj") || y.EndsWith("project.json") || y.EndsWith("proj"))));
-            }
+            await nuGetPackageManager.PreviewInstallPackageAsync(
+                buildIntegratedProject,
+                target,
+                new ResolutionContext(),
+                nugetProjectContext,
+                sourceRepositoryProvider.GetRepositories(),
+                sourceRepositoryProvider.GetRepositories(),
+                CancellationToken.None);
+
+            // Assert
+            telemetryEvents.Count.Should().BeGreaterThanOrEqualTo(2);
+            telemetryEvents.Count(p => p.Name == "ProjectRestoreInformation").Should().Be(2);
+            telemetryEvents.Count(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName).Should().Be(1);
+
+            telemetryEvents.Where(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName).Should().Contain(p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName);
+            telemetryEvents
+                .Where(p => p.Name == "ProjectRestoreInformation")
+                .ElementAt(1)["ErrorCodes"].Should().BeNull();
+
+            List<KeyValuePair<string, object>> projectFilePaths = telemetryEvents
+                .Where(p => p.Name == "ProjectRestoreInformation")
+                .SelectMany(x => x.GetPiiData())
+                .Where(x => x.Key == "ProjectFilePath")
+                .ToList();
+
+            // All of these events should be referencing the same path.
+            projectFilePaths.Should().HaveCount(2);
+            string singleFilePath = projectFilePaths.Distinct().Should().ContainSingle().Subject.Value.ToString();
+            string singlePath = Path.GetDirectoryName(singleFilePath);
+            singlePath.Should().Be(msBuildNuGetProjectSystem.ProjectFullPath);
         }
 
         private void VerifyPreviewActionsTelemetryEvents_PackagesConfig(IEnumerable<string> actual)

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
@@ -192,14 +192,14 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
-            var sourceRepository = CreateMockSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepository = CreateMockSourceRepository(pathContext.PackageSource);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
             var sources = sourceRepositoryProvider.GetRepositories();
             var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
-                NullSettings.Instance,
+                settings: testSettings,
                 solutionManager,
                 new TestDeleteOnRestartManager());
 
@@ -220,12 +220,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                 projectName);
 
             var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
-
             solutionManager.NuGetProjects.Add(buildIntegratedProject);
-
-            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
-            var providersCache = new RestoreCommandProvidersCache();
-            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
 
             // Act
             var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("99.9.9"));

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
@@ -290,14 +290,14 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
-            var sourceRepository = CreateMockSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepository = CreateMockSourceRepository(pathContext.PackageSource);
             var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
             var sources = sourceRepositoryProvider.GetRepositories();
             var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
-                NullSettings.Instance,
+                settings: testSettings,
                 solutionManager,
                 new TestDeleteOnRestartManager());
 
@@ -318,12 +318,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                 projectName);
 
             var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
-
             solutionManager.NuGetProjects.Add(buildIntegratedProject);
-
-            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
-            var providersCache = new RestoreCommandProvidersCache();
-            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
 
             // Act
             var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("4.6.9"));

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
@@ -13,11 +13,14 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using Newtonsoft.Json.Linq;
+using NuGet.Commands;
+using NuGet.Commands.Test;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test;
@@ -159,13 +162,20 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             }
         }
 
-        [Theory(Skip = "https://github.com/NuGet/Home/issues/10212")]
+
+
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task PreviewInstallPackage_VersionNotInRange_RaiseTelemetryEventsWithErrorCodeNU1102(bool errorCodeExistsInJson)
+        public async Task PreviewInstallPackage_VersionNotInRange_RaiseTelemetryEventsWithErrorCodeNU1102(bool projectSetupForError)
         {
             // Arrange
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+            using var pathContext = new SimpleTestPathContext();
+            using var solutionManager = new TestSolutionManager(pathContext);
+
+            var projectName = "testproj";
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
 
             // set up telemetry service
             var telemetrySession = new Mock<ITelemetrySession>();
@@ -179,39 +189,54 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             var telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
-            // Create Package Manager
-            using var solutionManager = new TestSolutionManager();
+            var testLogger = new TestLogger();
+
+            var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.7");
+            nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
+            var sourceRepository = CreateMockSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
+            var sources = sourceRepositoryProvider.GetRepositories();
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
-                Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config"),
+                NullSettings.Instance,
                 solutionManager,
                 new TestDeleteOnRestartManager());
 
-            JObject dependenciesJObject = null;
-            if (errorCodeExistsInJson)
+            // Create a PackageSpec for the PackageReference project.
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(
+                testSettings,
+                projectName,
+                pathContext.SolutionRoot,
+                framework: "uap10.0");
+
+            if (projectSetupForError)
             {
-                dependenciesJObject = new JObject()
-                {
-                    new JProperty("NuGet.Frameworks", "99.0.0")
-                };
+                PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency("NuGet.Versioning", VersionRange.Parse("99.0.0")));
             }
             else
             {
-                dependenciesJObject = new JObject();
+                PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency("NuGet.Versioning", VersionRange.Parse("1.0.0")));
             }
 
-            var json = new JObject
-            {
-                ["frameworks"] = new JObject
-                {
-                    ["net46"] = new JObject()
-                    {
-                        ["dependencies"] = dependenciesJObject
-                    }
-                }
-            };
 
-            var buildIntegratedProject = solutionManager.AddBuildIntegratedProject(json: json);
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                projectFullPath: Path.GetDirectoryName(packageSpec.FilePath),
+                projectName);
+
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
+
+            solutionManager.NuGetProjects.Add(buildIntegratedProject);
+
+            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+            var providersCache = new RestoreCommandProvidersCache();
+            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
 
             // Act
             var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("99.9.9"));
@@ -226,17 +251,35 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                 CancellationToken.None);
 
             // Assert
-            Assert.Equal(3, telemetryEvents.Count);
-            Assert.Equal(2, telemetryEvents.Count(p => p.Name == "ProjectRestoreInformation"));
-            Assert.Equal(1, telemetryEvents.Count(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName));
+            telemetryEvents.Count.Should().BeGreaterThanOrEqualTo(2);
+            telemetryEvents.Count(p => p.Name == "ProjectRestoreInformation").Should().Be(2);
+            telemetryEvents.Count(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName).Should().Be(1);
 
-            Assert.Contains(telemetryEvents.Where(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName), p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName);
-            Assert.Contains((string)telemetryEvents
-                .Last(p => p.Name == "ProjectRestoreInformation")["ErrorCodes"], NuGetLogCode.NU1102.ToString());
+            telemetryEvents.Where(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName).Should().Contain(p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName);
+            telemetryEvents
+                .Where(p => p.Name == "ProjectRestoreInformation")
+                .ElementAt(1)["ErrorCodes"].ToString()
+                .Should().Contain(NuGetLogCode.NU1102.ToString());
 
-            var projectFilePaths = telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").SelectMany(x => x.GetPiiData()).Where(x => x.Key == "ProjectFilePath");
-            Assert.Equal(2, projectFilePaths.Count());
-            Assert.True(projectFilePaths.All(p => p.Value is string y && File.Exists(y) && (y.EndsWith(".csproj") || y.EndsWith("project.json") || y.EndsWith("proj"))));
+            List<KeyValuePair<string, object>> projectFilePaths = telemetryEvents
+                .Where(p => p.Name == "ProjectRestoreInformation")
+                .SelectMany(x => x.GetPiiData())
+                .Where(x => x.Key == "ProjectFilePath")
+                .ToList();
+
+            projectFilePaths.Should().HaveCount(2);
+
+            // All of these events should be referencing the same path.
+            string singleFilePath = projectFilePaths.Distinct().Single().Value.ToString();
+            string singlePath = Path.GetDirectoryName(singleFilePath);
+
+            //var targetFramework = packageSpec.TargetFrameworks.Single();
+            //targetFramework.Dependencies.Should().ContainSingle(d => d.Name == "ExpectedPackage" && d.LibraryRange.VersionRange.MinVersion == new NuGetVersion("1.0.0"));
+            singlePath.Should().Be(msBuildNuGetProjectSystem.ProjectFullPath);
+
+            Directory.Exists(singlePath).Should().BeTrue();
+            var singlePathFiles = Directory.EnumerateFiles(singlePath).ToList();
+            singlePathFiles.Count.Should().Be(5, because: "PackageReference projects should an assets file, cache, dgspec, g.props and g.targets.");
         }
 
         [Fact(Skip = "https://github.com/NuGet/Home/issues/10093")]
@@ -638,6 +681,16 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
 
                 _telemetrySession.PostEvent(telemetryData);
             }
+        }
+
+        private static SourceRepository CreateMockSourceRepository(string sourcePath)
+        {
+            PackageSource packageSource = new(sourcePath);
+
+            var mockSourceRepository = new Mock<SourceRepository>(packageSource, new List<INuGetResourceProvider>());
+            mockSourceRepository.SetupGet(m => m.PackageSource).Returns(packageSource);
+
+            return mockSourceRepository.Object;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
@@ -267,19 +267,11 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                 .Where(x => x.Key == "ProjectFilePath")
                 .ToList();
 
-            projectFilePaths.Should().HaveCount(2);
-
             // All of these events should be referencing the same path.
-            string singleFilePath = projectFilePaths.Distinct().Single().Value.ToString();
+            projectFilePaths.Should().HaveCount(2);
+            string singleFilePath = projectFilePaths.Distinct().Should().ContainSingle().Subject.Value.ToString();
             string singlePath = Path.GetDirectoryName(singleFilePath);
-
-            //var targetFramework = packageSpec.TargetFrameworks.Single();
-            //targetFramework.Dependencies.Should().ContainSingle(d => d.Name == "ExpectedPackage" && d.LibraryRange.VersionRange.MinVersion == new NuGetVersion("1.0.0"));
             singlePath.Should().Be(msBuildNuGetProjectSystem.ProjectFullPath);
-
-            Directory.Exists(singlePath).Should().BeTrue();
-            var singlePathFiles = Directory.EnumerateFiles(singlePath).ToList();
-            singlePathFiles.Count.Should().Be(5, because: "PackageReference projects should an assets file, cache, dgspec, g.props and g.targets.");
         }
 
         [Fact(Skip = "https://github.com/NuGet/Home/issues/10093")]

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
@@ -274,11 +274,17 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             singlePath.Should().Be(msBuildNuGetProjectSystem.ProjectFullPath);
         }
 
-        [Fact(Skip = "https://github.com/NuGet/Home/issues/10093")]
+        //TODO: Fixes: https://github.com/NuGet/Home/issues/10093
+        [Fact]
         public async Task PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithWarningCode()
         {
             // Arrange
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+            using var pathContext = new SimpleTestPathContext();
+            using var solutionManager = new TestSolutionManager(pathContext);
+
+            var projectName = "testproj";
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var projectFolder = new DirectoryInfo(Path.Combine(solutionManager.SolutionDirectory, projectName));
 
             // set up telemetry service
             var telemetrySession = new Mock<ITelemetrySession>();
@@ -289,73 +295,95 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                 .Callback<TelemetryEvent>(x => telemetryEvents.Enqueue(x));
 
             var nugetProjectContext = new TestNuGetProjectContext();
-            var telemetryService = new TestNuGetVSTelemetryService(telemetrySession.Object, _logger);
+            var telemetryService = new NuGetVSTelemetryService(telemetrySession.Object);
             TelemetryActivity.NuGetTelemetryService = telemetryService;
 
-            // Create Package Manager
-            using (var solutionManager = new TestSolutionManager())
-            {
-                var nuGetPackageManager = new NuGetPackageManager(
-                    sourceRepositoryProvider,
-                    Settings.LoadSpecificSettings(solutionManager.SolutionDirectory, "NuGet.Config"),
-                    solutionManager,
-                    new TestDeleteOnRestartManager());
+            var testLogger = new TestLogger();
 
-                var json = new JObject
-                {
-                    ["dependencies"] = new JObject(),
-                    ["frameworks"] = new JObject
-                    {
-                        ["net46"] = new JObject()
-                    }
-                };
+            var nuGetVersioningPackageContext = new SimpleTestPackageContext("NuGet.Versioning", "1.0.7");
+            nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
-                var buildIntegratedProject = solutionManager.AddBuildIntegratedProject(json: json);
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
+            var sourceRepository = CreateMockSourceRepository(pathContext.UserPackagesFolder);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
+            var sources = sourceRepositoryProvider.GetRepositories();
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
-                // Act
-                var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("4.6.9"));
+            var nuGetPackageManager = new NuGetPackageManager(
+                sourceRepositoryProvider,
+                NullSettings.Instance,
+                solutionManager,
+                new TestDeleteOnRestartManager());
 
-                lock (_logger)
-                {
-                    // telemetry count has been flaky, these xunit logs should help track the extra source of events on CI
-                    // for issue https://github.com/NuGet/Home/issues/7105
-                    _logger.LogInformation("Begin PreviewInstallPackageAsync");
-                }
+            // Create a PackageSpec for the PackageReference project.
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(
+                testSettings,
+                projectName,
+                pathContext.SolutionRoot,
+                framework: "uap10.0");
 
-                await nuGetPackageManager.PreviewInstallPackageAsync(
-                    buildIntegratedProject,
-                    target,
-                    new ResolutionContext(),
-                    nugetProjectContext,
-                    sourceRepositoryProvider.GetRepositories(),
-                    sourceRepositoryProvider.GetRepositories(),
-                    CancellationToken.None);
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency("NuGet.Versioning", VersionRange.Parse("(, 1.0.0)")));
 
-                lock (_logger)
-                {
-                    _logger.LogInformation("End PreviewInstallPackageAsync");
-                }
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                projectFullPath: Path.GetDirectoryName(packageSpec.FilePath),
+                projectName);
 
-                // Assert
-                Assert.Equal(19, telemetryEvents.Count);
-                Assert.Equal(2, telemetryEvents.Count(p => p.Name == "ProjectRestoreInformation"));
-                Assert.Equal(2, telemetryEvents.Count(p => p.Name == "GenerateRestoreGraph"));
-                Assert.Equal(2, telemetryEvents.Count(p => p.Name == "GenerateAssetsFile"));
-                Assert.Equal(2, telemetryEvents.Count(p => p.Name == "ValidateRestoreGraphs"));
-                Assert.Equal(2, telemetryEvents.Count(p => p.Name == "CreateRestoreResult"));
-                Assert.Equal(2, telemetryEvents.Count(p => p.Name == "RestoreNoOpInformation"));
-                Assert.Equal(2, telemetryEvents.Count(p => p.Name == "CreateRestoreTargetGraph"));
-                Assert.Equal(1, telemetryEvents.Count(p => p.Name == "NugetActionSteps"));
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
 
-                Assert.Contains(telemetryEvents.Where(p => p.Name == "NugetActionSteps"), p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName);
+            solutionManager.NuGetProjects.Add(buildIntegratedProject);
 
-                Assert.True((string)telemetryEvents
-                    .Last(p => p.Name == "ProjectRestoreInformation")["WarningCodes"] == NuGetLogCode.NU1603.ToString());
+            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
+            var providersCache = new RestoreCommandProvidersCache();
+            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
 
-                var projectFilePaths = telemetryEvents.Where(p => p.Name == "ProjectRestoreInformation").SelectMany(x => x.GetPiiData()).Where(x => x.Key == "ProjectFilePath");
-                Assert.Equal(2, projectFilePaths.Count());
-                Assert.True(projectFilePaths.All(p => p.Value is string y && File.Exists(y) && (y.EndsWith(".csproj") || y.EndsWith("project.json") || y.EndsWith("proj"))));
-            }
+            // Act
+            var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("4.6.9"));
+
+            await nuGetPackageManager.PreviewInstallPackageAsync(
+                buildIntegratedProject,
+                target,
+                new ResolutionContext(),
+                nugetProjectContext,
+                sourceRepositoryProvider.GetRepositories(),
+                sourceRepositoryProvider.GetRepositories(),
+                CancellationToken.None);
+
+            // Assert
+            telemetryEvents.Count.Should().BeGreaterThanOrEqualTo(2);
+            telemetryEvents.Count(p => p.Name == "ProjectRestoreInformation").Should().Be(2);
+            telemetryEvents.Count(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName).Should().Be(1);
+
+            telemetryEvents.Where(p => p.Name == ActionTelemetryStepEvent.NugetActionStepsEventName).Should().Contain(p => (string)p["SubStepName"] == TelemetryConstants.PreviewBuildIntegratedStepName);
+            var eventsProjectRestoreInformation = telemetryEvents
+                .Where(p => p.Name == "ProjectRestoreInformation").ToList();
+            eventsProjectRestoreInformation.Should().HaveCountGreaterThanOrEqualTo(1);
+
+            string expectedLogCode = NuGetLogCode.NU1604.ToString();
+
+            List<string> warningCodes = eventsProjectRestoreInformation
+                .Select(item => item["WarningCodes"]?.ToString())
+                .Where(warningCode => warningCode is not null)
+                .ToList();
+
+            string because = $"Expected Warning Code {expectedLogCode} to be present in ProjectRestoreInformation telemetry event";
+            warningCodes.Should().NotBeNull(because);
+            warningCodes.Should().HaveCount(1, because);
+            warningCodes[0].Should().Be(expectedLogCode, because);
+
+            List<KeyValuePair<string, object>> projectFilePaths = telemetryEvents
+                .Where(p => p.Name == "ProjectRestoreInformation")
+                .SelectMany(x => x.GetPiiData())
+                .Where(x => x.Key == "ProjectFilePath")
+                .ToList();
+
+            // All of these events should be referencing the same path.
+            projectFilePaths.Should().HaveCount(2);
+            string singleFilePath = projectFilePaths.Distinct().Should().ContainSingle().Subject.Value.ToString();
+            string singlePath = Path.GetDirectoryName(singleFilePath);
+            singlePath.Should().Be(msBuildNuGetProjectSystem.ProjectFullPath);
         }
 
         [Fact(Skip = "https://github.com/NuGet/Home/issues/10212")]

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests/NuGetPackageManagerTelemetryTests.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
-using NuGet.Commands;
 using NuGet.Commands.Test;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -192,8 +191,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
-            var sourceRepository = CreateMockSourceRepository(pathContext.PackageSource);
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
+            PackageSource packageSource = new PackageSource(pathContext.PackageSource);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(packageSource);
             var sources = sourceRepositoryProvider.GetRepositories();
             var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
@@ -290,8 +289,8 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
-            var sourceRepository = CreateMockSourceRepository(pathContext.PackageSource);
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
+            PackageSource packageSource = new PackageSource(pathContext.PackageSource);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(packageSource);
             var sources = sourceRepositoryProvider.GetRepositories();
             var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
@@ -517,14 +516,14 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
             nuGetVersioningPackageContext.AddFile("lib/uap10.0/NuGet.Versioning.dll");
 
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, nuGetVersioningPackageContext);
-            var sourceRepository = CreateMockSourceRepository(pathContext.UserPackagesFolder);
-            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(sourceRepository.PackageSource);
+            PackageSource packageSource = new PackageSource(pathContext.PackageSource);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(packageSource);
             var sources = sourceRepositoryProvider.GetRepositories();
             var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
 
             var nuGetPackageManager = new NuGetPackageManager(
                 sourceRepositoryProvider,
-                NullSettings.Instance,
+                settings: testSettings,
                 solutionManager,
                 new TestDeleteOnRestartManager());
 
@@ -543,12 +542,7 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
                 projectName);
 
             var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
-
             solutionManager.NuGetProjects.Add(buildIntegratedProject);
-
-            var restoreContext = new DependencyGraphCacheContext(testLogger, testSettings);
-            var providersCache = new RestoreCommandProvidersCache();
-            var dgSpec1 = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec(solutionManager, restoreContext);
 
             // Act
             var target = new PackageIdentity("NuGet.Versioning", new NuGetVersion("1.0.0"));
@@ -638,16 +632,6 @@ namespace NuGet.PackageManagement.Test.NuGetPackageManagerTests
 
                 _telemetrySession.PostEvent(telemetryData);
             }
-        }
-
-        private static SourceRepository CreateMockSourceRepository(string sourcePath)
-        {
-            PackageSource packageSource = new(sourcePath);
-
-            var mockSourceRepository = new Mock<SourceRepository>(packageSource, new List<INuGetResourceProvider>());
-            mockSourceRepository.SetupGet(m => m.PackageSource).Returns(packageSource);
-
-            return mockSourceRepository.Object;
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Part of: https://github.com/NuGet/Home/issues/10212
Fixes: https://github.com/NuGet/Home/issues/10093

## Description

This refactors all remaining NuGetPackageManagerTelemetryTests to use PackageReference.

- ExecuteNuGetProjectActions_BuildIntegrated_RaiseTelemetryEvents
- PreviewInstallPackage_VersionNotInRange_RaiseTelemetryEventsWithErrorCodeNU1102
- PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithWarningCode


### Other changes
- Removed assertions around existence of a csproj and other files, as those seem irrelevant to telemetry tests, especially now that there's no project.json file to check.
- Deleted `PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithDupedWarningCodes` as the existing assertions didn't look different than the test, `PreviewInstallPackage_BuildIntegrated_RaiseTelemetryEventsWithWarningCode`.
- Redesigned the assertions so hopefully there's no flaky issues, so this should fix https://github.com/NuGet/Home/issues/10093

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
