### PR TITLE
Separate out symbol and non-symbol packages

### DIFF
--- a/build/publish.proj
+++ b/build/publish.proj
@@ -20,6 +20,11 @@
     <PropertyGroup>
       <AssetManifestFileName>nuget.client.xml</AssetManifestFileName>
       <AssetManifestPath>$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName)</AssetManifestPath>
+
+      <SymbolPackageBaseRelativeBlobPath>assets/symbols/</SymbolPackageBaseRelativeBlobPath>
+      <SymbolPackageBaseRelativeBlobPath Condition="'$(BUILD_REPOSITORY_NAME)' != ''">$(SymbolPackageBaseRelativeBlobPath)$(BUILD_REPOSITORY_NAME)/</SymbolPackageBaseRelativeBlobPath>
+      <SymbolPackageBaseRelativeBlobPath Condition="'$(BUILD_REPOSITORY_NAME)' == '' and '$(RepositoryName)' != ''">$(SymbolPackageBaseRelativeBlobPath)$(RepositoryName)/</SymbolPackageBaseRelativeBlobPath>
+      <SymbolPackageBaseRelativeBlobPath Condition="'$(BUILD_BUILDNUMBER)' != ''">$(SymbolPackageBaseRelativeBlobPath)$(BUILD_BUILDNUMBER)/</SymbolPackageBaseRelativeBlobPath>
     </PropertyGroup>
 
     <Error Condition="'$(NuGetClientNupkgsDirectoryPath)' == ''" Text="The property '$(NuGetClientNupkgsDirectoryPath)' is required.  Set it at the command-line with /property:&lt;NuGetClientNupkgsDirectoryPath&gt;" />
@@ -27,7 +32,14 @@
     <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
 
     <ItemGroup>
-      <ItemsToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.nupkg" Kind="Package" />
+      <ItemsToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.nupkg" Exclude="$(NuGetClientNupkgsDirectoryPath)/*.symbols.nupkg" Kind="Package" />
+      <ItemsToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.symbols.nupkg">
+        <!-- Update the kind of the symbol packages to blob -->
+        <Kind>Blob</Kind>
+        <!-- Set the category to Symbols (otherwise it will inherit the original package category -->
+        <Category>Symbols</Category>
+        <RelativeBlobPath>$(SymbolPackageBaseRelativeBlobPath)%(Filename)%(Extension)</RelativeBlobPath>
+      </ItemsToPush>
       <ItemsToPush Remove="$(NuGetClientNupkgsDirectoryPath)/NuGet.Packaging.Core.*" />
     </ItemGroup>
 

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -32,15 +32,15 @@
     <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
 
     <ItemGroup>
-      <ItemsToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.nupkg" Exclude="$(NuGetClientNupkgsDirectoryPath)/*.symbols.nupkg" Kind="Package" />
-      <ItemsToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.symbols.nupkg">
-        <!-- Update the kind of the symbol packages to blob -->
+      <NonSymbolPackagesToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.nupkg" Exclude="$(NuGetClientNupkgsDirectoryPath)/*.symbols.nupkg;$(NuGetClientNupkgsDirectoryPath)/NuGet.Packaging.Core.*" Kind="Package" />
+      <SymbolPackagesToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.symbols.nupkg">
+      <!-- Update the kind of the symbol packages to blob -->
         <Kind>Blob</Kind>
         <!-- Set the category to Symbols (otherwise it will inherit the original package category -->
         <Category>Symbols</Category>
         <RelativeBlobPath>$(SymbolPackageBaseRelativeBlobPath)%(Filename)%(Extension)</RelativeBlobPath>
-      </ItemsToPush>
-      <ItemsToPush Remove="$(NuGetClientNupkgsDirectoryPath)/NuGet.Packaging.Core.*" />
+      </SymbolPackagesToPush>
+      <ItemsToPush Include="@(NonSymbolPackagesToPush);@(SymbolPackagesToPush)" />
     </ItemGroup>
 
     <Error Condition="@(ItemsToPush->Count()) == 0" Text="There were no packages found at '$(NuGetClientNupkgsDirectoryPath)'." />

--- a/build/publish.proj
+++ b/build/publish.proj
@@ -32,15 +32,16 @@
     <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
 
     <ItemGroup>
-      <NonSymbolPackagesToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.nupkg" Exclude="$(NuGetClientNupkgsDirectoryPath)/*.symbols.nupkg;$(NuGetClientNupkgsDirectoryPath)/NuGet.Packaging.Core.*" Kind="Package" />
-      <SymbolPackagesToPush Include="$(NuGetClientNupkgsDirectoryPath)/*.symbols.nupkg">
+      <_NonSymbolPackages Include="$(NuGetClientNupkgsDirectoryPath)/*.nupkg" Exclude="$(NuGetClientNupkgsDirectoryPath)/*.symbols.nupkg;$(NuGetClientNupkgsDirectoryPath)/NuGet.Packaging.Core.*" Kind="Package" />
+      <_SymbolPackages Include="$(NuGetClientNupkgsDirectoryPath)/*.symbols.nupkg" />
+      <_SymbolPackagesWithMetadata Include="@(_SymbolPackages)">
       <!-- Update the kind of the symbol packages to blob -->
         <Kind>Blob</Kind>
         <!-- Set the category to Symbols (otherwise it will inherit the original package category -->
         <Category>Symbols</Category>
         <RelativeBlobPath>$(SymbolPackageBaseRelativeBlobPath)%(Filename)%(Extension)</RelativeBlobPath>
-      </SymbolPackagesToPush>
-      <ItemsToPush Include="@(NonSymbolPackagesToPush);@(SymbolPackagesToPush)" />
+      </_SymbolPackagesWithMetadata>
+      <ItemsToPush Include="@(_NonSymbolPackages);@(_SymbolPackagesWithMetadata)" />
     </ItemGroup>
 
     <Error Condition="@(ItemsToPush->Count()) == 0" Text="There were no packages found at '$(NuGetClientNupkgsDirectoryPath)'." />


### PR DESCRIPTION
Symbol packages got hoovered up in the original globbing pattern, and they both got Kind=Package. A package and a symbol package have the same identity though, and so Maestro's promotion logic rejected this. Instead, do what .NET repos do by default and make symbol packages blobs. Symbol packages will be archived on ci.dot.net and published to symbol servers, of course.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
