### PR TITLE
Fix dotnet integration tests affected by new slnx default

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -138,10 +138,10 @@ namespace Dotnet.Integration.Test
             => RestoreProjectOrSolution(workingDirectory, $"{projectName}.csproj", args, expectSuccess: true, testOutputHelper: testOutputHelper);
 
         internal CommandRunnerResult RestoreSolutionExpectFailure(string workingDirectory, string solutionName, string args = "", ITestOutputHelper testOutputHelper = null)
-            => RestoreProjectOrSolution(workingDirectory, $"{solutionName}.sln", args, expectSuccess: false, testOutputHelper: testOutputHelper);
+            => RestoreProjectOrSolution(workingDirectory, $"{solutionName}.slnx", args, expectSuccess: false, testOutputHelper: testOutputHelper);
 
         internal CommandRunnerResult RestoreSolutionExpectSuccess(string workingDirectory, string solutionName, string args = "", ITestOutputHelper testOutputHelper = null)
-            => RestoreProjectOrSolution(workingDirectory, $"{solutionName}.sln", args, expectSuccess: true, testOutputHelper: testOutputHelper);
+            => RestoreProjectOrSolution(workingDirectory, $"{solutionName}.slnx", args, expectSuccess: true, testOutputHelper: testOutputHelper);
 
         private CommandRunnerResult RestoreProjectOrSolution(string workingDirectory, string fileName, string args, bool expectSuccess, ITestOutputHelper testOutputHelper = null)
             => RunDotnet(workingDirectory, $"restore {fileName} {args ?? string.Empty} -nodereuse:false", expectSuccess, testOutputHelper: testOutputHelper);
@@ -310,10 +310,10 @@ namespace Dotnet.Integration.Test
             => PackProjectOrSolution(workingDirectory, $"{projectName}.csproj", args, expectSuccess: true, nuspecOutputPath, configuration, testOutputHelper);
 
         internal CommandRunnerResult PackSolutionExpectFailure(string workingDirectory, string solutionName, string args = "", string nuspecOutputPath = "obj", string configuration = "Debug", ITestOutputHelper testOutputHelper = null)
-            => PackProjectOrSolution(workingDirectory, $"{solutionName}.sln", args, expectSuccess: false, nuspecOutputPath, configuration, testOutputHelper);
+            => PackProjectOrSolution(workingDirectory, $"{solutionName}.slnx", args, expectSuccess: false, nuspecOutputPath, configuration, testOutputHelper);
 
         internal CommandRunnerResult PackSolutionExpectSuccess(string workingDirectory, string solutionName, string args = "", string nuspecOutputPath = "obj", string configuration = "Debug", ITestOutputHelper testOutputHelper = null)
-            => PackProjectOrSolution(workingDirectory, $"{solutionName}.sln", args, expectSuccess: true, nuspecOutputPath, configuration, testOutputHelper);
+            => PackProjectOrSolution(workingDirectory, $"{solutionName}.slnx", args, expectSuccess: true, nuspecOutputPath, configuration, testOutputHelper);
 
         private CommandRunnerResult PackProjectOrSolution(string workingDirectory, string file, string args, bool expectSuccess, string nuspecOutputPath = "obj", string configuration = "Debug", ITestOutputHelper testOutputHelper = null)
         {
@@ -337,10 +337,10 @@ namespace Dotnet.Integration.Test
         }
 
         internal void BuildSolutionExpectFailure(string workingDirectory, string solutionName, string args = "", bool? appendRidToOutputPath = false, ITestOutputHelper testOutputHelper = null)
-            => BuildProjectOrSolution(workingDirectory, $"{solutionName}.sln", args, expectSuccess: false, appendRidToOutputPath, testOutputHelper);
+            => BuildProjectOrSolution(workingDirectory, $"{solutionName}.slnx", args, expectSuccess: false, appendRidToOutputPath, testOutputHelper);
 
         internal void BuildSolutionExpectSuccess(string workingDirectory, string solutionName, string args = "", bool? appendRidToOutputPath = false, ITestOutputHelper testOutputHelper = null)
-            => BuildProjectOrSolution(workingDirectory, $"{solutionName}.sln", args, expectSuccess: true, appendRidToOutputPath, testOutputHelper);
+            => BuildProjectOrSolution(workingDirectory, $"{solutionName}.slnx", args, expectSuccess: true, appendRidToOutputPath, testOutputHelper);
 
         private CommandRunnerResult BuildProjectOrSolution(string workingDirectory, string file, string args, bool expectSuccess = true, bool? appendRidToOutputPath = false, ITestOutputHelper testOutputHelper = null)
         {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1246,7 +1246,7 @@ EndGlobal";
                     child.Save();
                 }
                 projectRoot.Save();
-                var solutionPath = Path.Combine(pathContext.SolutionRoot, "solution.sln");
+                var solutionPath = Path.Combine(pathContext.SolutionRoot, "solution.slnx");
                 _dotnetFixture.RunDotnetExpectSuccess(pathContext.SolutionRoot, $"new sln -n solution", testOutputHelper: _testOutputHelper);
 
                 foreach (var child in projects.Values)
@@ -1455,7 +1455,7 @@ EndGlobal";
                 _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName1}", testOutputHelper: _testOutputHelper);
                 _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName2}", testOutputHelper: _testOutputHelper);
                 _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName3}", testOutputHelper: _testOutputHelper);
-                var targetPath = Path.Combine(testDirectory, "test.sln");
+                var targetPath = Path.Combine(testDirectory, "test.slnx");
                 var standardDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "standard.dgspec.json");
                 var staticGraphDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "staticGraph.dgspec.json");
                 _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{standardDgSpecFile}\" {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);
@@ -1508,7 +1508,7 @@ EndGlobal";
                 _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName1}", testOutputHelper: _testOutputHelper);
                 _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName2}", testOutputHelper: _testOutputHelper);
                 _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"sln add {projectName3}", testOutputHelper: _testOutputHelper);
-                var targetPath = Path.Combine(testDirectory, "test.sln");
+                var targetPath = Path.Combine(testDirectory, "test.slnx");
                 var standardDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "standard.dgspec.json");
                 var staticGraphDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "staticGraph.dgspec.json");
                 _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"msbuild /nologo /t:GenerateRestoreGraphFile /p:RestoreGraphOutputPath=\"{staticGraphDgSpecFile}\" /p:RestoreUseStaticGraphEvaluation={useStaticGraphRestore} {targetPath}", environmentVariables, testOutputHelper: _testOutputHelper);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -184,13 +184,13 @@ namespace Dotnet.Integration.Test
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"restore {solutionName}.slnx", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RestoreSolutionExpectSuccess(testDirectory, solutionName, testOutputHelper: _testOutputHelper);
 
-                var nupkgPath = Path.Combine(projectFolder, @"bin\Release", $"{projectName}.1.0.0.nupkg");
-                var nuspecPath = Path.Combine(projectFolder, @"obj\Release", $"{projectName}.1.0.0.nuspec");
+                var nupkgPath = Path.Combine(projectFolder, @"bin\Debug", $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(projectFolder, @"obj\Debug", $"{projectName}.1.0.0.nuspec");
 
                 // Act
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"pack {solutionName}.slnx", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.PackSolutionExpectSuccess(testDirectory, solutionName, nuspecOutputPath: null, testOutputHelper: _testOutputHelper);
 
                 // Assert
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the default place");
@@ -240,17 +240,17 @@ namespace Dotnet.Integration.Test
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"restore {solutionName}.slnx", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"build {solutionName}.slnx -c Release", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RestoreSolutionExpectSuccess(testDirectory, solutionName, testOutputHelper: _testOutputHelper);
+                _dotnetFixture.BuildSolutionExpectSuccess(testDirectory, solutionName, testOutputHelper: _testOutputHelper);
 
                 // With default output path within project folder
 
                 // Arrange
-                var nupkgPath = Path.Combine(projectFolder, @"bin\Release", $"{projectName}.1.0.0.nupkg");
-                var nuspecPath = Path.Combine(projectFolder, @"obj\Release", $"{projectName}.1.0.0.nuspec");
+                var nupkgPath = Path.Combine(projectFolder, @"bin\Debug", $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(projectFolder, @"obj\Debug", $"{projectName}.1.0.0.nuspec");
 
                 // Act
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"pack {solutionName}.slnx --no-build", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.PackSolutionExpectSuccess(testDirectory, solutionName, "--no-build", nuspecOutputPath: null, testOutputHelper: _testOutputHelper);
 
                 // Assert
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the default place");
@@ -3323,12 +3323,12 @@ namespace ClassLibrary
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"restore {solutionName}.slnx", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RestoreSolutionExpectSuccess(testDirectory, solutionName, testOutputHelper: _testOutputHelper);
                 // Act
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"pack {solutionName}.slnx", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.PackSolutionExpectSuccess(testDirectory, solutionName, testOutputHelper: _testOutputHelper);
 
-                var nupkgPath = Path.Combine(projectFolder, "bin", "Release", $"{projectName}.1.0.0.nupkg");
-                var nuspecPath = Path.Combine(projectFolder, "obj", "Release", $"{projectName}.1.0.0.nuspec");
+                var nupkgPath = Path.Combine(projectFolder, "bin", "Debug", $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(projectFolder, "obj", $"{projectName}.1.0.0.nuspec");
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
                 Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -4818,7 +4818,7 @@ namespace ClassLibrary
         [PlatformTheory(Platform.Windows)]
         [InlineData("Microsoft.NETCore.App", "true", "netcoreapp3.0", "", "netcoreapp3.0")]
         [InlineData("Microsoft.NETCore.App", "false", "netcoreapp3.0", "", "")]
-        [InlineData("Microsoft.WindowsDesktop.App", "true", "netstandard2.1;netcoreapp3.0", "netcoreapp3.0", "netcoreapp3.0")]
+        [InlineData("Microsoft.WindowsDesktop.App", "true", "netstandard2.0;netcoreapp3.0", "netcoreapp3.0", "netcoreapp3.0")]
         [InlineData("Microsoft.WindowsDesktop.App;Microsoft.AspNetCore.App", "true;true", "netcoreapp3.0", "netcoreapp3.0", "netcoreapp3.0")]
         [InlineData("Microsoft.WindowsDesktop.App.WPF;Microsoft.WindowsDesktop.App.WindowsForms", "true;false", "netcoreapp3.0", "", "netcoreapp3.0")]
         public void PackCommand_PackProject_PacksFrameworkReferences(string frameworkReferences, string packForFrameworkRefs, string targetFrameworks, string conditionalFramework, string expectedTargetFramework)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -167,9 +167,9 @@ namespace Dotnet.Integration.Test
                 _dotnetFixture.CreateDotnetNewProject(Path.Combine(testDirectory.Path, reference2Folder), referencedProject2, "classlib", testOutputHelper: _testOutputHelper);
 
                 _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"new sln -n {solutionName}", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.sln add {projectFileRelativ}", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.sln add {referencedProject1RelativDir}", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.sln add {referencedProject2RelativDir}", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.slnx add {projectFileRelativ}", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.slnx add {referencedProject1RelativDir}", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.slnx add {referencedProject2RelativDir}", testOutputHelper: _testOutputHelper);
 
                 var projectFile = Path.Combine(testDirectory.Path, projectFileRelativ);
                 using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
@@ -184,13 +184,13 @@ namespace Dotnet.Integration.Test
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
-                _dotnetFixture.RestoreSolutionExpectSuccess(testDirectory, solutionName, testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"restore {solutionName}.slnx", testOutputHelper: _testOutputHelper);
 
-                var nupkgPath = Path.Combine(projectFolder, @"bin\Debug", $"{projectName}.1.0.0.nupkg");
-                var nuspecPath = Path.Combine(projectFolder, @"obj\Debug", $"{projectName}.1.0.0.nuspec");
+                var nupkgPath = Path.Combine(projectFolder, @"bin\Release", $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(projectFolder, @"obj\Release", $"{projectName}.1.0.0.nuspec");
 
                 // Act
-                _dotnetFixture.PackSolutionExpectSuccess(testDirectory, solutionName, nuspecOutputPath: null, testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"pack {solutionName}.slnx", testOutputHelper: _testOutputHelper);
 
                 // Assert
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the default place");
@@ -223,9 +223,9 @@ namespace Dotnet.Integration.Test
                 _dotnetFixture.CreateDotnetNewProject(Path.Combine(testDirectory.Path, reference2Folder), referencedProject2, "classlib", testOutputHelper: _testOutputHelper);
 
                 _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"new sln -n {solutionName}", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.sln add {projectFileRelativ}", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.sln add {referencedProject1RelativDir}", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.sln add {referencedProject2RelativDir}", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.slnx add {projectFileRelativ}", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.slnx add {referencedProject1RelativDir}", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.slnx add {referencedProject2RelativDir}", testOutputHelper: _testOutputHelper);
 
                 var projectFile = Path.Combine(testDirectory.Path, projectFileRelativ);
                 using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
@@ -240,17 +240,17 @@ namespace Dotnet.Integration.Test
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
-                _dotnetFixture.RestoreSolutionExpectSuccess(testDirectory, solutionName, testOutputHelper: _testOutputHelper);
-                _dotnetFixture.BuildSolutionExpectSuccess(testDirectory, solutionName, testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"restore {solutionName}.slnx", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"build {solutionName}.slnx -c Release", testOutputHelper: _testOutputHelper);
 
                 // With default output path within project folder
 
                 // Arrange
-                var nupkgPath = Path.Combine(projectFolder, @"bin\Debug", $"{projectName}.1.0.0.nupkg");
-                var nuspecPath = Path.Combine(projectFolder, @"obj\Debug", $"{projectName}.1.0.0.nuspec");
+                var nupkgPath = Path.Combine(projectFolder, @"bin\Release", $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(projectFolder, @"obj\Release", $"{projectName}.1.0.0.nuspec");
 
                 // Act
-                _dotnetFixture.PackSolutionExpectSuccess(testDirectory, solutionName, "--no-build", nuspecOutputPath: null, testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"pack {solutionName}.slnx --no-build", testOutputHelper: _testOutputHelper);
 
                 // Assert
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the default place");
@@ -3292,9 +3292,9 @@ namespace ClassLibrary
                 _dotnetFixture.CreateDotnetNewProject(Path.Combine(testDirectory.Path, rederence2Folder), referencedProject2, "classlib -f netstandard2.0", testOutputHelper: _testOutputHelper);
 
                 _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"new sln -n {solutionName}", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.sln add {projectFileRelativ}", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.sln add {referencedProject1RelativDir}", testOutputHelper: _testOutputHelper);
-                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.sln add {referencedProject2RelativDir}", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.slnx add {projectFileRelativ}", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.slnx add {referencedProject1RelativDir}", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory.Path, $"sln {solutionName}.slnx add {referencedProject2RelativDir}", testOutputHelper: _testOutputHelper);
 
                 var projectFile = Path.Combine(testDirectory.Path, projectFileRelativ);
                 using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
@@ -3323,12 +3323,12 @@ namespace ClassLibrary
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
-                _dotnetFixture.RestoreSolutionExpectSuccess(testDirectory, solutionName, testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"restore {solutionName}.slnx", testOutputHelper: _testOutputHelper);
                 // Act
-                _dotnetFixture.PackSolutionExpectSuccess(testDirectory, solutionName, testOutputHelper: _testOutputHelper);
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, $"pack {solutionName}.slnx", testOutputHelper: _testOutputHelper);
 
-                var nupkgPath = Path.Combine(projectFolder, "bin", "Debug", $"{projectName}.1.0.0.nupkg");
-                var nuspecPath = Path.Combine(projectFolder, "obj", $"{projectName}.1.0.0.nuspec");
+                var nupkgPath = Path.Combine(projectFolder, "bin", "Release", $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(projectFolder, "obj", "Release", $"{projectName}.1.0.0.nuspec");
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
                 Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: failing CI tests

## Description

NuGet's DotNet.Integration.Tests project by design gets the latest build of the .NET SDK (that corresponds to the version of NuGet being built), overwrites the NuGet.* dlls with NuGet's local build, and runs dotnet CLI tests, to test integration.  A bunch of our tests assumed that `dotnet new sln` will create a sln file, which broke once the sdk started writing `.slnx` instead.  This PR fixes those tests.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
