### PR TITLE
Stop loading esproj in VS

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectJsonProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectJsonProjectProvider.cs
@@ -54,7 +54,8 @@ namespace NuGet.PackageManagement.VisualStudio
             var guids = vsProjectAdapter.GetProjectTypeGuids();
 
             // Web sites cannot have project.json
-            if (guids.Contains(VsProjectTypes.WebSiteProjectTypeGuid, StringComparer.OrdinalIgnoreCase))
+            if (guids.Contains(VsProjectTypes.WebSiteProjectTypeGuid, StringComparer.OrdinalIgnoreCase) ||
+                guids.Contains(VsProjectTypes.ESProjTypeGuid, StringComparer.OrdinalIgnoreCase))
             {
                 return null;
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related: https://github.com/NuGet/Home/issues/13512

## Description

esproj may sometimes have a project.json but that project.json is not the NuGet project.json.
To prevent misdetection in VS, we explicitly exclude esproj from getting detected as a project.json.

We have already allow listed esproj in some places so this is just continuation of that to prevent attempts to migrate projects that simply are not project.json projects and hit other potential issues like https://github.com/nuget/home/issues/14553

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ Unfortunately this is a non-standard test that 
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
