### PR TITLE
Improve CI drop management

### DIFF
--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -90,6 +90,15 @@ stages:
     - download: ComponentBuildUnderTest
       artifact: BuildInfo
       displayName: 'Download buildinfo.json'
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        buildType: 'specific'
+        artifactName: 'DropMetadata-RunSettings'
+        targetPath: $(Pipeline.Workspace)\ComponentBuildUnderTest\DropMetadata-RunSettings
+        project: '$(System.TeamProjectId)'
+        definition: $(System.DefinitionId)
+        buildVersionToDownload: 'specific'
+        pipelineId: $(resources.pipeline.ComponentBuildUnderTest.pipelineId)
     - download: ComponentBuildUnderTest
       artifact: DropMetadata-RunSettings
       displayName: 'Download RunSettings VSDrop.json'

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -98,9 +98,9 @@ stages:
         project: '$(System.TeamProjectId)'
         definition: $(System.DefinitionId)
         buildVersionToDownload: 'specific'
-        pipelineId: $(resources.pipeline.ComponentBuildUnderTest.pipelineId)
+        pipelineId: $(resources.pipeline.ComponentBuildUnderTest.runId)
     - download: ComponentBuildUnderTest
-      artifact: DropMetadata-RunSettings
+      artifact: 'DropMetadata-RunSettings'
       displayName: 'Download RunSettings VSDrop.json'
     - powershell: |
         try {

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -91,6 +91,7 @@ stages:
       artifact: BuildInfo
       displayName: 'Download buildinfo.json'
     - task: DownloadPipelineArtifact@2
+      displayName: 'Download RunSettings drop metadata'
       inputs:
         buildType: 'specific'
         artifactName: 'DropMetadata-RunSettings'
@@ -99,9 +100,6 @@ stages:
         definition: $(System.DefinitionId)
         buildVersionToDownload: 'specific'
         pipelineId: $(resources.pipeline.ComponentBuildUnderTest.runId)
-    - download: ComponentBuildUnderTest
-      artifact: 'DropMetadata-RunSettings'
-      displayName: 'Download RunSettings VSDrop.json'
     - powershell: |
         try {
           Write-Host "Set VSBranch, VsTargetChannel &  VsTargetMajorVersion variables"

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -90,6 +90,9 @@ stages:
     - download: ComponentBuildUnderTest
       artifact: BuildInfo
       displayName: 'Download buildinfo.json'
+    - download: ComponentBuildUnderTest
+      artifact: DropMetadata-RunSettings
+      displayName: 'Download RunSettings VSDrop.json'
     - powershell: |
         try {
           Write-Host "Set VSBranch, VsTargetChannel &  VsTargetMajorVersion variables"
@@ -132,15 +135,22 @@ stages:
       displayName: 'Set VSBranch variable'
     - powershell : |
         try {
-          $branchName = "$(resources.pipeline.ComponentBuildUnderTest.sourceBranch)"
-          $branchName = $branchName.Replace('refs/heads/', '')
-
-          $RunSettingsURI = "https://vsdrop.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$branchName/$(resources.pipeline.ComponentBuildUnderTest.runID);NuGet.OptProfV2.runsettings"
-          Write-Host "RunSettingsURI: $RunSettingsURI"
-          # non-output variable for VS config in the configure machine job
-          # output variable for test execution job
-          Set-AzurePipelinesVariable 'RunSettingsURI' $RunSettingsURI
-          Set-AzurePipelinesVariable -IsOutput 'RunSettingsURI' $RunSettingsURI
+          $dropMetadata = ConvertFrom-Json (Get-Content "$(Pipeline.Workspace)\ComponentBuildUnderTest\DropMetadata-RunSettings\VSTSDrop.json" -Raw)
+          $dropUri = $dropMetadata.VstsDropBuildArtifact.VstsDropUrl
+          if ($dropUri)
+          {
+            $RunSettingsURI = "$dropUri;NuGet.OptProfV2.runsettings"
+            Write-Host "RunSettingsURI: $RunSettingsURI"
+            # non-output variable for VS config in the configure machine job
+            # output variable for test execution job
+            Set-AzurePipelinesVariable 'RunSettingsURI' $RunSettingsURI
+            Set-AzurePipelinesVariable -IsOutput 'RunSettingsURI' $RunSettingsURI
+          }
+          else
+          {
+            Write-Error "Drop metadata: $dropMetadata"
+            throw "VSTSDropUrl not found in VSTSDrop.json"
+          }
         }
         catch {
           Write-Host $_

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -148,6 +148,7 @@ stages:
           $dropUri = $dropMetadata.VstsDropBuildArtifact.VstsDropUrl
           if ($dropUri)
           {
+            $dropUri = $dropUri -replace '^(.*?)/RunSettings/', 'https://vsdrop.microsoft.com/file/v1/RunSettings/'
             $RunSettingsURI = "$dropUri;NuGet.OptProfV2.runsettings"
             Write-Host "RunSettingsURI: $RunSettingsURI"
             # non-output variable for VS config in the configure machine job

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -209,7 +209,7 @@ steps:
     inputs:
       solution: "build\\sign.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/restore /p:DryRunSigning=false /p:DotNetSignType=$(SigningType) /p:SigningLogDirectory=$(Build.StagingDirectory)\\binlog /binarylogger:$(Build.StagingDirectory)\\binlog\\15.Sign.binlog"
+      msbuildArguments: "/restore /p:DryRunSigning=false /p:DotNetSignType=${{parameters.SigningType}} /p:SigningLogDirectory=$(Build.StagingDirectory)\\binlog /binarylogger:$(Build.StagingDirectory)\\binlog\\15.Sign.binlog"
 
   - task: NuGetToolInstaller@1
     displayName: Use NuGet 6.x

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -264,76 +264,11 @@ steps:
       arguments: 'install Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks -Version 1.0.655 -Source $(VsPackageFeedUrl) -ConfigFile $(System.DefaultWorkingDirectory)\NuGet.config -OutputDirectory $(System.DefaultWorkingDirectory)\packages'
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-  - task: MicroBuildBuildVSBootstrapper@3
-    displayName: "Build a Visual Studio bootstrapper for tests"
-    inputs:
-      azureSubscription: "VSEng-VSDrop-MI"
-      channelName: "$(VsTargetChannelForTests)"
-      vsMajorVersion: "$(VsTargetMajorVersion)"
-      manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
-      outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-  - task: PowerShell@1
-    displayName: "Set Bootstrapper URL variable for tests"
-    name: "vsbootstrapper"
-    inputs:
-      scriptType: "inlineScript"
-      # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
-      inlineScript: |
-        try {
-          $json = Get-Content "${env:MicroBuildOutputFolderOverride}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-          $bootstrapperUrl = $json[0].bootstrapperUrl;
-          Write-Host "Bootstrapper URL: $bootstrapperUrl"
-          Write-Host "##vso[task.setvariable variable=bootstrapperUrl;isOutput=true]$bootstrapperUrl"
-        } catch {
-          Write-Host "##vso[task.LogIssue type=error;]Unable to set bootstrapperUrl: $_"
-          exit 1
-        }
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-  - task: PowerShell@1
-    displayName: "Set CloudBuild Session ID variable for tests"
-    name: "setcloudbuildsessionid"
-    continueOnError: true
-    inputs:
-      scriptType: "inlineScript"
-      # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
-      inlineScript: |
-        try {
-          $json = Get-Content "${env:MicroBuildOutputFolderOverride}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-          $qBuildSessionId = $json[0].QBuildSessionId;
-          Write-Host "CloudBuild Session ID: $qBuildSessionId"
-          Write-Host "##vso[task.setvariable variable=QBuildSessionId;isOutput=true]$qBuildSessionId"
-        } catch {
-          Write-Host "##vso[task.LogIssue type=error;]Unable to set CloudBuild Session ID: $_"
-        }
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-  - task: PowerShell@1
-    displayName: "Set Base Build Drop variable for tests"
-    name: "setbasebuilddrop"
-    continueOnError: true
-    inputs:
-      scriptType: "inlineScript"
-      # MicroBuildOutputFolderOverride defined by template and redirects MicroBuildBuildVSBootstrapper output https://dev.azure.com/devdiv/1ESPipelineTemplates/_git/MicroBuildTemplate?path=/azure-pipelines/Jobs/Job.yml&version=GBrelease&line=21&lineEnd=22&lineStartColumn=1&lineEndColumn=36&lineStyle=plain&_a=contents
-      inlineScript: |
-        try {
-          $json = Get-Content "${env:MicroBuildOutputFolderOverride}\MicroBuild\Output\Bootstrapperinfo.json" | ConvertFrom-Json
-          $buildDrop = $json[0].BuildDrop;
-          Write-Host "Base Build Drop: $buildDrop"
-          Write-Host "##vso[task.setvariable variable=BaseBuildDrop;isOutput=true]$buildDrop"
-        } catch {
-          Write-Host "##vso[task.LogIssue type=error;]Unable to set Base Build Drop: $_"
-        }
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
   - task: MSBuild@1
     displayName: "Generate .runsettings files"
     inputs:
       solution: 'build\runsettings.proj'
-      msbuildArguments: '/restore:false /property:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /property:TestDrop="RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)" /property:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)" /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateRunSettings.binlog'
+      msbuildArguments: '/restore:false /property:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /property:TestDrop="$(RunSettingsDropName)" /property:ProfilingInputsDrop="$(ProfilingInputsDropName)" /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateRunSettings.binlog'
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: PowerShell@1

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -162,15 +162,6 @@ stages:
         artifactName: "nupkgs - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
-      - output: pipelineArtifact
-        displayName: 'Publish BootstrapperInfo.json as a build artifact'
-        condition: "succeeded()"
-        targetPath: $(MicroBuildOutputFolderOverride)\MicroBuild\Output
-        artifactName: MicroBuildOutputs
-        # need to make daily Apex test pipeline build its own bootstrapper, and remove this from official pipeline
-        codeSignValidationEnabled: false
-        sbomEnabled: false
-
       - output: artifactsDrop
         displayName: 'Publish the .runsettings files to artifact services'
         condition: "succeeded()"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -119,6 +119,8 @@ stages:
       isOfficialBuild: ${{ parameters.isOfficialBuild }}
       BuildRTM: "false"
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
+      RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
+      ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     templateContext:
@@ -173,7 +175,7 @@ stages:
         displayName: 'Publish the .runsettings files to artifact services'
         condition: "succeeded()"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
+        buildNumber: '$(RunSettingsDropName)'
         sourcePath: 'artifacts\RunSettings'
         toLowerCase: false
         usePat: true
@@ -185,7 +187,7 @@ stages:
         displayName: 'OptProfV2:  publish profiling inputs to artifact services'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
+        buildNumber: '$(ProfilingInputsDropName)'
         sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
         toLowerCase: false
         usePat: true
@@ -208,7 +210,7 @@ stages:
         displayName: 'Upload VSTS Drop'
         condition: "succeeded()"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)'
+        buildNumber: '$(MicroBuild.ManifestDropName)'
         sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
         toLowerCase: false
         usePat: true


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Infrastructure

## Description

Really fixes OptProf for release/* branches, also makes all drops URLs have a single source of truth, and all other references programmatically calculate the URL. Includes other minor improvements

* The build CI's "Build Insertable" job defines variables for drop names it uses, so the variable can be shared instead of recalculated over and over.
* Stop building the VS bootstrapper. All the DartLab pipelines create their own bootstrapper, so this pipeline doesn't need to.
* Fix sending the SigningType parameter to the signing step, so test signing on the official pipeline actually works.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
