### PR TITLE
Fix up telemetry for package pruning, .NET Framework is no longer enabled by default

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -410,7 +410,7 @@ namespace NuGet.Commands
                 bool isPruningEnabled = framework.PackagesToPrune.Count > 0;
                 bool isNetCoreAppFramework = StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetCoreApp);
                 // .NETCoreApp >= 2.0, .NET Standard >= 2.0 are compatible with package pruning.
-                bool isPruningCompatibleFramework = (isNetCoreAppFramework && framework.FrameworkName.Version.Major >= 2 ) ||
+                bool isPruningCompatibleFramework = (isNetCoreAppFramework && framework.FrameworkName.Version.Major >= 2) ||
                     (StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetStandard) &&
                         framework.FrameworkName.Version.Major >= 2);
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -412,10 +412,7 @@ namespace NuGet.Commands
                 // All .NETCoreApp, .NET Standard >= 2.0 , and .NET Framework >= 4.6.1 projects are compatible with package pruning.
                 bool isPruningCompatibleFramework = isNetCoreAppFramework ||
                     (StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetStandard) &&
-                        framework.FrameworkName.Version.Major >= 2) ||
-                    (project.RestoreMetadata.UsingMicrosoftNETSdk &&
-                        StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.Net) &&
-                        framework.FrameworkName.Version >= FrameworkConstants.CommonFrameworks.Net461.Version);
+                        framework.FrameworkName.Version.Major >= 2);
 
                 pruningDefault |= isNetCoreAppFramework && framework.FrameworkName.Version.Major >= 10;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -409,8 +409,8 @@ namespace NuGet.Commands
             {
                 bool isPruningEnabled = framework.PackagesToPrune.Count > 0;
                 bool isNetCoreAppFramework = StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetCoreApp);
-                // All .NETCoreApp, .NET Standard >= 2.0 , and .NET Framework >= 4.6.1 projects are compatible with package pruning.
-                bool isPruningCompatibleFramework = isNetCoreAppFramework ||
+                // .NETCoreApp >= 2.0, .NET Standard >= 2.0 are compatible with package pruning.
+                bool isPruningCompatibleFramework = (isNetCoreAppFramework && framework.FrameworkName.Version.Major >= 2 ) ||
                     (StringComparer.OrdinalIgnoreCase.Equals(framework.FrameworkName.Framework, FrameworkConstants.FrameworkIdentifiers.NetStandard) &&
                         framework.FrameworkName.Version.Major >= 2);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_PrunePackageReference.cs
@@ -2679,6 +2679,14 @@ namespace NuGet.Commands.FuncTest
                                 },
                         }
                     },
+                    ""net9.0"": {
+                        ""dependencies"": {
+                                ""A"": {
+                                    ""version"": ""[1.0.0,)"",
+                                    ""target"": ""Package"",
+                                },
+                        }
+                    },
                   }
                 }";
 
@@ -2692,7 +2700,7 @@ namespace NuGet.Commands.FuncTest
             RestoreCommand.PopulatePruningEnabledTelemetry(projectSpec, testEvent);
             testEvent["Pruning.FrameworksEnabled.Count"].Should().Be(1);
             testEvent["Pruning.DefaultEnabled"].Should().Be(false);
-            testEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(1);
+            testEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(2);
             testEvent["Pruning.FrameworksDisabled.Count"].Should().Be(1);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -3104,8 +3104,8 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             projectInformationEvent["UpdatedMSBuildFiles"].Should().Be(false);
             projectInformationEvent["NETSdkVersion"].Should().Be(NuGetVersion.Parse("10.0.100"));
             projectInformationEvent["Pruning.FrameworksEnabled.Count"].Should().Be(0);
-            projectInformationEvent["Pruning.FrameworksDisabled.Count"].Should().Be(1);
-            projectInformationEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(0);
+            projectInformationEvent["Pruning.FrameworksDisabled.Count"].Should().Be(0);
+            projectInformationEvent["Pruning.FrameworksUnsupported.Count"].Should().Be(1);
             projectInformationEvent["Pruning.DefaultEnabled"].Should().Be(false);
             projectInformationEvent["UsesLegacyPackagesDirectory"].Should().Be(false);
         }


### PR DESCRIPTION
# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

When I originally wrote the telemetry, pruning was available for .NET Framework in addition to .NET Core App and .NET Standard. 
That's no longer the case https://github.com/dotnet/sdk/pull/50816.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
