### PR TITLE
Make tests of net472 projects work in VS again

### DIFF
--- a/build/sign.targets
+++ b/build/sign.targets
@@ -27,7 +27,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SignWithNuGetKey)' == 'true' Or '$(SignWithMicrosoftKey)' == 'true'">
-    <PublicSign>true</PublicSign>
+    <PublicSign Condition="'$(DotNetBuildFromVMR)' == 'true' Or '$(IsXplat)' == 'true' ">true</PublicSign>
+    <DelaySign Condition="'$(DotNetBuildFromVMR)' != 'true' And '$(IsXplat)' != 'true' ">true</DelaySign>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: running NuGet.Client's .NET Framework tests in VS

## Description

The .NET VMR team changed all NuGet assemblies to be PublicSigned two weeks ago: https://github.com/dotnet/dotnet/pull/1784

Since this change, Visual Studio's Test Platform to fail to load .NET Framework assemblies preventing us from being able to run and debug these tests in VS. The .NET (CoreApp) tests still work, it's just the .NET Framework tests that have a problem.

This change makes .NET Framework binaries (both test and product) to be delay signed when building outside the VMR, so hopefully it doesn't break the VMR.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~ (engineering issue)
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
