### PR TITLE
Add support for CPM with dotnet package update (#6796)

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -248,7 +248,7 @@ internal static class PackageUpdateCommandRunner
                         {
                             Id = packageIdentity.Id,
                             CurrentVersion = new VersionRange(packageIdentity.Version),
-                            NewVersion = new VersionRange(nonVulnerableVersion)
+                            NewVersion = VersionRange.Parse(nonVulnerableVersion.OriginalVersion!)
                         },
                         TargetFrameworkAliases = tfmAliases
                     });
@@ -341,7 +341,7 @@ internal static class PackageUpdateCommandRunner
                     continue;
                 }
 
-                upgradeVersion = new VersionRange(latestVersion);
+                upgradeVersion = VersionRange.Parse(latestVersion.OriginalVersion!);
                 if (upgradeVersion == existingVersion)
                 {
                     logger.LogMinimal(Messages.Warning_AlreadyHighestVersion(package.Id, latestVersion.OriginalVersion, project.FilePath), ConsoleColor.Yellow);
@@ -478,7 +478,7 @@ internal static class PackageUpdateCommandRunner
                 continue;
             }
 
-            var upgradeVersion = new VersionRange(latestVersion);
+            var upgradeVersion = VersionRange.Parse(latestVersion.OriginalVersion!);
             if (upgradeVersion.ToString() == package.identity.VersionRange.ToString())
             {
                 // Already using the highest version.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -191,11 +191,14 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
             packageDependency,
             resolvedVersion);
 
+        // MSBuildUtility only updated CPM Directory.Packages.props when "noVersion" is false.
+        const bool noVersion = false;
+
         // Determine whether to add package reference conditionally or unconditionally
         if (packageTfms.Count == updatedPackageSpec.TargetFrameworks.Count)
         {
             // package is used by all project TFMs (no condition)
-            _msbuildUtility.AddPackageReference(updatedPackageSpec.FilePath, libraryDependency, true);
+            _msbuildUtility.AddPackageReference(updatedPackageSpec.FilePath, libraryDependency, noVersion);
         }
         else
         {
@@ -203,7 +206,7 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
                 .Select(e => AddPackageReferenceCommandRunner.GetAliasForFramework(updatedPackageSpec, e))
                 .Where(originalFramework => originalFramework != null);
 
-            _msbuildUtility.AddPackageReferencePerTFM(updatedPackageSpec.FilePath, libraryDependency, frameworkAliases, true);
+            _msbuildUtility.AddPackageReferencePerTFM(updatedPackageSpec.FilePath, libraryDependency, frameworkAliases, noVersion);
         }
     }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
@@ -94,6 +94,66 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
+        public async Task SingleTfmCpmProject_PackageVersionUpdated()
+        {
+            // Arrange
+            using var testContext = new SimpleTestPathContext();
+            File.WriteAllText(testContext.NuGetConfig, string.Format(NugetConfigFormat, testContext.PackageSource));
+
+            var a1 = new SimpleTestPackageContext("NuGet.Internal.Test.a", "1.0.0");
+            var a2 = new SimpleTestPackageContext("NuGet.Internal.Test.a", "2.0.0");
+
+            SimpleTestPackageContext[] packages = [a1, a2];
+            await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packages);
+
+            var csprojContents = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                    <PropertyGroup>
+                        <TargetFramework>net9.0</TargetFramework>
+                    </PropertyGroup>
+                    <ItemGroup>
+                        <PackageReference Include="NuGet.Internal.Test.a" />
+                    </ItemGroup>
+                </Project>
+                """;
+            var csprojPath = Path.Combine(testContext.SolutionRoot, "my.csproj");
+            File.WriteAllText(csprojPath, csprojContents);
+
+            var packagesPropsContents = """
+                <Project>
+                    <PropertyGroup>
+                        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                    </PropertyGroup>
+                    <ItemGroup>
+                        <PackageVersion Include="NuGet.Internal.Test.a" Version="1.0.0" />
+                    </ItemGroup>
+                </Project>
+                """;
+            var packagesPropsPath = Path.Combine(testContext.SolutionRoot, "Directory.Packages.props");
+            File.WriteAllText(packagesPropsPath, packagesPropsContents);
+
+            // Act
+            var result = _testFixture.RunDotnetExpectSuccess(
+                workingDirectory: testContext.SolutionRoot,
+                args: $"package update NuGet.Internal.Test.a",
+                testOutputHelper: _testOutputHelper,
+                environmentVariables: _envVars);
+
+            // Assert
+            result.ExitCode.Should().Be(0);
+
+            XDocument csproj = XDocument.Load(csprojPath);
+            var packageReferenceA = csproj.XPathSelectElements("//PackageReference[@Include='NuGet.Internal.Test.a']").ToList();
+            packageReferenceA.Count.Should().Be(1);
+            packageReferenceA[0].Attribute("Version").Should().BeNull();
+
+            XDocument packagesProps = XDocument.Load(packagesPropsPath);
+            var packageVersionA = packagesProps.XPathSelectElements("//PackageVersion[@Include='NuGet.Internal.Test.a']").ToList();
+            packageVersionA.Count.Should().Be(1);
+            packageVersionA[0].Attribute("Version").Value.Should().Be("2.0.0");
+        }
+
+        [Fact]
         public async Task MultiTfmProject_PackageVersionUpdated()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14318

## Description
Cherry pick of https://github.com/NuGet/NuGet.Client/pull/6796. Copy-paste of that PR's description:

dotnet package update uses the existing helper methods written for dotnet package add to modify project files, and it supports CPM by using VersionRange.OriginalString to write the exact string that customers wrote on the command line. However, the constructor for VersionRange can create instances where OriginalString is null. So, use VersionRange.Parse instead to ensure that OriginalString will always have a value for MSBuildAPIUtility to use.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A

.NET approval template:
## Customer Impact

Impacts customers using Central Package Management (CPM). 

## Regression?

- [ ] Yes
- [x] No  

## Risk

- [ ] High
- [ ] Medium
- [x] Low  

Justification: dotnet package update is a new command in .NET 10.0.100, and this PR does not change any code shared with other commands.

## Verification

- [x] Manual (required)  
- [x] Automated  

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A  



