### PR TITLE
Minimize allocations in ConvertToPackageDependencyInfo

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -890,7 +890,9 @@ namespace NuGet.Commands
                         }
                     }
 
-                    dependencies = newDependencies;
+                    // If there are no dependencies, pass null.
+                    // The PackageDependencyInfo constructor will convert this to an empty array.
+                    dependencies = newDependencies.Count == 0 ? null : newDependencies;
                 }
 
                 result.Add(new PackageDependencyInfo(item.Key.Name, item.Key.Version, dependencies));

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -872,9 +872,26 @@ namespace NuGet.Commands
 
             foreach (var item in items)
             {
-                IEnumerable<PackageDependency> dependencies = item.Data?.Dependencies?
-                    .Where(i => i.ReferenceType == LibraryDependencyReferenceType.Direct) // Ignore transitively pinned dependencies
-                    .Select(dependency => new PackageDependency(dependency.Name, VersionRange.All));
+                IEnumerable<PackageDependency> dependencies;
+                if (item.Data?.Dependencies == null || item.Data.Dependencies.Count == 0)
+                {
+                    // If there are no dependencies, pass null.
+                    // The PackageDependencyInfo constructor will convert this to an empty array.
+                    dependencies = null;
+                }
+                else
+                {
+                    List<PackageDependency> newDependencies = new List<PackageDependency>(item.Data.Dependencies.Count);
+                    foreach (var dependency in item.Data.Dependencies)
+                    {
+                        if (dependency.ReferenceType == LibraryDependencyReferenceType.Direct)
+                        {
+                            newDependencies.Add(new PackageDependency(dependency.Name, VersionRange.All));
+                        }
+                    }
+
+                    dependencies = newDependencies;
+                }
 
                 result.Add(new PackageDependencyInfo(item.Key.Name, item.Key.Version, dependencies));
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

There are a handful of allocations that can be streamlined in `ConvertToPackageDependencyInfo`. The highlighted items in this trace are either reduced or completely eliminated.

<img width="1282" height="1060" alt="image" src="https://github.com/user-attachments/assets/ba15a9f5-e996-4a3e-9642-7db4a35db83d" />


## Description

There are allocations due to LINQ overhead (e.g. `WhereListIterator`) that can be avoided by using a traditional foreach. Additionally, we can pass in the list size to avoid resizing and use the static empty array when there are no dependencies.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
