### PR TITLE
Pin .NET SDK for testing to last working version

### DIFF
--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -2,4 +2,4 @@
 # To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
 -Channel 8.0 -Runtime dotnet
 -Channel 9.0 -Runtime dotnet
--Channel 10.0.1xx -Quality daily
+-Channel 10.0.1xx -Version 10.0.100-rc.2.25465.104

--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -1,4 +1,4 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 10.0.1xx -Quality daily
 -Channel 9.0 -Runtime dotnet
 -Channel 8.0 -Runtime dotnet
+-Channel 10.0.1xx -Quality daily

--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -1,4 +1,5 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 9.0 -Runtime dotnet
+# To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
 -Channel 8.0 -Runtime dotnet
+-Channel 9.0 -Runtime dotnet
 -Channel 10.0.1xx -Quality daily


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: dotnet.integration.tests

## Description

Our Dotnet.Integration.Tests are failing on CI (but I can't reproduce locally to validate my PR changes without pushing), and it seems to be related to the latest daily build of the SDK.  I found the last CI build that worked and pinning the SDK version to that build for now.

Also, while investigating, I found out from the dotnet-install script reference docs that the order of installs matters, so that non-versioned files (like dotnet.exe) have the correct latest version.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
