### PR TITLE
Revert "[dev] Source code updates from dotnet/dotnet (#6724)"

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -144,8 +144,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyVersion Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'">$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
-    <AssemblyVersion Condition="'$(TargetFramework)' == '$(NETCoreTargetFramework)'">$(SemanticVersion).0</AssemblyVersion>
+    <!-- Assembly attributes for net core projects -->
+    <AssemblyVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
     <FileVersion>$(SemanticVersion).$(PreReleaseVersion)</FileVersion>
     <InformationalVersion Condition="'$(BUILD_SOURCEVERSION)' == ''">$(SemanticVersion)$(PreReleaseInformationVersion)</InformationalVersion>
     <InformationalVersion Condition="'$(BUILD_SOURCEVERSION)' != ''">$(SemanticVersion)$(PreReleaseInformationVersion)+$(BUILD_SOURCEVERSION)</InformationalVersion>

--- a/build/config.props
+++ b/build/config.props
@@ -41,14 +41,14 @@
   </PropertyGroup>
 
  <PropertyGroup Condition=" '$(PreReleaseVersion)' == '' ">
-    <!-- This number is chosen to be higher than the assembly versions that the VMR-built NuGet uses, so that a dev build of NuGet can be patched over
-         the VMR build. -->
     <PreReleaseVersion>65534</PreReleaseVersion>
   </PropertyGroup>
 
   <!--Setting the Pre-release/Build meta-data from CI if Version is set-->
   <PropertyGroup Condition="'$(BuildNumber)' != ''">
     <PreReleaseVersion>$(BuildNumber)</PreReleaseVersion>
+    <!-- Add 500 to the revision number to avoid clashing with the existing msft official build. -->
+    <PreReleaseVersion Condition="'$(DotNetBuildFromVMR)' == 'true'">$([MSBuild]::Add($(BuildNumber), 500))</PreReleaseVersion>
   </PropertyGroup>
 
   <!--Setting the product information for Beta builds-->

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -22,8 +22,8 @@ This file should be imported by eng/Versions.props
     <!-- dotnet/corefx dependencies -->
     <SystemComponentModelCompositionPackageVersion>4.5.0</SystemComponentModelCompositionPackageVersion>
     <!-- dotnet/dotnet dependencies -->
-    <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.25416.105</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetXliffTasksPackageVersion>10.0.0-beta.25416.105</MicrosoftDotNetXliffTasksPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.25409.103</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetXliffTasksPackageVersion>10.0.0-beta.25409.103</MicrosoftDotNetXliffTasksPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="nuget-client" Sha="a01724db6d16445177cb31c6f300d38b0af06290" BarId="279606" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="nuget-client" Sha="e9f665e52848a3615736c099e5631af531b66a5c" BarId="278626" />
   <!--
     Currently this file is required to publish builds to .NET build asset registry.
     See https://github.com/dotnet/arcade/issues/2396 for details.
@@ -56,13 +56,13 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25416.105">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25409.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a01724db6d16445177cb31c6f300d38b0af06290</Sha>
+      <Sha>e9f665e52848a3615736c099e5631af531b66a5c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="10.0.0-beta.25416.105">
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="10.0.0-beta.25409.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>a01724db6d16445177cb31c6f300d38b0af06290</Sha>
+      <Sha>e9f665e52848a3615736c099e5631af531b66a5c</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/dotnet-build/dotnet-build.proj
+++ b/eng/dotnet-build/dotnet-build.proj
@@ -16,12 +16,9 @@
       <_CommonProperties Include="DotNetBuild=$(DotNetBuild)" Condition="'$(DotNetBuild)' != ''" />
       <_CommonProperties Include="DotNetBuildSourceOnly=$(DotNetBuildSourceOnly)" Condition="'$(DotNetBuildSourceOnly)' != ''" />
 
-      <!-- NuGet typically uses an auto-incremented AzDO variable to set the preview iteration version on its builds. (e.g. 7.0.0-preview.20, where 20 is the
-           number. This is not an approach that .NET uses for its builds, which use a date-varying number. However, the exact suffix is not that
-           important as long as it can be used as part of the assembly version, and does not overlap with NuGet's existing packages or assemblies.
-           One way we can achieve this is to intake .NET's normal version properties, and apply a bit of math to mimic how .NET would calculate assembly versions.
-           See https://github.com/dotnet/arcade/blob/d27184f7cb92b4abb4b20e91ecb5c43bc43de65b/src/Microsoft.DotNet.Arcade.Sdk/src/CalculateAssemblyAndFileVersions.cs#L65 -->
-      <_CommonProperties Include="BuildNumber=$([MSBuild]::Modulo($(_PatchNumber), 50000))" Condition="'$(_PatchNumber)' != ''" />
+      <!-- NuGet uses a pre-release string that is dependent on the build revision. This is normally set via their
+           YAML. Set based on the parsed version information. -->
+      <_CommonProperties Include="BuildNumber=$(VersionSuffixBuildOfTheDay)" Condition="'$(VersionSuffixBuildOfTheDay)' != ''" />
     </ItemGroup>
 
     <!-- Pass _ImportOrUseTooling = false to avoid attempting to restore unneeded packages in Tools.proj.

--- a/global.json
+++ b/global.json
@@ -9,7 +9,7 @@
     "pinned": true
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25416.105",
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25409.103",
     "Microsoft.Build.NoTargets": "3.7.0"
   }
 }

--- a/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
+++ b/src/NuGet.Core/NuGet.Localization/NuGet.Localization.csproj
@@ -6,7 +6,6 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Description>NuGet localization package for dotnet CLI.</Description>
     <NoWarn>$(NoWarn);CS1591;NU5128</NoWarn>
-    <XPLATProject>true</XPLATProject>
     <UsePublicApiAnalyzer>false</UsePublicApiAnalyzer>
     <LocalizationOutputDirectory>$(ArtifactsDirectory)LocalizedFiles</LocalizationOutputDirectory>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CreateNupkg</TargetsForTfmSpecificContentInPackage>


### PR DESCRIPTION
These builds are from the .NET 10.0.1xx channel, after main switched to .NET 11.0.1xx, so they need to be reverted