### PR TITLE
Use TargetAlias in AssetsFileDependencies snapshot

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileDependenciesSnapshot.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/SolutionExplorer/Models/AssetsFileDependenciesSnapshot.cs
@@ -96,11 +96,11 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
                     continue;
                 }
 
-                string targetAlias = GetTargetAlias(lockFileTarget.Name);
+                string targetAlias = lockFileTarget.TargetAlias;
 
                 previous.DataByTarget.TryGetValue(targetAlias, out AssetsFileTarget? previousTarget);
 
-                ImmutableArray<AssetsFileLogMessage> logMessages = ParseLogMessages(lockFile, previousTarget, lockFileTarget.Name);
+                ImmutableArray<AssetsFileLogMessage> logMessages = ParseLogMessages(lockFile, previousTarget, targetAlias);
 
                 dataByTarget.Add(
                     targetAlias,
@@ -113,34 +113,6 @@ namespace NuGet.VisualStudio.SolutionExplorer.Models
 
             DataByTarget = dataByTarget.ToImmutable();
             return;
-
-            string GetTargetAlias(string lockFileTargetName)
-            {
-                // In some places, the target alias specified in the project file (e.g. "net472") will not
-                // match the target name used throughout the lock file (e.g. ".NETFramework,Version=v4.7.2").
-                // The dependencies tree only uses the target alias (what's in the project file) so we need
-                // to map back to that. See https://github.com/dotnet/project-system/issues/6832.
-
-                if (lockFile.PackageSpec.TargetFrameworks.Any(t => t.TargetAlias == lockFileTargetName))
-                {
-                    // The target name used in the assets file matches the target alias in the project file.
-                    return lockFileTargetName;
-                }
-
-                // The target name used in the assets file does NOT match any target alias in the project.
-                // Attempt to find the name used in the project.
-                foreach (TargetFrameworkInformation targetInfo in lockFile.PackageSpec.TargetFrameworks)
-                {
-                    if (targetInfo.FrameworkName.DotNetFrameworkName == lockFileTargetName)
-                    {
-                        // We found a match, so return the alias.
-                        return targetInfo.TargetAlias;
-                    }
-                }
-
-                // No match was found. Not ideal. Nothing to do but return the original value.
-                return lockFileTargetName;
-            }
 
             static ImmutableArray<AssetsFileLogMessage> ParseLogMessages(LockFile lockFile, AssetsFileTarget? previousTarget, string target)
             {

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -4800,7 +4800,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                         "C:\\Program Files (x86)\\NuGet\\Config\\Xamarin.Offline.config"
                       ],
                       "originalTargetFrameworks": [
-                        "banana"
+                        "net8.0"
                       ],
                       "sources": {
                         "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
@@ -4810,7 +4810,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                       },
                       "frameworks": {
                         "net8.0": {
-                          "targetAlias": "banana",
+                          "targetAlias": "net8.0",
                           "projectReferences": {}
                         }
                       },
@@ -4827,7 +4827,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                     },
                     "frameworks": {
                       "net8.0": {
-                        "targetAlias": "banana",
+                        "targetAlias": "net8.0",
                         "dependencies": {
                           "Fluid.Core": {
                             "target": "Package",

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/SolutionExplorer/Models/AssetsFileDependenciesSnapshotTests.cs
@@ -4800,7 +4800,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                         "C:\\Program Files (x86)\\NuGet\\Config\\Xamarin.Offline.config"
                       ],
                       "originalTargetFrameworks": [
-                        "net8.0"
+                        "banana"
                       ],
                       "sources": {
                         "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
@@ -4810,7 +4810,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                       },
                       "frameworks": {
                         "net8.0": {
-                          "targetAlias": "net8.0",
+                          "targetAlias": "banana",
                           "projectReferences": {}
                         }
                       },
@@ -4827,7 +4827,7 @@ namespace NuGet.VisualStudio.Implementation.Test.SolutionExplorer.Models
                     },
                     "frameworks": {
                       "net8.0": {
-                        "targetAlias": "net8.0",
+                        "targetAlias": "banana",
                         "dependencies": {
                           "Fluid.Core": {
                             "target": "Package",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14584

## Description

Now that the reader "populates" the TargetAlias in LockFileTarget, we no longer need to do the look-up.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests - There are existing tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
