### PR TITLE
Only embed resources on CI, allow the up to date check to succeed

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -95,9 +95,9 @@
       <DependentUpon>NuGetResources.resx</DependentUpon>
     </Compile>
     <!-- nuget.exe localized assemblies -->
-    <EmbeddedResource Include="$(OutputPath)\**\$(AssemblyName).resources.dll" />
+    <EmbeddedResource Include="$(OutputPath)\**\$(AssemblyName).resources.dll" Condition="'$(CI)' != 'true'" />
     <!-- NuGet.Commands localized assemblies -->
-    <LocResource Include="$(OutputPath)\**\NuGet.Commands.resources.dll" />
+    <LocResource Include="$(OutputPath)\**\NuGet.Commands.resources.dll" Condition="'$(CI)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -95,9 +95,9 @@
       <DependentUpon>NuGetResources.resx</DependentUpon>
     </Compile>
     <!-- nuget.exe localized assemblies -->
-    <EmbeddedResource Include="$(OutputPath)\**\$(AssemblyName).resources.dll" Condition="'$(CI)' != 'true'" />
+    <EmbeddedResource Include="$(OutputPath)\**\$(AssemblyName).resources.dll" Condition="'$(CI)' == 'true'" />
     <!-- NuGet.Commands localized assemblies -->
-    <LocResource Include="$(OutputPath)\**\NuGet.Commands.resources.dll" Condition="'$(CI)' != 'true'" />
+    <LocResource Include="$(OutputPath)\**\NuGet.Commands.resources.dll" Condition="'$(CI)' == 'true'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Progress: https://github.com/nuget/home/issues/14500

## Description

Read https://github.com/nuget/home/issues/14500 and https://github.com/nuget/home/issues/14501 for more details, but the gist is that we've made the build input depend on it's own output which means the up to date check will never be correct. 

This sped up the up to date check on machine by 40s, down to under 10s, where it should've always been.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
