### PR TITLE
No longer preserve Invalid Package Source Mappings during Edit

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingPage.cs
@@ -168,7 +168,8 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 {
                     string packageIdOrPattern = packageSourceMapping.Key;
                     List<PackageSourceContextInfo> packageSources = packageSourceMapping.Value;
-                    List<string> packageSourceNames = packageSources.Select(source => source.Name).ToList();
+                    List<string> packageSourceNames = new(packageSources.Count);
+                    packageSourceNames.AddRange(packageSources.Select(source => source.Name));
 
                     var dict = new Dictionary<string, object>(capacity: 2)
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingPage.cs
@@ -115,9 +115,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
                 var sourceNamesToPackagePatterns = new Dictionary<string, List<PackagePatternItem>>();
 
-                // Keep any existing source mappings for package sources that are not configured.
-                PackageSourceMappingUtility.PreserveInvalidPackageSourceMappings(sourceNamesToPackagePatterns, existingPackageSources, originalPackageSourceMappings);
-
                 List<PackageSourceMappingSourceItem> packageSourceMappingSourceItems =
                     PackageSourceMappingUtility.ConvertPackageIdAndSourcesToSourceMappingSourceItems(sourceNamesToPackagePatterns, packagePatternToSources);
 
@@ -171,7 +168,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 {
                     string packageIdOrPattern = packageSourceMapping.Key;
                     List<PackageSourceContextInfo> packageSources = packageSourceMapping.Value;
-                    IEnumerable<string> packageSourceNames = packageSources.Select(source => source.Name);
+                    List<string> packageSourceNames = packageSources.Select(source => source.Name).ToList();
 
                     var dict = new Dictionary<string, object>(capacity: 2)
                     {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceMappingUtility.cs
@@ -32,31 +32,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return packageSourceMappingDictionary;
         }
 
-        /// <summary>
-        /// For existing package source mappings configured with package sources which don't exist, keep those invalid package source mappings in place.
-        /// Add any <paramref name="originalPackageSourceMappings"/> configured with package sources not in <paramref name="existingPackageSources"/>
-        /// back into <paramref name="sourceNamesToPackagePatterns"/>.
-        /// </summary>
-        internal static void PreserveInvalidPackageSourceMappings(
-            Dictionary<string, List<PackagePatternItem>> sourceNamesToPackagePatterns,
-            IReadOnlyList<PackageSource> existingPackageSources,
-            IReadOnlyList<PackageSourceMappingSourceItem> originalPackageSourceMappings)
-        {
-            HashSet<string> configuredPackageSourceNames = existingPackageSources
-                .Select(packageSource => packageSource.Name)
-                .ToHashSet<string>();
-
-            foreach (PackageSourceMappingSourceItem originalMapping in originalPackageSourceMappings)
-            {
-                string originalSourceName = originalMapping.Key;
-                if (!configuredPackageSourceNames.Contains(originalSourceName, StringComparer.OrdinalIgnoreCase))
-                {
-                    // Keep this invalid package source mapping.
-                    AddOrUpdateSourceWithPackagePatterns(sourceNamesToPackagePatterns, originalMapping.Patterns, originalSourceName);
-                }
-            }
-        }
-
         internal static List<PackageSourceMappingSourceItem> ConvertPackageIdAndSourcesToSourceMappingSourceItems(
             Dictionary<string, List<PackagePatternItem>> sourceNamesToPackagePatterns,
             IReadOnlyList<(string packageIdOrPattern, IEnumerable<string> sources)> packagePatternToSources)

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourceMappingPageTests.cs
@@ -306,23 +306,24 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             string addNewPackageSourceName4 = "unitTestingSourceName4";
             string packageIdPattern = "Contoso.*";
 
-            var unitTestingSourceMapping1 = new PackageSourceMappingSourceItem("unitTestingSourceName1", [new PackagePatternItem(packageIdPattern)]);
-            var nonExistantSourceInSourceMapping2 = new PackageSourceMappingSourceItem("nonExistantSourceName2", [new PackagePatternItem(packageIdPattern)]);
-            var unitTestingSourceMapping3 = new PackageSourceMappingSourceItem("unitTestingSourceName3", [new PackagePatternItem(packageIdPattern)]);
+            string sourceName1 = "unitTestingSourceName1";
+            string sourceUrl1 = "https://testsource1.com";
+
+            string nonExistantSourceName2 = "nonExistantSourceName2";
+            // nonExistantSourceName2 doesn't have a URL as it will not be a configured package source.
+
+            string sourceName3 = "unitTestingSourceName3";
+            string sourceUrl3 = "https://testsource3.com";
+
+            var unitTestingSourceMapping1 = new PackageSourceMappingSourceItem(sourceName1, [new PackagePatternItem(packageIdPattern)]);
+            var nonExistantSourceInSourceMapping2 = new PackageSourceMappingSourceItem(nonExistantSourceName2, [new PackagePatternItem(packageIdPattern)]);
+            var unitTestingSourceMapping3 = new PackageSourceMappingSourceItem(sourceName3, [new PackagePatternItem(packageIdPattern)]);
 
             _vsSettings.AddOrUpdate(ConfigurationConstants.PackageSourceMapping, unitTestingSourceMapping1);
             _vsSettings.AddOrUpdate(ConfigurationConstants.PackageSourceMapping, nonExistantSourceInSourceMapping2);
             _vsSettings.AddOrUpdate(ConfigurationConstants.PackageSourceMapping, unitTestingSourceMapping3);
 
             PackageSourceMappingPage instance = CreateInstance(_vsSettings);
-
-            string sourceName1 = "unitTestingSourceName1";
-            string sourceUrl1 = "https://testsource1.com";
-
-            // nonExistantSourceName2 is not added here intentionally.
-
-            string sourceName3 = "unitTestingSourceName3";
-            string sourceUrl3 = "https://testsource3.com";
 
             _packageSources =
             [
@@ -338,7 +339,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             sourceMappingDictionary1[PackageSourceMappingPage.MonikerPackageId] = unitTestingSourceMapping1.Patterns.Single().Pattern;
             sourceMappingDictionary1[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { unitTestingSourceMapping1.Key };
 
-            // nonExistantSourceName is not known to Unified Settings, so it is not part of the request to SetValue.
+            Dictionary<string, object> sourceMappingDictionary2 = new Dictionary<string, object>();
+            sourceMappingDictionary2[PackageSourceMappingPage.MonikerPackageId] = nonExistantSourceInSourceMapping2.Patterns.Single().Pattern;
+            sourceMappingDictionary2[PackageSourceMappingPage.MonikerSourceNames] = new List<string>() { nonExistantSourceInSourceMapping2.Key };
 
             // Unchanged package source mapping.
             Dictionary<string, object> sourceMappingDictionary3 = new Dictionary<string, object>();
@@ -354,25 +357,50 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
                 new List<IDictionary<string, object>>(capacity: 3)
                 {
                     sourceMappingDictionary1, // Pre-existing and unchanged.
-                    // No source mapping is sent by Unified Settings for nonExistantSourceName2.
+                    sourceMappingDictionary2, // Pre-existing and unchanged, with an unconfigured Package Source.
                     sourceMappingDictionary3, // Pre-existing and unchanged.
                     sourceMappingDictionary4 // A newly added source mapping.
                 };
 
             // Act
+            ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>> resultGetValueBeforeAddNew =
+                await instance.GetValueAsync<IReadOnlyList<IDictionary<string, object>>>(
+                    moniker: PackageSourceMappingPage.MonikerPackageSourceMapping,
+                    cancellationToken: CancellationToken.None);
+
             ExternalSettingOperationResult result = await instance.SetValueAsync(
                 PackageSourceMappingPage.MonikerPackageSourceMapping,
                 sourceMappingDictionaryList,
                 CancellationToken.None);
 
             // Assert
+
+            resultGetValueBeforeAddNew.Should().NotBeNull();
+            resultGetValueBeforeAddNew.Should().BeOfType<ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>>.Success>();
+            IReadOnlyList<IDictionary<string, object>> successResultGetValueBeforeAddNew =
+                ((ExternalSettingOperationResult<IReadOnlyList<IDictionary<string, object>>>.Success)resultGetValueBeforeAddNew)
+                .Value;
+
+            // Initially, 1 source mapping exists for 3 package sources.
+            // 1 of these package sources is not configured.
+            successResultGetValueBeforeAddNew.Should().HaveCount(1);
+            successResultGetValueBeforeAddNew[0].Should().ContainKey(PackageSourceMappingPage.MonikerPackageId);
+            successResultGetValueBeforeAddNew[0].TryGetValue(PackageSourceMappingPage.MonikerPackageId, out object? packageIdObject).Should().BeTrue();
+            ((string)packageIdObject).Should().Be(packageIdPattern);
+
+            successResultGetValueBeforeAddNew[0].Should().ContainKey(PackageSourceMappingPage.MonikerSourceNames);
+            successResultGetValueBeforeAddNew[0].TryGetValue(PackageSourceMappingPage.MonikerSourceNames, out object? sourceNamesObject).Should().BeTrue();
+            var sourceNamesBeforeAddNew = ((List<string>)sourceNamesObject);
+            sourceNamesBeforeAddNew.Should().HaveCount(3);
+            sourceNamesBeforeAddNew.Should().ContainEquivalentOf(sourceName1);
+            sourceNamesBeforeAddNew.Should().ContainEquivalentOf(nonExistantSourceName2);
+            sourceNamesBeforeAddNew.Should().ContainEquivalentOf(sourceName3);
+
+            // The customer added a new package source mapping, so now 4 total are expected.
             result.Should().NotBeNull();
             result.Should().BeOfType<ExternalSettingOperationResult.Success>();
-
             IReadOnlyList<PackageSourceMappingSourceItem> packageSourceMappingItems = instance._packageSourceMappingProvider.GetPackageSourceMappingItems();
-
             packageSourceMappingItems.Should().HaveCount(4);
-
             packageSourceMappingItems.Should().Contain(unitTestingSourceMapping1);
             packageSourceMappingItems.Should().Contain(nonExistantSourceInSourceMapping2);
             packageSourceMappingItems.Should().Contain(unitTestingSourceMapping3);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3386

## Description

Originally, Unified Settings was not sending our API invalid source mappings for package sources that were not configured.
The effect was any edit would delete invalid mappings, so those were being added back with a temporary utility method.

Now that this behavior has changed, we need to stop adding back invalid mappings. The Issue being fixed highlights this, where trying to remove an invalid source mapping appears to remove the item, but does not update it in the NuGet.Config.

This PR simply stops doing the lookup and adding back of invalid mappings. 

- Editing an Item with an invalid package source still shows the error as before:

  <img width="370" height="427" alt="image" src="https://github.com/user-attachments/assets/b7013e42-db6c-492d-b3c1-41023850aa42" />


- And either toggling a valid source, or adding another valid source clears that error, and removes the invalid source in the NuGet.Config when pressing Save:

  <img width="370" height="355" alt="image" src="https://github.com/user-attachments/assets/04ddc7aa-9695-4409-acd4-43bcb0cfb361" />


### Additional change

I also added a `ToList()` on the list of package sources we send to Unified Settings. This was a LINQ Where expression, which apparently worked within USX somehow, but I believe it's better to just allocate here and have a proper List.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
