### PR TITLE
dotnet package update should work with any project references

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -81,9 +81,7 @@ internal static class PackageUpdateCommandRunner
             return ExitCodes.Error;
         }
 
-        PackageSpec projectSpec = dgSpec.Projects.Count == 1
-            ? dgSpec.Projects[0]
-            : dgSpec.GetProjectSpec(dgSpec.Restore[0]);
+        PackageSpec projectSpec = dgSpec.GetProjectSpec(dgSpec.Restore[0]);
 
         // 2. Find suitable version of package(s) to update
         // Source provider will be needed to find the package version and to restore, so create it here.
@@ -141,7 +139,7 @@ internal static class PackageUpdateCommandRunner
             }
         }
 
-        var projectName = Path.GetFileNameWithoutExtension(dgSpec.Projects[0].FilePath);
+        var projectName = Path.GetFileNameWithoutExtension(projectSpec.FilePath);
         logger.LogInformation($"  {projectName}:");
 
         foreach (var packageResult in packagesToUpdateResult)
@@ -154,7 +152,7 @@ internal static class PackageUpdateCommandRunner
 
         // 3. Preview restore to validate changes
         logger.LogDebug(Strings.PackageUpdate_PreviewRestore);
-        var updatedDgSpec = GetUpdatedDependencyGraphSpec(dgSpec, packagesToUpdateResult);
+        var updatedDgSpec = GetUpdatedDependencyGraphSpec(projectSpec, dgSpec, packagesToUpdateResult);
         var restorePreviewResult = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(updatedDgSpec, logger, cancellationToken);
 
         if (!restorePreviewResult.Success)
@@ -165,7 +163,7 @@ internal static class PackageUpdateCommandRunner
 
         // 4. Update MSBuild files
 
-        var updatedPackageSpec = updatedDgSpec.Projects[0];
+        var updatedPackageSpec = updatedDgSpec.GetProjectSpec(projectSpec.FilePath);
         int updatedCount = 0;
 
         foreach (var packageResult in packagesToUpdateResult)
@@ -555,9 +553,9 @@ internal static class PackageUpdateCommandRunner
         return result;
     }
 
-    private static DependencyGraphSpec GetUpdatedDependencyGraphSpec(DependencyGraphSpec currentDgSpec, List<PackageUpdateResult> packagesToUpdate)
+    private static DependencyGraphSpec GetUpdatedDependencyGraphSpec(PackageSpec projectSpec, DependencyGraphSpec currentDgSpec, List<PackageUpdateResult> packagesToUpdate)
     {
-        var updatedPackageSpec = currentDgSpec.Projects[0].Clone();
+        var updatedPackageSpec = projectSpec.Clone();
 
         foreach (var packageResult in packagesToUpdate)
         {

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/MultiProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/MultiProjectTests.cs
@@ -30,15 +30,15 @@ public class MultiProjectTests
         var solutionDirectory = RuntimeEnvironmentHelper.IsWindows
             ? @"S:\path\to\repo\src"
             : @"/path/to/repo/src";
-        var project1Path = Path.Combine(solutionDirectory, "Project1", "Project1.csproj");
+        var project1Path = Path.Combine(solutionDirectory, "ConsoleApp1", "ConsoleApp1.csproj");
         var project1 = new TestPackageSpecFactory(project1Path, builder =>
         {
             builder.WithProperty("TargetFramework", "net9.0")
                    .WithItem("PackageReference", "Test.Package", [new("Version", "1.0.0")])
-                   .WithItem("ProjectReference", @"..\Project2\Project2.csproj", []);
+                   .WithItem("ProjectReference", @"..\ClassLib1\ClassLib1.csproj", []);
         }).Build();
 
-        var project2Path = Path.Combine(solutionDirectory, "Project2", "Project2.csproj");
+        var project2Path = Path.Combine(solutionDirectory, "ClassLib1", "ClassLib1.csproj");
         var project2 = new TestPackageSpecFactory(project2Path, builder =>
         {
             builder.WithProperty("TargetFramework", "net9.0");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14585

## Description

cherry pick https://github.com/NuGet/NuGet.Client/pull/6846 onto 7.0.x release branch

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~

.NET approval template:
## Customer Impact

Impacts .NET developers using the new `dotnet package update` command.  The bug impacts projects that have project references, and when the full list of projects are sorted alphabetically, the project being updated is not the first in that sorted list.

## Regression?

- [ ] Yes
- [x] No  

## Risk

- [ ] High
- [ ] Medium
- [x] Low  

Justification: The code modified only affects the `dotnet package update` command. No code shared with other commands or features is modified.

## Verification

- [x] Manual (required)  
- [x] Automated  

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A  



