### PR TITLE
Troubleshooting link is clickable when 'clearing local resources' fails

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1682,12 +1682,20 @@ namespace NuGet.PackageManagement.UI {
         
         /// <summary>
         ///   Looks up a localized string similar to NuGet storage clear failed at {0}. 
-        ///Error: {1}
-        ///Please see https://aka.ms/troubleshoot_nuget_cache for more help..
+        ///Error: {1}.
         /// </summary>
         public static string ShowMessage_LocalsCommandFailure {
             get {
                 return ResourceManager.GetString("ShowMessage_LocalsCommandFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to For more information, see.
+        /// </summary>
+        public static string ShowMessage_LocalsCommandMoreInformation {
+            get {
+                return ResourceManager.GetString("ShowMessage_LocalsCommandMoreInformation", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -551,8 +551,7 @@
   </data>
   <data name="ShowMessage_LocalsCommandFailure" xml:space="preserve">
     <value>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
+Error: {1}</value>
     <comment>{0} :error message;
 {1}: date and time
 </comment>
@@ -1012,5 +1011,8 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   </data>
   <data name="VSOptions_Text_ClearLocalsPromptTitle" xml:space="preserve">
     <value>Clear all local NuGet resources?</value>
+  </data>
+  <data name="ShowMessage_LocalsCommandMoreInformation" xml:space="preserve">
+    <value>For more information, see</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ClearNuGetLocalsViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/ClearNuGetLocalsViewModel.cs
@@ -16,11 +16,25 @@ namespace NuGet.PackageManagement.UI.ViewModels
         private string? _commandCompleteText;
         private readonly Func<Task> _clearNuGetLocalsCommandExecute;
         private bool _isExecuting;
+        private bool _hasError;
 
         public ClearNuGetLocalsViewModel(Func<Task> clearNuGetLocalsCommandExecute)
         {
             _clearNuGetLocalsCommandExecute = clearNuGetLocalsCommandExecute ?? throw new ArgumentNullException(nameof(clearNuGetLocalsCommandExecute));
         }
+
+        public bool HasError
+        {
+            get
+            {
+                return _hasError;
+            }
+            set
+            {
+                SetAndRaisePropertyChanged(ref _hasError, value);
+            }
+        }
+
 
         public bool IsCommandComplete
         {
@@ -62,11 +76,22 @@ namespace NuGet.PackageManagement.UI.ViewModels
                 {
                     if (task.IsFaulted)
                     {
-                        OnCommandComplete(string.Format(CultureInfo.CurrentCulture, Resources.ShowMessage_LocalsCommandFailure, DateTime.Now.ToString(Resources.Culture), task.Exception.InnerException.Message));
+                        string message = string.Format(
+                            CultureInfo.CurrentCulture,
+                            Resources.ShowMessage_LocalsCommandFailure,
+                            DateTime.Now.ToString(Resources.Culture),
+                            task.Exception.InnerException.Message);
+
+                        OnCommandComplete(message, hasError: true);
                     }
                     else
                     {
-                        OnCommandComplete(message: string.Format(CultureInfo.CurrentCulture, Resources.ShowMessage_LocalsCommandSuccess, DateTime.Now.ToString(Resources.Culture)));
+                        string message = string.Format(
+                            CultureInfo.CurrentCulture,
+                            Resources.ShowMessage_LocalsCommandSuccess,
+                            DateTime.Now.ToString(Resources.Culture));
+
+                        OnCommandComplete(message, hasError: false);
                     }
                 },
                 TaskScheduler.FromCurrentSynchronizationContext());
@@ -82,11 +107,12 @@ namespace NuGet.PackageManagement.UI.ViewModels
             });
         }
 
-        private void OnCommandComplete(string message)
+        private void OnCommandComplete(string message, bool hasError)
         {
             _isExecuting = false;
             CommandCompleteText = message;
             IsCommandComplete = true;
+            HasError = hasError;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ClearNuGetLocalResourcesWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ClearNuGetLocalResourcesWindow.xaml
@@ -31,8 +31,8 @@
   </Window.Resources>
   <Window.CommandBindings>
     <CommandBinding
-    Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
-    Executed="ExecuteOpenExternalLink" />
+      Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+      Executed="ExecuteOpenExternalLink" />
   </Window.CommandBindings>
   <Grid Margin="12,12,12,12" Focusable="False">
     <Grid.RowDefinitions>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ClearNuGetLocalResourcesWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ClearNuGetLocalResourcesWindow.xaml
@@ -8,6 +8,7 @@
   xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
   xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
   xmlns:imagingTheme="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
+  xmlns:shell_controls="clr-namespace:Microsoft.VisualStudio.Shell.Controls;assembly=Microsoft.VisualStudio.Shell.Styles"
   xmlns:vs="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
   xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
   mc:Ignorable="d"
@@ -28,6 +29,11 @@
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </Window.Resources>
+  <Window.CommandBindings>
+    <CommandBinding
+    Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+    Executed="ExecuteOpenExternalLink" />
+  </Window.CommandBindings>
   <Grid Margin="12,12,12,12" Focusable="False">
     <Grid.RowDefinitions>
       <!-- Top caption -->
@@ -52,17 +58,17 @@
     </ScrollViewer>
 
     <!-- Progress Bar -->
-    <Grid Grid.Row="2" Margin="0,9,0,0">
-      <ProgressBar Height="20" AutomationProperties.Name="{x:Static nuget:Resources.ShowMessage_LocalsCommandWorking}" IsIndeterminate="{Binding IsCommandComplete, Converter={StaticResource InverseBooleanConverter}}" Value="100" />
+    <StackPanel Grid.Row="2" Margin="0,9,0,0">
       <!--
         Special TextBlock to report loading status to assistive technologies (narrator).
         Changes to the Text property will trigger a narrator event.
       -->
       <vsui:LiveTextBlock
-        Visibility="Collapsed"
-        IsFrequencyLimited="True"
-        Focusable="False"
-        AutomationProperties.IsOffscreenBehavior="Offscreen">
+          x:Name="_commandTextBlock"
+          Visibility="Collapsed"
+          IsFrequencyLimited="True"
+          Focusable="False"
+          AutomationProperties.IsOffscreenBehavior="Offscreen">
         <vsui:LiveTextBlock.Resources>
           <Style TargetType="vsui:LiveTextBlock">
             <Style.Triggers>
@@ -76,7 +82,21 @@
           </Style>
         </vsui:LiveTextBlock.Resources>
       </vsui:LiveTextBlock>
-    </Grid>
+
+      <TextBlock
+        Margin="0,0,0,9"
+        Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}">
+        <Run Text="{x:Static nuget:Resources.ShowMessage_LocalsCommandMoreInformation}" />
+        <shell_controls:Hyperlink
+          NavigateUri="https://aka.ms/troubleshoot_nuget_cache"
+          Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+          AutomationProperties.LabeledBy="{Binding ElementName=_commandTextBlock}">
+            <Run Text="https://aka.ms/troubleshoot_nuget_cache" />
+        </shell_controls:Hyperlink>
+      </TextBlock>
+
+      <ProgressBar Height="20" AutomationProperties.Name="{x:Static nuget:Resources.ShowMessage_LocalsCommandWorking}" IsIndeterminate="{Binding IsCommandComplete, Converter={StaticResource InverseBooleanConverter}}" Value="100" />
+    </StackPanel>
 
     <!-- Buttons -->
     <StackPanel Grid.Row="3" Margin="0,18,0,0" Orientation="Horizontal" HorizontalAlignment="Right">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ClearNuGetLocalResourcesWindow.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ClearNuGetLocalResourcesWindow.xaml
@@ -53,8 +53,24 @@
     <TextBlock Grid.Row="0" Margin="0" Text="{x:Static nuget:Resources.ShowMessage_LocalsCommandWorking}" Visibility="{Binding IsCommandComplete, Converter={StaticResource NegatedBooleanToVisibilityConverter}}"/>
 
     <!-- Content -->
-    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-      <TextBlock TextWrapping="Wrap" Text="{Binding CommandCompleteText}" Visibility="{Binding IsCommandComplete, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Visibility="{Binding IsCommandComplete, Converter={StaticResource BooleanToVisibilityConverter}}">
+      <StackPanel>
+        <TextBlock TextWrapping="Wrap" Text="{Binding CommandCompleteText}" />
+
+        <!-- When the operation fails, show more information and a help link -->
+        <TextBlock
+          Margin="0,9,0,9"
+          TextWrapping="Wrap"
+          Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}">
+          <Run Text="{x:Static nuget:Resources.ShowMessage_LocalsCommandMoreInformation}" />
+          <shell_controls:Hyperlink
+            NavigateUri="https://aka.ms/troubleshoot_nuget_cache"
+            Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+            AutomationProperties.LabeledBy="{Binding ElementName=_commandTextBlock}">
+              <Run Text="https://aka.ms/troubleshoot_nuget_cache" />
+          </shell_controls:Hyperlink>
+        </TextBlock>
+      </StackPanel>
     </ScrollViewer>
 
     <!-- Progress Bar -->
@@ -82,18 +98,6 @@
           </Style>
         </vsui:LiveTextBlock.Resources>
       </vsui:LiveTextBlock>
-
-      <TextBlock
-        Margin="0,0,0,9"
-        Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}">
-        <Run Text="{x:Static nuget:Resources.ShowMessage_LocalsCommandMoreInformation}" />
-        <shell_controls:Hyperlink
-          NavigateUri="https://aka.ms/troubleshoot_nuget_cache"
-          Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
-          AutomationProperties.LabeledBy="{Binding ElementName=_commandTextBlock}">
-            <Run Text="https://aka.ms/troubleshoot_nuget_cache" />
-        </shell_controls:Hyperlink>
-      </TextBlock>
 
       <ProgressBar Height="20" AutomationProperties.Name="{x:Static nuget:Resources.ShowMessage_LocalsCommandWorking}" IsIndeterminate="{Binding IsCommandComplete, Converter={StaticResource InverseBooleanConverter}}" Value="100" />
     </StackPanel>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ClearNuGetLocalResourcesWindow.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ClearNuGetLocalResourcesWindow.xaml.cs
@@ -3,6 +3,9 @@
 
 #nullable enable
 
+using System.Diagnostics;
+using System.Windows.Documents;
+using System.Windows.Input;
 using Microsoft.VisualStudio.PlatformUI;
 using NuGet.PackageManagement.UI.ViewModels;
 using NuGet.VisualStudio.Telemetry;
@@ -29,6 +32,16 @@ namespace NuGet.PackageManagement.UI
         private void CloseButton_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             Close();
+        }
+
+        private void ExecuteOpenExternalLink(object sender, ExecutedRoutedEventArgs e)
+        {
+            var hyperlink = (Hyperlink)e.OriginalSource;
+            if (hyperlink.NavigateUri != null)
+            {
+                Process.Start(hyperlink.NavigateUri.AbsoluteUri);
+                e.Handled = true;
+            }
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ClearNuGetLocalResourcesWindow.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ClearNuGetLocalResourcesWindow.xaml.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using System.Diagnostics;
 using System.Windows.Documents;
 using System.Windows.Input;
 using Microsoft.VisualStudio.PlatformUI;
@@ -36,10 +35,11 @@ namespace NuGet.PackageManagement.UI
 
         private void ExecuteOpenExternalLink(object sender, ExecutedRoutedEventArgs e)
         {
-            var hyperlink = (Hyperlink)e.OriginalSource;
-            if (hyperlink.NavigateUri != null)
+            var hyperlink = e.OriginalSource as Hyperlink;
+            if (hyperlink != null
+                && hyperlink.NavigateUri != null)
             {
-                Process.Start(hyperlink.NavigateUri.AbsoluteUri);
+                UIUtility.LaunchExternalLink(hyperlink.NavigateUri);
                 e.Handled = true;
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.cs.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">Vymazání úložiště NuGet selhalo v {0}. 
+Error: {1}</source>
+        <target state="needs-review-translation">Vymazání úložiště NuGet selhalo v {0}. 
 Chyba: {1}
 Další nápovědu najdete na adrese https://aka.ms/troubleshoot_nuget_cache.</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.de.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">Fehler beim Löschen des NuGet-Speicher bei {0}. 
+Error: {1}</source>
+        <target state="needs-review-translation">Fehler beim Löschen des NuGet-Speicher bei {0}. 
 Fehler: {1}
 Weitere Informationen finden Sie unter https://aka.ms/troubleshoot_nuget_cache.</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.es.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">Error al borrar el almacenamiento de NuGet en {0}. 
+Error: {1}</source>
+        <target state="needs-review-translation">Error al borrar el almacenamiento de NuGet en {0}. 
 Error: {1}
 Consulte https://aka.ms/troubleshoot_nuget_cache para obtener ayuda.</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.fr.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">Nous n’avons pas pu effacer des caches NuGet de {0}. 
+Error: {1}</source>
+        <target state="needs-review-translation">Nous n’avons pas pu effacer des caches NuGet de {0}. 
 Erreur :{1}
 Consultez https://aka.ms/troubleshoot_nuget_cache pour obtenir de l’aide.</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.it.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">La pulizia dello spazio di archiviazione NuGet non è riuscita in {0}. 
+Error: {1}</source>
+        <target state="needs-review-translation">La pulizia dello spazio di archiviazione NuGet non è riuscita in {0}. 
 Errore: {1}
 Per altre informazioni, vedere https://aka.ms/troubleshoot_nuget_cache.</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ja.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">NuGet ストレージをクリアできませんでした ({0})。
+Error: {1}</source>
+        <target state="needs-review-translation">NuGet ストレージをクリアできませんでした ({0})。
 エラー: {1}
 詳しいヘルプについては、https://aka.ms/troubleshoot_nuget_cache をご覧ください。</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ko.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">{0}에서 NuGet 스토리지 지우기에 실패했습니다. 
+Error: {1}</source>
+        <target state="needs-review-translation">{0}에서 NuGet 스토리지 지우기에 실패했습니다. 
 오류: {1}
 자세한 도움말은 https://aka.ms/troubleshoot_nuget_cache를 참조하세요.</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pl.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">Czyszczenie pamięci podręcznych narzędzia NuGet nie powiodło się: {0}. 
+Error: {1}</source>
+        <target state="needs-review-translation">Czyszczenie pamięci podręcznych narzędzia NuGet nie powiodło się: {0}. 
 Błąd: {1}
 Aby uzyskać dodatkową pomoc, zobacz https://aka.ms/troubleshoot_nuget_cache.</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pt-BR.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">Falha ao limpar o armazenamento NuGet em {0}. 
+Error: {1}</source>
+        <target state="needs-review-translation">Falha ao limpar o armazenamento NuGet em {0}. 
 Erro: {1}
 Consulte https://aka.ms/troubleshoot_nuget_cache para obter mais ajuda.</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ru.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">Сбой очистки хранилища NuGet в {0}. 
+Error: {1}</source>
+        <target state="needs-review-translation">Сбой очистки хранилища NuGet в {0}. 
 Ошибка: {1}.
 Дополнительная справка: https://aka.ms/troubleshoot_nuget_cache.</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.tr.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">{0} konumundaki NuGet depolama alanını temizleme işlemi başarısız oldu. 
+Error: {1}</source>
+        <target state="needs-review-translation">{0} konumundaki NuGet depolama alanını temizleme işlemi başarısız oldu. 
 Hata: {1}
 Daha fazla yardım için https://aka.ms/troubleshoot_nuget_cache sayfasına bakın.</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hans.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">未能清理 {0} 处的 NuGet 存储。
+Error: {1}</source>
+        <target state="needs-review-translation">未能清理 {0} 处的 NuGet 存储。
 错误: {1}
 请参阅 https://aka.ms/troubleshoot_nuget_cache 以获取更多帮助。</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hant.xlf
@@ -904,14 +904,18 @@
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandFailure">
         <source>NuGet storage clear failed at {0}. 
-Error: {1}
-Please see https://aka.ms/troubleshoot_nuget_cache for more help.</source>
-        <target state="translated">清除位於 {0} 的 NuGet 儲存體失敗。
+Error: {1}</source>
+        <target state="needs-review-translation">清除位於 {0} 的 NuGet 儲存體失敗。
 錯誤: {1}
 如需詳細說明，請參閱 https://aka.ms/troubleshoot_nuget_cache。</target>
         <note>{0} :error message;
 {1}: date and time
 </note>
+      </trans-unit>
+      <trans-unit id="ShowMessage_LocalsCommandMoreInformation">
+        <source>For more information, see</source>
+        <target state="new">For more information, see</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMessage_LocalsCommandSuccess">
         <source>NuGet storage cleared at {0}</source>

--- a/src/NuGet.Clients/NuGet.Tools/Commands/ClearNuGetLocalResourcesCommand.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Commands/ClearNuGetLocalResourcesCommand.cs
@@ -125,9 +125,7 @@ namespace NuGet.Tools.Commands
             var localsArgs = new LocalsArgs(arguments, settings, logInformation, logError, clear: true, list: false);
 
             LocalsCommandRunner localsCommandRunner = new();
-            //localsCommandRunner.ExecuteCommand(localsArgs);
-            await Task.Delay(500);
-            throw new ApplicationException("testing");
+            localsCommandRunner.ExecuteCommand(localsArgs);
         }
 
         private void LogError(string message)

--- a/src/NuGet.Clients/NuGet.Tools/Commands/ClearNuGetLocalResourcesCommand.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Commands/ClearNuGetLocalResourcesCommand.cs
@@ -125,7 +125,9 @@ namespace NuGet.Tools.Commands
             var localsArgs = new LocalsArgs(arguments, settings, logInformation, logError, clear: true, list: false);
 
             LocalsCommandRunner localsCommandRunner = new();
-            localsCommandRunner.ExecuteCommand(localsArgs);
+            //localsCommandRunner.ExecuteCommand(localsArgs);
+            await Task.Delay(500);
+            throw new ApplicationException("testing");
         }
 
         private void LogError(string message)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3387

## Description

Separates the text out of the command completion string, and reworded it a bit:
> For more information, see https://aka.ms/troubleshoot_nuget_cache

Error example:
<img width="586" height="193" alt="image" src="https://github.com/user-attachments/assets/a9c24b98-67ea-4da7-9f23-8b35ffbf1495" />

Success still works:
<img width="586" height="193" alt="image" src="https://github.com/user-attachments/assets/08fe43d6-1e16-4157-96c9-5912820c354f" />


I tested that the screen reader still announces the status and does so upon completion. However, all screen readers didn't automatically announce the new quoted string above with the aka.ms link, but I'm not sure that's necessary.
When tabbing to the hyperlink, it was announced. Additionally, Accessibility Insights did not find an issue:
<img width="2321" height="610" alt="image" src="https://github.com/user-attachments/assets/92997ed7-dc0f-4b5d-93b0-1469880f46d8" />
Regardless, this PR is better as it provides a launchable link

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
