### PR TITLE
Fix up versioning

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -144,7 +144,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyVersion Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'">$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
+    <AssemblyVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetFramework)' == '$(NETCoreTargetFramework)'">$(SemanticVersion).0</AssemblyVersion>
     <FileVersion>$(SemanticVersion).$(PreReleaseVersion)</FileVersion>
     <InformationalVersion Condition="'$(BUILD_SOURCEVERSION)' == ''">$(SemanticVersion)$(PreReleaseInformationVersion)</InformationalVersion>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14504

## Description

We have a little bit of an ordering problem here. 

In the single tfm case, none of the conditions we based on framework seem to apply and the root cause seems to be the fact that we play around with setting and unsetting `TargetFramework` and `TargetFrameworks`. 

I'm not thrilled with this fix, we need to clean-up more of our infra, but this is good enough for now. 

After this change, NuGet.PackageManagement.UI and the likes are actually generating a `.prerelease` num versions which is what we wanted originally in https://github.com/dotnet/dotnet/pull/1881/files

These are the local version numbers: 

<img width="492" height="207" alt="image" src="https://github.com/user-attachments/assets/c27366e6-7b16-4758-a68e-3f7ca5a1a185" />


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
