### PR TITLE
PrunePackageReference: Do not prune auto referenced packages

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
@@ -69,7 +69,8 @@ namespace NuGet.Commands
 
             static bool IsDependencyPruned(LibraryDependency dependency, IReadOnlyDictionary<string, PrunePackageReference> packagesToPrune)
             {
-                if (packagesToPrune?.TryGetValue(dependency.Name, out PrunePackageReference packageToPrune) == true
+                if (!dependency.AutoReferenced
+                    && packagesToPrune?.TryGetValue(dependency.Name, out PrunePackageReference packageToPrune) == true
                     && dependency.LibraryRange.VersionRange.Satisfies(packageToPrune.VersionRange.MaxVersion))
                 {
                     return true;

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -404,7 +404,8 @@ namespace NuGet.ProjectModel
 
             static bool IsDependencyPruned(LibraryDependency dependency, IReadOnlyDictionary<string, PrunePackageReference> packagesToPrune)
             {
-                if (packagesToPrune?.TryGetValue(dependency.Name, out PrunePackageReference packageToPrune) == true
+                if (!dependency.AutoReferenced
+                    && packagesToPrune?.TryGetValue(dependency.Name, out PrunePackageReference packageToPrune) == true
                     && dependency.LibraryRange.VersionRange.Satisfies(packageToPrune.VersionRange.MaxVersion))
                 {
                     return true;

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -516,7 +516,8 @@ namespace NuGet.ProjectModel
 
             static bool IsDependencyPruned(LibraryDependency dependency, IReadOnlyDictionary<string, PrunePackageReference> packagesToPrune)
             {
-                if (packagesToPrune?.TryGetValue(dependency.Name, out PrunePackageReference packageToPrune) == true
+                if (!dependency.AutoReferenced
+                    && packagesToPrune?.TryGetValue(dependency.Name, out PrunePackageReference packageToPrune) == true
                     && dependency.LibraryRange.VersionRange.Satisfies(packageToPrune.VersionRange.MaxVersion))
                 {
                     return true;

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileUtilities.cs
@@ -240,7 +240,7 @@ namespace NuGet.ProjectModel
 
                                         if (p2pSpecProjectRestoreMetadataFrameworkInfo != null)
                                         {
-                                            (var hasChanged, var message) = HasP2PDependencyChanged(p2pSpecTargetFrameworkInformation.Dependencies, p2pSpecProjectRestoreMetadataFrameworkInfo.ProjectReferences, targetFrameworkInformation.PackagesToPrune, projectDependency, dgSpec);
+                                            (var hasChanged, var message) = HasP2PDependencyChanged(p2pSpecTargetFrameworkInformation.Dependencies, p2pSpecProjectRestoreMetadataFrameworkInfo.ProjectReferences, p2pSpecTargetFrameworkInformation.PackagesToPrune, targetFrameworkInformation.PackagesToPrune, projectDependency, dgSpec);
 
                                             if (hasChanged)
                                             {
@@ -443,13 +443,14 @@ namespace NuGet.ProjectModel
             return (false, string.Empty);
         }
 
-        private static (bool, string) HasP2PDependencyChanged(IEnumerable<LibraryDependency> newDependencies, IEnumerable<ProjectRestoreReference> projectRestoreReferences, IReadOnlyDictionary<string, PrunePackageReference> packagesToPrune, LockFileDependency projectDependency, DependencyGraphSpec dgSpec)
+        private static (bool, string) HasP2PDependencyChanged(IEnumerable<LibraryDependency> newDependencies, IEnumerable<ProjectRestoreReference> projectRestoreReferences, IReadOnlyDictionary<string, PrunePackageReference> dependentProjectPackagesToPrune, IReadOnlyDictionary<string, PrunePackageReference> packagesToPrune, LockFileDependency projectDependency, DependencyGraphSpec dgSpec)
         {
             // If the count is not the same, something has changed.
             // Otherwise we N^2 walk below determines whether anything has changed.
             var transitivelyFlowingDependencies = newDependencies.Where(
                 dep => dep.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package
-                    && dep.SuppressParent != LibraryIncludeFlags.All);
+                    && dep.SuppressParent != LibraryIncludeFlags.All
+                    && !(IsDependencyPruned(dep, dependentProjectPackagesToPrune) && !dep.AutoReferenced));
 
             var transitivelyFlowingProjectReferences = projectRestoreReferences.Where(e => e.PrivateAssets != LibraryIncludeFlags.All);
 
@@ -516,8 +517,7 @@ namespace NuGet.ProjectModel
 
             static bool IsDependencyPruned(LibraryDependency dependency, IReadOnlyDictionary<string, PrunePackageReference> packagesToPrune)
             {
-                if (!dependency.AutoReferenced
-                    && packagesToPrune?.TryGetValue(dependency.Name, out PrunePackageReference packageToPrune) == true
+                if (packagesToPrune?.TryGetValue(dependency.Name, out PrunePackageReference packageToPrune) == true
                     && dependency.LibraryRange.VersionRange.Satisfies(packageToPrune.VersionRange.MaxVersion))
                 {
                     return true;

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
@@ -2766,6 +2766,7 @@ namespace NuGet.Commands.FuncTest
                 restoreResult.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(1);
                 restoreResult.LockFile.Targets[0].Libraries[1].Name.Should().Be("packageB");
                 restoreResult.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(0);
+                restoreResult.LockFile.Targets[0].Libraries[1].CompileTimeAssemblies[0].Path.Should().NotEndWith("_._");
                 restoreResult.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
                 restoreResult.LockFile.Targets[0].Libraries[2].Dependencies.Should().HaveCount(2);
             }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
@@ -2431,108 +2431,18 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries[2].Name.Should().Be("C");
             result.LockFile.Targets[0].Libraries[2].Dependencies.Should().HaveCount(0);
             result.LockFile.Targets[0].Libraries[2].CompileTimeAssemblies.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries[2].CompileTimeAssemblies[0].Path.Should().EndWith("_._");
+            result.LockFile.Targets[0].Libraries[2].CompileTimeAssemblies[0].Path.Should().NotEndWith("_._");
             result.LockFile.Targets[0].Libraries[2].RuntimeAssemblies.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries[2].RuntimeAssemblies[0].Path.Should().EndWith("_._");
+            result.LockFile.Targets[0].Libraries[2].RuntimeAssemblies[0].Path.Should().NotEndWith("_._");
             result.LockFile.Targets[0].Libraries[2].FrameworkAssemblies.Should().BeEmpty();
             result.LockFile.Targets[0].Libraries[2].FrameworkReferences.Should().BeEmpty();
             result.LockFile.Targets[0].Libraries[2].NativeLibraries.Should().BeEmpty();
             result.LockFile.Targets[0].Libraries[2].ResourceAssemblies.Should().BeEmpty();
             result.LockFile.Targets[0].Libraries[2].RuntimeTargets.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries[2].RuntimeTargets[0].Path.Should().EndWith("_._");
+            result.LockFile.Targets[0].Libraries[2].RuntimeTargets[0].Path.Should().NotEndWith("_._");
             result.LockFile.Targets[0].Libraries[2].ContentFiles.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries[2].ContentFiles[0].Path.Should().EndWith("_._");
+            result.LockFile.Targets[0].Libraries[2].ContentFiles[0].Path.Should().NotEndWith("_._");
             result.LockFile.LogMessages.Should().BeEmpty();
-        }
-
-        [Fact]
-        public async Task RestoreCommand_WithAutoReferencedPackageSpecifiedForPruning_DoesNotPrune()
-        {
-            using var pathContext = new SimpleTestPathContext();
-
-            // Setup packages
-            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
-            {
-                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")]
-            };
-
-            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                pathContext.PackageSource,
-                PackageSaveMode.Defaultv3,
-                packageA);
-
-            var prePruningRootProject = @"
-        {
-          ""frameworks"": {
-            ""net472"": {
-                ""dependencies"": {
-                        ""packageA"": {
-                            ""version"": ""[1.0.0,)"",
-                            ""target"": ""Package"",
-                        },
-                }
-            }
-          }
-        }";
-
-            // Setup project
-            var prePruningSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, prePruningRootProject);
-            prePruningSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: false);
-
-            // Pre-Conditions
-            var setupResult = await RunRestoreAsync(pathContext, prePruningSpec);
-            setupResult.Success.Should().BeTrue();
-            await setupResult.CommitAsync(NullLogger.Instance, CancellationToken.None);
-
-            setupResult.LockFile.Targets.Should().HaveCount(1);
-            setupResult.LockFile.Targets[0].Libraries.Should().HaveCount(2);
-            setupResult.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
-            setupResult.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(1);
-            setupResult.LockFile.Targets[0].Libraries[0].Dependencies[0].Id.Should().Be("packageB");
-            setupResult.LockFile.Targets[0].Libraries[1].Name.Should().Be("packageB");
-
-            File.Delete(setupResult.LockFilePath); // Delete the assets file to avoid assets file library caching.
-
-            setupResult._newPackagesLockFile.Should().NotBeNull();
-            setupResult._newPackagesLockFile.Targets.Should().HaveCount(1);
-            setupResult._newPackagesLockFile.Targets[0].Dependencies.Should().HaveCount(2);
-            setupResult._newPackagesLockFile.Targets[0].Dependencies[0].Id.Should().Be("packageA");
-            setupResult._newPackagesLockFile.Targets[0].Dependencies[0].Dependencies.Should().HaveCount(1);
-            setupResult._newPackagesLockFile.Targets[0].Dependencies[0].Dependencies[0].Id.Should().Be("packageB");
-            setupResult._newPackagesLockFile.Targets[0].Dependencies[1].Id.Should().Be("packageB");
-            setupResult._newPackagesLockFile.Targets[0].Dependencies[1].Dependencies.Should().BeEmpty();
-
-            // Set-up again with LockedMode
-            var rootProject = @"
-        {
-          ""frameworks"": {
-            ""net472"": {
-                ""dependencies"": {
-                        ""packageA"": {
-                            ""version"": ""[1.0.0,)"",
-                            ""target"": ""Package"",
-                        },
-                },
-                ""packagesToPrune"": {
-                    ""packageB"" : ""(,1.0.0]"" 
-                }
-            }
-          }
-        }";
-            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
-            projectSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: true);
-
-            // Run again
-            var testLogger = new TestLogger();
-            var result = await RunRestoreAsync(pathContext, testLogger, projectSpec);
-            result.Success.Should().BeTrue(because: testLogger.ShowMessages());
-            result.LockFile.Targets.Should().HaveCount(1);
-            // packageB is part of the pre-pruning lock file, but after pruning is enabled, it gets pruned.
-            // The lock file does not get updated.
-            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
-            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
-            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
-            result._newPackagesLockFile.Should().BeNull();
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
@@ -2382,6 +2382,159 @@ namespace NuGet.Commands.FuncTest
             restoreResult.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(1);
         }
 
+        // P -> A 1.0.0 -> B 1.0.0
+        // P -> C 1.0.0
+        // Do not Prune C 1.0.0
+        [Fact]
+        public async Task RestoreCommand_WithAutoReferencedPackage_DoesNotPruneDirectDependencies()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            await SetupCommonPackagesAsync(pathContext);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""FRAMEWORK"": {
+                ""targetAlias"": ""targetAlias"",
+                ""dependencies"": {
+                        ""A"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                        ""C"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                            ""autoReferenced"": true
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""C"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }".Replace("FRAMEWORK", "net9.0");
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // Act & Assert
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("A");
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("B");
+            result.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(0);
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("C");
+            result.LockFile.Targets[0].Libraries[2].Dependencies.Should().HaveCount(0);
+            result.LockFile.Targets[0].Libraries[2].CompileTimeAssemblies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[2].CompileTimeAssemblies[0].Path.Should().EndWith("_._");
+            result.LockFile.Targets[0].Libraries[2].RuntimeAssemblies.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[2].RuntimeAssemblies[0].Path.Should().EndWith("_._");
+            result.LockFile.Targets[0].Libraries[2].FrameworkAssemblies.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[2].FrameworkReferences.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[2].NativeLibraries.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[2].ResourceAssemblies.Should().BeEmpty();
+            result.LockFile.Targets[0].Libraries[2].RuntimeTargets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[2].RuntimeTargets[0].Path.Should().EndWith("_._");
+            result.LockFile.Targets[0].Libraries[2].ContentFiles.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[2].ContentFiles[0].Path.Should().EndWith("_._");
+            result.LockFile.LogMessages.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithAutoReferencedPackageSpecifiedForPruning_DoesNotPrune()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var prePruningRootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var prePruningSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, prePruningRootProject);
+            prePruningSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: false);
+
+            // Pre-Conditions
+            var setupResult = await RunRestoreAsync(pathContext, prePruningSpec);
+            setupResult.Success.Should().BeTrue();
+            await setupResult.CommitAsync(NullLogger.Instance, CancellationToken.None);
+
+            setupResult.LockFile.Targets.Should().HaveCount(1);
+            setupResult.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+            setupResult.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            setupResult.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(1);
+            setupResult.LockFile.Targets[0].Libraries[0].Dependencies[0].Id.Should().Be("packageB");
+            setupResult.LockFile.Targets[0].Libraries[1].Name.Should().Be("packageB");
+
+            File.Delete(setupResult.LockFilePath); // Delete the assets file to avoid assets file library caching.
+
+            setupResult._newPackagesLockFile.Should().NotBeNull();
+            setupResult._newPackagesLockFile.Targets.Should().HaveCount(1);
+            setupResult._newPackagesLockFile.Targets[0].Dependencies.Should().HaveCount(2);
+            setupResult._newPackagesLockFile.Targets[0].Dependencies[0].Id.Should().Be("packageA");
+            setupResult._newPackagesLockFile.Targets[0].Dependencies[0].Dependencies.Should().HaveCount(1);
+            setupResult._newPackagesLockFile.Targets[0].Dependencies[0].Dependencies[0].Id.Should().Be("packageB");
+            setupResult._newPackagesLockFile.Targets[0].Dependencies[1].Id.Should().Be("packageB");
+            setupResult._newPackagesLockFile.Targets[0].Dependencies[1].Dependencies.Should().BeEmpty();
+
+            // Set-up again with LockedMode
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+            projectSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: true);
+
+            // Run again
+            var testLogger = new TestLogger();
+            var result = await RunRestoreAsync(pathContext, testLogger, projectSpec);
+            result.Success.Should().BeTrue(because: testLogger.ShowMessages());
+            result.LockFile.Targets.Should().HaveCount(1);
+            // packageB is part of the pre-pruning lock file, but after pruning is enabled, it gets pruned.
+            // The lock file does not get updated.
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+            result.LockFile.Targets[0].Libraries[0].Dependencies.Should().BeEmpty();
+            result._newPackagesLockFile.Should().BeNull();
+        }
+
         [Fact]
         public void PopulatePruningEnabledTelemetry_WithVariousFrameworks_PopulatesTelemetryCorrectly()
         {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
@@ -2446,6 +2446,332 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
+        public async Task RestoreCommand_WithLockFileAndPrunableAutoreferencedPackageFromProjectReference_WithLockedMode_Succeeds()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var leafProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                        ""packageB"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                            ""autoReferenced"": true
+                        },
+                },
+            }
+          }
+        }";
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+            projectSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: false);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, leafProject);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Pre-Conditions
+            var setupResult = await RunRestoreAsync(pathContext, projectSpec, projectSpec2);
+            setupResult.Success.Should().BeTrue();
+            await setupResult.CommitAsync(NullLogger.Instance, CancellationToken.None);
+            ValidateAssetsFile(setupResult);
+            File.Delete(setupResult.LockFilePath); // Delete the assets file to avoid assets file library caching.
+
+            // Set-up again with LockedMode
+            projectSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: true);
+
+            // Run again
+            var testLogger = new TestLogger();
+            var result = await RunRestoreAsync(pathContext, testLogger, projectSpec, projectSpec2);
+            result.Success.Should().BeTrue(because: testLogger.ShowMessages());
+            ValidateAssetsFile(result);
+
+            static void ValidateAssetsFile(RestoreResult restoreResult)
+            {
+                restoreResult.LockFile.Targets.Should().HaveCount(1);
+                restoreResult.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+                restoreResult.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+                restoreResult.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(0);
+                restoreResult.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+                restoreResult.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(1);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithLockFileAndPrunableAutoreferenced_WhenAutoReferencedPackageIsRemoved_Fails()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                        ""packageB"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                            ""autoReferenced"": true
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            var rootProjectWithoutAutoRefPackage = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        }
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+            projectSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: false);
+
+            // Pre-Conditions
+            var setupResult = await RunRestoreAsync(pathContext, projectSpec);
+            setupResult.Success.Should().BeTrue();
+            await setupResult.CommitAsync(NullLogger.Instance, CancellationToken.None);
+            ValidateAssetsFile(setupResult);
+            File.Delete(setupResult.LockFilePath); // Delete the assets file to avoid assets file library caching.
+
+            // Set-up again with LockedMode and remove the auto-referenced package
+            projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProjectWithoutAutoRefPackage);
+            projectSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: true);
+
+            // Run again
+            var testLogger = new TestLogger();
+            var result = await RunRestoreAsync(pathContext, testLogger, projectSpec);
+            result.Success.Should().BeFalse(because: testLogger.ShowMessages());
+
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(0);
+            result.LockFile.LogMessages.Should().HaveCount(1);
+            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1004);
+
+            static void ValidateAssetsFile(RestoreResult restoreResult)
+            {
+                restoreResult.LockFile.Targets.Should().HaveCount(1);
+                restoreResult.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+                restoreResult.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+                restoreResult.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(0);
+                restoreResult.LockFile.Targets[0].Libraries[1].Name.Should().Be("packageB");
+                restoreResult.LockFile.Targets[0].Libraries[1].Dependencies.Should().BeEmpty();
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithLockFileAndPrunablePackageFromProjectReference_WithLockedMode_Succeeds()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var leafProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                        ""packageB"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+            }
+          }
+        }";
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+            projectSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: false);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, leafProject);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Pre-Conditions
+            var setupResult = await RunRestoreAsync(pathContext, projectSpec, projectSpec2);
+            setupResult.Success.Should().BeTrue();
+            await setupResult.CommitAsync(NullLogger.Instance, CancellationToken.None);
+            ValidateAssetsFile(setupResult);
+            File.Delete(setupResult.LockFilePath); // Delete the assets file to avoid assets file library caching.
+
+            // Set-up again with LockedMode
+            projectSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: true);
+
+            // Run again
+            var testLogger = new TestLogger();
+            var result = await RunRestoreAsync(pathContext, testLogger, projectSpec, projectSpec2);
+            result.Success.Should().BeTrue(because: testLogger.ShowMessages());
+            ValidateAssetsFile(result);
+
+            static void ValidateAssetsFile(RestoreResult restoreResult)
+            {
+                restoreResult.LockFile.Targets.Should().HaveCount(1);
+                restoreResult.LockFile.Targets[0].Libraries.Should().HaveCount(2);
+                restoreResult.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+                restoreResult.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(1);
+                restoreResult.LockFile.Targets[0].Libraries[1].Name.Should().Be("Project2");
+                restoreResult.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(1);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithLockFileAndAutoReferencedPrunablePackageFromProjectReference_WithLockedMode_Succeeds()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("packageB", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA);
+
+            var leafProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+                ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                        },
+                        ""packageB"": {
+                            ""version"": ""[1.0.0,)"",
+                            ""target"": ""Package"",
+                            ""autoReferenced"": true,
+                        },
+                },
+                ""packagesToPrune"": {
+                    ""packageB"" : ""(,1.0.0]"" 
+                }
+            }
+          }
+        }";
+
+            var rootProject = @"
+        {
+          ""frameworks"": {
+            ""net472"": {
+            }
+          }
+        }";
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+            projectSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: false);
+            var projectSpec2 = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project2", pathContext.SolutionRoot, leafProject);
+            projectSpec = projectSpec.WithTestProjectReference(projectSpec2);
+
+            // Pre-Conditions
+            var setupResult = await RunRestoreAsync(pathContext, projectSpec, projectSpec2);
+            setupResult.Success.Should().BeTrue();
+            await setupResult.CommitAsync(NullLogger.Instance, CancellationToken.None);
+            ValidateAssetsFile(setupResult);
+            File.Delete(setupResult.LockFilePath); // Delete the assets file to avoid assets file library caching.
+
+            // Set-up again with LockedMode
+            projectSpec.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(restorePackagesWithLockFile: "true", nuGetLockFilePath: null, restoreLockedMode: true);
+
+            // Run again
+            var testLogger = new TestLogger();
+            var result = await RunRestoreAsync(pathContext, testLogger, projectSpec, projectSpec2);
+            result.Success.Should().BeTrue(because: testLogger.ShowMessages());
+            ValidateAssetsFile(result);
+
+            static void ValidateAssetsFile(RestoreResult restoreResult)
+            {
+                restoreResult.LockFile.Targets.Should().HaveCount(1);
+                restoreResult.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+                restoreResult.LockFile.Targets[0].Libraries[0].Name.Should().Be("packageA");
+                restoreResult.LockFile.Targets[0].Libraries[0].Dependencies.Should().HaveCount(1);
+                restoreResult.LockFile.Targets[0].Libraries[1].Name.Should().Be("packageB");
+                restoreResult.LockFile.Targets[0].Libraries[1].Dependencies.Should().HaveCount(0);
+                restoreResult.LockFile.Targets[0].Libraries[2].Name.Should().Be("Project2");
+                restoreResult.LockFile.Targets[0].Libraries[2].Dependencies.Should().HaveCount(2);
+            }
+        }
+
+        [Fact]
         public void PopulatePruningEnabledTelemetry_WithVariousFrameworks_PopulatesTelemetryCorrectly()
         {
             var rootProject = @"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14441

## Description

I think auto referenced packages shouldn't be pruned. Autoreferenmce means supplied by the SDK and it kind of conflicts with pruning. 
Given that auto referenced packages are usually PrivateAssets=all, I don't think they should be prunable. 
Someone can correct me otherwise, but I feel like this makes sense as a behavior. 
@dspliasted @zivkan looking for your input here. 


Assuming we agree, here's some helper for reviewing the changes:

- IncludeFlagUtils needs to account for pruning when applying private assets. It only does it for direct packages so the one change is enough.
- PackageSpecReferenceDependencyProvider applies to all of them and adds PrivateAssets=all. 
- PackagesLockFileUtilities changes are more substantial. When walking the transitives, we consider the prunable packages for the project being reviewed as well. This revealed a bug with lock files + directs pruning which I have since fixed.  That change is in HasP2PDependencyChanged. 
- When considering direcets, we don't want to remove an auto referenced package because itself, it is part of the graph.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
