### PR TITLE
Use localized title for Package Source Mapping array setting

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -260,7 +260,7 @@
       "properties": {
         "packageSourceMapping": {
           "type": "array",
-          "title": "Package Source Mapping",
+          "title": "@116;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
 
           // Metadata about items in this array
           "items": {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/14550

## Description

The array setting title is typically suppressed if it matches the page's title.
However, I mistakenly left a hard-coded string here, so for localized languages, the hard-coded string was appearing as a heading for the array.
This PR matches the array title to the page title and therefore hides the array's header entirely for non en-US languages.

<img width="473" height="547" alt="image" src="https://github.com/user-attachments/assets/6f42a71b-2c06-472b-b2d6-6d29cd1c98be" />

<img width="422" height="531" alt="image" src="https://github.com/user-attachments/assets/e29186df-b785-466f-ab15-772d53363670" />


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
