### PR TITLE
PM UI Package list & Tab Count reflects vulnerabilities found in Audit Sources

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetSourcesServiceWrapper.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetSourcesServiceWrapper.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.UI
@@ -78,6 +79,11 @@ namespace NuGet.PackageManagement.UI
             return Service.GetActivePackageSourceNameAsync(cancellationToken);
         }
 
+        public IReadOnlyList<SourceRepository> GetAuditSources()
+        {
+            return Service.GetAuditSources();
+        }
+
         private sealed class NullNuGetSourcesService : INuGetSourcesService
         {
             public event EventHandler<IReadOnlyList<PackageSourceContextInfo>>? PackageSourcesChanged { add { } remove { } }
@@ -91,6 +97,8 @@ namespace NuGet.PackageManagement.UI
             public ValueTask SavePackageSourceContextInfosAsync(IReadOnlyList<PackageSourceContextInfo> sources, CancellationToken cancellationToken) => new ValueTask();
 
             public ValueTask<string?> GetActivePackageSourceNameAsync(CancellationToken cancellationToken) => new ValueTask<string?>();
+
+            public IReadOnlyList<SourceRepository> GetAuditSources() => Array.Empty<SourceRepository>();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetSourcesServiceWrapper.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetSourcesServiceWrapper.cs
@@ -79,9 +79,9 @@ namespace NuGet.PackageManagement.UI
             return Service.GetActivePackageSourceNameAsync(cancellationToken);
         }
 
-        public IReadOnlyList<SourceRepository> GetAuditSources()
+        public IReadOnlyList<SourceRepository> GetEnabledAuditSources()
         {
-            return Service.GetAuditSources();
+            return Service.GetEnabledAuditSources();
         }
 
         private sealed class NullNuGetSourcesService : INuGetSourcesService
@@ -98,7 +98,7 @@ namespace NuGet.PackageManagement.UI
 
             public ValueTask<string?> GetActivePackageSourceNameAsync(CancellationToken cancellationToken) => new ValueTask<string?>();
 
-            public IReadOnlyList<SourceRepository> GetAuditSources() => Array.Empty<SourceRepository>();
+            public IReadOnlyList<SourceRepository> GetEnabledAuditSources() => Array.Empty<SourceRepository>();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -199,7 +199,7 @@ namespace NuGet.PackageManagement.UI
 
             List<SourceRepository> sourceRepositories = sourceRepositoryProvider.GetRepositories().ToList();
 
-            var auditSourceRepositories = Model.Context.SourceService.GetAuditSources();
+            var auditSourceRepositories = Model.Context.SourceService.GetEnabledAuditSources();
             _packageVulnerabilityService = new PackageVulnerabilityService(sourceRepositories, auditSourceRepositories, _uiLogger);
 
             var solutionManager = Model.Context.SolutionManagerService;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -197,8 +197,10 @@ namespace NuGet.PackageManagement.UI
                 controller.PackageManagerControl = this;
             }
 
-            var sourceRepositories = sourceRepositoryProvider.GetRepositories();
-            _packageVulnerabilityService = new PackageVulnerabilityService(sourceRepositories, _uiLogger);
+            List<SourceRepository> sourceRepositories = sourceRepositoryProvider.GetRepositories().ToList();
+
+            var auditSourceRepositories = Model.Context.SourceService.GetAuditSources();
+            _packageVulnerabilityService = new PackageVulnerabilityService(sourceRepositories, auditSourceRepositories, _uiLogger);
 
             var solutionManager = Model.Context.SolutionManagerService;
             solutionManager.ProjectAdded += OnProjectChanged;

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1076,6 +1076,14 @@ namespace NuGet.PackageManagement.UI
                 {
                     vulnerablePackagesCount++;
                 }
+                else // Fallback to checking audit sources.
+                {
+                    List<PackageVulnerabilityMetadataContextInfo> auditSourceVulnerabilityContextInfo = await _packageVulnerabilityService.GetVulnerabilityInfoAsync(s.Identity, token);
+                    if (auditSourceVulnerabilityContextInfo.Count > 0)
+                    {
+                        vulnerablePackagesCount++;
+                    }
+                }
                 if (d != null)
                 {
                     deprecatedPackagesCount++;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
@@ -53,7 +53,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 .ToList());
         }
 
-        public IReadOnlyList<SourceRepository> GetAuditSources()
+        public IReadOnlyList<SourceRepository> GetEnabledAuditSources()
         {
             IReadOnlyList<PackageSource> auditSources = _packageSourceProvider.LoadAuditSources();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSourcesService.cs
@@ -12,6 +12,8 @@ using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.ServiceHub.Framework.Services;
 using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -49,6 +51,24 @@ namespace NuGet.PackageManagement.VisualStudio
                 .LoadPackageSources()
                 .Select(PackageSourceContextInfo.Create)
                 .ToList());
+        }
+
+        public IReadOnlyList<SourceRepository> GetAuditSources()
+        {
+            IReadOnlyList<PackageSource> auditSources = _packageSourceProvider.LoadAuditSources();
+
+            List<SourceRepository> auditRepositories = new List<SourceRepository>(auditSources.Count);
+            for (int i = 0; i < auditSources.Count; i++)
+            {
+                PackageSource auditSource = auditSources[i];
+                if (auditSource.IsEnabled)
+                {
+                    SourceRepository repository = Repository.Factory.GetCoreV3(auditSource);
+                    auditRepositories.Add(repository);
+                }
+            }
+
+            return auditRepositories;
         }
 
         public ValueTask SavePackageSourceContextInfosAsync(IReadOnlyList<PackageSourceContextInfo> sources, CancellationToken cancellationToken)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -1,12 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Packaging.Core;
+using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
 using NuGet.Versioning;
@@ -16,14 +21,14 @@ namespace NuGet.PackageManagement.VisualStudio
 {
     public class PackageVulnerabilityService : IPackageVulnerabilityService
     {
-        private readonly IEnumerable<SourceRepository> _sourceRepositories;
-        private readonly IEnumerable<SourceRepository> _auditSourceRepositories;
-        private Task<GetVulnerabilityInfoResult> _vulnerabilitiesTask;
+        private readonly IReadOnlyList<SourceRepository> _sourceRepositories;
+        private readonly IReadOnlyList<SourceRepository> _auditSourceRepositories;
+        private Task<GetVulnerabilityInfoResult?>? _vulnerabilitiesTask;
         private INuGetUILogger _logger;
         private readonly object _lock = new();
 
         public PackageVulnerabilityService(
-            IEnumerable<SourceRepository> sourceRepositories,
+            IReadOnlyList<SourceRepository> sourceRepositories,
             IReadOnlyList<SourceRepository> auditSourceRepositories,
             INuGetUILogger logger)
         {
@@ -32,7 +37,7 @@ namespace NuGet.PackageManagement.VisualStudio
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<List<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken)
+        public async Task<List<PackageVulnerabilityMetadataContextInfo>?> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken)
         {
             if (_vulnerabilitiesTask == null)
             {
@@ -42,16 +47,16 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
             }
 
-            GetVulnerabilityInfoResult vulnerabilities = await _vulnerabilitiesTask;
+            GetVulnerabilityInfoResult? vulnerabilities = await _vulnerabilitiesTask;
 
-            IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
+            IEnumerable<PackageVulnerabilityInfo>? packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
 
             if (vulnerabilities?.Exceptions is not null)
             {
                 ReplayErrors(vulnerabilities.Exceptions);
             }
 
-            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> allVulnerabilities = vulnerabilities?.KnownVulnerabilities;
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>? allVulnerabilities = vulnerabilities?.KnownVulnerabilities;
             if (allVulnerabilities is not null && allVulnerabilities.Any())
             {
                 packageVulnerabilities = GetKnownVulnerabilities(packageId.Id, packageId.Version, allVulnerabilities);
@@ -69,22 +74,60 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         // Copied and adapted from NuGet.Commands.Restore.Utility.AuditUtility.GetAllVulnerabilityDataAsync
-        private async Task<GetVulnerabilityInfoResult> GetAllVulnerabilityDataAsync(CancellationToken cancellationToken)
+        private async Task<GetVulnerabilityInfoResult?> GetAllVulnerabilityDataAsync(CancellationToken cancellationToken)
         {
-            List<Task<GetVulnerabilityInfoResult>> results = _sourceRepositories.Select(sr => sr.GetVulnerabilityInfoAsync(cancellationToken)).ToList();
-            await Task.WhenAll(results);
+            using SourceCacheContext sourceCacheContext = new();
+            List<Task<GetVulnerabilityInfoResult?>> results;
+            IReadOnlyList<SourceRepository> vulnerabilitySources;
+            bool usingAuditSources;
+            if (_auditSourceRepositories.Count > 0)
+            {
+                results = new(capacity: _auditSourceRepositories.Count);
+                vulnerabilitySources = _auditSourceRepositories;
+                usingAuditSources = true;
+            }
+            else
+            {
+                results = new(capacity: _sourceRepositories.Count);
+                vulnerabilitySources = _sourceRepositories;
+                usingAuditSources = false;
+            }
 
+            for (int i = 0; i < vulnerabilitySources.Count; i++)
+            {
+                SourceRepository source = vulnerabilitySources[i];
+                //TODO logger?
+                Task<GetVulnerabilityInfoResult?> getVulnerabilityInfoResult = GetVulnerabilityInfoFromSourceAsync(source, sourceCacheContext, logger: NullLogger.Instance);
+                results.Add(getVulnerabilityInfoResult);
+            }
+
+            await Task.WhenAll(results);
             if (cancellationToken.IsCancellationRequested)
             {
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            List<Exception> errors = null;
-            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = null;
-            foreach (var resultTask in results)
+            List<Exception>? errors = null;
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>? knownVulnerabilities = null;
+            for (int i = 0; i < results.Count; i++)
             {
-                GetVulnerabilityInfoResult result = await resultTask;
-                if (result is null) continue;
+                Task<GetVulnerabilityInfoResult?> resultTask = results[i];
+                GetVulnerabilityInfoResult? result = await resultTask;
+
+                if (result is null)
+                {
+                    if (usingAuditSources)
+                    {
+                        //TODO Strings.Warning_AuditSourceWithoutData
+                        string message = string.Format(CultureInfo.CurrentCulture, "Audit source did not provide any vulnerability data.", vulnerabilitySources[i].PackageSource.Name);
+
+                        //TODO: remove log code?
+                        //RestoreLogMessage restoreLogMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1905, message);
+                        LogMessage logMessage = new LogMessage(LogLevel.Warning, message, NuGetLogCode.NU1905);
+                        _logger.Log(logMessage);
+                    }
+                    continue;
+                }
 
                 if (result.KnownVulnerabilities != null)
                 {
@@ -103,20 +146,42 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
             }
 
-            GetVulnerabilityInfoResult final =
+            GetVulnerabilityInfoResult? final =
                 knownVulnerabilities != null || errors != null
                 ? new(knownVulnerabilities, errors != null ? new AggregateException(errors) : null)
                 : null;
             return final;
         }
 
+        private static async Task<GetVulnerabilityInfoResult?> GetVulnerabilityInfoFromSourceAsync(SourceRepository source, SourceCacheContext cacheContext, ILogger logger)
+        {
+            try
+            {
+                IVulnerabilityInfoResource vulnerabilityInfoResource =
+                    await source.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None);
+                if (vulnerabilityInfoResource is null)
+                {
+                    return null;
+                }
+                return await vulnerabilityInfoResource.GetVulnerabilityInfoAsync(cacheContext, logger, CancellationToken.None);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                AggregateException aggregateException = new(exception);
+                GetVulnerabilityInfoResult result = new(knownVulnerabilities: null, exceptions: aggregateException);
+                return result;
+            }
+        }
+
         // Copied from NuGet.Commands.Restore.Utility.AuditUtility.GetKnownVulnerabilities
-        private static List<PackageVulnerabilityInfo> GetKnownVulnerabilities(
+        private static List<PackageVulnerabilityInfo>? GetKnownVulnerabilities(
             string name,
             NuGetVersion version,
             IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities)
         {
-            HashSet<PackageVulnerabilityInfo> vulnerabilities = null;
+            HashSet<PackageVulnerabilityInfo>? vulnerabilities = null;
 
             if (knownVulnerabilities == null) return null;
 
@@ -141,7 +206,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return vulnerabilities != null ? vulnerabilities.ToList() : null;
         }
 
-        private List<PackageVulnerabilityMetadataContextInfo> ConvertToPackageVulnerabilityMetadataContextInfo(IEnumerable<PackageVulnerabilityInfo> packageVulnerabilities)
+        private List<PackageVulnerabilityMetadataContextInfo>? ConvertToPackageVulnerabilityMetadataContextInfo(IEnumerable<PackageVulnerabilityInfo>? packageVulnerabilities)
         {
             if (packageVulnerabilities == null || !packageVulnerabilities.Any())
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -8,9 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Common;
 using NuGet.Packaging.Core;
-using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
 using NuGet.Versioning;
@@ -92,7 +90,7 @@ namespace NuGet.PackageManagement.VisualStudio
             for (int i = 0; i < vulnerabilitySources.Count; i++)
             {
                 SourceRepository source = vulnerabilitySources[i];
-                Task<GetVulnerabilityInfoResult?> getVulnerabilityInfoResult = GetVulnerabilityInfoFromSourceAsync(source, sourceCacheContext, logger: NullLogger.Instance);
+                Task<GetVulnerabilityInfoResult?> getVulnerabilityInfoResult = source.GetVulnerabilityInfoAsync(cancellationToken);
                 results.Add(getVulnerabilityInfoResult);
             }
 
@@ -136,28 +134,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 ? new(knownVulnerabilities, errors != null ? new AggregateException(errors) : null)
                 : null;
             return final;
-        }
-
-        private static async Task<GetVulnerabilityInfoResult?> GetVulnerabilityInfoFromSourceAsync(SourceRepository source, SourceCacheContext cacheContext, ILogger logger)
-        {
-            try
-            {
-                IVulnerabilityInfoResource vulnerabilityInfoResource =
-                    await source.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None);
-                if (vulnerabilityInfoResource is null)
-                {
-                    return null;
-                }
-                return await vulnerabilityInfoResource.GetVulnerabilityInfoAsync(cacheContext, logger, CancellationToken.None);
-            }
-#pragma warning disable CA1031 // Do not catch general exception types
-            catch (Exception exception)
-#pragma warning restore CA1031 // Do not catch general exception types
-            {
-                AggregateException aggregateException = new(exception);
-                GetVulnerabilityInfoResult result = new(knownVulnerabilities: null, exceptions: aggregateException);
-                return result;
-            }
         }
 
         // Copied from NuGet.Commands.Restore.Utility.AuditUtility.GetKnownVulnerabilities

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -79,24 +78,20 @@ namespace NuGet.PackageManagement.VisualStudio
             using SourceCacheContext sourceCacheContext = new();
             List<Task<GetVulnerabilityInfoResult?>> results;
             IReadOnlyList<SourceRepository> vulnerabilitySources;
-            bool usingAuditSources;
             if (_auditSourceRepositories.Count > 0)
             {
                 results = new(capacity: _auditSourceRepositories.Count);
                 vulnerabilitySources = _auditSourceRepositories;
-                usingAuditSources = true;
             }
             else
             {
                 results = new(capacity: _sourceRepositories.Count);
                 vulnerabilitySources = _sourceRepositories;
-                usingAuditSources = false;
             }
 
             for (int i = 0; i < vulnerabilitySources.Count; i++)
             {
                 SourceRepository source = vulnerabilitySources[i];
-                //TODO logger?
                 Task<GetVulnerabilityInfoResult?> getVulnerabilityInfoResult = GetVulnerabilityInfoFromSourceAsync(source, sourceCacheContext, logger: NullLogger.Instance);
                 results.Add(getVulnerabilityInfoResult);
             }
@@ -116,16 +111,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 if (result is null)
                 {
-                    if (usingAuditSources)
-                    {
-                        //TODO Strings.Warning_AuditSourceWithoutData
-                        string message = string.Format(CultureInfo.CurrentCulture, "Audit source did not provide any vulnerability data.", vulnerabilitySources[i].PackageSource.Name);
-
-                        //TODO: remove log code?
-                        //RestoreLogMessage restoreLogMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1905, message);
-                        LogMessage logMessage = new LogMessage(LogLevel.Warning, message, NuGetLogCode.NU1905);
-                        _logger.Log(logMessage);
-                    }
                     continue;
                 }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -17,13 +17,18 @@ namespace NuGet.PackageManagement.VisualStudio
     public class PackageVulnerabilityService : IPackageVulnerabilityService
     {
         private readonly IEnumerable<SourceRepository> _sourceRepositories;
+        private readonly IEnumerable<SourceRepository> _auditSourceRepositories;
         private Task<GetVulnerabilityInfoResult> _vulnerabilitiesTask;
         private INuGetUILogger _logger;
         private readonly object _lock = new();
 
-        public PackageVulnerabilityService(IEnumerable<SourceRepository> sourceRepositories, INuGetUILogger logger)
+        public PackageVulnerabilityService(
+            IEnumerable<SourceRepository> sourceRepositories,
+            IReadOnlyList<SourceRepository> auditSourceRepositories,
+            INuGetUILogger logger)
         {
             _sourceRepositories = sourceRepositories ?? throw new ArgumentNullException(nameof(sourceRepositories));
+            _auditSourceRepositories = auditSourceRepositories ?? throw new ArgumentNullException(nameof(auditSourceRepositories));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSourcesService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSourcesService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.VisualStudio.Internal.Contracts
 {
@@ -20,5 +21,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         ValueTask SavePackageSourceContextInfosAsync(IReadOnlyList<PackageSourceContextInfo> sources, CancellationToken cancellationToken);
 
         ValueTask<IReadOnlyList<PackageSourceContextInfo>> GetPackageSourcesAsync(CancellationToken cancellationToken);
+
+        public IReadOnlyList<SourceRepository> GetAuditSources();
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSourcesService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/INuGetSourcesService.cs
@@ -22,6 +22,6 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         ValueTask<IReadOnlyList<PackageSourceContextInfo>> GetPackageSourcesAsync(CancellationToken cancellationToken);
 
-        public IReadOnlyList<SourceRepository> GetAuditSources();
+        public IReadOnlyList<SourceRepository> GetEnabledAuditSources();
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGetSourcesServiceWrapperTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGetSourcesServiceWrapperTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio.Internal.Contracts;
 using Xunit;
 
@@ -128,6 +129,11 @@ namespace NuGet.PackageManagement.UI.Test
             public ValueTask<IReadOnlyList<PackageSourceContextInfo>> GetPackageSourcesAsync(CancellationToken cancellationToken)
             {
                 return new ValueTask<IReadOnlyList<PackageSourceContextInfo>>(PackageSources);
+            }
+
+            public IReadOnlyList<SourceRepository> GetAuditSources()
+            {
+                throw new NotImplementedException();
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGetSourcesServiceWrapperTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGetSourcesServiceWrapperTests.cs
@@ -131,7 +131,7 @@ namespace NuGet.PackageManagement.UI.Test
                 return new ValueTask<IReadOnlyList<PackageSourceContextInfo>>(PackageSources);
             }
 
-            public IReadOnlyList<SourceRepository> GetAuditSources()
+            public IReadOnlyList<SourceRepository> GetEnabledAuditSources()
             {
                 throw new NotImplementedException();
             }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
@@ -58,12 +58,14 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var providers = new List<INuGetResourceProvider> { new VulnerabilityInfoResourceProvider(vulnerabilityResults) };
 
             var sourceRepository = new SourceRepository(source, providers);
-            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository }, _testLogger);
+            IReadOnlyList<SourceRepository> auditSourceRepositories = new List<SourceRepository>().AsReadOnly();
+            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository }, auditSourceRepositories, _testLogger);
 
             // Act
-            List<PackageVulnerabilityMetadataContextInfo> vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            List<PackageVulnerabilityMetadataContextInfo>? vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
 
             // Assert
+            Assert.NotNull(vulnerabilities);
             Assert.Equal(1, vulnerabilities.Count);
         }
 
@@ -102,16 +104,20 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             sourceRepository.Setup(s => s.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None))
                 .ReturnsAsync(vulnerabilityResource.Object);
 
-            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository.Object }, _testLogger);
+            IReadOnlyList<SourceRepository> auditSourceRepositories = new List<SourceRepository>().AsReadOnly();
+            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository.Object }, auditSourceRepositories, _testLogger);
 
             // Act & Assert
-            List<PackageVulnerabilityMetadataContextInfo> vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            List<PackageVulnerabilityMetadataContextInfo>? vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.NotNull(vulnerabilities);
             Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(1, getVulnerabilityCallCount);
             vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.NotNull(vulnerabilities);
             Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(1, getVulnerabilityCallCount);
             vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.NotNull(vulnerabilities);
             Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(1, getVulnerabilityCallCount);
         }
@@ -151,20 +157,24 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             sourceRepository.Setup(s => s.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None))
                 .ReturnsAsync(vulnerabilityResource.Object);
 
-            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository.Object }, _testLogger);
+            IReadOnlyList<SourceRepository> auditSourceRepositories = new List<SourceRepository>().AsReadOnly();
+            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository.Object }, auditSourceRepositories, _testLogger);
 
             // Act & Assert
-            List<PackageVulnerabilityMetadataContextInfo> vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            List<PackageVulnerabilityMetadataContextInfo>? vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.NotNull(vulnerabilities);
             Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(1, getVulnerabilityCallCount);
             // Reset the vulnerability data
             packageVulnerabilityService.ResetVulnerabilityData();
             vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.NotNull(vulnerabilities);
             Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(2, getVulnerabilityCallCount);
             // Reset the vulnerability data again
             packageVulnerabilityService.ResetVulnerabilityData();
             vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+            Assert.NotNull(vulnerabilities);
             Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(3, getVulnerabilityCallCount);
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
@@ -70,6 +70,51 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
+        public async Task GetVulnerabilityInfoAsync_FromAuditSource_ReturnsVulnerabilityInfo()
+        {
+            // Arrange
+            PackageSource source = new PackageSource("https://contoso.test/v3/index.json");
+            PackageSource auditSource = new PackageSource("https://contoso.test/vulnerability/v3/index.json");
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
+            {
+                new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
+                {
+                    {
+                        "Package1",
+                        new PackageVulnerabilityInfo[] {
+                            new PackageVulnerabilityInfo(new Uri("https://vulnerability1"), PackageVulnerabilitySeverity.Low, VersionRange.Parse("[1.0.0,2.0.0)"))
+                        }
+                    }
+                }
+            };
+
+            Dictionary<string, GetVulnerabilityInfoResult> vulnerabilityResults = new()
+            {
+                { auditSource.Name, new GetVulnerabilityInfoResult(knownVulnerabilities, exceptions: null) }
+            };
+
+            var providers = new List<INuGetResourceProvider>();
+            var auditSourceProviders = new List<INuGetResourceProvider> { new VulnerabilityInfoResourceProvider(vulnerabilityResults) };
+
+            var sourceRepository = new SourceRepository(source, providers);
+            var auditSourceRepository = new SourceRepository(auditSource, auditSourceProviders);
+
+            IReadOnlyList<SourceRepository> auditSourceRepositories = new List<SourceRepository>(capacity: 1)
+            {
+                auditSourceRepository
+            };
+
+            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository }, auditSourceRepositories, _testLogger);
+
+            // Act
+            List<PackageVulnerabilityMetadataContextInfo>? vulnerabilities = await packageVulnerabilityService.GetVulnerabilityInfoAsync(new PackageIdentity("Package1", new NuGetVersion("1.0.0")), CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(vulnerabilities);
+            Assert.Equal(1, vulnerabilities.Count);
+        }
+
+        [Fact]
         public async Task GetVulnerabilityInfoAsync_MultipleTimes_LoadsVulnerabilityDataOnce()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13954

## Description

The Installed tab count & packages list show vulnerabilities from an Audit Source, when audit sources are enabled. 
The logic from AuditUtility is adapted here for PM UI.

<img width="1262" height="632" alt="image" src="https://github.com/user-attachments/assets/e58fa9eb-4076-4e8a-b167-297ecd65bac8" />


Next iteration:
- Versions combobox to indicate vulnerabilities from audit sources
- Details pane to show details of vulnerability found in audit sources

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
