### PR TITLE
Send telemetry for legacy package directory usage, remove RestoreArgs.IsLowercaseGlobalPackagesFolder 

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -476,8 +476,6 @@ NuGet.Commands.RestoreArgs.HideWarningsAndErrors.get -> bool
 NuGet.Commands.RestoreArgs.HideWarningsAndErrors.set -> void
 ~NuGet.Commands.RestoreArgs.Inputs.get -> System.Collections.Generic.List<string>
 ~NuGet.Commands.RestoreArgs.Inputs.set -> void
-NuGet.Commands.RestoreArgs.IsLowercaseGlobalPackagesFolder.get -> bool?
-NuGet.Commands.RestoreArgs.IsLowercaseGlobalPackagesFolder.set -> void
 NuGet.Commands.RestoreArgs.IsRestoreOriginalAction.get -> bool
 NuGet.Commands.RestoreArgs.IsRestoreOriginalAction.set -> void
 ~NuGet.Commands.RestoreArgs.Log.get -> NuGet.Common.ILogger

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -476,8 +476,6 @@ NuGet.Commands.RestoreArgs.HideWarningsAndErrors.get -> bool
 NuGet.Commands.RestoreArgs.HideWarningsAndErrors.set -> void
 ~NuGet.Commands.RestoreArgs.Inputs.get -> System.Collections.Generic.List<string>
 ~NuGet.Commands.RestoreArgs.Inputs.set -> void
-NuGet.Commands.RestoreArgs.IsLowercaseGlobalPackagesFolder.get -> bool?
-NuGet.Commands.RestoreArgs.IsLowercaseGlobalPackagesFolder.set -> void
 NuGet.Commands.RestoreArgs.IsRestoreOriginalAction.get -> bool
 NuGet.Commands.RestoreArgs.IsRestoreOriginalAction.set -> void
 ~NuGet.Commands.RestoreArgs.Log.get -> NuGet.Common.ILogger

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -23,8 +23,6 @@ namespace NuGet.Commands
 
         public string GlobalPackagesFolder { get; set; }
 
-        public bool? IsLowercaseGlobalPackagesFolder { get; set; }
-
         public bool DisableParallel { get; set; }
 
         public bool AllowNoOp { get; set; }
@@ -203,12 +201,6 @@ namespace NuGet.Commands
 
             request.RequestedRuntimes.UnionWith(Runtimes);
             request.FallbackRuntimes.UnionWith(FallbackRuntimes);
-
-            if (IsLowercaseGlobalPackagesFolder.HasValue)
-            {
-                request.IsLowercasePackagesDirectory = IsLowercaseGlobalPackagesFolder.Value;
-            }
-
             request.LockFileVersion = LockFileFormat.Version;
 
             // Run runtime asset checks for project.json, and for other types if enabled.

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -64,6 +64,7 @@ namespace NuGet.Commands
         private const string UpdatedAssetsFile = nameof(UpdatedAssetsFile);
         private const string UpdatedMSBuildFiles = nameof(UpdatedMSBuildFiles);
         private const string IsPackageInstallationTrigger = nameof(IsPackageInstallationTrigger);
+        private const string UsesLegacyPackagesDirectory = nameof(UsesLegacyPackagesDirectory);
 
         // no-op data names
         private const string NoOpDuration = nameof(NoOpDuration);
@@ -380,6 +381,7 @@ namespace NuGet.Commands
             telemetry.TelemetryEvent[UsingMicrosoftNETSdk] = _request.Project.RestoreMetadata.UsingMicrosoftNETSdk;
             telemetry.TelemetryEvent[NETSdkVersion] = _request.Project.RestoreSettings.SdkVersion;
             telemetry.TelemetryEvent[IsPackageInstallationTrigger] = !_request.IsRestoreOriginalAction;
+            telemetry.TelemetryEvent[UsesLegacyPackagesDirectory] = !_request.IsLowercasePackagesDirectory;
             _operationId = telemetry.OperationId;
 
             var isCpvmEnabled = _request.Project.RestoreMetadata?.CentralPackageVersionsEnabled ?? false;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2953,6 +2953,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["Pruning.DefaultEnabled"] = value => value.Should().BeOfType<bool>(),
                 ["Pruning.RemovablePackages.Count"] = value => value.Should().BeOfType<int>(),
                 ["Pruning.Pruned.Direct.Count"] = value => value.Should().BeOfType<int>(),
+                ["UsesLegacyPackagesDirectory"] = value => value.Should().Be(false),
             };
 
             HashSet<string> actualProperties = new();
@@ -3065,7 +3066,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
 
-            projectInformationEvent.Count.Should().Be(39);
+            projectInformationEvent.Count.Should().Be(40);
 
             projectInformationEvent["RestoreSuccess"].Should().Be(true);
             projectInformationEvent["NoOpResult"].Should().Be(true);
@@ -3106,6 +3107,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             projectInformationEvent["Pruning.FrameworksDisabled.Count"].Should().Be(1);
             projectInformationEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(0);
             projectInformationEvent["Pruning.DefaultEnabled"].Should().Be(false);
+            projectInformationEvent["UsesLegacyPackagesDirectory"].Should().Be(false);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -3165,7 +3165,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
 
-            projectInformationEvent.Count.Should().Be(47);
+            projectInformationEvent.Count.Should().Be(48);
             projectInformationEvent["RestoreSuccess"].Should().Be(true);
             projectInformationEvent["NoOpResult"].Should().Be(false);
             projectInformationEvent["TotalUniquePackagesCount"].Should().Be(2);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related: https://github.com/nuget/home/issues/14541

## Description

RestoreLegacyPackagesDirectory is very likely unused and as mentioned in the issue, we should remove it. 
The way to confirm that is get some telemetry so that's what this PR does.

I am also removing the RestoreArgs option that's not used in our code at all.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
