### PR TITLE
CI: Revert OneLoc syntax to last working

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -84,7 +84,7 @@ stages:
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-NuGetClient'
         MirrorRepo: 'NuGet.Client'
-        MirrorBranch: $[ variables['SourceBranch'] ]
+        MirrorBranch: ${{ variables['Build.SourceBranchName'] }}
         GitHubOrg: 'NuGet'
 
 - stage: StaticSourceAnalysis


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Infrastructure

## Description

Looking at the docs on OneLoc: https://github.com/dotnet/arcade/blob/main/Documentation/OneLocBuild.md#if-youre-releasing-from-a-branch-other-than-main-including-servicing-branches

It seems to me that the normal workflow is we only run OneLoc on the main (dev) branch, not release branches.

So, revert the OneLoc CI yaml to what last worked, and if we start getting loc updates from release branches, we'll deal with it when it happens, possibly by hardcoding the branch name in the release branch itself.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
