### PR TITLE
Remove RestoreArgs.LockFileVersion

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -226,7 +226,6 @@ namespace NuGet.Build.Tasks
                         var restoreContext = new RestoreArgs()
                         {
                             CacheContext = cacheContext,
-                            LockFileVersion = LockFileFormat.Version,
                             // 'dotnet restore' fails on slow machines (https://github.com/NuGet/Home/issues/6742)
                             // The workaround is to pass the '--disable-parallel' option.
                             // We apply the workaround by default when the system has 1 cpu.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -112,7 +112,6 @@ internal class PackageUpdateIO : IPackageUpdateIO
         var restoreContext = new RestoreArgs()
         {
             CacheContext = cacheContext,
-            LockFileVersion = LockFileFormat.Version,
             Log = restoreLogger,
             MachineWideSettings = new XPlatMachineWideSetting(),
             GlobalPackagesFolder = globalPackagesFolder,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -421,7 +421,6 @@ namespace NuGet.CommandLine.XPlat
                 var restoreContext = new RestoreArgs()
                 {
                     CacheContext = cacheContext,
-                    LockFileVersion = LockFileFormat.Version,
                     Log = packageReferenceArgs.Logger,
                     MachineWideSettings = new XPlatMachineWideSetting(),
                     GlobalPackagesFolder = packageReferenceArgs.PackageDirectory,

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -481,8 +481,6 @@ NuGet.Commands.RestoreArgs.IsLowercaseGlobalPackagesFolder.get -> bool?
 NuGet.Commands.RestoreArgs.IsLowercaseGlobalPackagesFolder.set -> void
 NuGet.Commands.RestoreArgs.IsRestoreOriginalAction.get -> bool
 NuGet.Commands.RestoreArgs.IsRestoreOriginalAction.set -> void
-NuGet.Commands.RestoreArgs.LockFileVersion.get -> int?
-NuGet.Commands.RestoreArgs.LockFileVersion.set -> void
 ~NuGet.Commands.RestoreArgs.Log.get -> NuGet.Common.ILogger
 ~NuGet.Commands.RestoreArgs.Log.set -> void
 ~NuGet.Commands.RestoreArgs.MachineWideSettings.get -> NuGet.Configuration.IMachineWideSettings

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -481,8 +481,6 @@ NuGet.Commands.RestoreArgs.IsLowercaseGlobalPackagesFolder.get -> bool?
 NuGet.Commands.RestoreArgs.IsLowercaseGlobalPackagesFolder.set -> void
 NuGet.Commands.RestoreArgs.IsRestoreOriginalAction.get -> bool
 NuGet.Commands.RestoreArgs.IsRestoreOriginalAction.set -> void
-NuGet.Commands.RestoreArgs.LockFileVersion.get -> int?
-NuGet.Commands.RestoreArgs.LockFileVersion.set -> void
 ~NuGet.Commands.RestoreArgs.Log.get -> NuGet.Common.ILogger
 ~NuGet.Commands.RestoreArgs.Log.set -> void
 ~NuGet.Commands.RestoreArgs.MachineWideSettings.get -> NuGet.Configuration.IMachineWideSettings

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -53,8 +53,6 @@ namespace NuGet.Commands
 
         public PackageSaveMode PackageSaveMode { get; set; } = PackageSaveMode.Defaultv3;
 
-        public int? LockFileVersion { get; set; }
-
         public bool? ValidateRuntimeAssets { get; set; }
 
         public bool HideWarningsAndErrors { get; set; } = false;
@@ -211,10 +209,7 @@ namespace NuGet.Commands
                 request.IsLowercasePackagesDirectory = IsLowercaseGlobalPackagesFolder.Value;
             }
 
-            if (LockFileVersion.HasValue && LockFileVersion.Value > 0)
-            {
-                request.LockFileVersion = LockFileVersion.Value;
-            }
+            request.LockFileVersion = LockFileFormat.Version;
 
             // Run runtime asset checks for project.json, and for other types if enabled.
             if (ValidateRuntimeAssets == null)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -153,10 +153,9 @@ namespace NuGet.Commands
             // Validate the lock file version requested
             if (_request.LockFileVersion < 1 || _request.LockFileVersion > LockFileFormat.Version)
             {
-                Debug.Fail($"Lock file version {_request.LockFileVersion} is not supported.");
                 throw new ArgumentOutOfRangeException(
                     paramName: nameof(request),
-                    message: nameof(request.LockFileVersion));
+                    message: $"Lock file version {_request.LockFileVersion} is not supported.");
             }
 
             var collectorLoggerHideWarningsAndErrors = request.Project.RestoreSettings.HideWarningsAndErrors
@@ -1408,11 +1407,7 @@ namespace NuGet.Commands
 
             if (string.IsNullOrEmpty(projectLockFilePath))
             {
-                if (_request.ProjectStyle == ProjectStyle.PackageReference)
-                {
-                    projectLockFilePath = Path.Combine(_request.RestoreOutputPath, LockFileFormat.AssetsFileName);
-                }
-                else if (_request.ProjectStyle == ProjectStyle.DotnetCliTool)
+                if (_request.ProjectStyle == ProjectStyle.DotnetCliTool)
                 {
                     var toolName = ToolRestoreUtility.GetToolIdOrNullFromSpec(_request.Project);
                     var lockFileLibrary = ToolRestoreUtility.GetToolTargetLibrary(lockFile, toolName);
@@ -1430,7 +1425,7 @@ namespace NuGet.Commands
                 }
                 else
                 {
-                    projectLockFilePath = Path.Combine(_request.Project.BaseDirectory, LockFileFormat.LockFileName);
+                    projectLockFilePath = Path.Combine(_request.RestoreOutputPath, LockFileFormat.AssetsFileName);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -16,7 +16,6 @@ namespace NuGet.ProjectModel
     public class LockFileFormat
     {
         public static readonly int Version = 3;
-        public static readonly string LockFileName = "project.lock.json";
         // If this is ever renamed, you should also rename NoOpRestoreUtilities.NoOpCacheFileName to keep them in sync.
         public static readonly string AssetsFileName = "project.assets.json";
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Shipped.txt
@@ -672,7 +672,6 @@ static readonly NuGet.ProjectModel.LockFile.DirectorySeparatorChar -> char
 ~static readonly NuGet.ProjectModel.LockFileContentFile.OutputPathProperty -> string
 ~static readonly NuGet.ProjectModel.LockFileContentFile.PPOutputPathProperty -> string
 ~static readonly NuGet.ProjectModel.LockFileFormat.AssetsFileName -> string
-~static readonly NuGet.ProjectModel.LockFileFormat.LockFileName -> string
 static readonly NuGet.ProjectModel.LockFileFormat.Version -> int
 ~static readonly NuGet.ProjectModel.LockFileItem.AliasesProperty -> string
 ~static readonly NuGet.ProjectModel.LockFileRuntimeTarget.AssetTypeProperty -> string


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14524

## Description

This is simply not used. 
The concept of a lock file version only ever applied in some early iterations of project.json and with project.json no longer relevant, we can remove it.
There will be a bunch of these clean-up PRs as I start digging deeper into the aliasing implementation. https://github.com/nuget/home/issues/5154 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
