### PR TITLE
Add mcp.json to VSIX

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -119,6 +119,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="mcp.json">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/mcp.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/mcp.json
@@ -1,0 +1,14 @@
+{
+  "servers": {
+    "nuget": {
+      "type": "stdio",
+      "command": "dnx",
+      "args": [
+        "NuGet.Mcp.Server@0.1.4-preview",
+        "--source",
+        "https://api.nuget.org/v3/index.json",
+        "--yes"
+      ]
+    }
+  }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vsixmanifest
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vsixmanifest
@@ -66,5 +66,7 @@
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Lucene.Net.dll" AssemblyName="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.Web.XmlTransform.dll" AssemblyName="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Newtonsoft.Json.dll" AssemblyName="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
+
+        <Asset Type="mcp.json" d:Source="File" Path="mcp.json" />
     </Assets>
 </PackageManifest>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3424

## Description
This allows our MCP server to come "in box" with Visual Studio.  This file gets read by VS setup and makes our MCP server available by default.  In our case, it will be installing the version we have specified from https://www.nuget.org/packages/nuget.mcp.server

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
