### PR TITLE
Direct Dependencies can use Audit Sources in PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageModelFactory.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/Package/PackageModelFactory.cs
@@ -32,18 +32,17 @@ namespace NuGet.PackageManagement.UI.Models.Package
             }
 
             EmbeddedResourcesCapability embeddedResources = new EmbeddedResourcesCapability(_packageFileService, metadata.Identity!, metadata.ReadmeUrl);
+            IVulnerableCapable vulnerableCapability = new VulnerableDatabaseCapability(_packageVulnerabilityService, metadata.Identity!);
 
             if (metadata.TransitiveOrigins != null)
             {
-                IVulnerableCapable vulnerableDatabaseCapability = new VulnerableDatabaseCapability(_packageVulnerabilityService, metadata.Identity!);
-                return CreateTransitivelyReferencedPackageModel(metadata, vulnerableDatabaseCapability, embeddedResources);
+                return CreateTransitivelyReferencedPackageModel(metadata, vulnerableCapability, embeddedResources);
             }
             else
             {
                 if (metadata.PackagePath != null)
                 {
                     PackageMetadataRetrievalAdapter packageMetadataRetrievalAdapter = new PackageMetadataRetrievalAdapter(_searchService, metadata.Identity!, _packageSources, _includePrerelease);
-                    IVulnerableCapable vulnerableCapability = new VulnerablePackageMetadataCapability(packageMetadataRetrievalAdapter);
 
                     if (itemFilter.Equals(ContractItemFilter.All))
                     {
@@ -57,7 +56,6 @@ namespace NuGet.PackageManagement.UI.Models.Package
                 {
                     PackageMetadataRetrievalAdapter packageMetadataRetrievalAdapter = new PackageMetadataRetrievalAdapter(_searchService, metadata.Identity!, _packageSources, _includePrerelease);
                     IDeprecationCapable deprecationCapable = new DeprecationPackageMetadataCapability(packageMetadataRetrievalAdapter);
-                    VulnerablePackageMetadataCapability vulnerableCapability = new VulnerablePackageMetadataCapability(packageMetadataRetrievalAdapter);
 
                     if (metadata.IsRecommended)
                     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3435

## Description

Direct dependencies in PM UI were using a `VulnerablePackageMetadataCapability` in the package model. The model instead needs to leverage the vulnerability service so that either the vulnerability data from the Package Source resources can be used, or the Audit Source, if configured.

<img width="2464" height="1346" alt="image" src="https://github.com/user-attachments/assets/f21a4247-0ab7-46a4-a1fb-caa410992a8f" />


### Validation

- All existing unit tests still pass.
- Validated nuget.org as a package source, a Top-Level & Transitive dependency both reflect vulnerabilities
- Validated nuget.org as an Audit source (only), a Top-Level & Transitive dependency both reflect vulnerabilities
- Validated that with no vulnerability resource (eg, here I removed nuget.org entirely), the PM UI renders the Installed packages with no vulnerability data.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
