### PR TITLE
Configure OneLocBuild id for release branch

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -82,7 +82,10 @@ stages:
     - template: /eng/common/templates-official/job/onelocbuild.yml
       parameters:
         LclSource: lclFilesfromPackage
-        LclPackageId: 'LCL-JUNO-PROD-NuGetClient'
+        ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/dev') }}:
+          LclPackageId: 'LCL-MAIN-PROD-NuGetClient'
+        ${{ else }}:
+          LclPackageId: 'LCL-JUNO-PROD-NuGetClientRel'
         MirrorRepo: 'NuGet.Client'
         MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
         GitHubOrg: 'NuGet'


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

Loc team said we need to configure this to avoid the release branch getting dev branch translations.

If we merge this before the loc system is updated, then the official build will fail.  But until we merge this, we might get more dev branch translation pull requests created on the release branch.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
