### PR TITLE
cache NuGetEnvironment.GetFolderPath values

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -26,6 +27,9 @@ namespace NuGet.Common
         private static readonly Lazy<string> _getHome = new Lazy<string>(() => GetHome());
 
         private static string _nuGetTempDirectory = null;
+
+        private static readonly ConcurrentDictionary<NuGetFolderPath, string> Cache = new ConcurrentDictionary<NuGetFolderPath, string>();
+
         internal static string NuGetTempDirectory
         {
             get { return _nuGetTempDirectory ??= GetNuGetTempDirectory(); }
@@ -65,6 +69,12 @@ namespace NuGet.Common
         }
 
         public static string GetFolderPath(NuGetFolderPath folder)
+        {
+            string path = Cache.GetOrAdd(folder, CalculateFolderPath);
+            return path;
+        }
+
+        private static string CalculateFolderPath(NuGetFolderPath folder)
         {
             switch (folder)
             {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NuGetEnvironmentTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NuGetEnvironmentTests.cs
@@ -21,6 +21,11 @@ namespace NuGet.Common.Test
         {
             foreach (NuGetFolderPath folderPath in (NuGetFolderPath[])System.Enum.GetValues(typeof(NuGetFolderPath)))
             {
+                if (folderPath == NuGetFolderPath.DefaultMsBuildPath)
+                {
+                    // Skip DefaultMsBuildPath as it throws on Mac and Linux
+                    continue;
+                }
                 yield return new object[] { folderPath };
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NuGetEnvironmentTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NuGetEnvironmentTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using NuGet.Common.Migrations;
 using NuGet.Test.Utility;
 using Xunit;
@@ -14,6 +15,23 @@ namespace NuGet.Common.Test
         {
             var nuGetTempDirectory = NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp);
             Assert.Equal("700", Migration1.GetPermissions(nuGetTempDirectory).ToString());
+        }
+
+        public static IEnumerable<object[]> AllNuGetFolderPaths()
+        {
+            foreach (NuGetFolderPath folderPath in (NuGetFolderPath[])System.Enum.GetValues(typeof(NuGetFolderPath)))
+            {
+                yield return new object[] { folderPath };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(AllNuGetFolderPaths))]
+        public void GetFolderPath_MultipleCalls_ReturnsCachedInstance(NuGetFolderPath folder)
+        {
+            var firstCall = NuGetEnvironment.GetFolderPath(folder);
+            var secondCall = NuGetEnvironment.GetFolderPath(folder);
+            Assert.Same(firstCall, secondCall);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14602

## Description

Every NuGetFolderPath value does at least one string.Concat, and some parts of NuGet call into NuGetEnvironment without implementing caching themselves. While the cache itself uses some memory, the overall memory allocations should be significantly improved.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
