### PR TITLE
No longer show a page-level error when enabling a duplicate package source

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -117,6 +117,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             }
         }
 
+        // Currently not used. Follow-up in https://github.com/NuGet/Home/issues/14507.
         internal static void ValidateUniquenessOrThrow(List<PackageSource> packageSources)
         {
             _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));
@@ -125,6 +126,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             EnsureUniqueSources(packageSources);
         }
 
+        // Currently not used. Follow-up in https://github.com/NuGet/Home/issues/14507.
         private static void EnsureUniqueNames(List<PackageSource> packageSources)
         {
             var seen = new HashSet<string>(
@@ -140,6 +142,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             }
         }
 
+        // Currently not used. Follow-up in https://github.com/NuGet/Home/issues/14507.
         private static void EnsureUniqueSources(List<PackageSource> packageSources)
         {
             var seen = new HashSet<string>(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -222,9 +222,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                     packageSources.Add(packageSource);
                 }
 
-                // Throw any validation errors before saving.
-                PackageSourceValidator.ValidateUniquenessOrThrow(packageSources);
-
                 _packageSourceProvider.SavePackageSources(packageSources);
 
                 hasAnyHiddenPropertyChanged = hasAnyPackageSourceNameChanged;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
@@ -23,6 +23,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
     public class PackageSourcesPageTests : NuGetExternalSettingsProviderTests<PackageSourcesPage>
     {
         private IEnumerable<PackageSource> _packageSources;
+        private IEnumerable<PackageSource> _savedPackageSources;
         private int _countEnablePackageSourceCalled = 0;
         private int _countDisablePackageSourceCalled = 0;
 
@@ -31,6 +32,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             sp.Reset();
             NuGetUIThreadHelper.SetCustomJoinableTaskFactory(ThreadHelper.JoinableTaskFactory);
             _packageSources = Enumerable.Empty<PackageSource>();
+            _savedPackageSources = Enumerable.Empty<PackageSource>();
         }
 
         protected override PackageSourcesPage CreateInstance(VSSettings? vsSettings)
@@ -38,6 +40,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             Mock<IPackageSourceProvider> mockedPackageSourceProvider = new Mock<IPackageSourceProvider>();
             mockedPackageSourceProvider.Setup(packageSourceProvider => packageSourceProvider.LoadPackageSources())
                 .Returns(_packageSources);
+
+            mockedPackageSourceProvider.Setup(packageSourceProvider =>
+                packageSourceProvider.SavePackageSources(It.IsAny<IEnumerable<PackageSource>>()))
+                    .Callback<IEnumerable<PackageSource>>(sources =>
+                    {
+                        _savedPackageSources = sources;
+                    });
 
             mockedPackageSourceProvider.Setup(packageSourceProvider =>
                 packageSourceProvider.EnablePackageSource(It.IsAny<string>()))
@@ -299,6 +308,79 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             _countDisablePackageSourceCalled.Should().Be(expectedDisableCount);
             result.Should().NotBeNull();
             result.Should().BeOfType<ExternalSettingOperationResult.Success>();
+        }
+
+        /// <summary>
+        /// NuGet's implementation does not validate uniqueness of sources, and therefore allows a duplicate to become
+        /// enabled. The Unified Settings registration.json enforces uniqueness by the declaration:
+        /// <code>"uniqueness": "caseInsensitive"</code>
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SetValueAsync_EnableDuplicateSource_ReturnsSuccessResultTaskAsync(bool isEnabled)
+        {
+            // Arrange
+            string sourceName1 = "unitTestingSourceName1";
+            string sourceUrl1 = "https://testsource1.com";
+            bool isSource1Enabled = !isEnabled;
+
+            string sourceName2 = "unitTestingSourceName2";
+            string sourceUrl2 = sourceUrl1;
+            bool isSource2Enabled = isEnabled;
+
+            var packageSource1 = new PackageSource(sourceUrl1, sourceName1, isSource1Enabled);
+            var packageSource2 = new PackageSource(sourceUrl2, sourceName2, isSource2Enabled);
+
+            // Configure 2 existing package sources
+            _packageSources =
+            [
+                packageSource1,
+                packageSource2
+            ];
+
+            PackageSourcesPage instance = CreateInstance(_vsSettings);
+
+            // Configure Unified Settings input to Toggle IsEnabled state on the disabled source.
+            Dictionary<string, object> packageSourceDictionary1 = new Dictionary<string, object>();
+            packageSourceDictionary1[PackageSourcesPage.MonikerPackageSourceId] = sourceName1;
+            packageSourceDictionary1[PackageSourcesPage.MonikerSourceName] = sourceName1;
+            packageSourceDictionary1[PackageSourcesPage.MonikerSourceUrl] = sourceUrl1;
+            packageSourceDictionary1[PackageSourcesPage.MonikerIsEnabled] = isEnabled; // Toggle the first source.
+            packageSourceDictionary1[PackageSourcesPage.MonikerAllowInsecureConnections] = false;
+
+            Dictionary<string, object> packageSourceDictionary2 = new Dictionary<string, object>();
+            packageSourceDictionary2[PackageSourcesPage.MonikerPackageSourceId] = sourceName2;
+            packageSourceDictionary2[PackageSourcesPage.MonikerSourceName] = sourceName2;
+            packageSourceDictionary2[PackageSourcesPage.MonikerSourceUrl] = sourceUrl2;
+            packageSourceDictionary2[PackageSourcesPage.MonikerIsEnabled] = isSource2Enabled;
+            packageSourceDictionary2[PackageSourcesPage.MonikerAllowInsecureConnections] = false;
+
+            IList<IDictionary<string, object>> packageSourceDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 2)
+                {
+                    packageSourceDictionary1,
+                    packageSourceDictionary2
+                };
+
+            // Act
+            ExternalSettingOperationResult resultSetValue = await instance.SetValueAsync(
+                PackageSourcesPage.MonikerPackageSources,
+                packageSourceDictionaryList,
+                CancellationToken.None);
+
+            // Assert
+
+            // The first package source should have its IsEnabled updated.
+            packageSource1.IsEnabled = isEnabled;
+
+            resultSetValue.Should().NotBeNull();
+            resultSetValue.Should().BeOfType<ExternalSettingOperationResult.Success>();
+
+            var savedPackageSources = _savedPackageSources.ToList();
+            savedPackageSources.Count.Should().Be(2);
+            savedPackageSources.Should().Contain(packageSource1);
+            savedPackageSources.Should().Contain(packageSource2);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14499

## Description

Removes NuGet's VS Options implementation validating uniqueness of sources and therefore allows a duplicate source to become enabled. The Unified Settings registration.json enforces uniqueness by the declaration:
<code>"uniqueness": "caseInsensitive"</code>

Removing this enables the scenario in the Issue, and as described below:

Starting with the scenario of a duplicate source that is not enabled:
<img width="598" height="95" alt="image" src="https://github.com/user-attachments/assets/62a112b3-364f-43f5-bee7-e840a3197644" />

After checking the box to enable this package source, the source is enabled in the NuGet.Config, and no page-level error occurs. The item-level error is still shown:

<img width="1140" height="436" alt="image" src="https://github.com/user-attachments/assets/ed502733-89f8-449b-86e7-e4576b69e978" />

Created a follow-up tracking changes that Unified Settings may make in https://github.com/NuGet/Home/issues/14507.
We will either bring the validation back at the array-item level or remove it and use a configurable uniqueness check that can consider Enabled sources.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14039
