### PR TITLE
Append Job Attempt Numbers to more artifact names to support re-running

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -143,21 +143,21 @@ stages:
         displayName: 'Publish buildinfo.json as an artifact'
         condition: "succeeded()"
         targetPath: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
-        artifactName: 'BuildInfo  - Attempt $(System.JobAttempt)'
+        artifactName: 'BuildInfo'
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.CommandLine.Test as artifact'
         condition: "and(succeeded(),ne(variables['RunMonoTestsOnMac'], 'false'))"
         targetPath: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
-        artifactName: "NuGet.CommandLine.Test - Attempt $(System.JobAttempt)"
+        artifactName: "NuGet.CommandLine.Test"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
-        artifactName: "nupkgs - $(RtmLabel) - Attempt $(System.JobAttempt)"
+        artifactName: "nupkgs - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
@@ -201,7 +201,7 @@ stages:
         displayName: 'Publish symbols as pipeline artifacts'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
-        artifactName: "symbols - $(RtmLabel)- Attempt $(System.JobAttempt)"
+        artifactName: "symbols - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: artifactsDrop
@@ -275,7 +275,7 @@ stages:
         displayName: 'Publish nupkgs'
         condition: "succeeded()"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
-        artifactName: "nupkgs - $(RtmLabel) - Attempt $(System.JobAttempt)"
+        artifactName: "nupkgs - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -194,7 +194,7 @@ stages:
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe and VSIX as artifact'
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-        artifactName: "$(VsixPublishDir) - Attempt $(System.JobAttempt)"
+        artifactName: "$(VsixPublishDir)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
@@ -281,7 +281,7 @@ stages:
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe and VSIX as artifact'
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-        artifactName: "$(VsixPublishDir)  - Attempt $(System.JobAttempt)"
+        artifactName: "$(VsixPublishDir)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -143,28 +143,28 @@ stages:
         displayName: 'Publish buildinfo.json as an artifact'
         condition: "succeeded()"
         targetPath: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
-        artifactName: 'BuildInfo'
+        artifactName: 'BuildInfo  - Attempt $(System.JobAttempt)'
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.CommandLine.Test as artifact'
         condition: "and(succeeded(),ne(variables['RunMonoTestsOnMac'], 'false'))"
         targetPath: "$(Build.Repository.LocalPath)\\test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\bin\\$(BuildConfiguration)\\net472"
-        artifactName: "NuGet.CommandLine.Test"
+        artifactName: "NuGet.CommandLine.Test - Attempt $(System.JobAttempt)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
-        artifactName: "nupkgs - $(RtmLabel)"
+        artifactName: "nupkgs - $(RtmLabel) - Attempt $(System.JobAttempt)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish BootstrapperInfo.json as a build artifact'
         condition: "succeeded()"
         targetPath: $(MicroBuildOutputFolderOverride)\MicroBuild\Output
-        artifactName: MicroBuildOutputs
+        artifactName: "MicroBuildOutputs - Attempt $(System.JobAttempt)"
         # need to make daily Apex test pipeline build its own bootstrapper, and remove this from official pipeline
         codeSignValidationEnabled: false
         sbomEnabled: false
@@ -194,14 +194,14 @@ stages:
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe and VSIX as artifact'
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-        artifactName: "$(VsixPublishDir)"
+        artifactName: "$(VsixPublishDir) - Attempt $(System.JobAttempt)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
-        artifactName: "symbols - $(RtmLabel)"
+        artifactName: "symbols - $(RtmLabel)- Attempt $(System.JobAttempt)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: artifactsDrop
@@ -217,7 +217,7 @@ stages:
       - output: pipelineArtifact
         displayName: 'LocValidation: Publish Logs as an artifact'
         condition: "succeededOrFailed()"
-        artifactName: LocValidationLogs
+        artifactName: LocValidationLogs - Attempt $(System.JobAttempt)
         targetPath: "$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs"
         sbomEnabled: true
 
@@ -230,7 +230,7 @@ stages:
 
       - output: pipelineArtifact
         displayName: Publish SBOM manifest
-        artifactName: $(ARTIFACT_NAME)
+        artifactName: $(ARTIFACT_NAME) - Attempt $(System.JobAttempt)
         targetPath: "$(Build.SourcesDirectory)/artifacts/_manifest"
         sbomEnabled: false
 
@@ -275,20 +275,20 @@ stages:
         displayName: 'Publish nupkgs'
         condition: "succeeded()"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
-        artifactName: "nupkgs - $(RtmLabel)"
+        artifactName: "nupkgs - $(RtmLabel) - Attempt $(System.JobAttempt)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe and VSIX as artifact'
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
-        artifactName: "$(VsixPublishDir)"
+        artifactName: "$(VsixPublishDir)  - Attempt $(System.JobAttempt)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
-        artifactName: "symbols - $(RtmLabel)"
+        artifactName: "symbols - $(RtmLabel) - Attempt $(System.JobAttempt)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -288,7 +288,7 @@ stages:
         displayName: 'Publish symbols as pipeline artifacts'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
-        artifactName: "symbols - $(RtmLabel) - Attempt $(System.JobAttempt)"
+        artifactName: "symbols - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -164,7 +164,7 @@ stages:
         displayName: 'Publish BootstrapperInfo.json as a build artifact'
         condition: "succeeded()"
         targetPath: $(MicroBuildOutputFolderOverride)\MicroBuild\Output
-        artifactName: "MicroBuildOutputs - Attempt $(System.JobAttempt)"
+        artifactName: MicroBuildOutputs
         # need to make daily Apex test pipeline build its own bootstrapper, and remove this from official pipeline
         codeSignValidationEnabled: false
         sbomEnabled: false
@@ -230,7 +230,7 @@ stages:
 
       - output: pipelineArtifact
         displayName: Publish SBOM manifest
-        artifactName: $(ARTIFACT_NAME) - Attempt $(System.JobAttempt)
+        artifactName: $(ARTIFACT_NAME)
         targetPath: "$(Build.SourcesDirectory)/artifacts/_manifest"
         sbomEnabled: false
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Infrastructure

## Description

For NuGet's publishing of pipeline artifacts from CI, append Job Attempt numbers to more artifact names.
This reduces the incidence of permanently failing a build when the first failed (Attempt # 1) publishes logs, so subsequent attempts are unable to re-publish those logs.

This artifact publishing step will now have an attempt number:
- **LocValidation: Publish Logs as an artifact** (this recently happened and inspired this change)

### When re-running can still fail
- There are still some NuGet steps that rely on a hard-coded artifact name during release. (eg, `nupkgs - RTM`).
- There are also SBOM generation jobs that publish artifacts without a JobAttempt (eg, `BuildConfiguration`), but we don't control this YML.
- Publish BootstrapperInfo.json as a build artifact
- Publish NuGet.exe and VSIX as artifact **Backup Build Artifacts** depends on this name: https://github.com/NuGet/NuGet.Client/blob/579b09a035c8fb29e66bc62fb4e559cc93f66dd2/eng/pipelines/backup_build_artifacts.yml#L29-L46


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
