### PR TITLE
bump .NET SDK version

### DIFF
--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -2,4 +2,4 @@
 # To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
 -Channel 8.0 -Runtime dotnet
 -Channel 9.0 -Runtime dotnet
--Channel 10.0.2xx -Quality preview
+-Channel 10.0.1xx -Quality GA

--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -2,4 +2,4 @@
 # To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
 -Channel 8.0 -Runtime dotnet
 -Channel 9.0 -Runtime dotnet
--Channel 10.0.1xx -Quality GA
+-Channel 10.0.1xx -Quality preview

--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -2,4 +2,4 @@
 # To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
 -Channel 8.0 -Runtime dotnet
 -Channel 9.0 -Runtime dotnet
--Channel 10.0.1xx -Quality daily
+-Channel 10.0.2xx -Quality preview


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

We use dotnet-install.ps1 to install the latest daily build from the 10.0.1xx channel, but it's now depending on ref packs that are not available yet, causing tests that need to download it to fail. Hence updated the .NET SDK version to download `preview` version instead of `daily` builds

Both ⁠[NuGet Client CI](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1180588&view=results) pipeline and ⁠[NuGet PrivateDev](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=8118) pipeline succeeded with this change.

## PR Checklist

- ~[ ] Meaningful title, helpful description and a linked NuGet/Home issue~
- ~[ ] Added tests~
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
