### PR TITLE
Allow github to index our build files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -72,3 +72,6 @@ project.json text
 *.pem   binary
 *.png 	binary
 *.zip   binary
+
+# https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files
+build/** linguist-generated=false


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

I didn't test this in another repo, but the docs explicitly call out how to get github's file finder to show build/* files: https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files

Hopefully it will make the search index read the files too

## PR Checklist

- [x] Meaningful title, helpful description and ~a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
