### PR TITLE
Publishing the SBOM artifact no longer publishes artifacts folder

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -231,7 +231,7 @@ stages:
       - output: pipelineArtifact
         displayName: Publish SBOM manifest
         artifactName: $(ARTIFACT_NAME)
-        targetPath: '$(Build.SourcesDirectory)/artifacts'
+        targetPath: "$(Build.SourcesDirectory)/artifacts/_manifest"
         sbomEnabled: false
 
     steps:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related: https://github.com/NuGet/Client.Engineering/issues/3186

## Description

Only need to publish the SBOM manifest, not the entire artifacts folder as an Azure DevOps artifact.

💡This fix needs to be applied to all newer branches including dev.
Already applied to 5.11.x in https://github.com/NuGet/NuGet.Client/pull/6698

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
