### PR TITLE
Set HashSet capacity in dependency resolver

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1254,11 +1254,7 @@ namespace NuGet.Commands
                 if (isRootProject)
                 {
 
-#if NETSTANDARD
-                    directPackageReferences = new HashSet<LibraryDependencyIndex>();
-#else
                     directPackageReferences = new HashSet<LibraryDependencyIndex>(capacity: chosenResolvedItem.Item.Data.Dependencies.Count);
-#endif
 
                     for (int i = 0; i < chosenResolvedItem.Item.Data.Dependencies.Count; i++)
                     {
@@ -1292,7 +1288,7 @@ namespace NuGet.Commands
                         // Suppress this dependency if PrivateAssets is set to "All"
                         if (dependency.SuppressParent == LibraryIncludeFlags.All)
                         {
-                            suppressions ??= new HashSet<LibraryDependencyIndex>();
+                            suppressions ??= new HashSet<LibraryDependencyIndex>(capacity: chosenResolvedItem.Item.Data.Dependencies.Count);
 
                             suppressions.Add(chosenResolvedItemChildLibraryDependencyIndex);
                         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -1288,7 +1288,7 @@ namespace NuGet.Commands
                         // Suppress this dependency if PrivateAssets is set to "All"
                         if (dependency.SuppressParent == LibraryIncludeFlags.All)
                         {
-                            suppressions ??= new HashSet<LibraryDependencyIndex>(capacity: chosenResolvedItem.Item.Data.Dependencies.Count);
+                            suppressions ??= new HashSet<LibraryDependencyIndex>(capacity: chosenResolvedItem.Item.Data.Dependencies.Count - i);
 
                             suppressions.Add(chosenResolvedItemChildLibraryDependencyIndex);
                         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14611

## Description
This was suggested by PRISM.  It sets the capacity of a `HashSet<T>` to avoid extra allocations during resizing.

https://prism.vsdata.io/failure/?eventType=Allocation&failureHash=f91dc5e1-bfea-70c1-5f3f-4b56a80af227

I also removed an unused `#if` for `NETSTANDARD` that is no longer needed.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
