### PR TITLE
bump .NET SDK version for tests in release/7.0.x branch and fix vulnerable dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">17.12.36</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">17.12.50</MicrosoftBuildVersion>
     <!-- Read docs/updating-packages.md before updating MSBuild's version -->
-    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">17.11.31</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">17.11.48</MicrosoftBuildVersion>
   </PropertyGroup>
 
     <!-- Overridden by source build to ensure the same version is used across products, do not remove these properties -->

--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -2,4 +2,4 @@
 # To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
 -Channel 8.0 -Runtime dotnet
 -Channel 9.0 -Runtime dotnet
--Channel 10.0.1xx -Quality daily
+-Channel 10.0.1xx -Quality preview

--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -2,4 +2,4 @@
 # To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
 -Channel 8.0 -Runtime dotnet
 -Channel 9.0 -Runtime dotnet
--Channel 10.0.1xx -Quality preview
+-Channel 10.0.1xx -Version 10.0.100-rtm.25514.116


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Cherry-pick https://github.com/NuGet/NuGet.Client/commit/4a281a14c7308cc92d022ccdbe81c3e348c8ecab into `release/7.0.x` branch to address test failures. More details can be found in https://github.com/NuGet/NuGet.Client/pull/6880 PR description.

I have also cherry-picked https://github.com/NuGet/NuGet.Client/commit/bd1cbb8df857ac96d909f2580481115917593134 commit to fix vulnerable dependency alerts in the release branch.

## PR Checklist

- ~[ ] Meaningful title, helpful description and a linked NuGet/Home issue~
- ~[ ] Added tests~
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
