### PR TITLE
Move pack targets to NuGet.Build.Tasks

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/ilmerge.props
+++ b/src/NuGet.Clients/NuGet.CommandLine/ilmerge.props
@@ -21,6 +21,7 @@
     <MergeAllowdup Include="FrameworkReducer"/>
     <MergeAllowdup Include="FrameworkRuntimePair"/>
     <MergeAllowdup Include="FrameworkSpecificMapping"/>
+    <MergeAllowDup Include="GetProjectTargetFrameworksTask"/>
     <MergeAllowdup Include="IFrameworkCompatibilityListProvider"/>
     <MergeAllowdup Include="IFrameworkCompatibilityProvider"/>
     <MergeAllowdup Include="IFrameworkMappings"/>

--- a/src/NuGet.Clients/NuGet.MSSigning.Extensions/ilmerge.props
+++ b/src/NuGet.Clients/NuGet.MSSigning.Extensions/ilmerge.props
@@ -37,6 +37,7 @@
     <MergeExclude Include="$(OutputPath)Microsoft.VisualStudio.Setup.Configuration.Interop.dll"/>
     <MergeExclude Include="$(OutputPath)Microsoft.CSharp.dll"/>
     <MergeExclude Include="$(OutputPath)mscorlib.dll"/>
+    <MergeExclude Include="$(OutputPath)NuGet.Build.Tasks.Pack.dll"/>
     <MergeExclude Include="$(OutputPath)System.Collections.Concurrent.dll"/>
     <MergeExclude Include="$(OutputPath)System.Collections.dll"/>
     <MergeExclude Include="$(OutputPath)System.ComponentModel.Composition.dll"/>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -105,6 +105,7 @@ Lucene.Net.dll
 Microsoft.Build.NuGetSdkResolver.xml
 Microsoft.VisualStudio.ExtensionEngineContract.xml
 NuGet.Build.Tasks.xml
+NuGet.Build.Tasks.Pack.xml
 NuGet.Commands.xml
 NuGet.Common.xml
 NuGet.Configuration.xml

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
@@ -26,6 +26,8 @@ NuGet.VisualStudio.resources.dll
 Microsoft.Build.NuGetSdkResolver.dll
 Microsoft.Build.NuGetSdkResolver.resources.dll
 NuGet.Build.Tasks.dll
+NuGet.Build.Tasks.Pack.dll
+NuGet.Build.Tasks.Pack.resources.dll
 NuGet.Build.Tasks.resources.dll
 NuGet.Commands.dll
 NuGet.Commands.resources.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -39,6 +39,10 @@
       <Link>NuGet.targets</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="..\..\NuGet.Core\NuGet.Build.Tasks\NuGet.Build.Tasks.Pack.targets">
+      <Link>NuGet.Build.Tasks.Pack.targets</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="registration.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -2,30 +2,26 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU5128</NoWarn>
     <AssemblyName>NuGet.Build.Tasks.Pack</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <XPLATProject>true</XPLATProject>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSatelliteOutputInPack>true</IncludeSatelliteOutputInPack>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CreatePackNupkg</TargetsForTfmSpecificContentInPackage>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <DevelopmentDependency>true</DevelopmentDependency>
     <Description>NuGet tasks for MSBuild and dotnet pack.</Description>
     <NoWarn>$(NoWarn);NU5100</NoWarn>
     <DepsFileGenerationMode>old</DepsFileGenerationMode>
     <UsePublicApiAnalyzer>false</UsePublicApiAnalyzer>
+    <DefineConstants>$(DefineConstants);PACK_TASKS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\NuGet.Build.Tasks\Common\MSBuildLogger.cs" />
     <Compile Include="..\NuGet.Build.Tasks\GetProjectTargetFrameworksTask.cs" />
-    <Content Include="NuGet.Build.Tasks.Pack.targets" Pack="true" PackagePath="build;buildCrossTargeting">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -35,10 +31,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <Reference Include="Microsoft.Build.Utilities.v4.0" Pack="false" />
     <Reference Include="Microsoft.Build.Framework" Pack="false" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="$(BuildCommonDirectory)NOTICES.txt" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != '$(NETFXTargetFramework)' ">
@@ -61,20 +53,5 @@
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
-  <Target Name="CreatePackNupkg">
-    <PropertyGroup>
-      <PackagePathDir Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'">Desktop/</PackagePathDir>
-      <PackagePathDir Condition="'$(TargetFramework)' == '$(NETCoreTargetFramework)'">CoreCLR/</PackagePathDir>
-    </PropertyGroup>
-    <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)**\NuGet*.resources.dll">
-        <PackagePath>$(PackagePathDir)</PackagePath>
-      </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(OutputPath)*.dll">
-        <PackagePath>$(PackagePathDir)</PackagePath>
-      </TfmSpecificPackageFile>
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
@@ -11,7 +11,12 @@ namespace NuGet.Build
     /// <summary>
     /// TaskLoggingHelper -> ILogger
     /// </summary>
-    public class MSBuildLogger : LoggerBase, Common.ILogger
+#if PACK_TASKS
+    internal
+#else
+    public
+#endif
+    class MSBuildLogger : LoggerBase, Common.ILogger
     {
         private readonly TaskLoggingHelper _taskLogging;
 
@@ -143,7 +148,7 @@ namespace NuGet.Build
             return;
         }
 
-        private void LogMessage(INuGetLogMessage logMessage,
+        private static void LogMessage(INuGetLogMessage logMessage,
             MessageImportance importance,
             LogMessageWithDetails logWithDetails,
             LogMessageAsString logAsString)
@@ -168,7 +173,7 @@ namespace NuGet.Build
             }
         }
 
-        private void LogError(INuGetLogMessage logMessage,
+        private static void LogError(INuGetLogMessage logMessage,
             LogErrorWithDetails logWithDetails,
             LogErrorAsString logAsString)
         {

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
@@ -14,7 +14,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Load NuGet.Build.Tasks.Pack.dll, this can be overridden to use a different version with $(NuGetPackTaskAssemblyFile) -->
   <PropertyGroup Condition="$(NuGetPackTaskAssemblyFile) == ''">
-    <NuGetPackTaskAssemblyFile Condition="'$(UsingMicrosoftNetSdk)' == 'true' And '$(MSBuildRuntimeType)' != 'Core'">Sdks\Microsoft.NET.Sdk\tools\net472</NuGetPackTaskAssemblyFile>
+    <NuGetPackTaskAssemblyFile Condition="'$(UsingMicrosoftNetSdk)' == 'true' And '$(MSBuildRuntimeType)' != 'Core'">Sdks\Microsoft.NET.Sdk\tools\net472\NuGet.Build.Tasks.Pack.dll</NuGetPackTaskAssemblyFile>
     <NuGetPackTaskAssemblyFile Condition="'$(NuGetPackTaskAssemblyFile)' == ''">NuGet.Build.Tasks.Pack.dll</NuGetPackTaskAssemblyFile>
   </PropertyGroup>
 
@@ -460,7 +460,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="_GetDebugSymbolsWithTfm"
-          DependsOnTargets="DebugSymbolsProjectOutputGroup;$(TargetsForTfmSpecificDebugSymbolsInPackage)" 
+          DependsOnTargets="DebugSymbolsProjectOutputGroup;$(TargetsForTfmSpecificDebugSymbolsInPackage)"
           Returns="@(_TargetPathsToSymbolsWithTfm)">
     <ItemGroup Condition="'$(IncludeBuildOutput)' == 'true'">
       <_TargetPathsToSymbolsWithTfm Include="@(DebugSymbolsProjectOutputGroupOutput)">

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
@@ -14,8 +14,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Load NuGet.Build.Tasks.Pack.dll, this can be overridden to use a different version with $(NuGetPackTaskAssemblyFile) -->
   <PropertyGroup Condition="$(NuGetPackTaskAssemblyFile) == ''">
-    <NuGetPackTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">..\CoreCLR\NuGet.Build.Tasks.Pack.dll</NuGetPackTaskAssemblyFile>
-    <NuGetPackTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">..\Desktop\NuGet.Build.Tasks.Pack.dll</NuGetPackTaskAssemblyFile>
+    <NuGetPackTaskAssemblyFile Condition="'$(UsingMicrosoftNetSdk)' == 'true' And '$(MSBuildRuntimeType)' != 'Core'">Sdks\Microsoft.NET.Sdk\tools\net472</NuGetPackTaskAssemblyFile>
+    <NuGetPackTaskAssemblyFile Condition="'$(NuGetPackTaskAssemblyFile)' == ''">NuGet.Build.Tasks.Pack.dll</NuGetPackTaskAssemblyFile>
   </PropertyGroup>
 
   <!-- Tasks -->
@@ -38,7 +38,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == '' AND '$(IsTool)' == 'true'">tools</BuildOutputTargetFolder>
     <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == ''">lib</BuildOutputTargetFolder>
     <ContentTargetFolders Condition="'$(ContentTargetFolders)' == ''">content;contentFiles</ContentTargetFolders>
-    <PackDependsOn>$(BeforePack); _IntermediatePack; GenerateNuspec; $(PackDependsOn)</PackDependsOn>
+    <PackDependsOn>$(BeforePack); _GetRestoreProjectStyle; _IntermediatePack; GenerateNuspec; $(PackDependsOn)</PackDependsOn>
     <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
     <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">symbols.nupkg</SymbolPackageFormat>
     <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
@@ -103,7 +103,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target Name="_GetOutputItemsFromPack"
           DependsOnTargets="_GetAbsoluteOutputPathsForPack"
-          Returns="@(_OutputPackItems)">
+          Returns="@(_OutputPackItems)"
+          Condition="'$(PackageReferenceCompatibleProjectStyle)' == 'true'">
 
     <!-- 'PackageOutputAbsolutePath' and 'NuspecOutputAbsolutePath' will be provided by '_GetAbsoluteOutputPathsForPack' target -->
 
@@ -209,7 +210,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="GenerateNuspec"
-          Condition="'$(IsPackable)' == 'true'"
+          Condition="'$(IsPackable)' == 'true' AND '$(PackageReferenceCompatibleProjectStyle)' == 'true'"
           Inputs="@(NuGetPackInput)" Outputs="@(NuGetPackOutput)"
           DependsOnTargets="$(GenerateNuspecDependsOn);_CalculateInputsOutputsForPack;_GetProjectReferenceVersions;_InitializeNuspecRepositoryInformationProperties">
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -27,10 +27,16 @@
       <PackagePath>runtimes\any\native</PackagePath>
       <Pack>true</Pack>
     </Content>
+    <Content Include="NuGet.Build.Tasks.Pack.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PackagePath>runtimes\any\native</PackagePath>
+      <Pack>true</Pack>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Commands\NuGet.Commands.csproj" />
+    <ProjectReference Include="..\NuGet.Build.Tasks.Pack\NuGet.Build.Tasks.Pack.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -301,36 +301,20 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
 
         private static void CopyPackSdkArtifacts(string artifactsDirectory, string pathToSdkInCli, string configuration)
         {
-            var pathToPackSdk = Path.Combine(pathToSdkInCli, "Sdks", "NuGet.Build.Tasks.Pack");
-
             const string packProjectName = "NuGet.Build.Tasks.Pack";
-            const string packTargetsName = "NuGet.Build.Tasks.Pack.targets";
 
             // Copy the pack SDK.
             var packProjectBinDirectory = Path.Combine(artifactsDirectory, packProjectName, "bin", configuration);
             var tfmToCopy = GetTfmToCopy(packProjectBinDirectory);
-
             var packProjectCoreArtifactsDirectory = new DirectoryInfo(Path.Combine(packProjectBinDirectory, tfmToCopy));
-
-            // We are only copying the CoreCLR assets, since, we're testing only them under Core MSBuild.
-            var targetRuntimeType = "CoreCLR";
-
-            var packAssemblyDestinationDirectory = Path.Combine(pathToPackSdk, targetRuntimeType);
 
             foreach (var assembly in packProjectCoreArtifactsDirectory.EnumerateFiles("*.dll"))
             {
                 File.Copy(
                     sourceFileName: assembly.FullName,
-                    destFileName: Path.Combine(packAssemblyDestinationDirectory, assembly.Name),
+                    destFileName: Path.Combine(pathToSdkInCli, assembly.Name),
                     overwrite: true);
             }
-
-            // Copy the pack targets
-            var packTargetsSource = Path.Combine(packProjectCoreArtifactsDirectory.FullName, packTargetsName);
-            var targetsDestination = Path.Combine(pathToPackSdk, "build", packTargetsName);
-            var targetsDestinationCrossTargeting = Path.Combine(pathToPackSdk, "buildCrossTargeting", packTargetsName);
-            File.Copy(packTargetsSource, targetsDestination, overwrite: true);
-            File.Copy(packTargetsSource, targetsDestinationCrossTargeting, overwrite: true);
         }
 
         public static void WriteGlobalJson(string path)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
NuGet's side of: https://github.com/NuGet/Home/issues/14046
Changes to the .NET SDK and VS will also be needed to complete the work.

Feature spec: https://github.com/NuGet/Home/blob/dev/accepted/2025/consolidate-pack-and-restore.md

## Description

This changes how NuGet's pack via msbuild works. The end goal is for the pack targets to ship in Visual Studio, so that non-SDK style projects using PackageReference can be packed.

Note, after this is merged, the first insertion into the .NET SDK will fail. The changes from this branch will need to be merged into the sdk to fix the insertion: https://github.com/dotnet/sdk/compare/main...zivkan:sdk:update-pack-tasks-layout

Key points:

* VS
   * Include `NuGet.Build.Tasks.Pack.[dll|targets]` in NuGet's vsix. By itself it does nothing, so a change to VS will be needed to import the targets file.
   * As per the feature spec, pack should only run for projects that restore with PackageReference, and no-op otherwise, so customers can run pack on solution files. So, the target to calculate restore style is added as a pack dependency, the GenerateNuspec target (which also creates the nupkg) is conditioned to run only when projects are PackageReference.  Since all SDK style projects are PackageReference, this should not have a negative impact on the .NET SDK
   * I couldn't think of a way for projects that already reference the NuGet.Build.Tasks.Pack package to use VS's pack targets instead. We'll just need to rely on deprecating the package on nuget.org, and wait for customers using the package to notice when they next try to update the package version.
* SDK
   * Currently pack in the SDK is installed to `$DOTNET_ROOT\sdk\<version>\sdk\NuGet.Build.Tasks.Pack\*`. wiith dubdirectories for netcore and netfx assemblies. This PR, along with the sdk changes, moves the targets file and netcore dll into the `sdk/<version>` directory, and moves the netfx tasks binary to the SDK's own net472 directory.
   * I was getting super weird runtime failures when testing with the N.B.T.Pack package listing its project packages as package dependencies. Hence, I kept in `SuppressDependenciesWhenPacking`, and needed to NoWarn NU5128.

It's very difficult to fully test because changes are needed in all products before pack works end-to-end. I was able to test that packing SDK style projects with the dotnet CLI and msbuild.exe works. But, I can't test msbuild.exe pack of non-sdk style projects until the VS changes are implemented.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ This PR isn't changing behaviour, just changing how msbuild pack is integrated with the sdk and VS. Hence, existing tests should be sufficient.
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14480
