### PR TITLE
Normalize package source names when resolving environment variable credentials

### DIFF
--- a/src/NuGet.Core/NuGet.Common/EnvironmentVariableWrapper.cs
+++ b/src/NuGet.Core/NuGet.Common/EnvironmentVariableWrapper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security;
+using System.Text.RegularExpressions;
 
 namespace NuGet.Common
 {
@@ -15,13 +16,19 @@ namespace NuGet.Common
             try
             {
 #pragma warning disable RS0030 // Do not use banned APIs
-                return Environment.GetEnvironmentVariable(variable);
+                return Environment.GetEnvironmentVariable(NormalizeSourceName(variable));
 #pragma warning restore RS0030 // Do not use banned APIs
             }
             catch (SecurityException)
             {
                 return null;
             }
+        }
+
+        private static string NormalizeSourceName(string sourceName)
+        {
+            // Replace invalid env var chars with underscore
+            return Regex.Replace(sourceName, @"[^A-Za-z0-9_]", "_");
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/EnvironmentVariableWrapperTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/EnvironmentVariableWrapperTests.cs
@@ -41,5 +41,23 @@ namespace NuGet.Common.Test
 
             Assert.Equal(expectedValue, actualValue);
         }
+
+        [Theory]
+        [InlineData("Foo", "Foo")]
+        [InlineData("Foo.Bar", "Foo_Bar")]
+        [InlineData("Foo-Bar", "Foo_Bar")]
+        [InlineData("Foo Bar!", "Foo_Bar_")]
+        [InlineData("^Foo@Bar#", "_Foo_Bar_")]
+        public void GetEnvironmentVariable_WhenVariableIsNotNormalized_NormalizeValue(string sourceName, string normalizedSourceName)
+        {
+            var expectedValue = Guid.NewGuid().ToString();
+            var instance = EnvironmentVariableWrapper.Instance;
+
+            Environment.SetEnvironmentVariable(normalizedSourceName, expectedValue);
+
+            var actualValue = instance.GetEnvironmentVariable(sourceName);
+
+            Assert.Equal(expectedValue, actualValue);
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug
Fixes: https://github.com/NuGet/Home/issues/14562

## Description
This PR fixes a bug where environment variable credential lookup fails if the package source key in `nuget.config` contains characters that are invalid in environment variable names (such as `-`, space, `@`, etc.).  

Currently, only `.` is normalized to `_` when constructing the environment variable name, but other invalid characters are not handled. For example:

- Source key: `foo-bar`  
- Expected env vars: `NuGetPackageSourceCredentials_foo_bar_Username`, `NuGetPackageSourceCredentials_foo_bar_ClearTextPassword`  
- Actual lookup: `NuGetPackageSourceCredentials_foo-bar_Username` (invalid, cannot be set as an environment variable)

This PR adds normalization logic so that **all non-alphanumeric characters are replaced with `_`** before environment variable lookup.  

### Example behavior

| Source key   | Old lookup name                                | New lookup name                               |
|--------------|-----------------------------------------------|-----------------------------------------------|
| `foo.bar`    | `NuGetPackageSourceCredentials_foo_bar_*`      | `NuGetPackageSourceCredentials_foo_bar_*` (unchanged) |
| `foo-bar`    | `NuGetPackageSourceCredentials_foo-bar_*` (invalid) | `NuGetPackageSourceCredentials_foo_bar_*` |
| `my source!` | `NuGetPackageSourceCredentials_my source!*` (invalid) | `NuGetPackageSourceCredentials_my_source_*` |

This change aligns behavior with the documentation and makes environment variable credentials usable with any source name.

## PR Checklist

- [ x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x ] Added tests
- [x ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
