### PR TITLE
Migrate tests that are using the dependencies element

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -123,12 +123,11 @@ namespace NuGet.ProjectModel
                     }
                     else if (jsonReader.ValueTextEquals(DependenciesPropertyName))
                     {
-                        throw new ArgumentException("The dependencies section is not allowed at the root of the project.json file. Move it inside a framework section.");
-                        //ReadDependencies(
-                        //    ref jsonReader,
-                        //    packageSpec.Dependencies,
-                        //    filePath,
-                        //    isGacOrFrameworkReference: false);
+                        ReadDependencies(
+                            ref jsonReader,
+                            packageSpec.Dependencies,
+                            filePath,
+                            isGacOrFrameworkReference: false);
                     }
                     else if (jsonReader.ValueTextEquals(FrameworksPropertyName))
                     {

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -123,6 +123,7 @@ namespace NuGet.ProjectModel
                     }
                     else if (jsonReader.ValueTextEquals(DependenciesPropertyName))
                     {
+                        throw new ArgumentException("The dependencies section is not allowed at the root of the project.json file. Move it inside a framework section.");
                         ReadDependencies(
                             ref jsonReader,
                             packageSpec.Dependencies,

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -1512,9 +1512,7 @@ namespace NuGet.ProjectModel
                 Warn = warn
             };
 
-#pragma warning disable CS0612 // Type or member is obsolete
             AddTargetFramework(packageSpec, frameworkName, secondaryFramework, targetFrameworkInformation);
-#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         private static HashSet<string> ReadSuppressedAdvisories(ref Utf8JsonStreamReader jsonReader)

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -124,11 +124,11 @@ namespace NuGet.ProjectModel
                     else if (jsonReader.ValueTextEquals(DependenciesPropertyName))
                     {
                         throw new ArgumentException("The dependencies section is not allowed at the root of the project.json file. Move it inside a framework section.");
-                        ReadDependencies(
-                            ref jsonReader,
-                            packageSpec.Dependencies,
-                            filePath,
-                            isGacOrFrameworkReference: false);
+                        //ReadDependencies(
+                        //    ref jsonReader,
+                        //    packageSpec.Dependencies,
+                        //    filePath,
+                        //    isGacOrFrameworkReference: false);
                     }
                     else if (jsonReader.ValueTextEquals(FrameworksPropertyName))
                     {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -272,6 +272,7 @@ namespace NuGet.Commands.FuncTest
                 var graph = result.RestoreGraphs.First();
                 Assert.Equal(0, graph.Conflicts.Count());
                 Assert.True(result.Success, "The restore should have been successful.");
+                result.RestoreGraphs.First().Flattened.Should().HaveCountGreaterThan(2);
             }
         }
 
@@ -660,6 +661,7 @@ namespace NuGet.Commands.FuncTest
                 Assert.Equal(0, logger.Errors);
                 Assert.Equal(0, logger.Warnings);
                 Assert.Equal(0, result.GetAllInstalled().Count);
+                Assert.Equal(2, result.RestoreGraphs.First().Flattened.Count);
             }
         }
 
@@ -1730,6 +1732,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Assert
                 Assert.True(result.Success);
+                result.LockFile.Libraries.Should().HaveCount(4);
             }
         }
 
@@ -2150,6 +2153,7 @@ namespace NuGet.Commands.FuncTest
 
                     // Assert
                     Assert.True(result.Success);
+                    result.LockFile.Libraries.Should().HaveCount(1);
                 }
             }
         }
@@ -2523,6 +2527,7 @@ namespace NuGet.Commands.FuncTest
 
                     // Assert
                     Assert.True(result.Success);
+                    result.LockFile.Libraries.Should().HaveCount(1);
                 }
             }
         }
@@ -2574,6 +2579,7 @@ namespace NuGet.Commands.FuncTest
 
                     // Assert
                     Assert.True(result.Success);
+                    result.LockFile.Libraries.Should().HaveCount(1);
                 }
             }
         }
@@ -2625,6 +2631,7 @@ namespace NuGet.Commands.FuncTest
 
                     // Assert
                     Assert.True(result.Success);
+                    result.LockFile.Libraries.Should().HaveCount(1);
                 }
             }
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -214,11 +214,12 @@ namespace NuGet.Commands.FuncTest
                     specPathB,
                     @"
                     {
-                      ""dependencies"": {
-                        ""microsoft.NETCore.Runtime.CoreCLR"": ""1.0.2-rc2-24027""
-                      },
                       ""frameworks"": {
-                        ""netstandard1.5"": {}
+                        ""netstandard1.5"": {
+                          ""dependencies"": {
+                            ""microsoft.NETCore.Runtime.CoreCLR"": ""1.0.2-rc2-24027""
+                          }
+                        }
                       }
                     }
                     ");
@@ -231,14 +232,16 @@ namespace NuGet.Commands.FuncTest
                     specPathA,
                     @"
                     {
-                      ""dependencies"": {
-                        ""b"": {
-                          ""target"": ""project""
-                        },
-                        ""Microsoft.NETCore.Runtime"": ""1.0.2-rc2-24027""
-                      },
                       ""frameworks"": {
-                        ""netcoreapp1.0"": {}
+                        ""netcoreapp1.0"": {
+                          ""dependencies"": {
+                            ""b"": {
+                              ""target"": ""project"",
+                              ""version"" : ""1.0.0""
+                            },
+                            ""Microsoft.NETCore.Runtime"": ""1.0.2-rc2-24027""
+                          }
+                        }
                       }
                     }
                     ");
@@ -616,13 +619,13 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1""
-                    },
                     ""frameworks"": {
                         ""dotnet"": {
                             ""imports"": ""portable-net452+win81"",
-                            ""warn"": false
+                            ""warn"": false,
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1""
+                            }
                         }
                     }
                 }");
@@ -833,8 +836,6 @@ namespace NuGet.Commands.FuncTest
                     ["net46"] = new JObject()
                 };
 
-                json["dependencies"] = new JObject();
-
                 json["frameworks"] = frameworks;
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
@@ -887,8 +888,6 @@ namespace NuGet.Commands.FuncTest
                 {
                     ["net46"] = new JObject()
                 };
-
-                json["dependencies"] = new JObject();
 
                 json["frameworks"] = frameworks;
 
@@ -1650,11 +1649,12 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_PopulatesProjectFileDependencyGroupsCorrectlyAsync()
         {
             const string project = @"{
-    ""dependencies"": {
-        ""Newtonsoft.Json"": ""6.0.4""
-    },
     ""frameworks"": {
-        ""net45"": {}
+        ""net45"": {
+            ""dependencies"": {
+                ""Newtonsoft.Json"": ""6.0.4""
+            }
+        }
     },
     ""supports"": {
     }
@@ -1696,11 +1696,12 @@ namespace NuGet.Commands.FuncTest
         {
             const string project = @"
 {
-    ""dependencies"": {
-        ""Microsoft.OData.Client"": ""6.12.0"",
-    },
     ""frameworks"": {
-        ""net40"": {}
+        ""net40"": {
+            ""dependencies"": {
+                ""Microsoft.OData.Client"": ""6.12.0"",
+            }
+        }
     }
 }
 ";
@@ -1938,11 +1939,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1""
+                            }
+                        }
                     }
                 }");
 
@@ -2065,11 +2067,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1-*""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1-*""
+                            }
+                        }
                     }
                 }");
 
@@ -2115,11 +2118,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1-*""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1-*""
+                            }
+                        }
                     }
                 }");
 
@@ -2487,11 +2491,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.91""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.91""
+                            }
+                        }
                     }
                 }");
 
@@ -2537,11 +2542,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.91""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.91""
+                            }
+                        }
                     }
                 }");
 
@@ -2587,11 +2593,12 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""NewtonSoft.Json"": ""7.0.91""
-                    },
                      ""frameworks"": {
-                        ""net45"": { }
+                        ""net45"": {
+                            ""dependencies"": {
+                                ""NewtonSoft.Json"": ""7.0.91""
+                            }
+                        }
                     }
                 }");
 
@@ -2805,8 +2812,6 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                    },
                      ""frameworks"": {
                         ""net45"": { }
                     }
@@ -2851,8 +2856,6 @@ namespace NuGet.Commands.FuncTest
             {
                 var configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                    },
                      ""frameworks"": {
                         ""net45"": { }
                     }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
@@ -237,6 +237,7 @@ namespace NuGet.Commands.FuncTest
                 Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
                 Assert.Equal(0, logger.Errors);
                 Assert.Equal(0, logger.Warnings);
+                Assert.Equal(13, result.LockFile.Libraries.Count);
             }
         }
 
@@ -444,6 +445,7 @@ namespace NuGet.Commands.FuncTest
             spec.RestoreMetadata.Sources = sources;
 
             (var mainResult, var legacyResult) = await RestoreCommandTests.ValidateRestoreAlgorithmEquivalency(pathContext, spec);
+            mainResult.LockFile.Libraries.Should().HaveCount(124);
         }
 
         private Stream GetResource(string name)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
@@ -207,12 +207,13 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestDirectory.Create())
             {
                 var configJson = JObject.Parse(@"{
-                  ""dependencies"": {
-                    ""System.Text.Encoding"": ""4.0.10"",
-                    ""System.Collections"": ""4.0.11-beta-23225""
-                  },
                   ""frameworks"": {
-                    ""uap10.0"": {}
+                    ""uap10.0"": {
+                      ""dependencies"": {
+                        ""System.Text.Encoding"": ""4.0.10"",
+                        ""System.Collections"": ""4.0.11-beta-23225""
+                      }
+                    }
                   }
                 }");
 
@@ -415,19 +416,20 @@ namespace NuGet.Commands.FuncTest
 
             using var pathContext = new SimpleTestPathContext();
             var configJson = JObject.Parse(@"{
-                ""dependencies"": {
-                ""Microsoft.ApplicationInsights"": ""1.0.0"",
-                ""Microsoft.ApplicationInsights.PersistenceChannel"": ""1.0.0"",
-                ""Microsoft.ApplicationInsights.WindowsApps"": ""1.0.0"",
-                ""Microsoft.Azure.ActiveDirectory.GraphClient"": ""2.0.6"",
-                ""Microsoft.IdentityModel.Clients.ActiveDirectory"": ""2.14.201151115"",
-                ""Microsoft.NETCore.UniversalWindowsPlatform"": ""5.0.0"",
-                ""Microsoft.Office365.Discovery"": ""1.0.22"",
-                ""Microsoft.Office365.OutlookServices"": ""1.0.35"",
-                ""Microsoft.Office365.SharePoint"": ""1.0.22""
-                },
                 ""frameworks"": {
-                ""uap10.0"": {}
+                ""uap10.0"": {
+                    ""dependencies"": {
+                        ""Microsoft.ApplicationInsights"": ""1.0.0"",
+                        ""Microsoft.ApplicationInsights.PersistenceChannel"": ""1.0.0"",
+                        ""Microsoft.ApplicationInsights.WindowsApps"": ""1.0.0"",
+                        ""Microsoft.Azure.ActiveDirectory.GraphClient"": ""2.0.6"",
+                        ""Microsoft.IdentityModel.Clients.ActiveDirectory"": ""2.14.201151115"",
+                        ""Microsoft.NETCore.UniversalWindowsPlatform"": ""5.0.0"",
+                        ""Microsoft.Office365.Discovery"": ""1.0.22"",
+                        ""Microsoft.Office365.OutlookServices"": ""1.0.35"",
+                        ""Microsoft.Office365.SharePoint"": ""1.0.22""
+                    }
+                }
                 },
                 ""runtimes"": {
                 ""win10-arm"": {},

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
@@ -90,16 +90,11 @@ namespace NuGet.Commands.Test
             var project1Json = @"
             {
               ""version"": ""1.0.0"",
-              ""description"": """",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
-              ""dependencies"": {
-                ""packageA"": ""1.0.0""
-              },
               ""frameworks"": {
                 ""net45"": {
+                  ""dependencies"": {
+                    ""packageA"": ""1.0.0""
+                  }
                 }
               }
             }";
@@ -107,11 +102,6 @@ namespace NuGet.Commands.Test
             var packageBProjectJson = @"
             {
               ""version"": ""1.0.0"",
-              ""description"": """",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
               ""frameworks"": {
                 ""net45"": {
                 }
@@ -391,19 +381,14 @@ namespace NuGet.Commands.Test
             var project1Json = @"
             {
               ""version"": ""1.0.0"",
-              ""description"": """",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
-              ""dependencies"": {
-                ""packageA"": {
-                    ""version"": ""1.0.0"",
-                    ""target"": ""project""
-                }
-              },
               ""frameworks"": {
                 ""net45"": {
+                  ""dependencies"": {
+                    ""packageA"": {
+                        ""version"": ""1.0.0"",
+                        ""target"": ""project""
+                    }
+                  }
                 }
               }
             }";

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
@@ -168,6 +168,7 @@ namespace NuGet.Commands.Test
                 var packageBLib = lockFile.GetLibrary("packageB", NuGetVersion.Parse("1.0.0"));
                 Assert.NotNull(packageBLib);
                 Assert.Equal(LibraryType.Project, packageBLib.Type);
+                Assert.Equal(2, lockFile.Libraries.Count);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
@@ -106,8 +106,6 @@ namespace NuGet.Commands.Test
             }";
 
                 var configJson1 = @"{
-                ""dependencies"": {
-                },
                 ""frameworks"": {
                 ""net46"": {}
                 },
@@ -228,8 +226,6 @@ namespace NuGet.Commands.Test
             }";
 
                 var configJson1 = @"{
-                ""dependencies"": {
-                },
                 ""frameworks"": {
                 ""net46"": {}
                 },
@@ -299,8 +295,6 @@ namespace NuGet.Commands.Test
             }";
 
                 var configJson1 = @"{
-                ""dependencies"": {
-                },
                 ""frameworks"": {
                 ""net46"": {}
                 },
@@ -761,8 +755,6 @@ namespace NuGet.Commands.Test
                 }";
 
                 var configJson1 = @"{
-                ""dependencies"": {
-                },
                 ""frameworks"": {
                 ""net46"": {}
                 },
@@ -811,8 +803,6 @@ namespace NuGet.Commands.Test
                 }";
 
                 var configJson1 = @"{
-                    ""dependencies"": {
-                    },
                     ""frameworks"": {
                     ""net46"": {}
                     },
@@ -956,21 +946,20 @@ namespace NuGet.Commands.Test
             using (var pathContext = new SimpleTestPathContext())
             {
                 var configJson2 = @"{
-                    ""dependencies"": {
-                        ""packageX"": {
-                            ""version"": ""1.0.0"",
-                            ""suppressParent"": ""all""
-                        }
-                    },
                     ""frameworks"": {
-                    ""net46"": {}
+                    ""net46"": {
+                            ""dependencies"": {
+                                ""packageX"": {
+                                    ""version"": ""1.0.0"",
+                                    ""suppressParent"": ""all""
+                                }
+                            }
+                        }
                     },
                     ""runtimes"": { ""any"": { } }
                 }";
 
                 var configJson1 = @"{
-                    ""dependencies"": {
-                    },
                     ""frameworks"": {
                     ""net46"": {}
                     },
@@ -1062,8 +1051,6 @@ namespace NuGet.Commands.Test
                 }";
 
                 var configJson2 = @"{
-                    ""dependencies"": {
-                    },
                     ""frameworks"": {
                     ""net46"": {}
                     },
@@ -1243,14 +1230,15 @@ namespace NuGet.Commands.Test
             {
 
                 var projectJson = @"{
-                        ""dependencies"": {
-                            ""packageX"": {
-                                ""version"": ""1.0.0"",
-                                ""exclude"": ""build""
-                            }
-                        },
                         ""frameworks"": {
-                            ""net46"": {}
+                            ""net46"": {
+                                ""dependencies"": {
+                                    ""packageX"": {
+                                        ""version"": ""1.0.0"",
+                                        ""exclude"": ""build""
+                                    }
+                                }
+                            }
                         },
                     ""runtimes"": { ""any"": { } }
                  }";

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
@@ -976,6 +976,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal(0, logger.Warnings);
                 Assert.Equal(0, target.Libraries.Count(lib => lib.Type == LibraryType.Package));
                 Assert.Equal(0, result.LockFile.Libraries.Count(lib => lib.Type == LibraryType.Package));
+                Assert.Equal(1, result.LockFile.Libraries.Count);
             }
         }
 
@@ -1260,6 +1261,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal(0, logger.Warnings);
 
                 Assert.Equal(0, msbuildTargets["TestProject"].Count);
+                Assert.Equal(3, result.LockFile.Libraries.Count);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/Project2ProjectInLockFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/Project2ProjectInLockFileTests.cs
@@ -28,8 +28,6 @@ namespace NuGet.Commands.Test
             var projectJson = @"
             {
                 ""version"": ""2.0.0"",
-                ""dependencies"": {
-                },
                 ""frameworks"": {
                     ""net45"": {}
                 }
@@ -38,16 +36,11 @@ namespace NuGet.Commands.Test
             var project2Json = @"
             {
               ""version"": ""2.0.0-*"",
-              ""description"": ""Proj2 Class Library"",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
-              ""dependencies"": {
-                ""project3"": ""2.0.0-*""
-              },
               ""frameworks"": {
                 ""net45"": {
+                  ""dependencies"": {
+                    ""project3"": ""2.0.0-*""
+                  }
                 }
               }
             }";
@@ -55,11 +48,6 @@ namespace NuGet.Commands.Test
             var project3Json = @"
             {
               ""version"": ""2.0.0-*"",
-              ""description"": ""Proj3 Class Library"",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
               ""frameworks"": {
                 ""net45"": {
                 }
@@ -133,8 +121,6 @@ namespace NuGet.Commands.Test
             var project1Json = @"
             {
                 ""version"": ""1.0.0"",
-                ""dependencies"": {
-                },
                 ""frameworks"": {
                     ""net45"": {}
                 }
@@ -143,11 +129,12 @@ namespace NuGet.Commands.Test
             var project2Json = @"
             {
                 ""version"": ""1.0.0"",
-                ""dependencies"": {
-                    ""Microsoft.VisualBasic"": ""10.0.0""
-                },
                 ""frameworks"": {
-                    ""net45"": {}
+                    ""net45"": {
+                        ""dependencies"": {
+                            ""Microsoft.VisualBasic"": ""10.0.0""
+                        }
+                    }
                 }
             }";
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
@@ -286,8 +286,6 @@ namespace NuGet.Commands.Test
                 var dgSpec = new DependencyGraphSpec();
                 var configJson = @"
                 {
-                    ""dependencies"": {
-                    },
                      ""frameworks"": {
                         ""net45"": { }
                     }
@@ -342,8 +340,6 @@ namespace NuGet.Commands.Test
             var dgSpec = new DependencyGraphSpec();
             var configJson = @"
                 {
-                    ""dependencies"": {
-                    },
                      ""frameworks"": {
                         ""net45"": { }
                     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
@@ -218,6 +218,7 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 Assert.True(result.Success, logger.ShowMessages());
+                Assert.Equal(2, result.LockFile.Libraries.Count);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
@@ -194,12 +194,13 @@ namespace NuGet.Commands.Test
                     ""uwp.10.0.app"": {},
                     ""dnxcore50.app"": {}
                 },
-                ""dependencies"": {
-                    ""packageA"": ""1.0.0"",
-                    ""runtimes"": ""1.0.0""
-                },
                 ""frameworks"": {
-                    ""_FRAMEWORK_"": {}
+                    ""_FRAMEWORK_"": {
+                        ""dependencies"": {
+                            ""packageA"": ""1.0.0"",
+                            ""runtimes"": ""1.0.0""
+                        }
+                    }
                 }
             }".Replace("_FRAMEWORK_", framework));
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
@@ -140,14 +140,15 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""version"": ""1.0.0"",
-                                    ""target"": ""blah""
-                                }
-                            },
                             ""frameworks"": {
-                                ""net46"": {}
+                                ""net46"": {
+                                    ""dependencies"": {
+                                        ""packageA"": {
+                                            ""version"": ""1.0.0"",
+                                            ""target"": ""blah""
+                                        }
+                                    }
+                                }
                             }
                         }";
 
@@ -176,14 +177,15 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""version"": ""1.0.0"",
-                                    ""target"": ""winmd""
-                                }
-                            },
                             ""frameworks"": {
-                                ""net46"": {}
+                                ""net46"": {
+                                    ""dependencies"": {
+                                        ""packageA"": {
+                                            ""version"": ""1.0.0"",
+                                            ""target"": ""winmd""
+                                        }
+                                    }
+                                }
                             }
                         }";
 
@@ -212,14 +214,15 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-                          ""dependencies"": {
-                                ""packageA"": {
-                                    ""version"": ""1.0.0"",
-                                    ""target"": ""package,project""
-                                }
-                            },
                             ""frameworks"": {
-                                ""net46"": {}
+                                ""net46"": {
+                                  ""dependencies"": {
+                                        ""packageA"": {
+                                            ""version"": ""1.0.0"",
+                                            ""target"": ""package,project""
+                                        }
+                                    }
+                                }
                             }
                         }";
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
@@ -168,8 +168,7 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             Assert.NotNull(exception);
-            Assert.Equal("Invalid dependency target value 'blah'.", exception.Message);
-            Assert.EndsWith("project.json", exception.Path);
+            Assert.Equal("Error reading '' : Invalid dependency target value 'blah'.", exception.Message);
         }
 
         [Fact]
@@ -205,8 +204,6 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             Assert.NotNull(exception);
-            Assert.Equal("Invalid dependency target value 'winmd'.", exception.Message);
-            Assert.EndsWith("project.json", exception.Path);
         }
 
         [Fact]
@@ -242,8 +239,7 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             Assert.NotNull(exception);
-            Assert.Equal("Invalid dependency target value 'package,project'.", exception.Message);
-            Assert.EndsWith("project.json", exception.Path);
+            Assert.Equal("Error reading '' : Invalid dependency target value 'package,project'.", exception.Message);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ImportFrameworkTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ImportFrameworkTest.cs
@@ -61,13 +61,13 @@ namespace NuGet.ProjectModel.Test
         {
             JObject configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1""
-                    },
                     ""frameworks"": {
                         ""netstandard1.2"": {
                             ""imports"": [""dotnet5.3""],
-                            ""warn"": false
+                            ""warn"": false,
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1""
+                            }
                         }
                     }
                 }");

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ImportFrameworkTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ImportFrameworkTest.cs
@@ -16,13 +16,13 @@ namespace NuGet.ProjectModel.Test
         {
             JObject configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1""
-                    },
                     ""frameworks"": {
                         ""netstandard1.2"": {
                             ""imports"": [""dotnet5.3"",""portable-net452+win81"",""futureFramework""],
-                            ""warn"": false
+                            ""warn"": false,
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1""
+                            }
                         }
                     }
                 }");
@@ -37,20 +37,20 @@ namespace NuGet.ProjectModel.Test
         {
             JObject configJson = JObject.Parse(@"
                 {
-                    ""dependencies"": {
-                        ""Newtonsoft.Json"": ""7.0.1""
-                    },
                     ""frameworks"": {
                         ""netstandard1.2"": {
                             ""imports"": """",
-                            ""warn"": false
+                            ""warn"": false,
+                            ""dependencies"": {
+                                ""Newtonsoft.Json"": ""7.0.1""
+                            }   
                         }
                     }
                 }");
 
             // Act
             PackageSpec spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json");
-            System.Collections.Generic.List<NuGetFramework> importFramework = spec.TargetFrameworks.First().Imports.ToList();
+            System.Collections.Generic.List<NuGetFramework> importFramework = [.. spec.TargetFrameworks.First().Imports];
 
             // Assert
             Assert.Equal(0, importFramework.Count);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -151,11 +151,9 @@ namespace NuGet.ProjectModel.Test
             var lockFileFormat = new LockFileFormat();
 
             // Act
-#pragma warning disable CS0612 // Type or member is obsolete
             var lockFileTrue = Parse(lockFileContentTrue, "In Memory");
             var lockFileFalse = Parse(lockFileContentFalse, "In Memory");
             var lockFileMissing = Parse(lockFileContentMissing, "In Memory");
-#pragma warning restore CS0612 // Type or member is obsolete
 
             var lockFileTrueString = lockFileFormat.Render(lockFileTrue);
             var lockFileFalseString = lockFileFormat.Render(lockFileFalse);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Progress: https://github.com/nuget/home/issues/14446

## Description

There are a bunch of tests that were still using the dependencies element, most of just declaring it. 
This PR takes care of that.
Note that I did add some extra asserts, because some of these tests should've failed when the PackageSpec.Dependencies element stopped being merged in restore. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
