### PR TITLE
CI pipelines should work when branch has slash

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -66,6 +66,7 @@ variables:
   RunMonoTestsOnMac: ${{ parameters.RunMonoTestsOnMac }}
   RunStaticAnalysis: ${{ parameters.RunStaticAnalysis }}
   OneLocBranch: 'dev'
+  SourceBranch: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
 
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -144,7 +144,7 @@ stages:
         }
         catch {
           Write-Host $_
-          Write-Error "Failed to set SourceBranchName pipeline variable"
+          Write-Error "Failed to set RunSettingsURI pipeline variable"
           throw
         }
       displayName: 'Set RunSettingsURI variable'
@@ -180,10 +180,10 @@ stages:
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Bootstrapper\Get-BootstrapperURL.ps1
         arguments: -BootstrapperInfoJsonURI '$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
     - task: artifactDropTask@0
-      displayName: "Upload VSTS Drop"
+      displayName: "Upload VS Bootstrapper"
       inputs:
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+        buildNumber: '$(MicroBuild.ManifestDropName)'
         sourcePath: "$(Pipeline.Workspace)\\ComponentBuildUnderTest\\VS15"
         toLowerCase: false
         usePat: true

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -46,6 +46,7 @@ resources:
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
     ref: refs/tags/release
+
 variables:
   BINLOG_DIRECTORY: $(Build.StagingDirectory)/binlog
   DOTNET_NOLOGO: 1
@@ -61,6 +62,8 @@ variables:
   RunTestsOnMac: ${{ parameters.RunTestsOnMac }}
   RunMonoTestsOnMac: ${{ parameters.RunMonoTestsOnMac }}
   RunStaticAnalysis: ${{ parameters.RunStaticAnalysis }}
+  SourceBranch: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
+
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -19,7 +19,7 @@ steps:
   - task: PowerShell@1
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-      arguments: "-BuildRTM $(BuildRTM) -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(Build.BuildNumber)"
+      arguments: "-BuildRTM $(BuildRTM) -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(SourceBranch) -CommitHash $(Build.SourceVersion) -BuildNumber $(Build.BuildNumber)"
     displayName: "Configure VSTS CI Environment"
 
   - task: PowerShell@1
@@ -333,7 +333,7 @@ steps:
     displayName: "Generate .runsettings files"
     inputs:
       solution: 'build\runsettings.proj'
-      msbuildArguments: '/restore:false /property:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /property:TestDrop="RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" /property:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateRunSettings.binlog'
+      msbuildArguments: '/restore:false /property:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /property:TestDrop="RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)" /property:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)" /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateRunSettings.binlog'
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: PowerShell@1
@@ -400,7 +400,7 @@ steps:
       scriptType: ps
       scriptLocation: inlineScript
       inlineScript: |
-        $(Agent.TempDirectory)/dotnet/dotnet msbuild $(Build.Repository.LocalPath)\build\publish.proj /t:PublishToBuildAssetRegistry /property:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /property:BUILD_BUILDNUMBER=$(Build.BuildNumber) /property:BUILD_SOURCEBRANCH=$(Build.SourceBranchName) /property:BUILD_SOURCEVERSION=$(Build.SourceVersion) /property:BUILD_REPOSITORY_URI=$(Build.Repository.Uri) /property:BUILD_REPOSITORY_NAME=$(Build.Repository.Name) /property:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ /binarylogger:$(Build.StagingDirectory)\binlog\21.PublishToBuildAssetRegistry.binlog /property:MaestroApiEndpoint=$(MaestroApiEndpoint)
+        $(Agent.TempDirectory)/dotnet/dotnet msbuild $(Build.Repository.LocalPath)\build\publish.proj /t:PublishToBuildAssetRegistry /property:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /property:BUILD_BUILDNUMBER=$(Build.BuildNumber) /property:BUILD_SOURCEBRANCH=$(SourceBranch) /property:BUILD_SOURCEVERSION=$(Build.SourceVersion) /property:BUILD_REPOSITORY_URI=$(Build.Repository.Uri) /property:BUILD_REPOSITORY_NAME=$(Build.Repository.Name) /property:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ /binarylogger:$(Build.StagingDirectory)\binlog\21.PublishToBuildAssetRegistry.binlog /property:MaestroApiEndpoint=$(MaestroApiEndpoint)
       workingDirectory: cli
       failOnStderr: true
     env:

--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -22,7 +22,7 @@ steps:
         } else {
           $targetMajorVersion = ((& dotnet msbuild $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /restore:false "/ConsoleLoggerParameters:Verbosity=Minimal;NoSummary;ForceNoAlign" /nologo /target:GetVsTargetMajorVersion) | Out-String).Trim()
         }
-        
+
         Write-Host "##vso[task.setvariable variable=VsTargetChannel;isOutput=true]$targetChannel"
         Write-Host "##vso[task.setvariable variable=VsTargetChannelForTests;isOutput=true]$targetChannelForTests"
         Write-Host "##vso[task.setvariable variable=VsTargetMajorVersion;isOutput=true]$targetMajorVersion"
@@ -33,14 +33,6 @@ steps:
         Write-Host "##vso[task.LogIssue type=error;]Unable to set build number"
         exit 1
       }
-
-- task: PowerShell@1
-  displayName: "Add Build Tags"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      Write-Host "##vso[build.addbuildtag]${env:BUILD_SOURCEVERSIONAUTHOR}"
-      Write-Host "##vso[build.addbuildtag]${env:BUILD_SOURCEBRANCHNAME}"
 
 - task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -49,9 +49,6 @@ parameters:
   - Real
   - Test
 
-variables:
-  SourceBranch: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
-
 stages:
 - stage: Initialize
   jobs:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -49,6 +49,9 @@ parameters:
   - Real
   - Test
 
+variables:
+  SourceBranch: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
+
 stages:
 - stage: Initialize
   jobs:
@@ -84,7 +87,7 @@ stages:
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-NuGetClient'
         MirrorRepo: 'NuGet.Client'
-        MirrorBranch: ${{ variables['Build.SourceBranchName'] }}
+        MirrorBranch: ${{ variables['SourceBranch'] }}
         GitHubOrg: 'NuGet'
 
 - stage: StaticSourceAnalysis
@@ -173,7 +176,7 @@ stages:
         displayName: 'Publish the .runsettings files to artifact services'
         condition: "succeeded()"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
+        buildNumber: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
         sourcePath: 'artifacts\RunSettings'
         toLowerCase: false
         usePat: true
@@ -185,7 +188,7 @@ stages:
         displayName: 'OptProfV2:  publish profiling inputs to artifact services'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)'
+        buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
         sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
         toLowerCase: false
         usePat: true
@@ -208,7 +211,7 @@ stages:
         displayName: 'Upload VSTS Drop'
         condition: "succeeded()"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+        buildNumber: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)'
         sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
         toLowerCase: false
         usePat: true

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -10,7 +10,7 @@ steps:
   - task: MicroBuildSwixPlugin@4
     displayName: "Install Swix Plugin"
     inputs:
-      dropName: "Tests/$(System.TeamProject)/$(Build.DefinitionName)/$(Build.SourceBranchName)/$(Build.BuildId)"
+      dropName: "Tests/$(System.TeamProject)/$(Build.DefinitionName)/$(SourceBranch)/$(Build.BuildId)"
   - task: PowerShell@1
     displayName: "Run Configure.ps1"
     inputs:
@@ -45,7 +45,7 @@ steps:
   - task: PowerShell@1
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-      arguments: "-BuildRTM false -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(NuGetVersion)"
+      arguments: "-BuildRTM false -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(SourceBranch) -CommitHash $(Build.SourceVersion) -BuildNumber $(NuGetVersion)"
     displayName: "Configure VSTS CI Environment"
 
   - task: PowerShell@1
@@ -214,7 +214,7 @@ steps:
           Write-Host "Base Build Drop: $buildDrop"
           Write-Host "##vso[task.setvariable variable=BaseBuildDrop;isOutput=true]$buildDrop"
 
-          $runSettingsDrop = "RunSettings/${env:System_TeamProject}/${env:Build_DefinitionName}/${env:Build_SourceBranchName}/${env:Build_BuildId}"
+          $runSettingsDrop = "RunSettings/${env:System_TeamProject}/${env:Build_DefinitionName}/${env:SourceBranch}/${env:Build_BuildId}"
           Write-Host "Run Settings Drop: $runSettingsDrop"
           Write-Host "##vso[task.setvariable variable=RunSettingsDrop]$runSettingsDrop"
           Write-Host "##vso[task.setvariable variable=RunSettingsDrop;isOutput=true]$runSettingsDrop"

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -62,6 +62,7 @@ variables:
   DOTNET_NOLOGO: 1
   CI: true
   Codeql.Enabled: false
+  SourceBranch: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
 
 stages:
 - stage: Build


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3483

## Description

There were several places our CI scripts look like it would either fail, or produce incorrect results, when a branch name has a slash (for example `release/7.x`). This PR tries to fix all of them.

* The OptProf pipeline was failing on the release/* branch, because the runsettings drop name was wrong. Fixed the build pipeline to publish it to the expected name
* ConfigureVstsBuild.ps1 writes the branch name to BuildInfo.json, and it was writing a branch name that doesn't exist.
* When publishing to BAR, we were telling it a branch name that doesn't exist. 
* Our init steps of the build were tagging the builds with the commit author name and branch name.  I don't believe these tags are useful, so I'm removing them. The branch name in particular is already visible in the Azure Pipelines GUI.
* Changing the OneLocBuild branch name.  I don't know much about this process, but considering the input name is `MirrorBranch`, it feels to me like it should match the full name, not the substring after the last `/`.
* I'm changing where the product gets published, so I'll need to update the release pipeline and all servicing branches with this change.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
