### PR TITLE
Fix dotnet package search table output

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/Table.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/Table.cs
@@ -145,7 +145,7 @@ namespace NuGet.CommandLine.XPlat
                 // Print column by column
                 for (int column = 0; column < _columns.Count; column++)
                 {
-                    logger.LogRaw("| ", color);
+                    logger.LogInline("| ", color);
                     string value = values[column];
 
                     // For each column, print character by character with the appropriate color
@@ -167,18 +167,18 @@ namespace NuGet.CommandLine.XPlat
                                 renderedColumns.Add(column);
                             }
 
-                            logger.LogRaw("".PadRight(_columns[column].Width - i), color);
+                            logger.LogInline("".PadRight(_columns[column].Width - i), color);
                             break;
                         }
 
                         // If the character index is within the length of the value, print the character
                         if (CharacterIndex < value.Length)
                         {
-                            logger.LogRaw(value[CharacterIndex].ToString(), color);
+                            logger.LogInline(value[CharacterIndex].ToString(), color);
                         }
                         else
                         {
-                            logger.LogRaw(" ", color);
+                            logger.LogInline(" ", color);
                         }
 
                         // If the character index is the last character in the value, add the column to the list of rendered columns
@@ -194,11 +194,11 @@ namespace NuGet.CommandLine.XPlat
                         color = _consoleColor;
                     }
 
-                    logger.LogRaw(" ", color);
+                    logger.LogInline(" ", color);
                 }
 
                 // New line for new row
-                logger.LogRaw("|", color);
+                logger.LogInline("|", color);
                 logger.LogMinimal("");
                 subRow++;
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/Table.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/Table.cs
@@ -145,7 +145,7 @@ namespace NuGet.CommandLine.XPlat
                 // Print column by column
                 for (int column = 0; column < _columns.Count; column++)
                 {
-                    logger.LogMinimal("| ", color);
+                    logger.LogRaw("| ", color);
                     string value = values[column];
 
                     // For each column, print character by character with the appropriate color
@@ -167,18 +167,18 @@ namespace NuGet.CommandLine.XPlat
                                 renderedColumns.Add(column);
                             }
 
-                            logger.LogMinimal("".PadRight(_columns[column].Width - i), color);
+                            logger.LogRaw("".PadRight(_columns[column].Width - i), color);
                             break;
                         }
 
                         // If the character index is within the length of the value, print the character
                         if (CharacterIndex < value.Length)
                         {
-                            logger.LogMinimal(value[CharacterIndex].ToString(), color);
+                            logger.LogRaw(value[CharacterIndex].ToString(), color);
                         }
                         else
                         {
-                            logger.LogMinimal(" ", color);
+                            logger.LogRaw(" ", color);
                         }
 
                         // If the character index is the last character in the value, add the column to the list of rendered columns
@@ -194,11 +194,11 @@ namespace NuGet.CommandLine.XPlat
                         color = _consoleColor;
                     }
 
-                    logger.LogMinimal(" ", color);
+                    logger.LogRaw(" ", color);
                 }
 
                 // New line for new row
-                logger.LogMinimal("|", color);
+                logger.LogRaw("|", color);
                 logger.LogMinimal("");
                 subRow++;
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
@@ -147,7 +147,7 @@ namespace NuGet.CommandLine.XPlat
             Console.ForegroundColor = currentColor;
         }
 
-        public void LogRaw(string data, ConsoleColor color)
+        public void LogInline(string data, ConsoleColor color)
         {
             var currentColor = Console.ForegroundColor;
             Console.ForegroundColor = color;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
@@ -146,5 +146,13 @@ namespace NuGet.CommandLine.XPlat
             LogInternal(LogLevel.Minimal, data);
             Console.ForegroundColor = currentColor;
         }
+
+        public void LogRaw(string data, ConsoleColor color)
+        {
+            var currentColor = Console.ForegroundColor;
+            Console.ForegroundColor = color;
+            Console.Write(data);
+            Console.ForegroundColor = currentColor;
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ILoggerWithColor.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ILoggerWithColor.cs
@@ -9,11 +9,18 @@ namespace NuGet.CommandLine.XPlat
     internal interface ILoggerWithColor : ILogger
     {
         /// <summary>
-        /// Logs a minimal level message to the console with the specified text and foreground color. 
-        /// This method writes the message directly without a newline character at the end.
+        /// Logs a minimal level message to the console with the specified text and foreground color.
         /// </summary>
         /// <param name="data">The message text to be logged.</param>
         /// <param name="color">The ConsoleColor value to set the text color.</param>
         void LogMinimal(string data, ConsoleColor color);
+
+        /// <summary>
+        /// Log a message directly to the console with the specified text and foreground color.
+        /// It does not add a newline character at the end of the message.
+        /// </summary>
+        /// <param name="data">The message text to be logged.</param>
+        /// <param name="color">The ConsoleColor value to set the text color.</param>
+        void LogRaw(string data, ConsoleColor color);
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ILoggerWithColor.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/ILoggerWithColor.cs
@@ -21,6 +21,6 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="data">The message text to be logged.</param>
         /// <param name="color">The ConsoleColor value to set the text color.</param>
-        void LogRaw(string data, ConsoleColor color);
+        void LogInline(string data, ConsoleColor color);
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageSearchTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageSearchTests.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
 using NuGet.CommandLine.Xplat.Tests;
 using NuGet.Test.Utility;
 using Xunit;
@@ -28,17 +31,17 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
-        public void DotnetPackageSearch_Succeed()
+        public void DotnetPackageSearch_WithJsonOutput_Succeed()
         {
             using (var pathContext = new SimpleTestPathContext())
             {
                 // Arrange
                 string source = $"{_packageSearchRunnerFixture.ServerWithMultipleEndpoints.Uri}v3/index.json";
                 pathContext.Settings.AddSource(source, source, allowInsecureConnectionsValue: "true");
-                var args = new string[] { "package", "search", "json", "--take", "10", "--prerelease", "--source", $"{_packageSearchRunnerFixture.ServerWithMultipleEndpoints.Uri}v3/index.json", "--format", "json" };
+                var args = $"package search json --take 10 --prerelease --source {_packageSearchRunnerFixture.ServerWithMultipleEndpoints.Uri}v3/index.json --format json";
 
                 // Act
-                var result = _testFixture.RunDotnetExpectSuccess(pathContext.PackageSource, string.Join(" ", args), testOutputHelper: _testOutputHelper);
+                var result = _testFixture.RunDotnetExpectSuccess(pathContext.PackageSource, args, testOutputHelper: _testOutputHelper);
 
                 // Assert
                 Assert.Equal(0, result.ExitCode);
@@ -50,19 +53,55 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
+        public void DotnetPackageSearch_WithConsoleOutput_Succeed()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                string source = $"{_packageSearchRunnerFixture.ServerWithMultipleEndpoints.Uri}v3/index.json";
+                pathContext.Settings.AddSource(source, source, allowInsecureConnectionsValue: "true");
+                var args = $"package search json --take 10 --prerelease --source {_packageSearchRunnerFixture.ServerWithMultipleEndpoints.Uri}v3/index.json";
+
+                // Act
+                var result = _testFixture.RunDotnetExpectSuccess(pathContext.PackageSource, args, testOutputHelper: _testOutputHelper);
+
+                // Assert
+                result.ExitCode.Should().Be(0, result.AllOutput);
+                List<string> table = new();
+                using (var stringReader = new StringReader(result.AllOutput))
+                {
+                    string line;
+                    while ((line = stringReader.ReadLine()) != null)
+                    {
+                        if (line.Length > 0 && line[0] == '|')
+                        {
+                            table.Add(line);
+                        }
+                    }
+                }
+
+                table.Count.Should().Be(4, $"Unexpected table in output: {string.Join("\n", table)}");
+                table[0].Should().Be("| Package ID           | Latest Version | Owners            | Total Downloads |");
+                table[1].Should().Be("| -------------------- | -------------- | ----------------- | --------------- |");
+                table[2].Should().Be("| Fake.Newtonsoft.Json | 12.0.3         | James Newton-King | 531,607,259     |");
+                table[3].Should().Be("| -------------------- | -------------- | ----------------- | --------------- |");
+            }
+        }
+
+        [Fact]
         public void DotnetPackageSearch_WithInvalidSource_FailWithNoHelpOutput()
         {
             using (var pathContext = new SimpleTestPathContext())
             {
                 // Arrange
                 string source = "invalid-source";
-                var args = new string[] { "package", "search", "json", "--source", source, "--format", "json" };
+                var args = $"package search json --source {source} --format json";
 
                 string error = "is invalid. Provide a valid source.";
                 string help = "dotnet package search [<SearchTerm>] [options]";
 
                 // Act
-                var result = _testFixture.RunDotnetExpectFailure(pathContext.SolutionRoot, string.Join(" ", args), testOutputHelper: _testOutputHelper);
+                var result = _testFixture.RunDotnetExpectFailure(pathContext.SolutionRoot, args, testOutputHelper: _testOutputHelper);
 
                 // Assert
                 Assert.Contains(error, result.AllOutput);

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NullLoggerWithColor.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NullLoggerWithColor.cs
@@ -17,6 +17,10 @@ namespace NuGet.CommandLine.Xplat.Tests
         {
         }
 
+        public void LogRaw(string data, ConsoleColor color)
+        {
+        }
+
         public LogLevel LogLevel
         {
             get => VerbosityLevel;

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NullLoggerWithColor.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NullLoggerWithColor.cs
@@ -17,7 +17,7 @@ namespace NuGet.CommandLine.Xplat.Tests
         {
         }
 
-        public void LogRaw(string data, ConsoleColor color)
+        public void LogInline(string data, ConsoleColor color)
         {
         }
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultTablePrinterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultTablePrinterTests.cs
@@ -53,96 +53,96 @@ namespace NuGet.CommandLine.Xplat.Tests
             else
             {
                 // Asserts for "| Package ID       "
-                mockLoggerWithColor.Verify(x => x.LogRaw("| ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("P", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("a", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("c", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("k", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("a", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("g", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("e", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw(" ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("I", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("D", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("| ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("P", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("a", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("c", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("k", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("a", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("g", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("e", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline(" ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("I", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("D", System.Console.ForegroundColor));
 
                 // Asserts for "| Latest Version "
-                mockLoggerWithColor.Verify(x => x.LogRaw("| ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("L", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("a", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("t", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("e", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("s", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("t", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw(" ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("V", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("e", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("r", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("s", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("i", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("o", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("n", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("| ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("L", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("a", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("t", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("e", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("s", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("t", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline(" ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("V", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("e", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("r", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("s", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("i", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("o", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("n", System.Console.ForegroundColor));
 
                 // Asserts for "| Owners "
-                mockLoggerWithColor.Verify(x => x.LogRaw("| ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("O", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("w", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("n", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("e", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("r", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("s", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw(" ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("| ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("O", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("w", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("n", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("e", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("r", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("s", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline(" ", System.Console.ForegroundColor));
 
                 // Asserts for "| Total Downloads "
-                mockLoggerWithColor.Verify(x => x.LogRaw("| ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("T", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("o", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("t", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("a", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("l", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw(" ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("D", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("o", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("w", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("n", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("l", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("o", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("a", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("d", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("s", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("| ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("T", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("o", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("t", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("a", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("l", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline(" ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("D", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("o", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("w", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("n", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("l", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("o", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("a", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("d", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("s", System.Console.ForegroundColor));
 
                 // Assert for "NuGet.Versioning"
-                mockLoggerWithColor.Verify(x => x.LogRaw("N", ConsoleColor.Red));
-                mockLoggerWithColor.Verify(x => x.LogRaw("u", ConsoleColor.Red));
-                mockLoggerWithColor.Verify(x => x.LogRaw("G", ConsoleColor.Red));
-                mockLoggerWithColor.Verify(x => x.LogRaw("e", ConsoleColor.Red));
-                mockLoggerWithColor.Verify(x => x.LogRaw("t", ConsoleColor.Red));
-                mockLoggerWithColor.Verify(x => x.LogRaw(".", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("V", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("e", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("r", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("s", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("i", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("o", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("n", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("i", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("n", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("g", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("N", ConsoleColor.Red));
+                mockLoggerWithColor.Verify(x => x.LogInline("u", ConsoleColor.Red));
+                mockLoggerWithColor.Verify(x => x.LogInline("G", ConsoleColor.Red));
+                mockLoggerWithColor.Verify(x => x.LogInline("e", ConsoleColor.Red));
+                mockLoggerWithColor.Verify(x => x.LogInline("t", ConsoleColor.Red));
+                mockLoggerWithColor.Verify(x => x.LogInline(".", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("V", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("e", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("r", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("s", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("i", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("o", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("n", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("i", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("n", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("g", System.Console.ForegroundColor));
 
                 // Assert for "4.3.0"
-                mockLoggerWithColor.Verify(x => x.LogRaw("4", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw(".", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("3", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw(".", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("0", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("4", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline(".", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("3", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline(".", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("0", System.Console.ForegroundColor));
 
                 // Assert for "123,456"
-                mockLoggerWithColor.Verify(x => x.LogRaw("1", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("2", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("3", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw(",", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("4", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("5", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogRaw("6", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("1", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("2", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("3", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline(",", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("4", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("5", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogInline("6", System.Console.ForegroundColor));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultTablePrinterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchResultTablePrinterTests.cs
@@ -53,96 +53,96 @@ namespace NuGet.CommandLine.Xplat.Tests
             else
             {
                 // Asserts for "| Package ID       "
-                mockLoggerWithColor.Verify(x => x.LogMinimal("| ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("P", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("a", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("c", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("k", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("a", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("g", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("e", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal(" ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("I", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("D", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("| ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("P", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("a", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("c", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("k", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("a", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("g", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("e", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw(" ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("I", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("D", System.Console.ForegroundColor));
 
                 // Asserts for "| Latest Version "
-                mockLoggerWithColor.Verify(x => x.LogMinimal("| ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("L", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("a", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("t", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("e", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("s", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("t", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal(" ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("V", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("e", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("r", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("s", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("i", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("o", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("n", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("| ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("L", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("a", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("t", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("e", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("s", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("t", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw(" ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("V", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("e", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("r", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("s", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("i", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("o", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("n", System.Console.ForegroundColor));
 
                 // Asserts for "| Owners "
-                mockLoggerWithColor.Verify(x => x.LogMinimal("| ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("O", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("w", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("n", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("e", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("r", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("s", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal(" ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("| ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("O", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("w", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("n", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("e", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("r", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("s", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw(" ", System.Console.ForegroundColor));
 
                 // Asserts for "| Total Downloads "
-                mockLoggerWithColor.Verify(x => x.LogMinimal("| ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("T", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("o", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("t", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("a", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("l", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal(" ", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("D", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("o", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("w", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("n", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("l", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("o", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("a", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("d", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("s", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("| ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("T", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("o", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("t", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("a", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("l", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw(" ", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("D", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("o", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("w", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("n", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("l", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("o", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("a", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("d", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("s", System.Console.ForegroundColor));
 
                 // Assert for "NuGet.Versioning"
-                mockLoggerWithColor.Verify(x => x.LogMinimal("N", ConsoleColor.Red));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("u", ConsoleColor.Red));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("G", ConsoleColor.Red));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("e", ConsoleColor.Red));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("t", ConsoleColor.Red));
-                mockLoggerWithColor.Verify(x => x.LogMinimal(".", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("V", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("e", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("r", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("s", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("i", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("o", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("n", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("i", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("n", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("g", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("N", ConsoleColor.Red));
+                mockLoggerWithColor.Verify(x => x.LogRaw("u", ConsoleColor.Red));
+                mockLoggerWithColor.Verify(x => x.LogRaw("G", ConsoleColor.Red));
+                mockLoggerWithColor.Verify(x => x.LogRaw("e", ConsoleColor.Red));
+                mockLoggerWithColor.Verify(x => x.LogRaw("t", ConsoleColor.Red));
+                mockLoggerWithColor.Verify(x => x.LogRaw(".", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("V", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("e", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("r", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("s", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("i", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("o", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("n", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("i", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("n", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("g", System.Console.ForegroundColor));
 
                 // Assert for "4.3.0"
-                mockLoggerWithColor.Verify(x => x.LogMinimal("4", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal(".", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("3", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal(".", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("0", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("4", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw(".", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("3", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw(".", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("0", System.Console.ForegroundColor));
 
                 // Assert for "123,456"
-                mockLoggerWithColor.Verify(x => x.LogMinimal("1", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("2", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("3", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal(",", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("4", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("5", System.Console.ForegroundColor));
-                mockLoggerWithColor.Verify(x => x.LogMinimal("6", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("1", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("2", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("3", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw(",", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("4", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("5", System.Console.ForegroundColor));
+                mockLoggerWithColor.Verify(x => x.LogRaw("6", System.Console.ForegroundColor));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchTestInitializer.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchTestInitializer.cs
@@ -36,7 +36,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             loggerWithColorMock.Setup(x => x.LogError(It.IsAny<string>()))
                 .Callback<string>(message => StoredErrorMessage += message);
 
-            loggerWithColorMock.Setup(x => x.LogRaw(It.IsAny<string>(), It.IsAny<ConsoleColor>()))
+            loggerWithColorMock.Setup(x => x.LogInline(It.IsAny<string>(), It.IsAny<ConsoleColor>()))
                 .Callback<string, ConsoleColor>((message, color) =>
                 {
                     if (!ColoredMessage.ContainsKey(color))

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchTestInitializer.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/PackageSearchTestInitializer.cs
@@ -36,7 +36,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             loggerWithColorMock.Setup(x => x.LogError(It.IsAny<string>()))
                 .Callback<string>(message => StoredErrorMessage += message);
 
-            loggerWithColorMock.Setup(x => x.LogMinimal(It.IsAny<string>(), It.IsAny<ConsoleColor>()))
+            loggerWithColorMock.Setup(x => x.LogRaw(It.IsAny<string>(), It.IsAny<ConsoleColor>()))
                 .Callback<string, ConsoleColor>((message, color) =>
                 {
                     if (!ColoredMessage.ContainsKey(color))

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/TableTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/TableTests.cs
@@ -85,7 +85,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             string searchTerm = "term";
             Dictionary<ConsoleColor, string> coloredMessage = new Dictionary<ConsoleColor, string>();
             Mock<ILoggerWithColor> mockLoggerWithColor = new Mock<ILoggerWithColor>();
-            mockLoggerWithColor.Setup(x => x.LogMinimal(It.IsAny<string>(), It.IsAny<ConsoleColor>()))
+            mockLoggerWithColor.Setup(x => x.LogRaw(It.IsAny<string>(), It.IsAny<ConsoleColor>()))
                 .Callback<string, ConsoleColor>((message, color) =>
                 {
                     if (!coloredMessage.ContainsKey(color))

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/TableTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/TableTests.cs
@@ -85,7 +85,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             string searchTerm = "term";
             Dictionary<ConsoleColor, string> coloredMessage = new Dictionary<ConsoleColor, string>();
             Mock<ILoggerWithColor> mockLoggerWithColor = new Mock<ILoggerWithColor>();
-            mockLoggerWithColor.Setup(x => x.LogRaw(It.IsAny<string>(), It.IsAny<ConsoleColor>()))
+            mockLoggerWithColor.Setup(x => x.LogInline(It.IsAny<string>(), It.IsAny<ConsoleColor>()))
                 .Callback<string, ConsoleColor>((message, color) =>
                 {
                     if (!coloredMessage.ContainsKey(color))


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/dotnet/sdk/issues/50756
Fixes: https://github.com/NuGet/Home/issues/14533

## Description

As @KalleOlaviNiemitalo pointed out in https://github.com/NuGet/NuGet.Client/pull/6565#discussion_r2340636090, the change to make `ILoggerWithColor.LogMinimal(string, ConsoleColor)` to have the same behaviour as `LogMinimal(string)` broke `dotnet package search`'s table output.

This PR adds a new method, `LogRaw`, to make it very clear that it's intended to have different behaviour than all other `Log*` methods in the interface.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
