### PR TITLE
Use macos-14 in CI

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -231,7 +231,7 @@ stages:
       parameters:
         displayName: Unit Tests on MacOS (.NET 9.0)
         osName: MacOS
-        vmImage: macos-latest
+        vmImage: macos-14
         testType: Unit
         testTargetFramework: net9.0
 
@@ -244,7 +244,7 @@ stages:
       parameters:
         displayName: Functional Tests on MacOS (.NET 9.0)
         osName: MacOS
-        vmImage: macos-latest
+        vmImage: macos-14
         testType: Functional
         testTargetFramework: net9.0
         timeoutInMinutes: 30


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
There is a spike in tests failures with very odd issues related to the move from `macos-14` to `macos-15` since we specify `macos-latest`.  This is temporary to get us unblocked.


## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
