### PR TITLE
Add Source URL Validation to Package Sources page

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -86,7 +86,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
         /// </summary>
         /// <returns>True when valid, false otherwise.</returns>
         /// <exception cref="ArgumentNullException"></exception>
-        internal static bool TryEnsureValidSources(PackageSource packageSource)
+        internal static bool IsValidSource(PackageSource packageSource)
         {
             _ = packageSource ?? throw new ArgumentNullException(nameof(packageSource));
             string source = packageSource.Source;
@@ -108,7 +108,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         internal static void EnsureValidSources(PackageSource packageSource)
         {
-            if (!TryEnsureValidSources(packageSource))
+            if (!IsValidSource(packageSource))
             {
                 throw new ArgumentOutOfRangeException(
                     paramName: nameof(PackageSource.Source),
@@ -117,11 +117,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             }
         }
 
-        /// <summary>
-        /// Validates the Uri of a remote or local package source.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
         internal static void ValidateUniquenessOrThrow(List<PackageSource> packageSources)
         {
             _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.VisualStudio.Package;
 using NuGet.Configuration;
 
 namespace NuGet.PackageManagement.VisualStudio.Options
@@ -83,13 +84,10 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
         /// <summary>
         /// Validates the Uri of a remote or local package source.
-        /// The regex used here will eventually be supported in the Unified Settings registration.json file
-        /// for the package sources page. See https://github.com/NuGet/Home/issues/14358.
         /// </summary>
-        /// <param name="packageSource"></param>
+        /// <returns>True when valid, false otherwise.</returns>
         /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        internal static void EnsureValidSources(PackageSource packageSource)
+        internal static bool TryEnsureValidSources(PackageSource packageSource)
         {
             _ = packageSource ?? throw new ArgumentNullException(nameof(packageSource));
             string source = packageSource.Source;
@@ -98,14 +96,33 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 !Common.PathValidator.IsValidUncPath(source) &&
                 !Common.PathValidator.IsValidUrl(source))
             {
-                //TODO: enable soft mode.
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Validates the Uri of a remote or local package source and throws <see cref="ArgumentOutOfRangeException"/> if invalid.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        internal static void EnsureValidSources(PackageSource packageSource)
+        {
+            if (!TryEnsureValidSources(packageSource))
+            {
                 throw new ArgumentOutOfRangeException(
                     paramName: nameof(PackageSource.Source),
-                    actualValue: source,
-                    Strings.Error_PackageSource_InvalidSource);
+                    actualValue: packageSource.Source,
+                    message: Strings.Error_PackageSource_InvalidSource);
             }
         }
 
+        /// <summary>
+        /// Validates the Uri of a remote or local package source.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         internal static void ValidateUniquenessOrThrow(List<PackageSource> packageSources)
         {
             _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualStudio.Package;
 using NuGet.Configuration;
 
 namespace NuGet.PackageManagement.VisualStudio.Options

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -98,6 +98,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 !Common.PathValidator.IsValidUncPath(source) &&
                 !Common.PathValidator.IsValidUrl(source))
             {
+                //TODO: enable soft mode.
                 throw new ArgumentOutOfRangeException(
                     paramName: nameof(PackageSource.Source),
                     actualValue: source,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -348,9 +348,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                         }
                     case MonikerSourceUrl:
                         {
-                            // TODO iterate all items since we don't know which item is the new one.
-                            // Actually arrayItemIndex probably helps.
-
                             var packageSourceDictionary = packageSourceDictionaryList[arrayItemIndex];
                             (PackageSource packageSource, bool _) parsedResult = ParsePackageSource(packageSourceDictionary);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -242,9 +242,8 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return (result, hasAnyHiddenPropertyChanged);
         }
 
-        private static (PackageSource, bool) ParsePackageSource(IReadOnlyDictionary<string, object> packageSourceDictionary)
+        private static PackageSource ParsePackageSource(IReadOnlyDictionary<string, object> packageSourceDictionary)
         {
-            bool hasPackageSourceNameChanged = false;
             string name = packageSourceDictionary[MonikerSourceName].ToString().Trim();
             string? lookupName;
 
@@ -252,12 +251,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             if (packageSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageSourceIdObj))
             {
                 lookupName = packageSourceIdObj.ToString().Trim();
-
-                if (!string.Equals(lookupName, name, StringComparison.CurrentCultureIgnoreCase))
-                {
-                    // Changing the ID needs to refresh Unified Settings since the ID is a hidden property.
-                    hasPackageSourceNameChanged = true;
-                }
             }
             else // Newly added Package Sources will not have a Package ID yet.
             {
@@ -273,7 +266,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 AllowInsecureConnections = allowInsecureConnections,
             };
 
-            return (packageSource, hasPackageSourceNameChanged);
+            return packageSource;
         }
 
         private static ExternalSettingOperationResult<T> GetValuePackageSources<T>(List<PackageSource> packageSources)
@@ -349,9 +342,9 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                     case MonikerSourceUrl:
                         {
                             var packageSourceDictionary = packageSourceDictionaryList[arrayItemIndex];
-                            (PackageSource packageSource, bool _) parsedResult = ParsePackageSource(packageSourceDictionary);
+                            var result = ParsePackageSource(packageSourceDictionary);
 
-                            var isValidSource = PackageSourceValidator.TryEnsureValidSources(parsedResult.packageSource);
+                            var isValidSource = PackageSourceValidator.TryEnsureValidSources(result);
                             if (!isValidSource)
                             {
                                 var validationMessage = new SettingMessage(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -360,8 +360,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                                 settingMessages.Add(validationMessage);
                             }
 
-                            // TODO?
-                            //PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
                             break;
                         }
                     case MonikerIsEnabled:

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -344,7 +344,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                             var packageSourceDictionary = packageSourceDictionaryList[arrayItemIndex];
                             var result = ParsePackageSource(packageSourceDictionary);
 
-                            var isValidSource = PackageSourceValidator.TryEnsureValidSources(result);
+                            var isValidSource = PackageSourceValidator.IsValidSource(result);
                             if (!isValidSource)
                             {
                                 var validationMessage = new SettingMessage(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -314,21 +314,20 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return default;
         }
 
-        public OneOrMany<SettingMessage> ValidateArrayItemProperty(string arraySettingMoniker, int arrayItemIndex, string propertyMoniker, IReadOnlyList<IReadOnlyDictionary<string, object>> arraySettingContent)
+        public OneOrMany<SettingMessage> ValidateArrayItemProperty(
+            string arraySettingMoniker,
+            int arrayItemIndex,
+            string propertyMoniker,
+            IReadOnlyList<IReadOnlyDictionary<string, object>> arraySettingContent)
         {
             var settingMessages = new OneOrMany<SettingMessage>();
-            var packageSourceDictionaryList = arraySettingContent as IReadOnlyList<IReadOnlyDictionary<string, object>>;
-            if (packageSourceDictionaryList is null)
-            {
-                throw new InvalidOperationException();
-            }
 
             if (arraySettingMoniker != MonikerPackageSources)
             {
                 return settingMessages;
             }
 
-            List<PackageSource> packageSources = new List<PackageSource>(capacity: packageSourceDictionaryList.Count);
+            List<PackageSource> packageSources = new List<PackageSource>(capacity: arraySettingContent.Count);
 
             try
             {
@@ -341,7 +340,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                         }
                     case MonikerSourceUrl:
                         {
-                            var packageSourceDictionary = packageSourceDictionaryList[arrayItemIndex];
+                            var packageSourceDictionary = arraySettingContent[arrayItemIndex];
                             var result = ParsePackageSource(packageSourceDictionary);
 
                             var isValidSource = PackageSourceValidator.IsValidSource(result);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -323,6 +323,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
         public OneOrMany<SettingMessage> ValidateArrayItemProperty(string arraySettingMoniker, int arrayItemIndex, string propertyMoniker, IReadOnlyList<IReadOnlyDictionary<string, object>> arraySettingContent)
         {
+            var settingMessages = new OneOrMany<SettingMessage>();
             var packageSourceDictionaryList = arraySettingContent as IReadOnlyList<IReadOnlyDictionary<string, object>>;
             if (packageSourceDictionaryList is null)
             {
@@ -331,7 +332,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
             if (arraySettingMoniker != MonikerPackageSources)
             {
-                return new OneOrMany<SettingMessage>();
+                return settingMessages;
             }
 
             List<PackageSource> packageSources = new List<PackageSource>(capacity: packageSourceDictionaryList.Count);
@@ -350,9 +351,17 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                             // TODO iterate all items since we don't know which item is the new one.
                             // Actually arrayItemIndex probably helps.
 
-                            var packageSourceDictionary = packageSourceDictionaryList[0];
+                            var packageSourceDictionary = packageSourceDictionaryList[arrayItemIndex];
                             (PackageSource packageSource, bool _) parsedResult = ParsePackageSource(packageSourceDictionary);
-                            PackageSourceValidator.EnsureValidSources(parsedResult.packageSource);
+
+                            var isValidSource = PackageSourceValidator.TryEnsureValidSources(parsedResult.packageSource);
+                            if (!isValidSource)
+                            {
+                                var validationMessage = new SettingMessage(
+                                    Text: Strings.Error_PackageSource_InvalidSource,
+                                    Severity: MessageSeverity.Error);
+                                settingMessages.Add(validationMessage);
+                            }
 
                             // TODO?
                             //PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
@@ -375,10 +384,10 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 #pragma warning restore CA1031 // Do not catch general exception types
             {
                 var validationMessage = new SettingMessage(Text: ex.Message, Severity: MessageSeverity.Error);
-                return new OneOrMany<SettingMessage>(validationMessage);
+                settingMessages.Add(validationMessage);
             }
 
-            return new OneOrMany<SettingMessage>();
+            return settingMessages;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -10,13 +10,14 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudio.Utilities.UnifiedSettings;
 using NuGet.Configuration;
 
 namespace NuGet.PackageManagement.VisualStudio.Options
 {
     [Guid("15C605EC-4FD7-446B-BA4A-75ECF0C0B2D0")]
-    public class PackageSourcesPage : NuGetExternalSettingsProvider
+    public class PackageSourcesPage : NuGetExternalSettingsProvider, IExternalSettingValidator
     {
         internal const string MonikerPackageSources = "packageSources";
         internal const string MonikerMachineWideSources = "machineWidePackageSources";
@@ -27,11 +28,18 @@ namespace NuGet.PackageManagement.VisualStudio.Options
         internal const string MonikerAllowInsecureConnections = "allowInsecureConnections";
 
         private IPackageSourceProvider _packageSourceProvider;
+        public event EventHandler? RevalidationRequired;
 
         public PackageSourcesPage(VSSettings vsSettings, IPackageSourceProvider packageSourceProvider)
             : base(vsSettings)
         {
             _packageSourceProvider = packageSourceProvider ?? throw new ArgumentNullException(nameof(packageSourceProvider));
+        }
+
+        internal override void VsSettings_SettingsChanged(object sender, EventArgs e)
+        {
+            RevalidationRequired?.Invoke(sender, e);
+            base.VsSettings_SettingsChanged(sender, e);
         }
 
         private List<PackageSource> LoadPackageSources(bool isMachineWide)
@@ -234,6 +242,40 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return (result, hasAnyHiddenPropertyChanged);
         }
 
+        private static (PackageSource, bool) ParsePackageSource(IReadOnlyDictionary<string, object> packageSourceDictionary)
+        {
+            bool hasPackageSourceNameChanged = false;
+            string name = packageSourceDictionary[MonikerSourceName].ToString().Trim();
+            string? lookupName;
+
+            // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have a Package ID.
+            if (packageSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageSourceIdObj))
+            {
+                lookupName = packageSourceIdObj.ToString().Trim();
+
+                if (!string.Equals(lookupName, name, StringComparison.CurrentCultureIgnoreCase))
+                {
+                    // Changing the ID needs to refresh Unified Settings since the ID is a hidden property.
+                    hasPackageSourceNameChanged = true;
+                }
+            }
+            else // Newly added Package Sources will not have a Package ID yet.
+            {
+                lookupName = name;
+            }
+
+            string source = packageSourceDictionary[MonikerSourceUrl].ToString().Trim();
+            bool isEnabled = (bool)packageSourceDictionary[MonikerIsEnabled];
+            bool allowInsecureConnections = (bool)packageSourceDictionary[MonikerAllowInsecureConnections];
+
+            var packageSource = new PackageSource(source, lookupName, isEnabled)
+            {
+                AllowInsecureConnections = allowInsecureConnections,
+            };
+
+            return (packageSource, hasPackageSourceNameChanged);
+        }
+
         private static ExternalSettingOperationResult<T> GetValuePackageSources<T>(List<PackageSource> packageSources)
         {
             ExternalSettingOperationResult<T> result;
@@ -272,6 +314,71 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             }
 
             return result;
+        }
+
+        public OneOrMany<SettingMessage> ValidateSetting(string moniker, object value)
+        {
+            return default;
+        }
+
+        public OneOrMany<SettingMessage> ValidateArrayItemProperty(string arraySettingMoniker, int arrayItemIndex, string propertyMoniker, IReadOnlyList<IReadOnlyDictionary<string, object>> arraySettingContent)
+        {
+            var packageSourceDictionaryList = arraySettingContent as IReadOnlyList<IReadOnlyDictionary<string, object>>;
+            if (packageSourceDictionaryList is null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            if (arraySettingMoniker != MonikerPackageSources)
+            {
+                return new OneOrMany<SettingMessage>();
+            }
+
+            List<PackageSource> packageSources = new List<PackageSource>(capacity: packageSourceDictionaryList.Count);
+
+            try
+            {
+
+                switch (propertyMoniker)
+                {
+                    case MonikerSourceName:
+                        {
+                            break;
+                        }
+                    case MonikerSourceUrl:
+                        {
+                            // TODO iterate all items since we don't know which item is the new one.
+                            // Actually arrayItemIndex probably helps.
+
+                            var packageSourceDictionary = packageSourceDictionaryList[0];
+                            (PackageSource packageSource, bool _) parsedResult = ParsePackageSource(packageSourceDictionary);
+                            PackageSourceValidator.EnsureValidSources(parsedResult.packageSource);
+
+                            // TODO?
+                            //PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
+                            break;
+                        }
+                    case MonikerIsEnabled:
+                        {
+                            break;
+                        }
+                    case MonikerAllowInsecureConnections:
+                        {
+                            break;
+                        }
+                    default:
+                        throw new InvalidOperationException();
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                var validationMessage = new SettingMessage(Text: ex.Message, Severity: MessageSeverity.Error);
+                return new OneOrMany<SettingMessage>(validationMessage);
+            }
+
+            return new OneOrMany<SettingMessage>();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
@@ -259,7 +259,7 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The source specified is invalid..
+        ///   Looks up a localized string similar to A valid local or remote path must be specified..
         /// </summary>
         public static string Error_PackageSource_InvalidSource {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
@@ -293,7 +293,7 @@
     <value>_Open</value>
   </data>
   <data name="Error_PackageSource_InvalidSource" xml:space="preserve">
-    <value>The source specified is invalid.</value>
+    <value>A valid local or remote path must be specified.</value>
   </data>
   <data name="Error_PackageSource_UniqueName" xml:space="preserve">
     <value>The name specified has already been added to the list of available package sources.</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.cs.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.cs.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">Zadaný zdroj není platný.</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">Zadaný zdroj není platný.</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.de.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.de.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">Die angegebene Quelle ist ungültig.</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">Die angegebene Quelle ist ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.es.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.es.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">El origen especificado no es válido.</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">El origen especificado no es válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.fr.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.fr.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">La source spécifiée est invalide.</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">La source spécifiée est invalide.</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.it.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.it.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">L'origine specificata non è valida.</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">L'origine specificata non è valida.</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ja.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ja.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">指定されたソースは無効です。</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">指定されたソースは無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ko.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ko.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">지정된 원본이 잘못되었습니다.</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">지정된 원본이 잘못되었습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.pl.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.pl.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">Określone źródło jest nieprawidłowe.</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">Określone źródło jest nieprawidłowe.</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.pt-BR.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">A origem especificada é inválida.</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">A origem especificada é inválida.</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ru.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ru.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">Указанный источник недопустим.</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">Указанный источник недопустим.</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.tr.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.tr.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">Belirtilen kaynak geçersiz.</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">Belirtilen kaynak geçersiz.</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.zh-Hans.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">指定的源无效。</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">指定的源无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.zh-Hant.xlf
@@ -117,8 +117,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_InvalidSource">
-        <source>The source specified is invalid.</source>
-        <target state="translated">指定的來源無效。</target>
+        <source>A valid local or remote path must be specified.</source>
+        <target state="needs-review-translation">指定的來源無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSource_UniqueName">


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14359
Fixes: https://github.com/NuGet/Client.Engineering/issues/3385

## Description

Implements the Unified Settings validation API `IExternalSettingValidator` for array item settings on the Package Sources page.

Pressing "Save" with an invalid source would result in a permanent error on the Package Sources page, resolved only by VS Restart.
Now, a blocking error message is shown on the dialog:

Example 1:
<img width="370" height="375" alt="image" src="https://github.com/user-attachments/assets/2c7f21a2-5a59-4232-9fbc-48fbb99c80ca" />

Example 2:
<img width="683" height="662" alt="image" src="https://github.com/user-attachments/assets/5e7cdccb-6cc8-45a4-abad-7b1d90bbb5b5" />

### Change details
- Reworded the "invalid source" error string to be a little more explicit about what types of paths would work in the source field
- Added a "Try" version of the validator method to return a boolean instead of throwing.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ Tested manually and this code is invoking an already tested Validator class. Let me know if anyone feels another test would be useful.
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14039
