### PR TITLE
Fix syntax to run OneLoc in CI builds

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -84,7 +84,7 @@ stages:
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-NuGetClient'
         MirrorRepo: 'NuGet.Client'
-        MirrorBranch: ${{ variables['SourceBranch'] }}
+        MirrorBranch: $[ variables['SourceBranch'] ]
         GitHubOrg: 'NuGet'
 
 - stage: StaticSourceAnalysis


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

My previous PR changed a `${{ .. }}` compile time expression to try to use a pipeline variable. That doesn't work, because variables are loaded after the yaml is "compiled".  So, this PR switches it to a `$[ .. ]` runtime expression, so it can load pipeline variables.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
