### PR TITLE
Add backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,19 @@
+name: Backport PR to branch
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  backport:
+    uses: dotnet/arcade/.github/workflows/backport-base.yml@main
+    with:
+        pr_description_template: |
+          Backport of #%source_pr_number% to %target_branch%
+
+          /cc %cc_users%


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
This enables a bot that can handle porting changes.

https://github.com/dotnet/msbuild/pull/12594#issuecomment-3361220311

So on a merged PR to `dev`, you can comment on the PR with
> /backport to release/7.0.x

And the workflow will create a PR to bring that change to the specified branch.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
