### PR TITLE
Improve pruning telemetry

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -414,9 +414,7 @@ namespace NuGet.Commands
                         framework.FrameworkName.Version.Major >= 2) ||
                     (project.RestoreMetadata.UsingMicrosoftNETSdk &&
                         StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.Net) &&
-                        framework.FrameworkName.Version.Major >= 4 &&
-                        framework.FrameworkName.Version.Minor >= 6 &&
-                        framework.FrameworkName.Version.Revision >= 1);
+                        framework.FrameworkName.Version >= FrameworkConstants.CommonFrameworks.Net461.Version);
 
                 pruningDefault |= isNetCoreAppFramework && framework.FrameworkName.Version.Major >= 10;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -135,9 +135,9 @@ namespace NuGet.Commands
         private const string AuditSuppressedAdvisoriesDistinctPackageDownloadAdvisoriesSuppressedCount = "Audit.Vulnerability.PackageDownload.DistinctAdvisoriesSuppressed.Count";
 
         // PackagePruning names
+        private const string PackagePruningDefaultEnabled = "Pruning.DefaultEnabled";
         private const string PackagePruningFrameworksEnabledCount = "Pruning.FrameworksEnabled.Count";
         private const string PackagePruningFrameworksDisabledCount = "Pruning.FrameworksDisabled.Count";
-        private const string PackagePruningFrameworksDefaultDisabledCount = "Pruning.FrameworksDefaultDisabled.Count";
         private const string PackagePruningFrameworksUnsupportedCount = "Pruning.FrameworksUnsupported.Count";
         private const string PackagePruningRemovablePackagesCount = "Pruning.RemovablePackages.Count";
         private const string PackagePruningDirectCount = "Pruning.Pruned.Direct.Count";
@@ -401,16 +401,24 @@ namespace NuGet.Commands
         {
             int pruningEnabledCount = 0;
             int pruningDisabledCount = 0;
-            int pruningDefaultDisabledCount = 0;
             int pruningNotApplicableCount = 0;
+            bool pruningDefault = false;
 
             foreach (var framework in project.TargetFrameworks.NoAllocEnumerate())
             {
                 bool isPruningEnabled = framework.PackagesToPrune.Count > 0;
-                bool isPruningCompatibleNSFramework = StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetStandard) && framework.FrameworkName.Version.Major >= 2;
                 bool isNetCoreAppFramework = StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetCoreApp);
-                bool isNetCoreAppFrameworkWithPruningByDefault = isNetCoreAppFramework && framework.FrameworkName.Version.Major >= 8;
-                bool isFrameworkPruningEnabledByDefault = isNetCoreAppFrameworkWithPruningByDefault || isPruningCompatibleNSFramework;
+                // All .NETCoreApp, .NET Standard >= 2.0 , and .NET Framework >= 4.6.1 projects are compatible with package pruning.
+                bool isPruningCompatibleFramework = isNetCoreAppFramework ||
+                    (StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetStandard) &&
+                        framework.FrameworkName.Version.Major >= 2) ||
+                    (project.RestoreMetadata.UsingMicrosoftNETSdk &&
+                        StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.Net) &&
+                        framework.FrameworkName.Version.Major >= 4 &&
+                        framework.FrameworkName.Version.Minor >= 6 &&
+                        framework.FrameworkName.Version.Revision >= 1);
+
+                pruningDefault |= isNetCoreAppFramework && framework.FrameworkName.Version.Major >= 10;
 
                 if (isPruningEnabled)
                 {
@@ -418,13 +426,9 @@ namespace NuGet.Commands
                 }
                 else
                 {
-                    if (isFrameworkPruningEnabledByDefault)
+                    if (isPruningCompatibleFramework)
                     {
                         pruningDisabledCount++;
-                    }
-                    else if (isNetCoreAppFramework && !isNetCoreAppFrameworkWithPruningByDefault)
-                    {
-                        pruningDefaultDisabledCount++;
                     }
                     else
                     {
@@ -432,9 +436,10 @@ namespace NuGet.Commands
                     }
                 }
             }
+
+            telemetryEvent[PackagePruningDefaultEnabled] = pruningDefault;
             telemetryEvent[PackagePruningFrameworksEnabledCount] = pruningEnabledCount;
             telemetryEvent[PackagePruningFrameworksDisabledCount] = pruningDisabledCount;
-            telemetryEvent[PackagePruningFrameworksDefaultDisabledCount] = pruningDefaultDisabledCount;
             telemetryEvent[PackagePruningFrameworksUnsupportedCount] = pruningNotApplicableCount;
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
@@ -2641,9 +2641,9 @@ namespace NuGet.Commands.FuncTest
 
             RestoreCommand.PopulatePruningEnabledTelemetry(projectSpec, testEvent);
             testEvent["Pruning.FrameworksEnabled.Count"].Should().Be(4);
-            testEvent["Pruning.FrameworksDisabled.Count"].Should().Be(1);
+            testEvent["Pruning.DefaultEnabled"].Should().Be(true);
             testEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(2);
-            testEvent["Pruning.FrameworksDefaultDisabled.Count"].Should().Be(1);
+            testEvent["Pruning.FrameworksDisabled.Count"].Should().Be(2);
         }
 
         // Add a test where a new package is introduced, but a different package gets pruned, bringing the counter to be the same.

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
@@ -2659,6 +2659,9 @@ namespace NuGet.Commands.FuncTest
                                     ""target"": ""Package"",
                                 },
                         },
+                        ""packagesToPrune"": {
+                            ""a"" : ""(,1.0.0]"" 
+                        }
                     },
                     ""net472"": {
                         ""dependencies"": {
@@ -2666,9 +2669,6 @@ namespace NuGet.Commands.FuncTest
                                     ""version"": ""[1.0.0,)"",
                                     ""target"": ""Package"",
                                 },
-                        },
-                        ""packagesToPrune"": {
-                            ""a"" : ""(,1.0.0]"" 
                         }
                     },
                     ""net46"": {
@@ -2683,6 +2683,9 @@ namespace NuGet.Commands.FuncTest
                 }";
 
             var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", Path.GetTempPath(), rootProject);
+            projectSpec.RestoreMetadata.SdkAnalysisLevel = NuGetVersion.Parse("10.0.100");
+            projectSpec.RestoreMetadata.UsingMicrosoftNETSdk = true;
+
             var testLogger = new TestLogger();
             var testEvent = new TelemetryEvent("dummyEvent");
 
@@ -2691,6 +2694,54 @@ namespace NuGet.Commands.FuncTest
             testEvent["Pruning.DefaultEnabled"].Should().Be(false);
             testEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(1);
             testEvent["Pruning.FrameworksDisabled.Count"].Should().Be(1);
+        }
+
+        [Fact]
+        public void PopulatePruningEnabledTelemetry_WithPruningEnabled_WithoutNETSDK_AndVariousFrameworks_PopulatesTelemetryCorrectly()
+        {
+            var rootProject = @"
+                {
+                  ""frameworks"": {
+                    ""net10.0"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        },
+                        ""packagesToPrune"": {
+                            ""a"" : ""(,1.0.0]"" 
+                        }
+                    },
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        }
+                    },
+                    ""net46"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        }
+                    },
+                  }
+                }";
+
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", Path.GetTempPath(), rootProject);
+
+            var testLogger = new TestLogger();
+            var testEvent = new TelemetryEvent("dummyEvent");
+
+            RestoreCommand.PopulatePruningEnabledTelemetry(projectSpec, testEvent);
+            testEvent["Pruning.FrameworksEnabled.Count"].Should().Be(1);
+            testEvent["Pruning.DefaultEnabled"].Should().Be(true);
+            testEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(2);
+            testEvent["Pruning.FrameworksDisabled.Count"].Should().Be(0);
         }
 
         internal static Task<RestoreResult> RunRestoreAsync(SimpleTestPathContext pathContext, params PackageSpec[] projects)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
@@ -2551,7 +2551,7 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
-        public void PopulatePruningEnabledTelemetry_WithVariousFrameworks_PopulatesTelemetryCorrectly()
+        public void PopulatePruningEnabledTelemetry_WithPruningEnabledByDefault_AndVariousFrameworks_PopulatesTelemetryCorrectly()
         {
             var rootProject = @"
                 {
@@ -2646,7 +2646,52 @@ namespace NuGet.Commands.FuncTest
             testEvent["Pruning.FrameworksDisabled.Count"].Should().Be(2);
         }
 
-        // Add a test where a new package is introduced, but a different package gets pruned, bringing the counter to be the same.
+        [Fact]
+        public void PopulatePruningEnabledTelemetry_WithPruningDisabledByDefault_AndVariousFrameworks_PopulatesTelemetryCorrectly()
+        {
+            var rootProject = @"
+                {
+                  ""frameworks"": {
+                    ""netstandard2.1"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        },
+                    },
+                    ""net472"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        },
+                        ""packagesToPrune"": {
+                            ""a"" : ""(,1.0.0]"" 
+                        }
+                    },
+                    ""net46"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        }
+                    },
+                  }
+                }";
+
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", Path.GetTempPath(), rootProject);
+            var testLogger = new TestLogger();
+            var testEvent = new TelemetryEvent("dummyEvent");
+
+            RestoreCommand.PopulatePruningEnabledTelemetry(projectSpec, testEvent);
+            testEvent["Pruning.FrameworksEnabled.Count"].Should().Be(1);
+            testEvent["Pruning.DefaultEnabled"].Should().Be(false);
+            testEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(1);
+            testEvent["Pruning.FrameworksDisabled.Count"].Should().Be(1);
+        }
 
         internal static Task<RestoreResult> RunRestoreAsync(SimpleTestPathContext pathContext, params PackageSpec[] projects)
         {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2950,7 +2950,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["Pruning.FrameworksEnabled.Count"] = value => value.Should().BeOfType<int>(),
                 ["Pruning.FrameworksDisabled.Count"] = value => value.Should().BeOfType<int>(),
                 ["Pruning.FrameworksUnsupported.Count"] = value => value.Should().BeOfType<int>(),
-                ["Pruning.FrameworksDefaultDisabled.Count"] = value => value.Should().BeOfType<int>(),
+                ["Pruning.DefaultEnabled"] = value => value.Should().BeOfType<bool>(),
                 ["Pruning.RemovablePackages.Count"] = value => value.Should().BeOfType<int>(),
                 ["Pruning.Pruned.Direct.Count"] = value => value.Should().BeOfType<int>(),
             };
@@ -3105,7 +3105,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             projectInformationEvent["Pruning.FrameworksEnabled.Count"].Should().Be(0);
             projectInformationEvent["Pruning.FrameworksDisabled.Count"].Should().Be(0);
             projectInformationEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(1);
-            projectInformationEvent["Pruning.FrameworksDefaultDisabled.Count"].Should().Be(0);
+            projectInformationEvent["Pruning.DefaultEnabled"].Should().Be(false);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -3103,8 +3103,8 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             projectInformationEvent["UpdatedMSBuildFiles"].Should().Be(false);
             projectInformationEvent["NETSdkVersion"].Should().Be(NuGetVersion.Parse("10.0.100"));
             projectInformationEvent["Pruning.FrameworksEnabled.Count"].Should().Be(0);
-            projectInformationEvent["Pruning.FrameworksDisabled.Count"].Should().Be(0);
-            projectInformationEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(1);
+            projectInformationEvent["Pruning.FrameworksDisabled.Count"].Should().Be(1);
+            projectInformationEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(0);
             projectInformationEvent["Pruning.DefaultEnabled"].Should().Be(false);
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Progress: https://github.com/NuGet/Client.Engineering/issues/3401

## Description

With the changes in what is enabled by default, the telemetry needs to be improved. 
This takes care of that.

The telemetry is simpler now.

"Pruning.DefaultEnabled" - Where one of the tfms was .NET 10. 
"Pruning.FrameworksEnabled.Count" - how many tfms it's enabled for, same as before. 
"Pruning.FrameworksDisabled.Count" - pruning compatible tfms for which pruning is disabled. If defaultenabled is false it effectively means someone explicitly disabled it.
 "Pruning.FrameworksUnsupported.Count" - not enabled but unsupported, this basically tells us it's ok if pruning is not enabled for this framework.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
