### PR TITLE
Rename _RestorePackagePruningDefault to RestorePackagePruningDefault

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -338,7 +338,7 @@ namespace NuGet.SolutionRestoreManager
 
         internal static bool IsPruningEnabledGlobally(IReadOnlyList<IVsTargetFrameworkInfo4> tfms)
         {
-            foreach (var value in GetNonEvaluatedPropertyOrNull(tfms, "_RestorePackagePruningDefault", s => s))
+            foreach (var value in GetNonEvaluatedPropertyOrNull(tfms, "RestorePackagePruningDefault", s => s))
             {
                 if (value is not null && MSBuildStringUtility.IsTrue(value))
                 {

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -1082,7 +1082,7 @@ namespace NuGet.Build.Tasks.Console
         {
             foreach (var item in innerBuilds.NoAllocEnumerate())
             {
-                if (item.IsPropertyTrue("_RestorePackagePruningDefault"))
+                if (item.IsPropertyTrue("RestorePackagePruningDefault"))
                 {
                     return true;
                 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -83,7 +83,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Package pruning is enabled for all projects targeting .NET 10 or greater, including multi-targeted projects. -->
   <PropertyGroup>
     <!-- We only set the RestoreEnablePackagePruning default for single TFM projects. 
-    For multi-targeted projects that requires knowing the other inner builds, so we rely on _RestorePackagePruningDefault. -->
+    For multi-targeted projects that requires knowing the other inner builds, so we rely on RestorePackagePruningDefault. -->
     <RestoreEnablePackagePruning Condition="'$(RestoreEnablePackagePruning)' == ''
                     AND '$(UsingMicrosoftNETSdk)' == 'true'
                     AND '$(TargetFrameworks)' == ''
@@ -93,13 +93,13 @@ Copyright (c) .NET Foundation. All rights reserved.
                     AND ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0')))"
                     >true</RestoreEnablePackagePruning>
     <RestoreEnablePackagePruning Condition="$(RestoreEnablePackagePruning) == '' AND '$(TargetFrameworks)' == ''">false</RestoreEnablePackagePruning>
-    <_RestorePackagePruningDefault Condition="'$(UsingMicrosoftNETSdk)' == 'true'
+    <RestorePackagePruningDefault Condition="'$(UsingMicrosoftNETSdk)' == 'true'
                     AND '$(NuGetExeSkipSdkAnalysisLevelCheck)' != 'true'
                     AND '$(SdkAnalysisLevel)' != ''
                     AND $([MSBuild]::VersionGreaterThanOrEquals('$(SdkAnalysisLevel)', '10.0.100'))
                     AND ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0')))"
-                    >true</_RestorePackagePruningDefault>
-    <_RestorePackagePruningDefault Condition="'$(_RestorePackagePruningDefault)' == ''">false</_RestorePackagePruningDefault>
+                    >true</RestorePackagePruningDefault>
+    <RestorePackagePruningDefault Condition="'$(RestorePackagePruningDefault)' == ''">false</RestorePackagePruningDefault>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -1217,7 +1217,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RuntimeIdentifierGraphPath>$(RuntimeIdentifierGraphPath)</RuntimeIdentifierGraphPath>
         <WindowsTargetPlatformMinVersion>$(WindowsTargetPlatformMinVersion)</WindowsTargetPlatformMinVersion>
         <RestoreEnablePackagePruning>$(RestoreEnablePackagePruning)</RestoreEnablePackagePruning>
-        <_RestorePackagePruningDefault>$(_RestorePackagePruningDefault)</_RestorePackagePruningDefault>
+        <RestorePackagePruningDefault>$(RestorePackagePruningDefault)</RestorePackagePruningDefault>
         <NuGetAuditMode>$(NuGetAuditMode)</NuGetAuditMode>
       </_RestoreGraphEntry>
     </ItemGroup>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -727,7 +727,7 @@ namespace NuGet.Commands
             bool isPruningEnabledGlobally = false;
             foreach (var item in targetFrameworkInfos)
             {
-                if (IsPropertyTrue(item, "_RestorePackagePruningDefault"))
+                if (IsPropertyTrue(item, "RestorePackagePruningDefault"))
                 {
                     isPruningEnabledGlobally = true;
                     break;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
@@ -252,7 +252,7 @@ namespace NuGet.Commands.Restore.Utility
         {
             foreach (var item in project.TargetFrameworks.NoAllocEnumerate())
             {
-                if (item.Value.IsPropertyTrue("_RestorePackagePruningDefault"))
+                if (item.Value.IsPropertyTrue("RestorePackagePruningDefault"))
                 {
                     return true;
                 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -63,6 +63,6 @@ namespace NuGet.ProjectManagement
         public const string UsingMicrosoftNETSdk = nameof(UsingMicrosoftNETSdk);
         public const string RestoreUseLegacyDependencyResolver = nameof(RestoreUseLegacyDependencyResolver);
         public const string RestoreEnablePackagePruning = nameof(RestoreEnablePackagePruning);
-        public const string RestorePackagePruningDefault = "_" + nameof(RestorePackagePruningDefault);
+        public const string RestorePackagePruningDefault = nameof(RestorePackagePruningDefault);
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.PackageManagement/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-~const NuGet.ProjectManagement.ProjectBuildProperties.RestorePackagePruningDefault = "_RestorePackagePruningDefault" -> string
+~const NuGet.ProjectManagement.ProjectBuildProperties.RestorePackagePruningDefault = "RestorePackagePruningDefault" -> string

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetPropertyDefaultsTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetPropertyDefaultsTests.cs
@@ -134,7 +134,7 @@ namespace Msbuild.Integration.Test
         [InlineData("9.0.100", "net8.0", "false")]
         [InlineData("9.0.100", "netstandard2.1", "false")]
         [InlineData("9.0.100", "netstandard2.0", "false")]
-        public void PackagePruningDefaults__RestorePackagePruningDefault(string SdkAnalysisLevel, string targetFramework, string expected)
+        public void PackagePruningDefaults_RestorePackagePruningDefault(string SdkAnalysisLevel, string targetFramework, string expected)
         {
             // Arrange
             using var testDirectory = TestDirectory.Create();
@@ -145,7 +145,7 @@ namespace Msbuild.Integration.Test
             var projectFilePath = Path.Combine(testDirectory, "my.proj");
             File.WriteAllText(projectFilePath, projectText);
 
-            string args = $"{projectFilePath} -getProperty:_RestorePackagePruningDefault";
+            string args = $"{projectFilePath} -getProperty:RestorePackagePruningDefault";
             if (!string.IsNullOrEmpty(SdkAnalysisLevel)) args += $" -p:SdkAnalysisLevel={SdkAnalysisLevel}";
 
             var framework = NuGetFramework.Parse(targetFramework);

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -1306,7 +1306,7 @@ namespace NuGet.Build.Tasks.Console.Test
                         { "TargetFrameworkIdentifier", ".NETFramework" },
                         { "TargetFrameworkVersion", "v4.7.2" },
                         { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
-                        { "_RestorePackagePruningDefault", firstDefault },
+                        { "RestorePackagePruningDefault", firstDefault },
                     },
                     new Dictionary<string, IList<IMSBuildItem>>
                     {
@@ -1323,7 +1323,7 @@ namespace NuGet.Build.Tasks.Console.Test
                         { "TargetFrameworkIdentifier", ".NETFramework" },
                         { "TargetFrameworkVersion", "v4.7.1" },
                         { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.1" },
-                        { "_RestorePackagePruningDefault", secondDefault },
+                        { "RestorePackagePruningDefault", secondDefault },
                     },
                     new Dictionary<string, IList<IMSBuildItem>>
                     {
@@ -1339,7 +1339,7 @@ namespace NuGet.Build.Tasks.Console.Test
                         { "TargetFrameworkIdentifier", ".NETFramework" },
                         { "TargetFrameworkVersion", "v4.7.0" },
                         { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.0" },
-                        { "_RestorePackagePruningDefault", thirdDefault },
+                        { "RestorePackagePruningDefault", thirdDefault },
                     },
                     new Dictionary<string, IList<IMSBuildItem>>
                     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/nuget/home/issues/14511

## Description

_RestorePackagePruningDefault is not cached by CPS and leads to extra design time builds when the project is loaded from the cache. 

The `_` here just clarifies that customers shouldn't use this property, but there's really no true benefit to it, since it's convention anyways, it's not like MSBuild enforces it.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
