### PR TITLE
VS Manifest SBOM path is set explicitly & Build Fails when file doesn't exist

### DIFF
--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -1,409 +1,409 @@
 parameters:
-- name: BuildRTM
-  type: boolean
-- name: RunUnitTests
-  displayName: Run unit tests
-  type: boolean
-  default: true
-- name: SigningType
-  displayName: Type of signing to use
-  type: string
+  - name: BuildRTM
+    type: boolean
+  - name: RunUnitTests
+    displayName: Run unit tests
+    type: boolean
+    default: true
+  - name: SigningType
+    displayName: Type of signing to use
+    type: string
 
 steps:
-- task: PowerShell@1
-  inputs:
-    scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
-    arguments: "-Force"
-  displayName: "Run Configure.ps1"
+  - task: PowerShell@1
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
+      arguments: "-Force"
+    displayName: "Run Configure.ps1"
 
-- task: PowerShell@1
-  inputs:
-    scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-    arguments: "-BuildRTM $(BuildRTM) -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(Build.BuildNumber)"
-  displayName: "Configure VSTS CI Environment"
+  - task: PowerShell@1
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
+      arguments: "-BuildRTM $(BuildRTM) -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(Build.BuildNumber)"
+    displayName: "Configure VSTS CI Environment"
 
-- task: PowerShell@1
-  displayName: "Print Environment Variables"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
+  - task: PowerShell@1
+    displayName: "Print Environment Variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
-# NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
-# However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package
-# won't be able to determine the URL to embed in the pdbs.
-# Therefore, we need to add the GitHub repo URL as a remote, and tell SourceLink.GitHub what that remote name is.
-# We do this even when github is the origin URL, to avoid warnings in the CI logs.
-- task: PowerShell@1
-  displayName: "Prepare for source link"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        $nugetUrl = "https://github.com/NuGet/NuGet.Client.git"
-        if (@(& git remote).Contains("github"))
-        {
-          $currentGitHubRemoteUrl = & git remote get-url github
-          Write-Host "Current github remote URL: $currentGitHubRemoteUrl"
-          if ($currentGitHubRemoteUrl -ne $nugetUrl)
+  # NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
+  # However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package
+  # won't be able to determine the URL to embed in the pdbs.
+  # Therefore, we need to add the GitHub repo URL as a remote, and tell SourceLink.GitHub what that remote name is.
+  # We do this even when github is the origin URL, to avoid warnings in the CI logs.
+  - task: PowerShell@1
+    displayName: "Prepare for source link"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        try {
+          $nugetUrl = "https://github.com/NuGet/NuGet.Client.git"
+          if (@(& git remote).Contains("github"))
           {
-            Write-Host "git remote set-url github $nugetUrl"
-            & git remote set-url github $nugetUrl
+            $currentGitHubRemoteUrl = & git remote get-url github
+            Write-Host "Current github remote URL: $currentGitHubRemoteUrl"
+            if ($currentGitHubRemoteUrl -ne $nugetUrl)
+            {
+              Write-Host "git remote set-url github $nugetUrl"
+              & git remote set-url github $nugetUrl
+            }
+            else
+            {
+              Write-Host "Git remote url already correct"
+            }
           }
           else
           {
-            Write-Host "Git remote url already correct"
+            Write-Host "git remote add github $nugetUrl"
+            & git remote add github $nugetUrl
           }
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
+          exit 1
         }
-        else
-        {
-          Write-Host "git remote add github $nugetUrl"
-          & git remote add github $nugetUrl
-        }
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
-        exit 1
-      }
 
-- task: CodeQL3000Init@0
-  displayName: Initialize CodeQL
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['Codeql.Enabled'], 'true'))"
+  - task: CodeQL3000Init@0
+    displayName: Initialize CodeQL
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['Codeql.Enabled'], 'true'))"
 
-- task: MSBuild@1
-  displayName: "Restore"
-  inputs:
-    solution: "build\\build.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:RestoreVS /property:BuildNumber=$(BuildNumber) /property:BuildRTM=$(BuildRTM) /property:IncludeApex=true /binarylogger:$(Build.StagingDirectory)\\binlog\\01.Restore.binlog"
-
-- task: CmdLine@2
-  displayName: "Restore packages to publish to the .NET Core build asset registry (BAR)"
-  inputs:
-    script: dotnet restore $(Build.Repository.LocalPath)\build\publish.proj -binarylogger:$(Build.StagingDirectory)\\binlog\\01.Restore-publish.binlog"
-    workingDirectory: cli
-    failOnStderr: true
-  env:
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    DOTNET_MULTILEVEL_LOOKUP: true
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-- task: PowerShell@1
-  displayName: "Set IncludeApex variable"
-  name: "includeapex"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        $IncludeApex = -not [bool]::Parse($env:BuildRTM)
-        Write-Host "IncludeApex URL: $IncludeApex"
-        Write-Host "##vso[task.setvariable variable=IncludeApex]$IncludeApex"
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Unable to set IncludeApex: $_"
-        exit 1
-      }
-
-- task: MSBuild@1
-  displayName: "Build"
-  inputs:
-    solution: "build\\build.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:BuildNoVSIX /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:GitRepositoryRemoteName=github /property:IncludeApex=$(IncludeApex) /binarylogger:$(Build.StagingDirectory)\\binlog\\02.Build.binlog /property:MicroBuild_SigningEnabled=false"
-
-# NuGet.exe embeds its own satellite resources, but satellite resources are built after the main assembly.
-# This means on the first build it's missing the resources, so we have to build nuget.exe a second time.
-- task: MSBuild@1
-  displayName: "Build localized NuGet.exe"
-  inputs:
-    solution: "src\\NuGet.Clients\\NuGet.CommandLine"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:GitRepositoryRemoteName=github /binarylogger:$(Build.StagingDirectory)\\binlog\\02a.Build_NuGet.exe.binlog /property:MicroBuild_SigningEnabled=false"
-
-- task: CodeQL3000Finalize@0
-  displayName: Finalize CodeQL
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['Codeql.Enabled'], 'true'))"
-
-- task: MSBuild@1
-  displayName: "Publish NuGet.exe (ILMerged) into NuGet.CommandLine.Test (Mac tests use this)"
-  inputs:
-    solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:CopyFinalNuGetExeToOutputPath /binarylogger:$(Build.StagingDirectory)\\binlog\\06.CopyFinalNuGetExeToOutputPath.binlog"
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'), ne(variables['RunMonoTestsOnMac'], 'false'))"
-
-- ${{ if eq(parameters.RunUnitTests, true) }}:
   - task: MSBuild@1
-    displayName: "Run unit tests (stop on error)"
-    continueOnError: "false"
+    displayName: "Restore"
     inputs:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.RunUnitTests.binlog"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
+      msbuildArguments: "/restore:false /target:RestoreVS /property:BuildNumber=$(BuildNumber) /property:BuildRTM=$(BuildRTM) /property:IncludeApex=true /binarylogger:$(Build.StagingDirectory)\\binlog\\01.Restore.binlog"
 
-- ${{ if eq(parameters.RunUnitTests, true) }}:
+  - task: CmdLine@2
+    displayName: "Restore packages to publish to the .NET Core build asset registry (BAR)"
+    inputs:
+      script: dotnet restore $(Build.Repository.LocalPath)\build\publish.proj -binarylogger:$(Build.StagingDirectory)\\binlog\\01.Restore-publish.binlog"
+      workingDirectory: cli
+      failOnStderr: true
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      DOTNET_MULTILEVEL_LOOKUP: true
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+  - task: PowerShell@1
+    displayName: "Set IncludeApex variable"
+    name: "includeapex"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        try {
+          $IncludeApex = -not [bool]::Parse($env:BuildRTM)
+          Write-Host "IncludeApex URL: $IncludeApex"
+          Write-Host "##vso[task.setvariable variable=IncludeApex]$IncludeApex"
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]Unable to set IncludeApex: $_"
+          exit 1
+        }
+
   - task: MSBuild@1
-    displayName: "Run unit tests (continue on error)"
-    continueOnError: "true"
+    displayName: "Build"
     inputs:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.RunUnitTests.binlog"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
+      msbuildArguments: "/restore:false /target:BuildNoVSIX /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:GitRepositoryRemoteName=github /property:IncludeApex=$(IncludeApex) /binarylogger:$(Build.StagingDirectory)\\binlog\\02.Build.binlog /property:MicroBuild_SigningEnabled=false"
 
-- ${{ if eq(parameters.RunUnitTests, true) }}:
-  - task: PublishTestResults@2
-    displayName: "Publish Test Results"
+  # NuGet.exe embeds its own satellite resources, but satellite resources are built after the main assembly.
+  # This means on the first build it's missing the resources, so we have to build nuget.exe a second time.
+  - task: MSBuild@1
+    displayName: "Build localized NuGet.exe"
     inputs:
-      testRunner: "VSTest"
-      testResultsFiles: "*.trx"
-      testRunTitle: "NuGet.Client Unit Tests On Windows"
-      searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
-      publishRunAttachments: "false"
-    condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
+      solution: "src\\NuGet.Clients\\NuGet.CommandLine"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:GitRepositoryRemoteName=github /binarylogger:$(Build.StagingDirectory)\\binlog\\02a.Build_NuGet.exe.binlog /property:MicroBuild_SigningEnabled=false"
 
-- task: MSBuild@1
-  displayName: "Pack Nupkgs"
-  inputs:
-    solution: "build\\build.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:Pack /property:BuildRTM=$(BuildRTM) /property:ExcludeTestProjects=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /binarylogger:$(Build.StagingDirectory)\\binlog\\11.Pack.binlog /property:MicroBuild_SigningEnabled=false"
+  - task: CodeQL3000Finalize@0
+    displayName: Finalize CodeQL
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['Codeql.Enabled'], 'true'))"
 
-- task: PowerShell@1
-  displayName: "Check expected packages exist for publishing"
-  name: "EnsureAllPackagesExist"
-  inputs:
-    scriptName: "$(Build.Repository.LocalPath)\\scripts\\utils\\EnsureAllPackagesExist.ps1"
-    arguments: "-BuildRTM:$$(BuildRTM) -NupkgOutputPath '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'"
+  - task: MSBuild@1
+    displayName: "Publish NuGet.exe (ILMerged) into NuGet.CommandLine.Test (Mac tests use this)"
+    inputs:
+      solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:CopyFinalNuGetExeToOutputPath /binarylogger:$(Build.StagingDirectory)\\binlog\\06.CopyFinalNuGetExeToOutputPath.binlog"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'), ne(variables['RunMonoTestsOnMac'], 'false'))"
 
-- task: MSBuild@1
-  displayName: "Ensure all Nupkgs and Symbols are created"
-  inputs:
-    solution: "build\\build.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:EnsurePackagesExist /property:ExcludeTestProjects=$(BuildRTM) /binarylogger:$(Build.StagingDirectory)\\binlog\\12.EnsurePackagesExist.binlog"
+  - ${{ if eq(parameters.RunUnitTests, true) }}:
+      - task: MSBuild@1
+        displayName: "Run unit tests (stop on error)"
+        continueOnError: "false"
+        inputs:
+          solution: "build\\build.proj"
+          configuration: "$(BuildConfiguration)"
+          msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.RunUnitTests.binlog"
+        condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
 
-- task: MSBuild@1
-  displayName: "Pack VSIX"
-  inputs:
-    solution: "build\\build.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:BuildVSIX /property:BuildRTM=$(BuildRTM) /property:ExcludeTestProjects=$(BuildRTM) /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\13.PackVSIX.binlog"
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
-- ${{ if not(parameters.BuildRTM)}}:
-  - template: /eng/common/templates-official/steps/generate-sbom.yml@self
-    parameters:
-      PackageName: 'NuGet.Client'
-      PackageVersion: "$(SemanticVersion)"
-      publishArtifacts: false
+  - ${{ if eq(parameters.RunUnitTests, true) }}:
+      - task: MSBuild@1
+        displayName: "Run unit tests (continue on error)"
+        continueOnError: "true"
+        inputs:
+          solution: "build\\build.proj"
+          configuration: "$(BuildConfiguration)"
+          msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.RunUnitTests.binlog"
+        condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
 
-- task: MSBuild@1
-  displayName: "Generate Build Tools package"
-  inputs:
-    solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.BuildToolsVSIX.binlog"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  - ${{ if eq(parameters.RunUnitTests, true) }}:
+      - task: PublishTestResults@2
+        displayName: "Publish Test Results"
+        inputs:
+          testRunner: "VSTest"
+          testResultsFiles: "*.trx"
+          testRunTitle: "NuGet.Client Unit Tests On Windows"
+          searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
+          publishRunAttachments: "false"
+        condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
 
-- task: MSBuild@1
-  displayName: "Sign"
-  inputs:
-    solution: "build\\sign.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore /p:DryRunSigning=false /p:DotNetSignType=$(SigningType) /p:SigningLogDirectory=$(Build.StagingDirectory)\\binlog /binarylogger:$(Build.StagingDirectory)\\binlog\\15.Sign.binlog"
+  - task: MSBuild@1
+    displayName: "Pack Nupkgs"
+    inputs:
+      solution: "build\\build.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:Pack /property:BuildRTM=$(BuildRTM) /property:ExcludeTestProjects=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /binarylogger:$(Build.StagingDirectory)\\binlog\\11.Pack.binlog /property:MicroBuild_SigningEnabled=false"
 
-- task: NuGetToolInstaller@1
-  displayName: Use NuGet 6.x
-  inputs:
-    versionSpec: 6.x
+  - task: PowerShell@1
+    displayName: "Check expected packages exist for publishing"
+    name: "EnsureAllPackagesExist"
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\scripts\\utils\\EnsureAllPackagesExist.ps1"
+      arguments: "-BuildRTM:$$(BuildRTM) -NupkgOutputPath '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'"
 
-- task: NuGetCommand@2
-  displayName: "Verify Nupkg Signatures"
-  inputs:
-    command: "custom"
-    arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
+  - task: MSBuild@1
+    displayName: "Ensure all Nupkgs and Symbols are created"
+    inputs:
+      solution: "build\\build.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:EnsurePackagesExist /property:ExcludeTestProjects=$(BuildRTM) /binarylogger:$(Build.StagingDirectory)\\binlog\\12.EnsurePackagesExist.binlog"
 
-- task: MicroBuildCodesignVerify@3
-  displayName: Verify Assembly Signatures and StrongName for the nupkgs
-  inputs:
-    TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+  - task: MSBuild@1
+    displayName: "Pack VSIX"
+    inputs:
+      solution: "build\\build.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:BuildVSIX /property:BuildRTM=$(BuildRTM) /property:ExcludeTestProjects=$(BuildRTM) /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\13.PackVSIX.binlog"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+  - ${{ if not(parameters.BuildRTM)}}:
+      - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+        parameters:
+          PackageName: "NuGet.Client"
+          PackageVersion: "$(SemanticVersion)"
+          publishArtifacts: false
 
-- task: MicroBuildCodesignVerify@3
-  displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
-  inputs:
-    TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
-    ApprovalListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-    ApprovalListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+  - task: MSBuild@1
+    displayName: "Generate Build Tools package"
+    inputs:
+      solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.BuildToolsVSIX.binlog"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: MSBuild@1
-  displayName: "Generate VSMAN file for NuGet Core VSIX"
-  inputs:
-    solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\16.GenerateVSManifestForVSIX.binlog"
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+  - task: MSBuild@1
+    displayName: "Sign"
+    inputs:
+      solution: "build\\sign.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore /p:DryRunSigning=false /p:DotNetSignType=$(SigningType) /p:SigningLogDirectory=$(Build.StagingDirectory)\\binlog /binarylogger:$(Build.StagingDirectory)\\binlog\\15.Sign.binlog"
 
-- task: MSBuild@1
-  displayName: "Generate VSMAN file for Build Tools VSIX"
-  inputs:
-    solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateVSManifestForToolsVSIX.binlog"
-  condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 6.x
+    inputs:
+      versionSpec: 6.x
 
-- task: NuGetCommand@2
-  displayName: 'Add the VSEng package source'
-  inputs:
-    command: 'custom'
-    arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  - task: NuGetCommand@2
+    displayName: "Verify Nupkg Signatures"
+    inputs:
+      command: "custom"
+      arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
 
-- task: NuGetCommand@2
-  displayName: 'Install the NuGet package for building .runsettingsproj files'
-  inputs:
-    command: 'custom'
-    arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  - task: MicroBuildCodesignVerify@3
+    displayName: Verify Assembly Signatures and StrongName for the nupkgs
+    inputs:
+      TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
 
-- task: MicroBuildBuildVSBootstrapper@3
-  displayName: 'Build a Visual Studio bootstrapper for tests'
-  inputs:
-    azureSubscription: 'VSEng-VSDrop-MI'
-    channelName: "$(VsTargetChannelForTests)"
-    vsMajorVersion: "$(VsTargetMajorVersion)"
-    manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
-    outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-  env:
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-- task: PowerShell@1
-  displayName: "Set Bootstrapper URL variable for tests"
-  name: "vsbootstrapper"
-  inputs:
-    scriptType: "inlineScript"
-    # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
-    inlineScript: |
-      try {
-        $json = Get-Content "${env:MicroBuildOutputFolderOverride}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-        $bootstrapperUrl = $json[0].bootstrapperUrl;
-        Write-Host "Bootstrapper URL: $bootstrapperUrl"
-        Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
-        exit 1
-      }
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  - task: MicroBuildCodesignVerify@3
+    displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
+    inputs:
+      TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
+      ApprovalListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+      ApprovalListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
 
-- task: PowerShell@1
-  displayName: "Set CloudBuild Session ID variable for tests"
-  name: "setcloudbuildsessionid"
-  continueOnError: true
-  inputs:
-    scriptType: "inlineScript"
-    # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
-    inlineScript: |
-      try {
-        $json = Get-Content "${env:MicroBuildOutputFolderOverride}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-        $qBuildSessionId = $json[0].QBuildSessionId;
-        Write-Host "CloudBuild Session ID: $qBuildSessionId"
-        Write-Host "##vso[task.setvariable variable=QBuildSessionId;isOutput=true]$qBuildSessionId"
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Unable to set CloudBuild Session ID: $_"
-      }
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  - task: MSBuild@1
+    displayName: "Generate VSMAN file for NuGet Core VSIX"
+    inputs:
+      solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/property:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\16.GenerateVSManifestForVSIX.binlog"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
-- task: PowerShell@1
-  displayName: "Set Base Build Drop variable for tests"
-  name: "setbasebuilddrop"
-  continueOnError: true
-  inputs:
-    scriptType: "inlineScript"
-    # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
-    inlineScript: |
-      try {
-        $json = Get-Content "${env:MicroBuildOutputFolderOverride}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-        $buildDrop = $json[0].BuildDrop;
-        Write-Host "Base Build Drop: $buildDrop"
-        Write-Host "##vso[task.setvariable variable=BaseBuildDrop;isOutput=true]$buildDrop"
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Unable to set Base Build Drop: $_"
-      }
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  - task: MSBuild@1
+    displayName: "Generate VSMAN file for Build Tools VSIX"
+    inputs:
+      solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateVSManifestForToolsVSIX.binlog"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
-- task: MSBuild@1
-  displayName: 'Generate .runsettings files'
-  inputs:
-    solution: 'build\runsettings.proj'
-    msbuildArguments: '/restore:false /property:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /property:TestDrop="RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" /property:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateRunSettings.binlog'
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  - task: NuGetCommand@2
+    displayName: "Add the VSEng package source"
+    inputs:
+      command: "custom"
+      arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: PowerShell@1
-  displayName: 'Copy VS integration test binaries'
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        Write-Output "Copying NuGet.OptProf binaries"
-        Copy-Item test\NuGet.Tests.Apex\NuGet.OptProf\bin\$(BuildConfiguration) artifacts\RunSettings\NuGet.OptProf\ -Recurse -ErrorAction Stop
-        Write-Output "Copying NuGet.Tests.Apex binaries"
-        Copy-Item test\NuGet.Tests.Apex\NuGet.Tests.Apex\bin\$(BuildConfiguration) artifacts\RunSettings\NuGet.Tests.Apex\ -Recurse -ErrorAction Stop
-        Write-Output "Copying NuGet.Tests.Apex.Daily binaries"
-        Copy-Item test\NuGet.Tests.Apex\NuGet.Tests.Apex.Daily\bin\$(BuildConfiguration) artifacts\RunSettings\NuGet.Tests.Apex.Daily\ -Recurse -ErrorAction Stop
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]$_"
-        exit 1
-      }
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  - task: NuGetCommand@2
+    displayName: "Install the NuGet package for building .runsettingsproj files"
+    inputs:
+      command: "custom"
+      arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: MSBuild@1
-  displayName: "Collect Build Symbols"
-  inputs:
-    solution: "build\\symbols.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:IsSymbolBuild=true /property:BuildRTM=$(BuildRTM) /binarylogger:$(Build.StagingDirectory)\\binlog\\18.CollectBuildSymbols.binlog"
-    maximumCpuCount: true
-  condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
+  - task: MicroBuildBuildVSBootstrapper@3
+    displayName: "Build a Visual Studio bootstrapper for tests"
+    inputs:
+      azureSubscription: "VSEng-VSDrop-MI"
+      channelName: "$(VsTargetChannelForTests)"
+      vsMajorVersion: "$(VsTargetMajorVersion)"
+      manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
+      outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+  - task: PowerShell@1
+    displayName: "Set Bootstrapper URL variable for tests"
+    name: "vsbootstrapper"
+    inputs:
+      scriptType: "inlineScript"
+      # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
+      inlineScript: |
+        try {
+          $json = Get-Content "${env:MicroBuildOutputFolderOverride}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+          $bootstrapperUrl = $json[0].bootstrapperUrl;
+          Write-Host "Bootstrapper URL: $bootstrapperUrl"
+          Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
+          exit 1
+        }
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: MSBuild@1
-  displayName: "LocValidation: Verify VSIX"
-  inputs:
-    solution: "build\\BuildValidator.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/target:ValidateVsix /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\19.ValidateVsixLocalization.binlog"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  - task: PowerShell@1
+    displayName: "Set CloudBuild Session ID variable for tests"
+    name: "setcloudbuildsessionid"
+    continueOnError: true
+    inputs:
+      scriptType: "inlineScript"
+      # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
+      inlineScript: |
+        try {
+          $json = Get-Content "${env:MicroBuildOutputFolderOverride}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+          $qBuildSessionId = $json[0].QBuildSessionId;
+          Write-Host "CloudBuild Session ID: $qBuildSessionId"
+          Write-Host "##vso[task.setvariable variable=QBuildSessionId;isOutput=true]$qBuildSessionId"
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]Unable to set CloudBuild Session ID: $_"
+        }
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: MSBuild@1
-  displayName: "LocValidation: Verify Artifacts"
-  inputs:
-    solution: "build\\BuildValidator.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/target:ValidateArtifacts /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\20.ValidateArtifactsLocalization.binlog"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+  - task: PowerShell@1
+    displayName: "Set Base Build Drop variable for tests"
+    name: "setbasebuilddrop"
+    continueOnError: true
+    inputs:
+      scriptType: "inlineScript"
+      # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
+      inlineScript: |
+        try {
+          $json = Get-Content "${env:MicroBuildOutputFolderOverride}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+          $buildDrop = $json[0].BuildDrop;
+          Write-Host "Base Build Drop: $buildDrop"
+          Write-Host "##vso[task.setvariable variable=BaseBuildDrop;isOutput=true]$buildDrop"
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]Unable to set Base Build Drop: $_"
+        }
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-  # Use dotnet msbuild instead of MSBuild CLI.
-  # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.
-  # The Microsoft.DotNet.Build.Tasks.Feed package includes NuGet.Common 4.9.0.6 and a binding redirection in Microsoft.DotNet.Build.Tasks.Feed.dll.config but the binding redirection is not processed.
-  # This would probably solve it:  https://github.com/Microsoft/msbuild/issues/1309
-- task: UseDotNet@2
-  displayName: "Install .NET 10.0.0 for BAR publishing"
-  inputs:
-    packageType: sdk
-    version: 10.0.x
-    includePreviewVersions: true
-    installationPath: $(Agent.TempDirectory)/dotnet
-    workingDirectory: $(Agent.TempDirectory)
-  condition: "and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false'))"
+  - task: MSBuild@1
+    displayName: "Generate .runsettings files"
+    inputs:
+      solution: 'build\runsettings.proj'
+      msbuildArguments: '/restore:false /property:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /property:TestDrop="RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" /property:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateRunSettings.binlog'
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-- task: AzureCLI@2
-  displayName: "Publish to the .NET Core build asset registry (BAR)"
-  inputs:
-    azureSubscription: "Darc: Maestro Production"
-    scriptType: ps
-    scriptLocation: inlineScript
-    inlineScript: |
-      $(Agent.TempDirectory)/dotnet/dotnet msbuild $(Build.Repository.LocalPath)\build\publish.proj /t:PublishToBuildAssetRegistry /property:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /property:BUILD_BUILDNUMBER=$(Build.BuildNumber) /property:BUILD_SOURCEBRANCH=$(Build.SourceBranchName) /property:BUILD_SOURCEVERSION=$(Build.SourceVersion) /property:BUILD_REPOSITORY_URI=$(Build.Repository.Uri) /property:BUILD_REPOSITORY_NAME=$(Build.Repository.Name) /property:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ /binarylogger:$(Build.StagingDirectory)\binlog\21.PublishToBuildAssetRegistry.binlog /property:MaestroApiEndpoint=$(MaestroApiEndpoint)
-    workingDirectory: cli
-    failOnStderr: true
-  env:
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    DOTNET_MULTILEVEL_LOOKUP: true
-  condition: "and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false'))"
+  - task: PowerShell@1
+    displayName: "Copy VS integration test binaries"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        try {
+          Write-Output "Copying NuGet.OptProf binaries"
+          Copy-Item test\NuGet.Tests.Apex\NuGet.OptProf\bin\$(BuildConfiguration) artifacts\RunSettings\NuGet.OptProf\ -Recurse -ErrorAction Stop
+          Write-Output "Copying NuGet.Tests.Apex binaries"
+          Copy-Item test\NuGet.Tests.Apex\NuGet.Tests.Apex\bin\$(BuildConfiguration) artifacts\RunSettings\NuGet.Tests.Apex\ -Recurse -ErrorAction Stop
+          Write-Output "Copying NuGet.Tests.Apex.Daily binaries"
+          Copy-Item test\NuGet.Tests.Apex\NuGet.Tests.Apex.Daily\bin\$(BuildConfiguration) artifacts\RunSettings\NuGet.Tests.Apex.Daily\ -Recurse -ErrorAction Stop
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]$_"
+          exit 1
+        }
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+  - task: MSBuild@1
+    displayName: "Collect Build Symbols"
+    inputs:
+      solution: "build\\symbols.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:IsSymbolBuild=true /property:BuildRTM=$(BuildRTM) /binarylogger:$(Build.StagingDirectory)\\binlog\\18.CollectBuildSymbols.binlog"
+      maximumCpuCount: true
+    condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
+
+  - task: MSBuild@1
+    displayName: "LocValidation: Verify VSIX"
+    inputs:
+      solution: "build\\BuildValidator.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/target:ValidateVsix /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\19.ValidateVsixLocalization.binlog"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+  - task: MSBuild@1
+    displayName: "LocValidation: Verify Artifacts"
+    inputs:
+      solution: "build\\BuildValidator.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/target:ValidateArtifacts /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\20.ValidateArtifactsLocalization.binlog"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+    # Use dotnet msbuild instead of MSBuild CLI.
+    # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.
+    # The Microsoft.DotNet.Build.Tasks.Feed package includes NuGet.Common 4.9.0.6 and a binding redirection in Microsoft.DotNet.Build.Tasks.Feed.dll.config but the binding redirection is not processed.
+    # This would probably solve it:  https://github.com/Microsoft/msbuild/issues/1309
+  - task: UseDotNet@2
+    displayName: "Install .NET 10.0.0 for BAR publishing"
+    inputs:
+      packageType: sdk
+      version: 10.0.x
+      includePreviewVersions: true
+      installationPath: $(Agent.TempDirectory)/dotnet
+      workingDirectory: $(Agent.TempDirectory)
+    condition: "and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false'))"
+
+  - task: AzureCLI@2
+    displayName: "Publish to the .NET Core build asset registry (BAR)"
+    inputs:
+      azureSubscription: "Darc: Maestro Production"
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        $(Agent.TempDirectory)/dotnet/dotnet msbuild $(Build.Repository.LocalPath)\build\publish.proj /t:PublishToBuildAssetRegistry /property:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /property:BUILD_BUILDNUMBER=$(Build.BuildNumber) /property:BUILD_SOURCEBRANCH=$(Build.SourceBranchName) /property:BUILD_SOURCEVERSION=$(Build.SourceVersion) /property:BUILD_REPOSITORY_URI=$(Build.Repository.Uri) /property:BUILD_REPOSITORY_NAME=$(Build.Repository.Name) /property:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ /binarylogger:$(Build.StagingDirectory)\binlog\21.PublishToBuildAssetRegistry.binlog /property:MaestroApiEndpoint=$(MaestroApiEndpoint)
+      workingDirectory: cli
+      failOnStderr: true
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      DOTNET_MULTILEVEL_LOOKUP: true
+    condition: "and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false'))"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -196,6 +196,18 @@ steps:
       PackageVersion: "$(SemanticVersion)"
       publishArtifacts: false
 
+- task: PowerShell@2
+  inputs:
+    targetType: 'inline'
+    script: |
+      Write-Host "The value of ARTIFACT_NAME is: $(ARTIFACT_NAME)"
+      Write-Host "The value of ARTIFACT_NAME is: $ARTIFACT_NAME"
+      Write-Host "The value of ARTIFACTNAME is: $(ARTIFACTNAME)"
+      Write-Host "The value of ARTIFACTNAME is: $ARTIFACTNAME"
+      Write-Host "The value of SafeArtifactName is: $(SafeArtifactName)"
+      throw "Stop!!"
+    failOnStderr: true
+
 - task: MSBuild@1
   displayName: "Generate Build Tools package"
   inputs:

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -196,18 +196,6 @@ steps:
       PackageVersion: "$(SemanticVersion)"
       publishArtifacts: false
 
-- task: PowerShell@2
-  inputs:
-    targetType: 'inline'
-    script: |
-      Write-Host "The value of ARTIFACT_NAME is: $(ARTIFACT_NAME)"
-      Write-Host "The value of ARTIFACT_NAME is: $ARTIFACT_NAME"
-      Write-Host "The value of ARTIFACTNAME is: $(ARTIFACTNAME)"
-      Write-Host "The value of ARTIFACTNAME is: $ARTIFACTNAME"
-      Write-Host "The value of SafeArtifactName is: $(SafeArtifactName)"
-      throw "Stop!!"
-    failOnStderr: true
-
 - task: MSBuild@1
   displayName: "Generate Build Tools package"
   inputs:

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -201,7 +201,7 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.BuildToolsVSIX.binlog"
+    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:SkipSbomExistsCheck=true /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.BuildToolsVSIX.binlog"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -201,7 +201,7 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:SkipSbomExistsCheck=true /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.BuildToolsVSIX.binlog"
+    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.BuildToolsVSIX.binlog"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -144,14 +144,14 @@ steps:
     inputs:
       solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
+      msbuildArguments: "/property:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
 
   - task: MSBuild@1
     displayName: "Generate VSMAN file for Build Tools VSIX"
     inputs:
       solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
+      msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.ArtifactStagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
 
   - task: MSBuild@1
     displayName: "Create EndToEnd Test Package"

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -1,294 +1,293 @@
 steps:
-- task: MicroBuildLocalizationPlugin@4
-  displayName: "Install Localization Plugin"
+  - task: MicroBuildLocalizationPlugin@4
+    displayName: "Install Localization Plugin"
 
-- task: MicroBuildSigningPlugin@4
-  inputs:
-    signType: "Test"
-  displayName: "Install Signing Plugin"
+  - task: MicroBuildSigningPlugin@4
+    inputs:
+      signType: "Test"
+    displayName: "Install Signing Plugin"
 
-- task: MicroBuildSwixPlugin@4
-  displayName: "Install Swix Plugin"
-  inputs:
-    dropName: "Tests/$(System.TeamProject)/$(Build.DefinitionName)/$(Build.SourceBranchName)/$(Build.BuildId)"
-- task: PowerShell@1
-  displayName: "Run Configure.ps1"
-  inputs:
-    scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
-    arguments: "-Force"
+  - task: MicroBuildSwixPlugin@4
+    displayName: "Install Swix Plugin"
+    inputs:
+      dropName: "Tests/$(System.TeamProject)/$(Build.DefinitionName)/$(Build.SourceBranchName)/$(Build.BuildId)"
+  - task: PowerShell@1
+    displayName: "Run Configure.ps1"
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
+      arguments: "-Force"
 
-- task: PowerShell@1
-  displayName: "Set build variables"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        $buildNumber = dotnet msbuild -getProperty:PreReleaseVersion $(Build.Repository.LocalPath)\build\config.props
-        Write-Host "Setting build number to: $buildNumber"
-        Write-Host "##vso[task.setvariable variable=BuildNumber]$buildNumber"
+  - task: PowerShell@1
+    displayName: "Set build variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        try {
+          $buildNumber = dotnet msbuild -getProperty:PreReleaseVersion $(Build.Repository.LocalPath)\build\config.props
+          Write-Host "Setting build number to: $buildNumber"
+          Write-Host "##vso[task.setvariable variable=BuildNumber]$buildNumber"
 
-        $version = dotnet msbuild -getProperty:AssemblyVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
-        Write-Host "Setting NuGet version to: $version"
-        Write-Host "##vso[task.setvariable variable=NuGetVersion]$version"
+          $version = dotnet msbuild -getProperty:AssemblyVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
+          Write-Host "Setting NuGet version to: $version"
+          Write-Host "##vso[task.setvariable variable=NuGetVersion]$version"
 
-        $VsTargetChannelForTests = dotnet msbuild -getProperty:VsTargetChannelForTests $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
-        Write-Host "Setting VsTargetChannelForTests to: $VsTargetChannelForTests"
-        Write-Host "##vso[task.setvariable variable=VsTargetChannelForTests]$VsTargetChannelForTests"
+          $VsTargetChannelForTests = dotnet msbuild -getProperty:VsTargetChannelForTests $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
+          Write-Host "Setting VsTargetChannelForTests to: $VsTargetChannelForTests"
+          Write-Host "##vso[task.setvariable variable=VsTargetChannelForTests]$VsTargetChannelForTests"
 
-        $VsTargetMajorVersion = dotnet msbuild -getProperty:VsTargetMajorVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
-        Write-Host "Setting VsTargetMajorVersion to: $VsTargetMajorVersion"
-        Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion]$VsTargetMajorVersion"
-      } catch {
-        throw $_
-      }
+          $VsTargetMajorVersion = dotnet msbuild -getProperty:VsTargetMajorVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
+          Write-Host "Setting VsTargetMajorVersion to: $VsTargetMajorVersion"
+          Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion]$VsTargetMajorVersion"
+        } catch {
+          throw $_
+        }
 
+  - task: PowerShell@1
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
+      arguments: "-BuildRTM false -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(NuGetVersion)"
+    displayName: "Configure VSTS CI Environment"
 
-- task: PowerShell@1
-  inputs:
-    scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-    arguments: "-BuildRTM false -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(NuGetVersion)"
-  displayName: "Configure VSTS CI Environment"
+  - task: PowerShell@1
+    displayName: "Print Environment Variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
+    condition: "always()"
 
-- task: PowerShell@1
-  displayName: "Print Environment Variables"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
-  condition: "always()"
-
-# NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
-# However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package
-# won't be able to determine the URL to embed in the pdbs.
-# Therefore, we need to add the GitHub repo URL as a remote, and tell SourceLink.GitHub what that remote name is.
-# We do this even when github is the origin URL, to avoid warnings in the CI logs.
-- task: PowerShell@1
-  displayName: "Prepare for source link"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        $nugetUrl = "https://github.com/NuGet/NuGet.Client.git"
-        if (@(& git remote).Contains("github"))
-        {
-          $currentGitHubRemoteUrl = & git remote get-url github
-          Write-Host "Current github remote URL: $currentGitHubRemoteUrl"
-          if ($currentGitHubRemoteUrl -ne $nugetUrl)
+  # NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
+  # However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package
+  # won't be able to determine the URL to embed in the pdbs.
+  # Therefore, we need to add the GitHub repo URL as a remote, and tell SourceLink.GitHub what that remote name is.
+  # We do this even when github is the origin URL, to avoid warnings in the CI logs.
+  - task: PowerShell@1
+    displayName: "Prepare for source link"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        try {
+          $nugetUrl = "https://github.com/NuGet/NuGet.Client.git"
+          if (@(& git remote).Contains("github"))
           {
-            Write-Host "git remote set-url github $nugetUrl"
-            & git remote set-url github $nugetUrl
+            $currentGitHubRemoteUrl = & git remote get-url github
+            Write-Host "Current github remote URL: $currentGitHubRemoteUrl"
+            if ($currentGitHubRemoteUrl -ne $nugetUrl)
+            {
+              Write-Host "git remote set-url github $nugetUrl"
+              & git remote set-url github $nugetUrl
+            }
+            else
+            {
+              Write-Host "Git remote url already correct"
+            }
           }
           else
           {
-            Write-Host "Git remote url already correct"
+            Write-Host "git remote add github $nugetUrl"
+            & git remote add github $nugetUrl
           }
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
+          exit 1
         }
-        else
-        {
-          Write-Host "git remote add github $nugetUrl"
-          & git remote add github $nugetUrl
+
+  - task: MSBuild@1
+    displayName: "Restore"
+    inputs:
+      solution: "NuGet.sln"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:Restore /binarylogger:$(Build.StagingDirectory)\\binlog\\01.Restore.binlog"
+
+  - task: MSBuild@1
+    displayName: "Build"
+    inputs:
+      solution: "NuGet.sln"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:Build /property:GitRepositoryRemoteName=github /binarylogger:$(Build.StagingDirectory)\\binlog\\02.Build.binlog /property:MicroBuild_SigningEnabled=false"
+
+  - task: MSBuild@1
+    displayName: "Pack VSIX"
+    inputs:
+      solution: "build\\build.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:BuildVSIX /property:ExcludeTestProjects=false /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.PackVSIX.binlog"
+
+  - task: MSBuild@1
+    displayName: "Sign"
+    inputs:
+      solution: "build\\sign.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore /p:DryRunSigning=false /p:DotNetSignType=test /binarylogger:$(Build.StagingDirectory)\\binlog\\09.SignPackages.binlog"
+
+  - task: MicroBuildCodesignVerify@3
+    displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
+    inputs:
+      TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
+      ApprovalListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+      ApprovalListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+
+  - task: MSBuild@1
+    displayName: "Create EndToEnd Test Package"
+    inputs:
+      solution: "$(Build.Repository.LocalPath)\\test\\TestUtilities\\CreateEndToEndTestPackage\\CreateEndToEndTestPackage.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/property:EndToEndPackageOutputPath=$(Build.StagingDirectory)\\E2ETests /property:BuildProjectReferences=false /binarylogger:$(Build.StagingDirectory)\\binlog\\12.CreateEndToEndTestPackage.binlog"
+
+  - task: CopyFiles@2
+    displayName: "Copy NuGet.exe for E2E Tests"
+    inputs:
+      SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+      Contents: "NuGet.exe"
+      TargetFolder: "$(Build.StagingDirectory)\\E2ETests"
+
+  - task: NuGetToolInstaller@1
+
+  - task: NuGetCommand@2
+    displayName: "Add the VSEng package source"
+    inputs:
+      command: "custom"
+      arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+
+  - task: NuGetCommand@2
+    displayName: "Install the NuGet package for building .runsettingsproj files"
+    inputs:
+      command: "custom"
+      arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+
+  - task: MicroBuildBuildVSBootstrapper@3
+    displayName: "Build a Visual Studio bootstrapper for tests"
+    inputs:
+      azureSubscription: "VSEng-VSDrop-MI"
+      channelName: "$(VsTargetChannelForTests)"
+      vsMajorVersion: "$(VsTargetMajorVersion)"
+      manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
+      outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+  - task: PowerShell@1
+    displayName: "Set DartLab variables for tests"
+    name: "dartlab_variables"
+    inputs:
+      scriptType: "inlineScript"
+      # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
+      inlineScript: |
+        try {
+          $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+
+          $bootstrapperUrl = $json[0].bootstrapperUrl;
+          Write-Host "Bootstrapper URL: $bootstrapperUrl"
+          Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
+
+          $qBuildSessionId = $json[0].QBuildSessionId;
+          Write-Host "CloudBuild Session ID: $qBuildSessionId"
+          Write-Host "##vso[task.setvariable variable=QBuildSessionId;isOutput=true]$qBuildSessionId"
+
+          $buildDrop = $json[0].BuildDrop;
+          Write-Host "Base Build Drop: $buildDrop"
+          Write-Host "##vso[task.setvariable variable=BaseBuildDrop;isOutput=true]$buildDrop"
+
+          $runSettingsDrop = "RunSettings/${env:System_TeamProject}/${env:Build_DefinitionName}/${env:Build_SourceBranchName}/${env:Build_BuildId}"
+          Write-Host "Run Settings Drop: $runSettingsDrop"
+          Write-Host "##vso[task.setvariable variable=RunSettingsDrop]$runSettingsDrop"
+          Write-Host "##vso[task.setvariable variable=RunSettingsDrop;isOutput=true]$runSettingsDrop"
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]Unable to set variables for DartLab: $_"
+          exit 1
         }
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
-        exit 1
-      }
 
-- task: MSBuild@1
-  displayName: "Restore"
-  inputs:
-    solution: "NuGet.sln"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:Restore /binarylogger:$(Build.StagingDirectory)\\binlog\\01.Restore.binlog"
+  - task: MSBuild@1
+    displayName: "Generate .runsettings files"
+    inputs:
+      solution: 'build\runsettings.proj'
+      msbuildArguments: '/restore:false /property:OutputPath="$(Build.StagingDirectory)\RunSettings" /property:TestDrop="$(RunSettingsDrop)" /binarylogger:$(Build.StagingDirectory)\\binlog\\13.GenerateRunSettings.binlog'
 
-- task: MSBuild@1
-  displayName: "Build"
-  inputs:
-    solution: "NuGet.sln"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:Build /property:GitRepositoryRemoteName=github /binarylogger:$(Build.StagingDirectory)\\binlog\\02.Build.binlog /property:MicroBuild_SigningEnabled=false"
+  - task: PowerShell@1
+    displayName: "Copy VS integration test binaries"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        try {
+          Write-Output "Copying NuGet.OptProf binaries"
+          Copy-Item "test\NuGet.Tests.Apex\NuGet.OptProf\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.OptProf\" -Recurse -ErrorAction Stop
+          Write-Output "Copying NuGet.Tests.Apex binaries"
+          Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex\" -Recurse -ErrorAction Stop
+          Write-Output "Copying NuGet.Tests.Apex.Daily binaries"
+          Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex.Daily\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex.Daily\" -Recurse -ErrorAction Stop
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]$_"
+          exit 1
+        }
 
-- task: MSBuild@1
-  displayName: "Pack VSIX"
-  inputs:
-    solution: "build\\build.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:BuildVSIX /property:ExcludeTestProjects=false /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.PackVSIX.binlog"
+  - task: MSBuild@1
+    displayName: "Collect Build Symbols"
+    inputs:
+      solution: "build\\symbols.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:IsSymbolBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.CollectBuildSymbols.binlog"
+      maximumCpuCount: true
+    condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
-- task: MSBuild@1
-  displayName: "Sign"
-  inputs:
-    solution: "build\\sign.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore /p:DryRunSigning=false /p:DotNetSignType=test /binarylogger:$(Build.StagingDirectory)\\binlog\\09.SignPackages.binlog"
+  - task: MSBuild@1
+    displayName: "LocValidation: Verify VSIX"
+    inputs:
+      solution: "build\\BuildValidator.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/target:ValidateVsix /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\15.ValidateVsixLocalization.binlog"
 
-- task: MicroBuildCodesignVerify@3
-  displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
-  inputs:
-    TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
-    ApprovalListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-    ApprovalListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+  - task: MSBuild@1
+    displayName: "LocValidation: Verify Artifacts"
+    inputs:
+      solution: "build\\BuildValidator.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/target:ValidateArtifacts /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\16.ValidateArtifactsLocalization.binlog"
 
-- task: MSBuild@1
-  displayName: "Create EndToEnd Test Package"
-  inputs:
-    solution: "$(Build.Repository.LocalPath)\\test\\TestUtilities\\CreateEndToEndTestPackage\\CreateEndToEndTestPackage.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:EndToEndPackageOutputPath=$(Build.StagingDirectory)\\E2ETests /property:BuildProjectReferences=false /binarylogger:$(Build.StagingDirectory)\\binlog\\12.CreateEndToEndTestPackage.binlog"
+  - task: PublishBuildArtifacts@1
+    displayName: "Publish BootstrapperInfo.json as a build artifact"
+    inputs:
+      PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+      ArtifactName: MicroBuildOutputs
+      ArtifactType: Container
 
-- task: CopyFiles@2
-  displayName: "Copy NuGet.exe for E2E Tests"
-  inputs:
-    SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-    Contents: "NuGet.exe"
-    TargetFolder: "$(Build.StagingDirectory)\\E2ETests"
+  - task: artifactDropTask@0
+    displayName: "Upload VS bootstapper Drop"
+    inputs:
+      dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
+      buildNumber: "$(MicroBuild.ManifestDropName)"
+      sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+      toLowerCase: false
+      usePat: true
+      dropMetadataContainerName: "DropMetadata-Product"
 
-- task: NuGetToolInstaller@1
+  - task: artifactDropTask@0
+    displayName: "Publish the .runsettings files to artifact services"
+    inputs:
+      dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
+      buildNumber: "$(RunSettingsDrop)"
+      sourcePath: '$(Build.StagingDirectory)\RunSettings'
+      toLowerCase: false
+      usePat: true
+      dropMetadataContainerName: "DropMetadata-RunSettings"
 
-- task: NuGetCommand@2
-  displayName: 'Add the VSEng package source'
-  inputs:
-    command: 'custom'
-    arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+  - task: PublishPipelineArtifact@1
+    displayName: "Publish E2E tests"
+    inputs:
+      artifactName: "E2ETests"
+      targetPath: "$(Build.StagingDirectory)\\E2ETests"
 
-- task: NuGetCommand@2
-  displayName: 'Install the NuGet package for building .runsettingsproj files'
-  inputs:
-    command: 'custom'
-    arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+  - task: PublishPipelineArtifact@1
+    displayName: "Publish scripts"
+    inputs:
+      artifactName: "scripts"
+      targetPath: "$(Build.Repository.LocalPath)\\scripts"
 
-- task: MicroBuildBuildVSBootstrapper@3
-  displayName: 'Build a Visual Studio bootstrapper for tests'
-  inputs:
-    azureSubscription: 'VSEng-VSDrop-MI'
-    channelName: "$(VsTargetChannelForTests)"
-    vsMajorVersion: "$(VsTargetMajorVersion)"
-    manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
-    outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
-  env:
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+  - task: PublishPipelineArtifact@1
+    displayName: "Publish binlogs"
+    inputs:
+      artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
+      targetPath: $(Build.StagingDirectory)\binlog
+    condition: " or(failed(), eq(variables['System.debug'], 'true')) "
 
-- task: PowerShell@1
-  displayName: "Set DartLab variables for tests"
-  name: "dartlab_variables"
-  inputs:
-    scriptType: "inlineScript"
-    # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
-    inlineScript: |
-      try {
-        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-
-        $bootstrapperUrl = $json[0].bootstrapperUrl;
-        Write-Host "Bootstrapper URL: $bootstrapperUrl"
-        Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
-
-        $qBuildSessionId = $json[0].QBuildSessionId;
-        Write-Host "CloudBuild Session ID: $qBuildSessionId"
-        Write-Host "##vso[task.setvariable variable=QBuildSessionId;isOutput=true]$qBuildSessionId"
-
-        $buildDrop = $json[0].BuildDrop;
-        Write-Host "Base Build Drop: $buildDrop"
-        Write-Host "##vso[task.setvariable variable=BaseBuildDrop;isOutput=true]$buildDrop"
-
-        $runSettingsDrop = "RunSettings/${env:System_TeamProject}/${env:Build_DefinitionName}/${env:Build_SourceBranchName}/${env:Build_BuildId}"
-        Write-Host "Run Settings Drop: $runSettingsDrop"
-        Write-Host "##vso[task.setvariable variable=RunSettingsDrop]$runSettingsDrop"
-        Write-Host "##vso[task.setvariable variable=RunSettingsDrop;isOutput=true]$runSettingsDrop"
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Unable to set variables for DartLab: $_"
-        exit 1
-      }
-
-- task: MSBuild@1
-  displayName: 'Generate .runsettings files'
-  inputs:
-    solution: 'build\runsettings.proj'
-    msbuildArguments: '/restore:false /property:OutputPath="$(Build.StagingDirectory)\RunSettings" /property:TestDrop="$(RunSettingsDrop)" /binarylogger:$(Build.StagingDirectory)\\binlog\\13.GenerateRunSettings.binlog'
-
-- task: PowerShell@1
-  displayName: 'Copy VS integration test binaries'
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        Write-Output "Copying NuGet.OptProf binaries"
-        Copy-Item "test\NuGet.Tests.Apex\NuGet.OptProf\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.OptProf\" -Recurse -ErrorAction Stop
-        Write-Output "Copying NuGet.Tests.Apex binaries"
-        Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex\" -Recurse -ErrorAction Stop
-        Write-Output "Copying NuGet.Tests.Apex.Daily binaries"
-        Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex.Daily\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex.Daily\" -Recurse -ErrorAction Stop
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]$_"
-        exit 1
-      }
-
-- task: MSBuild@1
-  displayName: "Collect Build Symbols"
-  inputs:
-    solution: "build\\symbols.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:IsSymbolBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.CollectBuildSymbols.binlog"
-    maximumCpuCount: true
-  condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
-
-- task: MSBuild@1
-  displayName: "LocValidation: Verify VSIX"
-  inputs:
-    solution: "build\\BuildValidator.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/target:ValidateVsix /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\15.ValidateVsixLocalization.binlog"
-
-- task: MSBuild@1
-  displayName: "LocValidation: Verify Artifacts"
-  inputs:
-    solution: "build\\BuildValidator.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/target:ValidateArtifacts /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\16.ValidateArtifactsLocalization.binlog"
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish BootstrapperInfo.json as a build artifact'
-  inputs:
-    PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-    ArtifactName: MicroBuildOutputs
-    ArtifactType: Container
-
-- task: artifactDropTask@0
-  displayName: "Upload VS bootstapper Drop"
-  inputs:
-    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-    buildNumber: '$(MicroBuild.ManifestDropName)'
-    sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-    toLowerCase: false
-    usePat: true
-    dropMetadataContainerName: "DropMetadata-Product"
-
-- task: artifactDropTask@0
-  displayName: 'Publish the .runsettings files to artifact services'
-  inputs:
-    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-    buildNumber: '$(RunSettingsDrop)'
-    sourcePath: '$(Build.StagingDirectory)\RunSettings'
-    toLowerCase: false
-    usePat: true
-    dropMetadataContainerName: 'DropMetadata-RunSettings'
-
-- task: PublishPipelineArtifact@1
-  displayName: "Publish E2E tests"
-  inputs:
-    artifactName: "E2ETests"
-    targetPath: "$(Build.StagingDirectory)\\E2ETests"
-
-- task: PublishPipelineArtifact@1
-  displayName: "Publish scripts"
-  inputs:
-    artifactName: "scripts"
-    targetPath: "$(Build.Repository.LocalPath)\\scripts"
-
-- task: PublishPipelineArtifact@1
-  displayName: "Publish binlogs"
-  inputs:
-    artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
-    targetPath: $(Build.StagingDirectory)\binlog
-  condition: " or(failed(), eq(variables['System.debug'], 'true')) "
-
-- task: MicroBuildCleanup@1
-  displayName: "Perform Cleanup Tasks"
+  - task: MicroBuildCleanup@1
+    displayName: "Perform Cleanup Tasks"

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -119,7 +119,7 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:SkipSbomExistsCheck=true /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.BuildToolsVSIX.binlog"
+    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.BuildToolsVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Sign"
@@ -140,14 +140,14 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /property:SkipSbomExistsCheck=true /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
+    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Generate VSMAN file for Build Tools VSIX"
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:IsVsixBuild=false /property:SkipSbomExistsCheck=true /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
+    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Create EndToEnd Test Package"

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -115,13 +115,6 @@ steps:
     msbuildArguments: "/restore:false /target:BuildVSIX /property:ExcludeTestProjects=false /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.PackVSIX.binlog"
 
 - task: MSBuild@1
-  displayName: "Generate Build Tools package"
-  inputs:
-    solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:SkipSbomExistsCheck=true /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.BuildToolsVSIX.binlog"
-
-- task: MSBuild@1
   displayName: "Sign"
   inputs:
     solution: "build\\sign.proj"
@@ -134,20 +127,6 @@ steps:
     TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
     ApprovalListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
     ApprovalListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-
-- task: MSBuild@1
-  displayName: "Generate VSMAN file for NuGet Core VSIX"
-  inputs:
-    solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /property:SkipSbomExistsCheck=true /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
-
-- task: MSBuild@1
-  displayName: "Generate VSMAN file for Build Tools VSIX"
-  inputs:
-    solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:IsVsixBuild=false /property:SkipSbomExistsCheck=true /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Create EndToEnd Test Package"

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -119,7 +119,7 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.BuildToolsVSIX.binlog"
+    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:SkipSbomExistsCheck=true /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.BuildToolsVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Sign"
@@ -140,14 +140,14 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
+    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /property:SkipSbomExistsCheck=true /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Generate VSMAN file for Build Tools VSIX"
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
+    msbuildArguments: "/property:IsVsixBuild=false /property:SkipSbomExistsCheck=true /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Create EndToEnd Test Package"

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -114,11 +114,6 @@ steps:
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/restore:false /target:BuildVSIX /property:ExcludeTestProjects=false /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.PackVSIX.binlog"
 
-- template: /eng/common/templates/steps/generate-sbom.yml@self
-  parameters:
-    PackageName: 'NuGet.Client'
-    PackageVersion: "$(NuGetVersion)"
-
 - task: MSBuild@1
   displayName: "Generate Build Tools package"
   inputs:
@@ -145,14 +140,14 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
+    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /property:SkipSbomExistsCheck=true /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Generate VSMAN file for Build Tools VSIX"
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
+    msbuildArguments: "/property:IsVsixBuild=false /property:SkipSbomExistsCheck=true /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Create EndToEnd Test Package"

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -1,293 +1,320 @@
 steps:
-  - task: MicroBuildLocalizationPlugin@4
-    displayName: "Install Localization Plugin"
+- task: MicroBuildLocalizationPlugin@4
+  displayName: "Install Localization Plugin"
 
-  - task: MicroBuildSigningPlugin@4
-    inputs:
-      signType: "Test"
-    displayName: "Install Signing Plugin"
+- task: MicroBuildSigningPlugin@4
+  inputs:
+    signType: "Test"
+  displayName: "Install Signing Plugin"
 
-  - task: MicroBuildSwixPlugin@4
-    displayName: "Install Swix Plugin"
-    inputs:
-      dropName: "Tests/$(System.TeamProject)/$(Build.DefinitionName)/$(Build.SourceBranchName)/$(Build.BuildId)"
-  - task: PowerShell@1
-    displayName: "Run Configure.ps1"
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
-      arguments: "-Force"
+- task: MicroBuildSwixPlugin@4
+  displayName: "Install Swix Plugin"
+  inputs:
+    dropName: "Tests/$(System.TeamProject)/$(Build.DefinitionName)/$(Build.SourceBranchName)/$(Build.BuildId)"
+- task: PowerShell@1
+  displayName: "Run Configure.ps1"
+  inputs:
+    scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
+    arguments: "-Force"
 
-  - task: PowerShell@1
-    displayName: "Set build variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        try {
-          $buildNumber = dotnet msbuild -getProperty:PreReleaseVersion $(Build.Repository.LocalPath)\build\config.props
-          Write-Host "Setting build number to: $buildNumber"
-          Write-Host "##vso[task.setvariable variable=BuildNumber]$buildNumber"
+- task: PowerShell@1
+  displayName: "Set build variables"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      try {
+        $buildNumber = dotnet msbuild -getProperty:PreReleaseVersion $(Build.Repository.LocalPath)\build\config.props
+        Write-Host "Setting build number to: $buildNumber"
+        Write-Host "##vso[task.setvariable variable=BuildNumber]$buildNumber"
 
-          $version = dotnet msbuild -getProperty:AssemblyVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
-          Write-Host "Setting NuGet version to: $version"
-          Write-Host "##vso[task.setvariable variable=NuGetVersion]$version"
+        $version = dotnet msbuild -getProperty:AssemblyVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
+        Write-Host "Setting NuGet version to: $version"
+        Write-Host "##vso[task.setvariable variable=NuGetVersion]$version"
 
-          $VsTargetChannelForTests = dotnet msbuild -getProperty:VsTargetChannelForTests $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
-          Write-Host "Setting VsTargetChannelForTests to: $VsTargetChannelForTests"
-          Write-Host "##vso[task.setvariable variable=VsTargetChannelForTests]$VsTargetChannelForTests"
+        $VsTargetChannelForTests = dotnet msbuild -getProperty:VsTargetChannelForTests $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
+        Write-Host "Setting VsTargetChannelForTests to: $VsTargetChannelForTests"
+        Write-Host "##vso[task.setvariable variable=VsTargetChannelForTests]$VsTargetChannelForTests"
 
-          $VsTargetMajorVersion = dotnet msbuild -getProperty:VsTargetMajorVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
-          Write-Host "Setting VsTargetMajorVersion to: $VsTargetMajorVersion"
-          Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion]$VsTargetMajorVersion"
-        } catch {
-          throw $_
-        }
+        $VsTargetMajorVersion = dotnet msbuild -getProperty:VsTargetMajorVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
+        Write-Host "Setting VsTargetMajorVersion to: $VsTargetMajorVersion"
+        Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion]$VsTargetMajorVersion"
+      } catch {
+        throw $_
+      }
 
-  - task: PowerShell@1
-    inputs:
-      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-      arguments: "-BuildRTM false -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(NuGetVersion)"
-    displayName: "Configure VSTS CI Environment"
 
-  - task: PowerShell@1
-    displayName: "Print Environment Variables"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
-    condition: "always()"
+- task: PowerShell@1
+  inputs:
+    scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
+    arguments: "-BuildRTM false -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(NuGetVersion)"
+  displayName: "Configure VSTS CI Environment"
 
-  # NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
-  # However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package
-  # won't be able to determine the URL to embed in the pdbs.
-  # Therefore, we need to add the GitHub repo URL as a remote, and tell SourceLink.GitHub what that remote name is.
-  # We do this even when github is the origin URL, to avoid warnings in the CI logs.
-  - task: PowerShell@1
-    displayName: "Prepare for source link"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        try {
-          $nugetUrl = "https://github.com/NuGet/NuGet.Client.git"
-          if (@(& git remote).Contains("github"))
+- task: PowerShell@1
+  displayName: "Print Environment Variables"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
+  condition: "always()"
+
+# NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
+# However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package
+# won't be able to determine the URL to embed in the pdbs.
+# Therefore, we need to add the GitHub repo URL as a remote, and tell SourceLink.GitHub what that remote name is.
+# We do this even when github is the origin URL, to avoid warnings in the CI logs.
+- task: PowerShell@1
+  displayName: "Prepare for source link"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      try {
+        $nugetUrl = "https://github.com/NuGet/NuGet.Client.git"
+        if (@(& git remote).Contains("github"))
+        {
+          $currentGitHubRemoteUrl = & git remote get-url github
+          Write-Host "Current github remote URL: $currentGitHubRemoteUrl"
+          if ($currentGitHubRemoteUrl -ne $nugetUrl)
           {
-            $currentGitHubRemoteUrl = & git remote get-url github
-            Write-Host "Current github remote URL: $currentGitHubRemoteUrl"
-            if ($currentGitHubRemoteUrl -ne $nugetUrl)
-            {
-              Write-Host "git remote set-url github $nugetUrl"
-              & git remote set-url github $nugetUrl
-            }
-            else
-            {
-              Write-Host "Git remote url already correct"
-            }
+            Write-Host "git remote set-url github $nugetUrl"
+            & git remote set-url github $nugetUrl
           }
           else
           {
-            Write-Host "git remote add github $nugetUrl"
-            & git remote add github $nugetUrl
+            Write-Host "Git remote url already correct"
           }
-        } catch {
-          Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
-          exit 1
         }
-
-  - task: MSBuild@1
-    displayName: "Restore"
-    inputs:
-      solution: "NuGet.sln"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/restore:false /target:Restore /binarylogger:$(Build.StagingDirectory)\\binlog\\01.Restore.binlog"
-
-  - task: MSBuild@1
-    displayName: "Build"
-    inputs:
-      solution: "NuGet.sln"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/restore:false /target:Build /property:GitRepositoryRemoteName=github /binarylogger:$(Build.StagingDirectory)\\binlog\\02.Build.binlog /property:MicroBuild_SigningEnabled=false"
-
-  - task: MSBuild@1
-    displayName: "Pack VSIX"
-    inputs:
-      solution: "build\\build.proj"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/restore:false /target:BuildVSIX /property:ExcludeTestProjects=false /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.PackVSIX.binlog"
-
-  - task: MSBuild@1
-    displayName: "Sign"
-    inputs:
-      solution: "build\\sign.proj"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/restore /p:DryRunSigning=false /p:DotNetSignType=test /binarylogger:$(Build.StagingDirectory)\\binlog\\09.SignPackages.binlog"
-
-  - task: MicroBuildCodesignVerify@3
-    displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
-    inputs:
-      TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
-      ApprovalListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-      ApprovalListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-
-  - task: MSBuild@1
-    displayName: "Create EndToEnd Test Package"
-    inputs:
-      solution: "$(Build.Repository.LocalPath)\\test\\TestUtilities\\CreateEndToEndTestPackage\\CreateEndToEndTestPackage.proj"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/property:EndToEndPackageOutputPath=$(Build.StagingDirectory)\\E2ETests /property:BuildProjectReferences=false /binarylogger:$(Build.StagingDirectory)\\binlog\\12.CreateEndToEndTestPackage.binlog"
-
-  - task: CopyFiles@2
-    displayName: "Copy NuGet.exe for E2E Tests"
-    inputs:
-      SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-      Contents: "NuGet.exe"
-      TargetFolder: "$(Build.StagingDirectory)\\E2ETests"
-
-  - task: NuGetToolInstaller@1
-
-  - task: NuGetCommand@2
-    displayName: "Add the VSEng package source"
-    inputs:
-      command: "custom"
-      arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
-
-  - task: NuGetCommand@2
-    displayName: "Install the NuGet package for building .runsettingsproj files"
-    inputs:
-      command: "custom"
-      arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-
-  - task: MicroBuildBuildVSBootstrapper@3
-    displayName: "Build a Visual Studio bootstrapper for tests"
-    inputs:
-      azureSubscription: "VSEng-VSDrop-MI"
-      channelName: "$(VsTargetChannelForTests)"
-      vsMajorVersion: "$(VsTargetMajorVersion)"
-      manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
-      outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
-  - task: PowerShell@1
-    displayName: "Set DartLab variables for tests"
-    name: "dartlab_variables"
-    inputs:
-      scriptType: "inlineScript"
-      # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
-      inlineScript: |
-        try {
-          $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-
-          $bootstrapperUrl = $json[0].bootstrapperUrl;
-          Write-Host "Bootstrapper URL: $bootstrapperUrl"
-          Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
-
-          $qBuildSessionId = $json[0].QBuildSessionId;
-          Write-Host "CloudBuild Session ID: $qBuildSessionId"
-          Write-Host "##vso[task.setvariable variable=QBuildSessionId;isOutput=true]$qBuildSessionId"
-
-          $buildDrop = $json[0].BuildDrop;
-          Write-Host "Base Build Drop: $buildDrop"
-          Write-Host "##vso[task.setvariable variable=BaseBuildDrop;isOutput=true]$buildDrop"
-
-          $runSettingsDrop = "RunSettings/${env:System_TeamProject}/${env:Build_DefinitionName}/${env:Build_SourceBranchName}/${env:Build_BuildId}"
-          Write-Host "Run Settings Drop: $runSettingsDrop"
-          Write-Host "##vso[task.setvariable variable=RunSettingsDrop]$runSettingsDrop"
-          Write-Host "##vso[task.setvariable variable=RunSettingsDrop;isOutput=true]$runSettingsDrop"
-        } catch {
-          Write-Host "##vso[task.LogIssue type=error;]Unable to set variables for DartLab: $_"
-          exit 1
+        else
+        {
+          Write-Host "git remote add github $nugetUrl"
+          & git remote add github $nugetUrl
         }
+      } catch {
+        Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
+        exit 1
+      }
 
-  - task: MSBuild@1
-    displayName: "Generate .runsettings files"
-    inputs:
-      solution: 'build\runsettings.proj'
-      msbuildArguments: '/restore:false /property:OutputPath="$(Build.StagingDirectory)\RunSettings" /property:TestDrop="$(RunSettingsDrop)" /binarylogger:$(Build.StagingDirectory)\\binlog\\13.GenerateRunSettings.binlog'
+- task: MSBuild@1
+  displayName: "Restore"
+  inputs:
+    solution: "NuGet.sln"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/restore:false /target:Restore /binarylogger:$(Build.StagingDirectory)\\binlog\\01.Restore.binlog"
 
-  - task: PowerShell@1
-    displayName: "Copy VS integration test binaries"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        try {
-          Write-Output "Copying NuGet.OptProf binaries"
-          Copy-Item "test\NuGet.Tests.Apex\NuGet.OptProf\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.OptProf\" -Recurse -ErrorAction Stop
-          Write-Output "Copying NuGet.Tests.Apex binaries"
-          Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex\" -Recurse -ErrorAction Stop
-          Write-Output "Copying NuGet.Tests.Apex.Daily binaries"
-          Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex.Daily\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex.Daily\" -Recurse -ErrorAction Stop
-        } catch {
-          Write-Host "##vso[task.LogIssue type=error;]$_"
-          exit 1
-        }
+- task: MSBuild@1
+  displayName: "Build"
+  inputs:
+    solution: "NuGet.sln"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/restore:false /target:Build /property:GitRepositoryRemoteName=github /binarylogger:$(Build.StagingDirectory)\\binlog\\02.Build.binlog /property:MicroBuild_SigningEnabled=false"
 
-  - task: MSBuild@1
-    displayName: "Collect Build Symbols"
-    inputs:
-      solution: "build\\symbols.proj"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:IsSymbolBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.CollectBuildSymbols.binlog"
-      maximumCpuCount: true
-    condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
+- task: MSBuild@1
+  displayName: "Pack VSIX"
+  inputs:
+    solution: "build\\build.proj"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/restore:false /target:BuildVSIX /property:ExcludeTestProjects=false /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.PackVSIX.binlog"
 
-  - task: MSBuild@1
-    displayName: "LocValidation: Verify VSIX"
-    inputs:
-      solution: "build\\BuildValidator.proj"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/target:ValidateVsix /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\15.ValidateVsixLocalization.binlog"
+- template: /eng/common/templates/steps/generate-sbom.yml@self
+  parameters:
+    PackageName: 'NuGet.Client'
+    PackageVersion: "$(NuGetVersion)"
 
-  - task: MSBuild@1
-    displayName: "LocValidation: Verify Artifacts"
-    inputs:
-      solution: "build\\BuildValidator.proj"
-      configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/target:ValidateArtifacts /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\16.ValidateArtifactsLocalization.binlog"
+- task: MSBuild@1
+  displayName: "Generate Build Tools package"
+  inputs:
+    solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.BuildToolsVSIX.binlog"
 
-  - task: PublishBuildArtifacts@1
-    displayName: "Publish BootstrapperInfo.json as a build artifact"
-    inputs:
-      PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-      ArtifactName: MicroBuildOutputs
-      ArtifactType: Container
+- task: MSBuild@1
+  displayName: "Sign"
+  inputs:
+    solution: "build\\sign.proj"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/restore /p:DryRunSigning=false /p:DotNetSignType=test /binarylogger:$(Build.StagingDirectory)\\binlog\\09.SignPackages.binlog"
 
-  - task: artifactDropTask@0
-    displayName: "Upload VS bootstapper Drop"
-    inputs:
-      dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
-      buildNumber: "$(MicroBuild.ManifestDropName)"
-      sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-      toLowerCase: false
-      usePat: true
-      dropMetadataContainerName: "DropMetadata-Product"
+- task: MicroBuildCodesignVerify@3
+  displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
+  inputs:
+    TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
+    ApprovalListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+    ApprovalListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
 
-  - task: artifactDropTask@0
-    displayName: "Publish the .runsettings files to artifact services"
-    inputs:
-      dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
-      buildNumber: "$(RunSettingsDrop)"
-      sourcePath: '$(Build.StagingDirectory)\RunSettings'
-      toLowerCase: false
-      usePat: true
-      dropMetadataContainerName: "DropMetadata-RunSettings"
+- task: MSBuild@1
+  displayName: "Generate VSMAN file for NuGet Core VSIX"
+  inputs:
+    solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
 
-  - task: PublishPipelineArtifact@1
-    displayName: "Publish E2E tests"
-    inputs:
-      artifactName: "E2ETests"
-      targetPath: "$(Build.StagingDirectory)\\E2ETests"
+- task: MSBuild@1
+  displayName: "Generate VSMAN file for Build Tools VSIX"
+  inputs:
+    solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
 
-  - task: PublishPipelineArtifact@1
-    displayName: "Publish scripts"
-    inputs:
-      artifactName: "scripts"
-      targetPath: "$(Build.Repository.LocalPath)\\scripts"
+- task: MSBuild@1
+  displayName: "Create EndToEnd Test Package"
+  inputs:
+    solution: "$(Build.Repository.LocalPath)\\test\\TestUtilities\\CreateEndToEndTestPackage\\CreateEndToEndTestPackage.proj"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/property:EndToEndPackageOutputPath=$(Build.StagingDirectory)\\E2ETests /property:BuildProjectReferences=false /binarylogger:$(Build.StagingDirectory)\\binlog\\12.CreateEndToEndTestPackage.binlog"
 
-  - task: PublishPipelineArtifact@1
-    displayName: "Publish binlogs"
-    inputs:
-      artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
-      targetPath: $(Build.StagingDirectory)\binlog
-    condition: " or(failed(), eq(variables['System.debug'], 'true')) "
+- task: CopyFiles@2
+  displayName: "Copy NuGet.exe for E2E Tests"
+  inputs:
+    SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+    Contents: "NuGet.exe"
+    TargetFolder: "$(Build.StagingDirectory)\\E2ETests"
 
-  - task: MicroBuildCleanup@1
-    displayName: "Perform Cleanup Tasks"
+- task: NuGetToolInstaller@1
+
+- task: NuGetCommand@2
+  displayName: 'Add the VSEng package source'
+  inputs:
+    command: 'custom'
+    arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+
+- task: NuGetCommand@2
+  displayName: 'Install the NuGet package for building .runsettingsproj files'
+  inputs:
+    command: 'custom'
+    arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+
+- task: MicroBuildBuildVSBootstrapper@3
+  displayName: 'Build a Visual Studio bootstrapper for tests'
+  inputs:
+    azureSubscription: 'VSEng-VSDrop-MI'
+    channelName: "$(VsTargetChannelForTests)"
+    vsMajorVersion: "$(VsTargetMajorVersion)"
+    manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
+    outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+- task: PowerShell@1
+  displayName: "Set DartLab variables for tests"
+  name: "dartlab_variables"
+  inputs:
+    scriptType: "inlineScript"
+    # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
+    inlineScript: |
+      try {
+        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+
+        $bootstrapperUrl = $json[0].bootstrapperUrl;
+        Write-Host "Bootstrapper URL: $bootstrapperUrl"
+        Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
+
+        $qBuildSessionId = $json[0].QBuildSessionId;
+        Write-Host "CloudBuild Session ID: $qBuildSessionId"
+        Write-Host "##vso[task.setvariable variable=QBuildSessionId;isOutput=true]$qBuildSessionId"
+
+        $buildDrop = $json[0].BuildDrop;
+        Write-Host "Base Build Drop: $buildDrop"
+        Write-Host "##vso[task.setvariable variable=BaseBuildDrop;isOutput=true]$buildDrop"
+
+        $runSettingsDrop = "RunSettings/${env:System_TeamProject}/${env:Build_DefinitionName}/${env:Build_SourceBranchName}/${env:Build_BuildId}"
+        Write-Host "Run Settings Drop: $runSettingsDrop"
+        Write-Host "##vso[task.setvariable variable=RunSettingsDrop]$runSettingsDrop"
+        Write-Host "##vso[task.setvariable variable=RunSettingsDrop;isOutput=true]$runSettingsDrop"
+      } catch {
+        Write-Host "##vso[task.LogIssue type=error;]Unable to set variables for DartLab: $_"
+        exit 1
+      }
+
+- task: MSBuild@1
+  displayName: 'Generate .runsettings files'
+  inputs:
+    solution: 'build\runsettings.proj'
+    msbuildArguments: '/restore:false /property:OutputPath="$(Build.StagingDirectory)\RunSettings" /property:TestDrop="$(RunSettingsDrop)" /binarylogger:$(Build.StagingDirectory)\\binlog\\13.GenerateRunSettings.binlog'
+
+- task: PowerShell@1
+  displayName: 'Copy VS integration test binaries'
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      try {
+        Write-Output "Copying NuGet.OptProf binaries"
+        Copy-Item "test\NuGet.Tests.Apex\NuGet.OptProf\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.OptProf\" -Recurse -ErrorAction Stop
+        Write-Output "Copying NuGet.Tests.Apex binaries"
+        Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex\" -Recurse -ErrorAction Stop
+        Write-Output "Copying NuGet.Tests.Apex.Daily binaries"
+        Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex.Daily\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex.Daily\" -Recurse -ErrorAction Stop
+      } catch {
+        Write-Host "##vso[task.LogIssue type=error;]$_"
+        exit 1
+      }
+
+- task: MSBuild@1
+  displayName: "Collect Build Symbols"
+  inputs:
+    solution: "build\\symbols.proj"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:IsSymbolBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.CollectBuildSymbols.binlog"
+    maximumCpuCount: true
+  condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
+
+- task: MSBuild@1
+  displayName: "LocValidation: Verify VSIX"
+  inputs:
+    solution: "build\\BuildValidator.proj"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/target:ValidateVsix /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\15.ValidateVsixLocalization.binlog"
+
+- task: MSBuild@1
+  displayName: "LocValidation: Verify Artifacts"
+  inputs:
+    solution: "build\\BuildValidator.proj"
+    configuration: "$(BuildConfiguration)"
+    msbuildArguments: "/target:ValidateArtifacts /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\16.ValidateArtifactsLocalization.binlog"
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish BootstrapperInfo.json as a build artifact'
+  inputs:
+    PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+    ArtifactName: MicroBuildOutputs
+    ArtifactType: Container
+
+- task: artifactDropTask@0
+  displayName: "Upload VS bootstapper Drop"
+  inputs:
+    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+    buildNumber: '$(MicroBuild.ManifestDropName)'
+    sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+    toLowerCase: false
+    usePat: true
+    dropMetadataContainerName: "DropMetadata-Product"
+
+- task: artifactDropTask@0
+  displayName: 'Publish the .runsettings files to artifact services'
+  inputs:
+    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+    buildNumber: '$(RunSettingsDrop)'
+    sourcePath: '$(Build.StagingDirectory)\RunSettings'
+    toLowerCase: false
+    usePat: true
+    dropMetadataContainerName: 'DropMetadata-RunSettings'
+
+- task: PublishPipelineArtifact@1
+  displayName: "Publish E2E tests"
+  inputs:
+    artifactName: "E2ETests"
+    targetPath: "$(Build.StagingDirectory)\\E2ETests"
+
+- task: PublishPipelineArtifact@1
+  displayName: "Publish scripts"
+  inputs:
+    artifactName: "scripts"
+    targetPath: "$(Build.Repository.LocalPath)\\scripts"
+
+- task: PublishPipelineArtifact@1
+  displayName: "Publish binlogs"
+  inputs:
+    artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
+    targetPath: $(Build.StagingDirectory)\binlog
+  condition: " or(failed(), eq(variables['System.debug'], 'true')) "
+
+- task: MicroBuildCleanup@1
+  displayName: "Perform Cleanup Tasks"

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -1,320 +1,319 @@
 steps:
-- task: MicroBuildLocalizationPlugin@4
-  displayName: "Install Localization Plugin"
+  - task: MicroBuildLocalizationPlugin@4
+    displayName: "Install Localization Plugin"
 
-- task: MicroBuildSigningPlugin@4
-  inputs:
-    signType: "Test"
-  displayName: "Install Signing Plugin"
+  - task: MicroBuildSigningPlugin@4
+    inputs:
+      signType: "Test"
+    displayName: "Install Signing Plugin"
 
-- task: MicroBuildSwixPlugin@4
-  displayName: "Install Swix Plugin"
-  inputs:
-    dropName: "Tests/$(System.TeamProject)/$(Build.DefinitionName)/$(Build.SourceBranchName)/$(Build.BuildId)"
-- task: PowerShell@1
-  displayName: "Run Configure.ps1"
-  inputs:
-    scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
-    arguments: "-Force"
+  - task: MicroBuildSwixPlugin@4
+    displayName: "Install Swix Plugin"
+    inputs:
+      dropName: "Tests/$(System.TeamProject)/$(Build.DefinitionName)/$(Build.SourceBranchName)/$(Build.BuildId)"
+  - task: PowerShell@1
+    displayName: "Run Configure.ps1"
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\configure.ps1"
+      arguments: "-Force"
 
-- task: PowerShell@1
-  displayName: "Set build variables"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        $buildNumber = dotnet msbuild -getProperty:PreReleaseVersion $(Build.Repository.LocalPath)\build\config.props
-        Write-Host "Setting build number to: $buildNumber"
-        Write-Host "##vso[task.setvariable variable=BuildNumber]$buildNumber"
+  - task: PowerShell@1
+    displayName: "Set build variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        try {
+          $buildNumber = dotnet msbuild -getProperty:PreReleaseVersion $(Build.Repository.LocalPath)\build\config.props
+          Write-Host "Setting build number to: $buildNumber"
+          Write-Host "##vso[task.setvariable variable=BuildNumber]$buildNumber"
 
-        $version = dotnet msbuild -getProperty:AssemblyVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
-        Write-Host "Setting NuGet version to: $version"
-        Write-Host "##vso[task.setvariable variable=NuGetVersion]$version"
+          $version = dotnet msbuild -getProperty:AssemblyVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
+          Write-Host "Setting NuGet version to: $version"
+          Write-Host "##vso[task.setvariable variable=NuGetVersion]$version"
 
-        $VsTargetChannelForTests = dotnet msbuild -getProperty:VsTargetChannelForTests $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
-        Write-Host "Setting VsTargetChannelForTests to: $VsTargetChannelForTests"
-        Write-Host "##vso[task.setvariable variable=VsTargetChannelForTests]$VsTargetChannelForTests"
+          $VsTargetChannelForTests = dotnet msbuild -getProperty:VsTargetChannelForTests $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
+          Write-Host "Setting VsTargetChannelForTests to: $VsTargetChannelForTests"
+          Write-Host "##vso[task.setvariable variable=VsTargetChannelForTests]$VsTargetChannelForTests"
 
-        $VsTargetMajorVersion = dotnet msbuild -getProperty:VsTargetMajorVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
-        Write-Host "Setting VsTargetMajorVersion to: $VsTargetMajorVersion"
-        Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion]$VsTargetMajorVersion"
-      } catch {
-        throw $_
-      }
+          $VsTargetMajorVersion = dotnet msbuild -getProperty:VsTargetMajorVersion $(Build.Repository.LocalPath)\src\NuGet.Clients\NuGet.VisualStudio.Client\
+          Write-Host "Setting VsTargetMajorVersion to: $VsTargetMajorVersion"
+          Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion]$VsTargetMajorVersion"
+        } catch {
+          throw $_
+        }
 
+  - task: PowerShell@1
+    inputs:
+      scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
+      arguments: "-BuildRTM false -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(NuGetVersion)"
+    displayName: "Configure VSTS CI Environment"
 
-- task: PowerShell@1
-  inputs:
-    scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-    arguments: "-BuildRTM false -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(NuGetVersion)"
-  displayName: "Configure VSTS CI Environment"
+  - task: PowerShell@1
+    displayName: "Print Environment Variables"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
+    condition: "always()"
 
-- task: PowerShell@1
-  displayName: "Print Environment Variables"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
-  condition: "always()"
-
-# NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
-# However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package
-# won't be able to determine the URL to embed in the pdbs.
-# Therefore, we need to add the GitHub repo URL as a remote, and tell SourceLink.GitHub what that remote name is.
-# We do this even when github is the origin URL, to avoid warnings in the CI logs.
-- task: PowerShell@1
-  displayName: "Prepare for source link"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        $nugetUrl = "https://github.com/NuGet/NuGet.Client.git"
-        if (@(& git remote).Contains("github"))
-        {
-          $currentGitHubRemoteUrl = & git remote get-url github
-          Write-Host "Current github remote URL: $currentGitHubRemoteUrl"
-          if ($currentGitHubRemoteUrl -ne $nugetUrl)
+  # NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
+  # However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package
+  # won't be able to determine the URL to embed in the pdbs.
+  # Therefore, we need to add the GitHub repo URL as a remote, and tell SourceLink.GitHub what that remote name is.
+  # We do this even when github is the origin URL, to avoid warnings in the CI logs.
+  - task: PowerShell@1
+    displayName: "Prepare for source link"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        try {
+          $nugetUrl = "https://github.com/NuGet/NuGet.Client.git"
+          if (@(& git remote).Contains("github"))
           {
-            Write-Host "git remote set-url github $nugetUrl"
-            & git remote set-url github $nugetUrl
+            $currentGitHubRemoteUrl = & git remote get-url github
+            Write-Host "Current github remote URL: $currentGitHubRemoteUrl"
+            if ($currentGitHubRemoteUrl -ne $nugetUrl)
+            {
+              Write-Host "git remote set-url github $nugetUrl"
+              & git remote set-url github $nugetUrl
+            }
+            else
+            {
+              Write-Host "Git remote url already correct"
+            }
           }
           else
           {
-            Write-Host "Git remote url already correct"
+            Write-Host "git remote add github $nugetUrl"
+            & git remote add github $nugetUrl
           }
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
+          exit 1
         }
-        else
-        {
-          Write-Host "git remote add github $nugetUrl"
-          & git remote add github $nugetUrl
+
+  - task: MSBuild@1
+    displayName: "Restore"
+    inputs:
+      solution: "NuGet.sln"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:Restore /binarylogger:$(Build.StagingDirectory)\\binlog\\01.Restore.binlog"
+
+  - task: MSBuild@1
+    displayName: "Build"
+    inputs:
+      solution: "NuGet.sln"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:Build /property:GitRepositoryRemoteName=github /binarylogger:$(Build.StagingDirectory)\\binlog\\02.Build.binlog /property:MicroBuild_SigningEnabled=false"
+
+  - task: MSBuild@1
+    displayName: "Pack VSIX"
+    inputs:
+      solution: "build\\build.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /target:BuildVSIX /property:ExcludeTestProjects=false /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.PackVSIX.binlog"
+
+  - template: /eng/common/templates/steps/generate-sbom.yml@self
+    parameters:
+      PackageName: "NuGet.Client"
+      PackageVersion: "$(NuGetVersion)"
+
+  - task: MSBuild@1
+    displayName: "Generate Build Tools package"
+    inputs:
+      solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.BuildToolsVSIX.binlog"
+
+  - task: MSBuild@1
+    displayName: "Sign"
+    inputs:
+      solution: "build\\sign.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore /p:DryRunSigning=false /p:DotNetSignType=test /binarylogger:$(Build.StagingDirectory)\\binlog\\09.SignPackages.binlog"
+
+  - task: MicroBuildCodesignVerify@3
+    displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
+    inputs:
+      TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
+      ApprovalListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+      ApprovalListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+
+  - task: MSBuild@1
+    displayName: "Generate VSMAN file for NuGet Core VSIX"
+    inputs:
+      solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
+
+  - task: MSBuild@1
+    displayName: "Generate VSMAN file for Build Tools VSIX"
+    inputs:
+      solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
+
+  - task: MSBuild@1
+    displayName: "Create EndToEnd Test Package"
+    inputs:
+      solution: "$(Build.Repository.LocalPath)\\test\\TestUtilities\\CreateEndToEndTestPackage\\CreateEndToEndTestPackage.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/property:EndToEndPackageOutputPath=$(Build.StagingDirectory)\\E2ETests /property:BuildProjectReferences=false /binarylogger:$(Build.StagingDirectory)\\binlog\\12.CreateEndToEndTestPackage.binlog"
+
+  - task: CopyFiles@2
+    displayName: "Copy NuGet.exe for E2E Tests"
+    inputs:
+      SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+      Contents: "NuGet.exe"
+      TargetFolder: "$(Build.StagingDirectory)\\E2ETests"
+
+  - task: NuGetToolInstaller@1
+
+  - task: NuGetCommand@2
+    displayName: "Add the VSEng package source"
+    inputs:
+      command: "custom"
+      arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
+
+  - task: NuGetCommand@2
+    displayName: "Install the NuGet package for building .runsettingsproj files"
+    inputs:
+      command: "custom"
+      arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
+
+  - task: MicroBuildBuildVSBootstrapper@3
+    displayName: "Build a Visual Studio bootstrapper for tests"
+    inputs:
+      azureSubscription: "VSEng-VSDrop-MI"
+      channelName: "$(VsTargetChannelForTests)"
+      vsMajorVersion: "$(VsTargetMajorVersion)"
+      manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
+      outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+  - task: PowerShell@1
+    displayName: "Set DartLab variables for tests"
+    name: "dartlab_variables"
+    inputs:
+      scriptType: "inlineScript"
+      # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
+      inlineScript: |
+        try {
+          $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
+
+          $bootstrapperUrl = $json[0].bootstrapperUrl;
+          Write-Host "Bootstrapper URL: $bootstrapperUrl"
+          Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
+
+          $qBuildSessionId = $json[0].QBuildSessionId;
+          Write-Host "CloudBuild Session ID: $qBuildSessionId"
+          Write-Host "##vso[task.setvariable variable=QBuildSessionId;isOutput=true]$qBuildSessionId"
+
+          $buildDrop = $json[0].BuildDrop;
+          Write-Host "Base Build Drop: $buildDrop"
+          Write-Host "##vso[task.setvariable variable=BaseBuildDrop;isOutput=true]$buildDrop"
+
+          $runSettingsDrop = "RunSettings/${env:System_TeamProject}/${env:Build_DefinitionName}/${env:Build_SourceBranchName}/${env:Build_BuildId}"
+          Write-Host "Run Settings Drop: $runSettingsDrop"
+          Write-Host "##vso[task.setvariable variable=RunSettingsDrop]$runSettingsDrop"
+          Write-Host "##vso[task.setvariable variable=RunSettingsDrop;isOutput=true]$runSettingsDrop"
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]Unable to set variables for DartLab: $_"
+          exit 1
         }
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
-        exit 1
-      }
 
-- task: MSBuild@1
-  displayName: "Restore"
-  inputs:
-    solution: "NuGet.sln"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:Restore /binarylogger:$(Build.StagingDirectory)\\binlog\\01.Restore.binlog"
+  - task: MSBuild@1
+    displayName: "Generate .runsettings files"
+    inputs:
+      solution: 'build\runsettings.proj'
+      msbuildArguments: '/restore:false /property:OutputPath="$(Build.StagingDirectory)\RunSettings" /property:TestDrop="$(RunSettingsDrop)" /binarylogger:$(Build.StagingDirectory)\\binlog\\13.GenerateRunSettings.binlog'
 
-- task: MSBuild@1
-  displayName: "Build"
-  inputs:
-    solution: "NuGet.sln"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:Build /property:GitRepositoryRemoteName=github /binarylogger:$(Build.StagingDirectory)\\binlog\\02.Build.binlog /property:MicroBuild_SigningEnabled=false"
+  - task: PowerShell@1
+    displayName: "Copy VS integration test binaries"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        try {
+          Write-Output "Copying NuGet.OptProf binaries"
+          Copy-Item "test\NuGet.Tests.Apex\NuGet.OptProf\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.OptProf\" -Recurse -ErrorAction Stop
+          Write-Output "Copying NuGet.Tests.Apex binaries"
+          Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex\" -Recurse -ErrorAction Stop
+          Write-Output "Copying NuGet.Tests.Apex.Daily binaries"
+          Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex.Daily\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex.Daily\" -Recurse -ErrorAction Stop
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]$_"
+          exit 1
+        }
 
-- task: MSBuild@1
-  displayName: "Pack VSIX"
-  inputs:
-    solution: "build\\build.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /target:BuildVSIX /property:ExcludeTestProjects=false /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.PackVSIX.binlog"
+  - task: MSBuild@1
+    displayName: "Collect Build Symbols"
+    inputs:
+      solution: "build\\symbols.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:IsSymbolBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.CollectBuildSymbols.binlog"
+      maximumCpuCount: true
+    condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
-- template: /eng/common/templates/steps/generate-sbom.yml@self
-  parameters:
-    PackageName: 'NuGet.Client'
-    PackageVersion: "$(NuGetVersion)"
+  - task: MSBuild@1
+    displayName: "LocValidation: Verify VSIX"
+    inputs:
+      solution: "build\\BuildValidator.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/target:ValidateVsix /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\15.ValidateVsixLocalization.binlog"
 
-- task: MSBuild@1
-  displayName: "Generate Build Tools package"
-  inputs:
-    solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.BuildToolsVSIX.binlog"
+  - task: MSBuild@1
+    displayName: "LocValidation: Verify Artifacts"
+    inputs:
+      solution: "build\\BuildValidator.proj"
+      configuration: "$(BuildConfiguration)"
+      msbuildArguments: "/target:ValidateArtifacts /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\16.ValidateArtifactsLocalization.binlog"
 
-- task: MSBuild@1
-  displayName: "Sign"
-  inputs:
-    solution: "build\\sign.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore /p:DryRunSigning=false /p:DotNetSignType=test /binarylogger:$(Build.StagingDirectory)\\binlog\\09.SignPackages.binlog"
+  - task: PublishBuildArtifacts@1
+    displayName: "Publish BootstrapperInfo.json as a build artifact"
+    inputs:
+      PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+      ArtifactName: MicroBuildOutputs
+      ArtifactType: Container
 
-- task: MicroBuildCodesignVerify@3
-  displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
-  inputs:
-    TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
-    ApprovalListPathForCerts: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
-    ApprovalListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
+  - task: artifactDropTask@0
+    displayName: "Upload VS bootstapper Drop"
+    inputs:
+      dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
+      buildNumber: "$(MicroBuild.ManifestDropName)"
+      sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+      toLowerCase: false
+      usePat: true
+      dropMetadataContainerName: "DropMetadata-Product"
 
-- task: MSBuild@1
-  displayName: "Generate VSMAN file for NuGet Core VSIX"
-  inputs:
-    solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\10.GenerateVSManifestForVSIX.binlog"
+  - task: artifactDropTask@0
+    displayName: "Publish the .runsettings files to artifact services"
+    inputs:
+      dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
+      buildNumber: "$(RunSettingsDrop)"
+      sourcePath: '$(Build.StagingDirectory)\RunSettings'
+      toLowerCase: false
+      usePat: true
+      dropMetadataContainerName: "DropMetadata-RunSettings"
 
-- task: MSBuild@1
-  displayName: "Generate VSMAN file for Build Tools VSIX"
-  inputs:
-    solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\11.GenerateVSManifestForToolsVSIX.binlog"
+  - task: PublishPipelineArtifact@1
+    displayName: "Publish E2E tests"
+    inputs:
+      artifactName: "E2ETests"
+      targetPath: "$(Build.StagingDirectory)\\E2ETests"
 
-- task: MSBuild@1
-  displayName: "Create EndToEnd Test Package"
-  inputs:
-    solution: "$(Build.Repository.LocalPath)\\test\\TestUtilities\\CreateEndToEndTestPackage\\CreateEndToEndTestPackage.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:EndToEndPackageOutputPath=$(Build.StagingDirectory)\\E2ETests /property:BuildProjectReferences=false /binarylogger:$(Build.StagingDirectory)\\binlog\\12.CreateEndToEndTestPackage.binlog"
+  - task: PublishPipelineArtifact@1
+    displayName: "Publish scripts"
+    inputs:
+      artifactName: "scripts"
+      targetPath: "$(Build.Repository.LocalPath)\\scripts"
 
-- task: CopyFiles@2
-  displayName: "Copy NuGet.exe for E2E Tests"
-  inputs:
-    SourceFolder: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-    Contents: "NuGet.exe"
-    TargetFolder: "$(Build.StagingDirectory)\\E2ETests"
+  - task: PublishPipelineArtifact@1
+    displayName: "Publish binlogs"
+    inputs:
+      artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
+      targetPath: $(Build.StagingDirectory)\binlog
+    condition: " or(failed(), eq(variables['System.debug'], 'true')) "
 
-- task: NuGetToolInstaller@1
-
-- task: NuGetCommand@2
-  displayName: 'Add the VSEng package source'
-  inputs:
-    command: 'custom'
-    arguments: 'sources add -Name VS -Source $(VsPackageFeedUrl) -UserName $(VsPackageFeedUsername) -Password $(VsPackageFeedPassword) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config'
-
-- task: NuGetCommand@2
-  displayName: 'Install the NuGet package for building .runsettingsproj files'
-  inputs:
-    command: 'custom'
-    arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
-
-- task: MicroBuildBuildVSBootstrapper@3
-  displayName: 'Build a Visual Studio bootstrapper for tests'
-  inputs:
-    azureSubscription: 'VSEng-VSDrop-MI'
-    channelName: "$(VsTargetChannelForTests)"
-    vsMajorVersion: "$(VsTargetMajorVersion)"
-    manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
-    outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
-  env:
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
-- task: PowerShell@1
-  displayName: "Set DartLab variables for tests"
-  name: "dartlab_variables"
-  inputs:
-    scriptType: "inlineScript"
-    # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
-    inlineScript: |
-      try {
-        $json = Get-Content "${env:Build_StagingDirectory}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-
-        $bootstrapperUrl = $json[0].bootstrapperUrl;
-        Write-Host "Bootstrapper URL: $bootstrapperUrl"
-        Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
-
-        $qBuildSessionId = $json[0].QBuildSessionId;
-        Write-Host "CloudBuild Session ID: $qBuildSessionId"
-        Write-Host "##vso[task.setvariable variable=QBuildSessionId;isOutput=true]$qBuildSessionId"
-
-        $buildDrop = $json[0].BuildDrop;
-        Write-Host "Base Build Drop: $buildDrop"
-        Write-Host "##vso[task.setvariable variable=BaseBuildDrop;isOutput=true]$buildDrop"
-
-        $runSettingsDrop = "RunSettings/${env:System_TeamProject}/${env:Build_DefinitionName}/${env:Build_SourceBranchName}/${env:Build_BuildId}"
-        Write-Host "Run Settings Drop: $runSettingsDrop"
-        Write-Host "##vso[task.setvariable variable=RunSettingsDrop]$runSettingsDrop"
-        Write-Host "##vso[task.setvariable variable=RunSettingsDrop;isOutput=true]$runSettingsDrop"
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]Unable to set variables for DartLab: $_"
-        exit 1
-      }
-
-- task: MSBuild@1
-  displayName: 'Generate .runsettings files'
-  inputs:
-    solution: 'build\runsettings.proj'
-    msbuildArguments: '/restore:false /property:OutputPath="$(Build.StagingDirectory)\RunSettings" /property:TestDrop="$(RunSettingsDrop)" /binarylogger:$(Build.StagingDirectory)\\binlog\\13.GenerateRunSettings.binlog'
-
-- task: PowerShell@1
-  displayName: 'Copy VS integration test binaries'
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      try {
-        Write-Output "Copying NuGet.OptProf binaries"
-        Copy-Item "test\NuGet.Tests.Apex\NuGet.OptProf\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.OptProf\" -Recurse -ErrorAction Stop
-        Write-Output "Copying NuGet.Tests.Apex binaries"
-        Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex\" -Recurse -ErrorAction Stop
-        Write-Output "Copying NuGet.Tests.Apex.Daily binaries"
-        Copy-Item "test\NuGet.Tests.Apex\NuGet.Tests.Apex.Daily\bin\$(BuildConfiguration)" "$(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex.Daily\" -Recurse -ErrorAction Stop
-      } catch {
-        Write-Host "##vso[task.LogIssue type=error;]$_"
-        exit 1
-      }
-
-- task: MSBuild@1
-  displayName: "Collect Build Symbols"
-  inputs:
-    solution: "build\\symbols.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:IsSymbolBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.CollectBuildSymbols.binlog"
-    maximumCpuCount: true
-  condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
-
-- task: MSBuild@1
-  displayName: "LocValidation: Verify VSIX"
-  inputs:
-    solution: "build\\BuildValidator.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/target:ValidateVsix /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\15.ValidateVsixLocalization.binlog"
-
-- task: MSBuild@1
-  displayName: "LocValidation: Verify Artifacts"
-  inputs:
-    solution: "build\\BuildValidator.proj"
-    configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/target:ValidateArtifacts /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\16.ValidateArtifactsLocalization.binlog"
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish BootstrapperInfo.json as a build artifact'
-  inputs:
-    PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-    ArtifactName: MicroBuildOutputs
-    ArtifactType: Container
-
-- task: artifactDropTask@0
-  displayName: "Upload VS bootstapper Drop"
-  inputs:
-    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-    buildNumber: '$(MicroBuild.ManifestDropName)'
-    sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-    toLowerCase: false
-    usePat: true
-    dropMetadataContainerName: "DropMetadata-Product"
-
-- task: artifactDropTask@0
-  displayName: 'Publish the .runsettings files to artifact services'
-  inputs:
-    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-    buildNumber: '$(RunSettingsDrop)'
-    sourcePath: '$(Build.StagingDirectory)\RunSettings'
-    toLowerCase: false
-    usePat: true
-    dropMetadataContainerName: 'DropMetadata-RunSettings'
-
-- task: PublishPipelineArtifact@1
-  displayName: "Publish E2E tests"
-  inputs:
-    artifactName: "E2ETests"
-    targetPath: "$(Build.StagingDirectory)\\E2ETests"
-
-- task: PublishPipelineArtifact@1
-  displayName: "Publish scripts"
-  inputs:
-    artifactName: "scripts"
-    targetPath: "$(Build.Repository.LocalPath)\\scripts"
-
-- task: PublishPipelineArtifact@1
-  displayName: "Publish binlogs"
-  inputs:
-    artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
-    targetPath: $(Build.StagingDirectory)\binlog
-  condition: " or(failed(), eq(variables['System.debug'], 'true')) "
-
-- task: MicroBuildCleanup@1
-  displayName: "Perform Cleanup Tasks"
+  - task: MicroBuildCleanup@1
+    displayName: "Perform Cleanup Tasks"

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -124,7 +124,7 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.BuildToolsVSIX.binlog"
+    msbuildArguments: "/property:BuildNumber=$(BuildNumber) /property:SkipSbomExistsCheck=true /property:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.BuildToolsVSIX.binlog"
 
 - task: MSBuild@1
   displayName: "Sign"

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -15,8 +15,8 @@
   -->
   <Target Name="_ensureSbomExists" BeforeTargets="Build" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
     <Error Condition="!Exists($(SBOMFileLocation)) AND '$(SBOMFileLocation)' != ''"
-      Message="SBOM file '$(SBOMFileLocation)' does not exist" />
+      Text="SBOM file '$(SBOMFileLocation)' does not exist" />
     <Error Condition="'$(SBOMFileLocation)' == ''"
-      Message="Property 'SBOMFileLocation' is not defined" />
+      Text="Property 'SBOMFileLocation' is not defined" />
   </Target>
 </Project>

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -8,4 +8,15 @@
     <TargetFileName>$(TargetName)$(TargetExt)</TargetFileName>
     <TargetPath>$(TargetDir)$(TargetFileName)</TargetPath>
   </PropertyGroup>
+
+  <!--
+    VS requires the generated vsman files to contain the path to an SBOM file, but this isn't validated until VS insertion.
+    So, check here that the file exists and fail our build, so we get early notice of build errors.
+  -->
+  <Target Name="_ensureSbomExists" BeforeTargets="Build" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
+    <Error Condition="!Exists($(SBOMFileLocation)) AND '$(SBOMFileLocation)' != ''"
+      Message="SBOM file '$(SBOMFileLocation)' does not exist" />
+    <Error Condition="'$(SBOMFileLocation)' == ''"
+      Message="Property 'SBOMFileLocation' is not defined" />
+  </Target>
 </Project>

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -13,7 +13,7 @@
     VS requires the generated vsman files to contain the path to an SBOM file, but this isn't validated until VS insertion.
     So, check here that the file exists and fail our build, so we get early notice of build errors.
   -->
-  <Target Name="_ensureSbomExists" BeforeTargets="AddSBOM" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
+  <Target Name="_ensureSbomExists" BeforeTargets="AddSBOM" Condition=" '$(MSBuildProjectExtension)' == '.vsmanproj' ">
     <Error Condition="!Exists($(SBOMFileLocation)) AND '$(SBOMFileLocation)' != ''"
       Text="SBOM file '$(SBOMFileLocation)' does not exist" />
     <Error Condition="'$(SBOMFileLocation)' == ''"

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -13,7 +13,7 @@
     VS requires the generated vsman files to contain the path to an SBOM file, but this isn't validated until VS insertion.
     So, check here that the file exists and fail our build, so we get early notice of build errors.
   -->
-  <Target Name="_ensureSbomExists" BeforeTargets="Build" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
+  <Target Name="_ensureSbomExists" BeforeTargets="ValidateManifest" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
     <Error Condition="!Exists($(SBOMFileLocation)) AND '$(SBOMFileLocation)' != ''"
       Text="SBOM file '$(SBOMFileLocation)' does not exist" />
     <Error Condition="'$(SBOMFileLocation)' == ''"

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -13,7 +13,7 @@
     VS requires the generated vsman files to contain the path to an SBOM file, but this isn't validated until VS insertion.
     So, check here that the file exists and fail our build, so we get early notice of build errors.
   -->
-  <Target Name="_ensureSbomExists" BeforeTargets="AddSBOM" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
+  <Target Name="_ensureSbomExists" BeforeTargets="AddSBOM" Condition=" '$(IsVsixBuild)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
     <Error Condition="!Exists($(SBOMFileLocation)) AND '$(SBOMFileLocation)' != ''"
       Text="SBOM file '$(SBOMFileLocation)' does not exist" />
     <Error Condition="'$(SBOMFileLocation)' == ''"

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -13,7 +13,7 @@
     VS requires the generated vsman files to contain the path to an SBOM file, but this isn't validated until VS insertion.
     So, check here that the file exists and fail our build, so we get early notice of build errors.
   -->
-  <Target Name="_ensureSbomExists" BeforeTargets="AddSBOM" Condition=" '$(MSBuildProjectExtension)' == '.vsmanproj' ">
+  <Target Name="_ensureSbomExists" BeforeTargets="AddSBOM" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
     <Error Condition="!Exists($(SBOMFileLocation)) AND '$(SBOMFileLocation)' != ''"
       Text="SBOM file '$(SBOMFileLocation)' does not exist" />
     <Error Condition="'$(SBOMFileLocation)' == ''"

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -13,7 +13,7 @@
     VS requires the generated vsman files to contain the path to an SBOM file, but this isn't validated until VS insertion.
     So, check here that the file exists and fail our build, so we get early notice of build errors.
   -->
-  <Target Name="_ensureSbomExists" BeforeTargets="Build" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
+  <Target Name="_ensureSbomExists" BeforeTargets="AddSBOM" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
     <Error Condition="!Exists($(SBOMFileLocation)) AND '$(SBOMFileLocation)' != ''"
       Text="SBOM file '$(SBOMFileLocation)' does not exist" />
     <Error Condition="'$(SBOMFileLocation)' == ''"

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -13,7 +13,7 @@
     VS requires the generated vsman files to contain the path to an SBOM file, but this isn't validated until VS insertion.
     So, check here that the file exists and fail our build, so we get early notice of build errors.
   -->
-  <Target Name="_ensureSbomExists" BeforeTargets="ValidateManifest" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
+  <Target Name="_ensureSbomExists" BeforeTargets="Build" Condition=" '$(SkipSbomExistsCheck)' != 'true' AND '$(MSBuildProjectExtension)' == '.vsmanproj' ">
     <Error Condition="!Exists($(SBOMFileLocation)) AND '$(SBOMFileLocation)' != ''"
       Text="SBOM file '$(SBOMFileLocation)' does not exist" />
     <Error Condition="'$(SBOMFileLocation)' == ''"

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -9,7 +9,7 @@
     <TargetName>$(MSBuildProjectName)</TargetName>
     <OutputPath>$(VsixPublishDestination)</OutputPath>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <SBOMFileLocation>$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
+    <SBOMFileLocation>$(ManifestDirPath)\$(ARTIFACT_NAME)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -9,6 +9,7 @@
     <TargetName>$(MSBuildProjectName)</TargetName>
     <OutputPath>$(VsixPublishDestination)</OutputPath>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <SBOMFileLocation>$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
@@ -25,7 +26,7 @@
 
   <ItemGroup Condition=" '$(IsVsixBuild)' != 'true' ">
     <MergeManifest Include="$(VsixPublishDestination)$(MSBuildProjectName).json"
-                   SBOMFileLocation="$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json" />
+                   SBOMFileLocation="$(SBOMFileLocation)" />
   </ItemGroup>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />

--- a/setup/Microsoft.VisualStudio.NuGet.Core/Microsoft.VisualStudio.NuGet.Core.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.Core/Microsoft.VisualStudio.NuGet.Core.vsmanproj
@@ -9,12 +9,13 @@
     <TargetName>$(MSBuildProjectName)</TargetName>
     <OutputPath>$(VsixPublishDestination)</OutputPath>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <SBOMFileLocation>$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
   </PropertyGroup>
 
   <ItemGroup>
     <MergeManifest Include="$(VsixPublishDestination)Microsoft.VisualStudio.NuGet.Core.json"
-                   SBOMFileLocation="$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json" />
+                   SBOMFileLocation="$(SBOMFileLocation)" />
   </ItemGroup>
-  
+
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 </Project>

--- a/setup/Microsoft.VisualStudio.NuGet.Core/Microsoft.VisualStudio.NuGet.Core.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.Core/Microsoft.VisualStudio.NuGet.Core.vsmanproj
@@ -9,7 +9,7 @@
     <TargetName>$(MSBuildProjectName)</TargetName>
     <OutputPath>$(VsixPublishDestination)</OutputPath>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <SBOMFileLocation>$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
+    <SBOMFileLocation>$(ManifestDirPath)\$(ARTIFACT_NAME)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3430
## Description
_Supersedes https://github.com/NuGet/NuGet.Client/pull/6289_

### Fix path
 Corrects the path so that the MicroBuild task no longer searches the root artifacts folder for an SBOM (which is both inefficient and has potential to find the wrong SBOM).
  - The key change is we need to look in the same subfolder as the generate-sbom templates do, specifically not just ManifestDirPath, but $(ManifestDirPath)\ **$(ARTIFACT_NAME)**

    #### Previous search behavior
    MSBuild Task `AddSBOM` had been searching the entire root artifacts folder for the SBOM.

    >No SBOM file exists or explicitly mentioned by the user. Checking now at directory level: 'D:\a\_work' and looking for pattern 'manifest.spdx.json' as per the documentation: ....

    <img width="1718" height="188" alt="image" src="https://github.com/user-attachments/assets/de779424-dd44-443f-848c-8015a55d5d20" />


    #### Corrected search behavior
    MSBuild Task `AddSBOM` now finds the SBOM immediately without searching the entire root artifacts folder .
    <img width="1693" height="157" alt="image" src="https://github.com/user-attachments/assets/b9e2a673-6d6c-4049-a04e-de197bdd964a" />

### Fail if not found
- The Build now Fails when the SBOM file is not found. This prevents us from having to find out later when inserting into VS. An error is easier than piecing together what went wrong after-the-fact.

  - I've built upon @zivkan's suggestion and WIP from https://github.com/NuGet/NuGet.Client/pull/6289 and it appears that it will detect issues with the SBOM such as what was addressed in https://github.com/NuGet/NuGet.Client/pull/6786 by @jeffkl.

#### Example Failing build: 
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=12445368&view=results
<img width="2372" height="536" alt="image" src="https://github.com/user-attachments/assets/cfd423b2-86de-4c45-a32a-d3ab99ae7dbb" />

#### Example Successful build: 
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=12445358&view=results

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ See example builds
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
