### PR TITLE
[Feature] Add package source mapping to `package download`

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -48,18 +50,22 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
 
         public static async Task<int> RunAsync(PackageDownloadArgs args, ILoggerWithColor logger, IReadOnlyList<PackageSource> packageSources, ISettings settings, CancellationToken token)
         {
-            // Check for insecure sources
-            if (DetectAndReportInsecureSources(args.AllowInsecureConnections, packageSources, logger))
+            var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+            var hasSourcesArg = args.Sources != null && args.Sources.Count > 0;
+            var mappingDisabled = (packageSourceMapping != null && !packageSourceMapping.IsEnabled) || packageSourceMapping == null;
+            if ((mappingDisabled || hasSourcesArg) && DetectAndReportInsecureSources(args.AllowInsecureConnections, packageSources, logger))
             {
                 return ExitCodeError;
             }
 
             string outputDirectory = args.OutputDirectory ?? Directory.GetCurrentDirectory();
             var cache = new SourceCacheContext();
-            IReadOnlyList<SourceRepository> sourceRepositories = GetSourceRepositories(packageSources);
+
+            IReadOnlyDictionary<string, SourceRepository> sourceRepositoriesMap = GetSourceRepositories(packageSources);
+
             bool downloadedAllSuccessfully = true;
 
-            foreach (var package in args.Packages)
+            foreach (var package in args.Packages ?? [])
             {
                 logger.LogMinimal(string.Format(
                     CultureInfo.CurrentCulture,
@@ -67,9 +73,22 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
                     package.Id,
                     string.IsNullOrEmpty(package.NuGetVersion?.ToNormalizedString()) ? Strings.PackageDownloadCommand_LatestVersion : package.NuGetVersion.ToNormalizedString()));
 
+                // Resolve which repositories to use for this package
+                if (!TryGetRepositoriesForPackage(
+                        package.Id,
+                        args,
+                        packageSources,
+                        packageSourceMapping,
+                        sourceRepositoriesMap,
+                        logger,
+                        out List<SourceRepository> sourceRepositories))
+                {
+                    return ExitCodeError;
+                }
+
                 try
                 {
-                    (NuGetVersion version, SourceRepository downloadRepository) =
+                    (NuGetVersion? version, SourceRepository? downloadRepository) =
                         await ResolvePackageDownloadVersion(
                             package,
                             sourceRepositories,
@@ -88,7 +107,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
                     bool success = await DownloadPackageAsync(
                         package.Id,
                         version,
-                        downloadRepository,
+                        downloadRepository!,
                         cache,
                         settings,
                         outputDirectory,
@@ -127,7 +146,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             return downloadedAllSuccessfully ? ExitCodeSuccess : ExitCodeError;
         }
 
-        internal static async Task<(NuGetVersion, SourceRepository)> ResolvePackageDownloadVersion(
+        internal static async Task<(NuGetVersion?, SourceRepository?)> ResolvePackageDownloadVersion(
             PackageWithNuGetVersion packageWithNuGetVersion,
             IEnumerable<SourceRepository> sourceRepositories,
             SourceCacheContext cache,
@@ -135,8 +154,8 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             bool includePrerelease,
             CancellationToken token)
         {
-            NuGetVersion versionToDownload = null;
-            SourceRepository downloadSourceRepository = null;
+            NuGetVersion? versionToDownload = null;
+            SourceRepository? downloadSourceRepository = null;
             bool versionSpecified = packageWithNuGetVersion.NuGetVersion != null;
 
             foreach (var repo in sourceRepositories)
@@ -186,6 +205,67 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             }
 
             return (versionToDownload, downloadSourceRepository);
+        }
+
+        /// <summary>
+        /// Builds the set of SourceRepository objects to use for a given package,
+        /// applying package source mapping (when --source is not provided) and
+        /// validating HTTP usage only on the *effective* sources.
+        /// </summary>
+        private static bool TryGetRepositoriesForPackage(
+            string packageId,
+            PackageDownloadArgs args,
+            IReadOnlyList<PackageSource> allPackageSources,
+            PackageSourceMapping? packageSourceMapping,
+            IReadOnlyDictionary<string, SourceRepository> sourceRepositoriesMap,
+            ILoggerWithColor logger,
+            out List<SourceRepository> repositories)
+        {
+            List<PackageSource> effectiveSources;
+
+            var sourceExplicitlyProvided = args.Sources?.Count > 0;
+            if (sourceExplicitlyProvided || (packageSourceMapping != null && !packageSourceMapping.IsEnabled))
+            {
+                // --source given OR mapping disabled: use all provided sources as-is
+                effectiveSources = [.. allPackageSources];
+            }
+            else
+            {
+                // Mapping enabled, no --source: try mapped names first
+                var mappedNames = packageSourceMapping == null ? [] : packageSourceMapping.GetConfiguredPackageSources(packageId);
+
+                // Build effective sources in the same order as mappedNames
+                var mapped = mappedNames
+                    .Select(n => allPackageSources.FirstOrDefault(ps =>
+                        string.Equals(ps.Name, n, StringComparison.OrdinalIgnoreCase)))
+                    .ToList();
+
+                // Only validate insecure sources when mapping produced something
+                if (mapped.Count > 0)
+                {
+                    if (DetectAndReportInsecureSources(args.AllowInsecureConnections, mapped!, logger))
+                    {
+                        repositories = [];
+                        return false;
+                    }
+
+                    effectiveSources = mapped!;
+                }
+                else
+                {
+                    // No mapping for this package: fall back to all sources
+                    effectiveSources = [.. allPackageSources];
+                }
+            }
+
+            // Convert effective sources to repositories
+            repositories = new List<SourceRepository>(effectiveSources.Count);
+            foreach (var src in effectiveSources)
+            {
+                repositories.Add(sourceRepositoriesMap[src.Name]);
+            }
+
+            return true;
         }
 
         private static async Task<bool> DownloadPackageAsync(
@@ -239,7 +319,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             return success;
         }
 
-        private static IReadOnlyList<PackageSource> GetPackageSources(IList<string> sources, IPackageSourceProvider sourceProvider)
+        private static IReadOnlyList<PackageSource> GetPackageSources(IList<string>? sources, IPackageSourceProvider sourceProvider)
         {
             IEnumerable<PackageSource> configuredSources = sourceProvider.LoadPackageSources()
                 .Where(s => s.IsEnabled);
@@ -271,13 +351,13 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             return false;
         }
 
-        private static IReadOnlyList<SourceRepository> GetSourceRepositories(IReadOnlyList<PackageSource> packageSources)
+        private static IReadOnlyDictionary<string, SourceRepository> GetSourceRepositories(IReadOnlyList<PackageSource> packageSources)
         {
             IEnumerable<Lazy<INuGetResourceProvider>> providers = Repository.Provider.GetCoreV3();
-            List<SourceRepository> sourceRepositories = [];
+            Dictionary<string, SourceRepository> sourceRepositories = [];
             foreach (var source in packageSources)
             {
-                sourceRepositories.Add(Repository.CreateSource(providers, source, FeedType.Undefined));
+                sourceRepositories[source.Name] = Repository.CreateSource(providers, source, FeedType.Undefined);
             }
 
             return sourceRepositories;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
@@ -51,11 +51,13 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
         public static async Task<int> RunAsync(PackageDownloadArgs args, ILoggerWithColor logger, IReadOnlyList<PackageSource> packageSources, ISettings settings, CancellationToken token)
         {
             var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
-            var hasSourcesArg = args.Sources != null && args.Sources.Count > 0;
+            var hasSourcesArg = args.Sources?.Count > 0;
             var mappingDisabled = (packageSourceMapping != null && !packageSourceMapping.IsEnabled) || packageSourceMapping == null;
             bool ignorePackageSourceMapping = hasSourcesArg || mappingDisabled;
 
-            // Validate all configured sources only when mapping is disabled
+            // When package source mapping is disabled, validate all configured sources upfront.
+            // When mapping is enabled, source validation is deferred to the per-package resolution step,
+            // since each package may map to a different subset of sources.
             if (ignorePackageSourceMapping && DetectAndReportInsecureSources(args.AllowInsecureConnections, packageSources, logger))
             {
                 return ExitCodeError;
@@ -231,14 +233,29 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             out List<SourceRepository> repositories)
         {
             var mappedNames = packageSourceMapping.GetConfiguredPackageSources(packageId);
-            var mappedRepos = mappedNames
-                .Select(name => sourceRepositoriesMap[name])
-                .ToList();
 
             // Only validate insecure sources when mapping produced something
-            if (mappedRepos.Count > 0)
+            if (mappedNames.Count > 0)
             {
-                if (DetectAndReportInsecureSources(args.AllowInsecureConnections, mappedRepos.Select(sourceRepo => sourceRepo.PackageSource), logger))
+                var mappedRepos = new List<SourceRepository>(mappedNames.Count);
+                foreach (var mappedName in mappedNames)
+                {
+                    if (sourceRepositoriesMap.TryGetValue(mappedName, out SourceRepository? sourceRepository))
+                    {
+                        mappedRepos.Add(sourceRepository);
+                    }
+                    else
+                    {
+                        logger.LogVerbose(
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.PackageDownloadCommand_PackageSourceMapping_NoSuchSource,
+                                mappedName,
+                                packageId));
+                    }
+                }
+
+                if (DetectAndReportInsecureSources(args.AllowInsecureConnections, mappedRepos.Select(repo => repo.PackageSource), logger))
                 {
                     repositories = [];
                     return false;
@@ -341,9 +358,9 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
         private static (IReadOnlyDictionary<string, SourceRepository>, List<SourceRepository>) GetSourceRepositories(IReadOnlyList<PackageSource> packageSources)
         {
             IEnumerable<Lazy<INuGetResourceProvider>> providers = Repository.Provider.GetCoreV3();
-            Dictionary<string, SourceRepository> sourceRepositories = [];
-            List<SourceRepository> allRepositories = [];
-            foreach (var source in packageSources)
+            Dictionary<string, SourceRepository> sourceRepositories = new Dictionary<string, SourceRepository>(packageSources?.Count ?? 0);
+            List<SourceRepository> allRepositories = new List<SourceRepository>(packageSources?.Count ?? 0);
+            foreach (var source in packageSources ?? [])
             {
                 sourceRepositories[source.Name] = Repository.CreateSource(providers, source, FeedType.Undefined);
                 allRepositories.Add(sourceRepositories[source.Name]);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
@@ -72,7 +72,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
 
             string outputDirectory = args.OutputDirectory ?? Directory.GetCurrentDirectory();
             var cache = new SourceCacheContext();
-            (IReadOnlyDictionary<string, SourceRepository> sourceRepositoriesMap, List<SourceRepository> allRepositories) = GetSourceRepositories(packageSources);
+            IReadOnlyList<SourceRepository> allRepositories = GetSourceRepositories(packageSources);
             bool downloadedAllSuccessfully = true;
 
             foreach (var package in args.Packages ?? [])
@@ -84,7 +84,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
                     string.IsNullOrEmpty(package.NuGetVersion?.ToNormalizedString()) ? Strings.PackageDownloadCommand_LatestVersion : package.NuGetVersion.ToNormalizedString()));
 
                 // Resolve which repositories to use for this package
-                List<SourceRepository> sourceRepositories;
+                IReadOnlyList<SourceRepository> sourceRepositories;
                 if (ignorePackageSourceMapping)
                 {
                     sourceRepositories = allRepositories;
@@ -95,7 +95,6 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
                         package.Id,
                         args,
                         packageSourceMapping!,
-                        sourceRepositoriesMap,
                         allRepositories,
                         logger,
                         out sourceRepositories))
@@ -166,7 +165,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
 
         internal static async Task<(NuGetVersion?, SourceRepository?)> ResolvePackageDownloadVersion(
             PackageWithNuGetVersion packageWithNuGetVersion,
-            IEnumerable<SourceRepository> sourceRepositories,
+            IReadOnlyList<SourceRepository> sourceRepositories,
             SourceCacheContext cache,
             ILoggerWithColor logger,
             bool includePrerelease,
@@ -234,10 +233,9 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             string packageId,
             PackageDownloadArgs args,
             PackageSourceMapping packageSourceMapping,
-            IReadOnlyDictionary<string, SourceRepository> sourceRepositoriesMap,
-            List<SourceRepository> allRepos,
+            IReadOnlyList<SourceRepository> allRepos,
             ILoggerWithColor logger,
-            out List<SourceRepository> repositories)
+            out IReadOnlyList<SourceRepository> repositories)
         {
             var mappedNames = packageSourceMapping.GetConfiguredPackageSources(packageId);
 
@@ -247,9 +245,19 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
                 var mappedRepos = new List<SourceRepository>(mappedNames.Count);
                 foreach (var mappedName in mappedNames)
                 {
-                    if (sourceRepositoriesMap.TryGetValue(mappedName, out SourceRepository? sourceRepository))
+                    SourceRepository? repo = null;
+                    for (int i = 0; i < allRepos.Count; i++)
                     {
-                        mappedRepos.Add(sourceRepository);
+                        if (string.Equals(allRepos[i].PackageSource.Name, mappedName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            repo = allRepos[i];
+                            break;
+                        }
+                    }
+
+                    if (repo != null)
+                    {
+                        mappedRepos.Add(repo);
                     }
                     else
                     {
@@ -362,18 +370,16 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             return false;
         }
 
-        private static (IReadOnlyDictionary<string, SourceRepository>, List<SourceRepository>) GetSourceRepositories(IReadOnlyList<PackageSource> packageSources)
+        private static IReadOnlyList<SourceRepository> GetSourceRepositories(IReadOnlyList<PackageSource> packageSources)
         {
             IEnumerable<Lazy<INuGetResourceProvider>> providers = Repository.Provider.GetCoreV3();
-            Dictionary<string, SourceRepository> sourceRepositories = new Dictionary<string, SourceRepository>(packageSources?.Count ?? 0);
-            List<SourceRepository> allRepositories = new List<SourceRepository>(packageSources?.Count ?? 0);
-            foreach (var source in packageSources ?? [])
+            List<SourceRepository> sourceRepositories = [];
+            foreach (var source in packageSources)
             {
-                sourceRepositories[source.Name] = Repository.CreateSource(providers, source, FeedType.Undefined);
-                allRepositories.Add(sourceRepositories[source.Name]);
+                sourceRepositories.Add(Repository.CreateSource(providers, source, FeedType.Undefined));
             }
 
-            return (sourceRepositories, allRepositories);
+            return sourceRepositories;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
@@ -50,10 +50,17 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
 
         public static async Task<int> RunAsync(PackageDownloadArgs args, ILoggerWithColor logger, IReadOnlyList<PackageSource> packageSources, ISettings settings, CancellationToken token)
         {
-            var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
-            var hasSourcesArg = args.Sources?.Count > 0;
-            var mappingDisabled = (packageSourceMapping != null && !packageSourceMapping.IsEnabled) || packageSourceMapping == null;
-            bool ignorePackageSourceMapping = hasSourcesArg || mappingDisabled;
+            bool hasSourcesArg = args.Sources?.Count > 0;
+            PackageSourceMapping? packageSourceMapping = null;
+            if (!hasSourcesArg)
+            {
+                packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+            }
+
+            bool ignorePackageSourceMapping =
+                hasSourcesArg
+                || packageSourceMapping is null
+                || !packageSourceMapping.IsEnabled;
 
             // When package source mapping is disabled, validate all configured sources upfront.
             // When mapping is enabled, source validation is deferred to the per-package resolution step,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
@@ -53,7 +53,10 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
             var hasSourcesArg = args.Sources != null && args.Sources.Count > 0;
             var mappingDisabled = (packageSourceMapping != null && !packageSourceMapping.IsEnabled) || packageSourceMapping == null;
-            if ((mappingDisabled || hasSourcesArg) && DetectAndReportInsecureSources(args.AllowInsecureConnections, packageSources, logger))
+            bool ignorePackageSourceMapping = hasSourcesArg || mappingDisabled;
+
+            // Validate all configured sources only when mapping is disabled
+            if (ignorePackageSourceMapping && DetectAndReportInsecureSources(args.AllowInsecureConnections, packageSources, logger))
             {
                 return ExitCodeError;
             }
@@ -74,16 +77,23 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
                     string.IsNullOrEmpty(package.NuGetVersion?.ToNormalizedString()) ? Strings.PackageDownloadCommand_LatestVersion : package.NuGetVersion.ToNormalizedString()));
 
                 // Resolve which repositories to use for this package
-                if (!TryGetRepositoriesForPackage(
+                List<SourceRepository> sourceRepositories;
+                if (ignorePackageSourceMapping)
+                {
+                    sourceRepositories = [.. sourceRepositoriesMap.Values];
+                }
+                else
+                {
+                    if (!TryGetRepositoriesForPackage(
                         package.Id,
                         args,
-                        packageSources,
-                        packageSourceMapping,
+                        packageSourceMapping!,
                         sourceRepositoriesMap,
                         logger,
-                        out List<SourceRepository> sourceRepositories))
-                {
-                    return ExitCodeError;
+                        out sourceRepositories))
+                    {
+                        return ExitCodeError;
+                    }
                 }
 
                 try
@@ -209,63 +219,40 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
 
         /// <summary>
         /// Builds the set of SourceRepository objects to use for a given package,
-        /// applying package source mapping (when --source is not provided) and
+        /// applying package source mapping
         /// validating HTTP usage only on the *effective* sources.
         /// </summary>
         private static bool TryGetRepositoriesForPackage(
             string packageId,
             PackageDownloadArgs args,
-            IReadOnlyList<PackageSource> allPackageSources,
-            PackageSourceMapping? packageSourceMapping,
+            PackageSourceMapping packageSourceMapping,
             IReadOnlyDictionary<string, SourceRepository> sourceRepositoriesMap,
             ILoggerWithColor logger,
             out List<SourceRepository> repositories)
         {
-            List<PackageSource> effectiveSources;
+            var mappedNames = packageSourceMapping.GetConfiguredPackageSources(packageId);
+            var mappedRepos = mappedNames
+                .Select(name => sourceRepositoriesMap[name])
+                .ToList();
 
-            var sourceExplicitlyProvided = args.Sources?.Count > 0;
-            if (sourceExplicitlyProvided || (packageSourceMapping != null && !packageSourceMapping.IsEnabled))
+            // Only validate insecure sources when mapping produced something
+            if (mappedRepos.Count > 0)
             {
-                // --source given OR mapping disabled: use all provided sources as-is
-                effectiveSources = [.. allPackageSources];
+                if (DetectAndReportInsecureSources(args.AllowInsecureConnections, mappedRepos.Select(sourceRepo => sourceRepo.PackageSource), logger))
+                {
+                    repositories = [];
+                    return false;
+                }
+
+                repositories = mappedRepos;
+                return true;
             }
             else
             {
-                // Mapping enabled, no --source: try mapped names first
-                var mappedNames = packageSourceMapping == null ? [] : packageSourceMapping.GetConfiguredPackageSources(packageId);
-
-                // Build effective sources in the same order as mappedNames
-                var mapped = mappedNames
-                    .Select(n => allPackageSources.FirstOrDefault(ps =>
-                        string.Equals(ps.Name, n, StringComparison.OrdinalIgnoreCase)))
-                    .ToList();
-
-                // Only validate insecure sources when mapping produced something
-                if (mapped.Count > 0)
-                {
-                    if (DetectAndReportInsecureSources(args.AllowInsecureConnections, mapped!, logger))
-                    {
-                        repositories = [];
-                        return false;
-                    }
-
-                    effectiveSources = mapped!;
-                }
-                else
-                {
-                    // No mapping for this package: fall back to all sources
-                    effectiveSources = [.. allPackageSources];
-                }
+                // No mapping for this package: fall back to all sources
+                repositories = [.. sourceRepositoriesMap.Values];
+                return true;
             }
-
-            // Convert effective sources to repositories
-            repositories = new List<SourceRepository>(effectiveSources.Count);
-            foreach (var src in effectiveSources)
-            {
-                repositories.Add(sourceRepositoriesMap[src.Name]);
-            }
-
-            return true;
         }
 
         private static async Task<bool> DownloadPackageAsync(

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
@@ -63,9 +63,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
 
             string outputDirectory = args.OutputDirectory ?? Directory.GetCurrentDirectory();
             var cache = new SourceCacheContext();
-
-            IReadOnlyDictionary<string, SourceRepository> sourceRepositoriesMap = GetSourceRepositories(packageSources);
-
+            (IReadOnlyDictionary<string, SourceRepository> sourceRepositoriesMap, List<SourceRepository> allRepositories) = GetSourceRepositories(packageSources);
             bool downloadedAllSuccessfully = true;
 
             foreach (var package in args.Packages ?? [])
@@ -80,7 +78,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
                 List<SourceRepository> sourceRepositories;
                 if (ignorePackageSourceMapping)
                 {
-                    sourceRepositories = [.. sourceRepositoriesMap.Values];
+                    sourceRepositories = allRepositories;
                 }
                 else
                 {
@@ -89,6 +87,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
                         args,
                         packageSourceMapping!,
                         sourceRepositoriesMap,
+                        allRepositories,
                         logger,
                         out sourceRepositories))
                     {
@@ -227,6 +226,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             PackageDownloadArgs args,
             PackageSourceMapping packageSourceMapping,
             IReadOnlyDictionary<string, SourceRepository> sourceRepositoriesMap,
+            List<SourceRepository> allRepos,
             ILoggerWithColor logger,
             out List<SourceRepository> repositories)
         {
@@ -250,7 +250,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             else
             {
                 // No mapping for this package: fall back to all sources
-                repositories = [.. sourceRepositoriesMap.Values];
+                repositories = allRepos;
                 return true;
             }
         }
@@ -338,16 +338,18 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             return false;
         }
 
-        private static IReadOnlyDictionary<string, SourceRepository> GetSourceRepositories(IReadOnlyList<PackageSource> packageSources)
+        private static (IReadOnlyDictionary<string, SourceRepository>, List<SourceRepository>) GetSourceRepositories(IReadOnlyList<PackageSource> packageSources)
         {
             IEnumerable<Lazy<INuGetResourceProvider>> providers = Repository.Provider.GetCoreV3();
             Dictionary<string, SourceRepository> sourceRepositories = [];
+            List<SourceRepository> allRepositories = [];
             foreach (var source in packageSources)
             {
                 sourceRepositories[source.Name] = Repository.CreateSource(providers, source, FeedType.Undefined);
+                allRepositories.Add(sourceRepositories[source.Name]);
             }
 
-            return sourceRepositories;
+            return (sourceRepositories, allRepositories);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -1662,6 +1662,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The mapped source &apos;{0}&apos; for package &apos;{1}&apos; was not found among the configured sources..
+        /// </summary>
+        internal static string PackageDownloadCommand_PackageSourceMapping_NoSuchSource {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_PackageSourceMapping_NoSuchSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specifies one or more NuGet package sources to use..
         /// </summary>
         internal static string PackageDownloadCommand_SourcesDescription {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -1157,4 +1157,9 @@ Do not translate "PackageVersion"</comment>
   <data name="Error_PackageDownload_VersionNotFound" xml:space="preserve">
     <value>Unable to find a valid package version</value>
   </data>
+  <data name="PackageDownloadCommand_PackageSourceMapping_NoSuchSource" xml:space="preserve">
+    <value>The mapped source '{0}' for package '{1}' was not found among the configured sources.</value>
+    <comment>0 - package source name
+1 - package name</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
@@ -929,6 +929,12 @@ Další informace najdete tady: https://docs.nuget.org/docs/reference/command-li
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
@@ -929,6 +929,12 @@ Weitere Informationen finden Sie unter: https://docs.nuget.org/docs/reference/co
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
@@ -929,6 +929,12 @@ Para obtener más información, visite https://docs.nuget.org/docs/reference/com
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
@@ -929,6 +929,12 @@ Pour plus d'informations, visitez https://docs.nuget.org/docs/reference/command-
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
@@ -929,6 +929,12 @@ Per altre informazioni, vedere https://docs.nuget.org/docs/reference/command-lin
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
@@ -929,6 +929,12 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
@@ -929,6 +929,12 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
@@ -929,6 +929,12 @@ Aby uzyskać więcej informacji, odwiedź stronę https://docs.nuget.org/docs/re
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
@@ -929,6 +929,12 @@ Para obter mais informações, acesse https://docs.nuget.org/docs/reference/comm
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
@@ -929,6 +929,12 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
@@ -930,6 +930,12 @@ Daha fazla bilgi için bkz. https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
@@ -929,6 +929,12 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
@@ -929,6 +929,12 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
@@ -502,7 +502,7 @@ public class PackageDownloadRunnerTests
 
     [Theory]
     [MemberData(nameof(Cases))]
-    public async Task RunAsync_WithSourceMapping_ListDriven_UsingCleanSetup(
+    public async Task RunAsync_WithSourceMapping(
         IReadOnlyList<(string id, string version)> sourceAPackages,
         IReadOnlyList<(string id, string version)> sourceBPackages,
         IReadOnlyList<(string source, string pattern)> sourceMappings,

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using global::Test.Utility;
+using Test.Utility;
 using Moq;
 using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Package;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Test.Utility;
 using Moq;
 using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Package;
@@ -17,6 +17,7 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.CommandLine.Xplat.Tests;
@@ -600,5 +601,61 @@ public class PackageDownloadRunnerTests
         {
             exit.Should().Be(PackageDownloadRunner.ExitCodeError);
         }
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenMappedSourceMissing_LogsVerbose()
+    {
+        // Arrange
+        using var context = new SimpleTestPathContext();
+        string srcADirectory = Path.Combine(context.PackageSource, "SourceA");
+        using var serverA = new FileSystemBackedV3MockServer(srcADirectory);
+
+        await SimpleTestPackageUtility.CreateFullPackageAsync(srcADirectory, "Contoso.Utils", "1.0.0");
+        context.Settings.AddSource("A", serverA.ServiceIndexUri);
+
+        // Map the package to a NON-EXISTING source name "MissingSource"
+        context.Settings.AddPackageSourceMapping("MissingSource", "Contoso.*");
+        var settings = Settings.LoadSettingsGivenConfigPaths([context.Settings.ConfigPath]);
+
+        var args = new PackageDownloadArgs
+        {
+            Packages =
+            [
+                new PackageWithNuGetVersion
+                {
+                    Id = "Contoso.Utils",
+                    NuGetVersion = NuGetVersion.Parse("1.0.0")
+                }
+            ],
+            OutputDirectory = context.WorkingDirectory,
+            AllowInsecureConnections = true,
+            Sources = []
+        };
+        string capturedVerbose = string.Empty;
+        var logger = new Mock<ILoggerWithColor>(MockBehavior.Loose);
+        logger.Setup(l => l.LogVerbose(It.IsAny<string>()))
+              .Callback<string>(msg => capturedVerbose += msg + Environment.NewLine);
+
+        // Act
+        serverA.Start();
+
+        var exit = await PackageDownloadRunner.RunAsync(
+            args,
+            logger.Object,
+            [new(serverA.ServiceIndexUri, "A")],
+            settings,
+            CancellationToken.None);
+
+        serverA.Stop();
+
+        // Assert
+        var expected = string.Format(
+            CultureInfo.CurrentCulture,
+            Strings.PackageDownloadCommand_PackageSourceMapping_NoSuchSource,
+            "MissingSource",
+            "Contoso.Utils");
+
+        capturedVerbose.Should().Contain(expected, because: "a package mapped to a non-existing source name must log a verbose diagnostic");
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using global::Test.Utility;
 using Moq;
 using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Package;
@@ -425,5 +426,179 @@ public class PackageDownloadRunnerTests
 
         File.Exists(Path.Combine(context.WorkingDirectory, $"{id.ToLowerInvariant()}.{v}.nupkg"))
             .Should().BeFalse("Package does not exist in sources");
+    }
+
+    public static IEnumerable<object[]> Cases()
+    {
+        // Parameters:
+        // A-packages, B-packages, sourceMappings, sourcesArgs, downloadId, downloadVersion,
+        // allowInsecureConnections, expectSuccess, expectedInstalled
+
+        // --source specified, mapping ignored, package only in A -> success
+        yield return new object[]
+        {
+            new List<(string,string)> { ("Contoso.Lib", "1.0.0") }, // A
+            new List<(string,string)>(),                            // B
+            new List<(string,string)> { ("B", "Contoso.*") },       // mapping ignored
+            new List<string> { "A" },                               // --source A
+            "Contoso.Lib", "1.0.0",                                  // downloadId, downloadVersion
+            true,                                                   // allow insecure
+            true,                                                   // expect success
+            ("Contoso.Lib", "1.0.0")                                // expectedInstalled
+        };
+
+        // no --source, mapping -> B, package only in B -> success
+        yield return new object[]
+        {
+            new List<(string,string)>(),                            // A
+            new List<(string,string)> { ("Contoso.Mapped", "2.0.0") }, // B
+            new List<(string,string)> { ("B", "Contoso.*") },       // mapping -> B
+            null,                                                   // no --source
+            "Contoso.Mapped", "2.0.0",                              // downloadId, downloadVersion
+            true,                                                   // allow insecure
+            true,                                                   // expect success
+            ("Contoso.Mapped", "2.0.0")                             // expectedInstalled
+        };
+
+        // no --source, mapping -> A, package only in B -> fail
+        yield return new object[]
+        {
+            new List<(string,string)>(),                            // A
+            new List<(string,string)> { ("Contoso.Mapped", "2.0.0") },
+            new List<(string,string)> { ("A", "Contoso.*") },       // mapped to A
+            null,
+            "Contoso.Mapped", "2.0.0",
+            true,
+            false,
+            null!
+        };
+
+        // --source specified, no source mapping with an insecure source
+        yield return new object[]
+        {
+            new List<(string,string)> { ("Contoso.Lib", "1.0.0") }, // A
+            new List<(string,string)>(),
+            new List<(string,string)> { ("A", "Contoso.*") },
+            new List<string> { "A" },                               // --source
+            "Contoso.Lib", "1.0.0",
+            false,                                                  // allow insecure connections false / not set to true
+            false,
+            null!
+        };
+
+        // no --source, mapping -> B, allow insecure not enabled -> fail
+        yield return new object[]
+        {
+            new List<(string,string)>(),                            // A
+            new List<(string,string)> { ("Contoso.Mapped", "1.0.0") },
+            new List<(string,string)> { ("B", "Contoso.*") },
+            null,
+            "Contoso.Mapped", "1.0.0",
+            false,                                                   // allow insecure connections false / not set to true
+            false,
+            null!
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public async Task RunAsync_WithSourceMapping_ListDriven_UsingCleanSetup(
+        IReadOnlyList<(string id, string version)> sourceAPackages,
+        IReadOnlyList<(string id, string version)> sourceBPackages,
+        IReadOnlyList<(string source, string pattern)> sourceMappings,
+        IReadOnlyList<string> sourcesArgs,
+        string downloadId,
+        string downloadVersion,
+        bool allowInsecureConnections,
+        bool expectSuccess,
+        (string id, string version)? expectedInstalled)
+    {
+        // Arrange
+        using var context = new SimpleTestPathContext();
+        string srcADirectory = Path.Combine(context.PackageSource, "SourceA");
+        string srcBDirectory = Path.Combine(context.PackageSource, "SourceB");
+
+        using var serverA = new FileSystemBackedV3MockServer(srcADirectory);
+        using var serverB = new FileSystemBackedV3MockServer(srcBDirectory);
+
+        foreach (var (id, ver) in sourceAPackages)
+        {
+            await SimpleTestPackageUtility.CreateFullPackageAsync(srcADirectory, id, ver);
+        }
+
+        foreach (var (id, ver) in sourceBPackages)
+        {
+            await SimpleTestPackageUtility.CreateFullPackageAsync(srcBDirectory, id, ver);
+        }
+
+        serverA.Start();
+        serverB.Start();
+
+        // sources
+        context.Settings.AddSource("A", serverA.ServiceIndexUri);
+        context.Settings.AddSource("B", serverB.ServiceIndexUri);
+
+        // mapping
+        foreach (var (src, pattern) in sourceMappings)
+        {
+            context.Settings.AddPackageSourceMapping(src, pattern);
+        }
+
+        var settings = Settings.LoadSettingsGivenConfigPaths([context.Settings.ConfigPath]);
+
+        var packageSources = new List<PackageSource>
+        {
+            new(serverA.ServiceIndexUri, "A"),
+            new(serverB.ServiceIndexUri, "B")
+        };
+
+        // args
+        var args = new PackageDownloadArgs
+        {
+            Packages =
+            [
+                new PackageWithNuGetVersion
+                {
+                    Id = downloadId,
+                    NuGetVersion = downloadVersion is null ? null : NuGetVersion.Parse(downloadVersion)
+                }
+            ],
+            OutputDirectory = context.WorkingDirectory,
+            AllowInsecureConnections = allowInsecureConnections,
+            Sources = sourcesArgs == null ? [] : sourcesArgs.ToList()
+        };
+
+        string capturedLogs = string.Empty;
+        var logger = new Mock<ILoggerWithColor>(MockBehavior.Loose);
+        logger
+            .Setup(l => l.LogError(It.IsAny<string>()))
+            .Callback<string>(msg => capturedLogs += msg + Environment.NewLine);
+
+        // Act
+        var exit = await PackageDownloadRunner.RunAsync(
+            args,
+            logger.Object,
+            packageSources,
+            settings,
+            CancellationToken.None);
+
+        serverA.Stop();
+        serverB.Stop();
+
+        // Assert
+        if (expectSuccess)
+        {
+            exit.Should().Be(PackageDownloadRunner.ExitCodeSuccess, because: capturedLogs);
+            expectedInstalled.Should().NotBeNull();
+
+            var (expId, expVer) = expectedInstalled!.Value;
+            var installDir = Path.Combine(context.WorkingDirectory, expId.ToLowerInvariant(), expVer);
+            Directory.Exists(installDir).Should().BeTrue();
+            File.Exists(Path.Combine(installDir, $"{expId.ToLowerInvariant()}.{expVer}.nupkg")).Should().BeTrue();
+        }
+        else
+        {
+            exit.Should().Be(PackageDownloadRunner.ExitCodeError);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadRunnerTests.cs
@@ -200,5 +200,4 @@ public class PackageDownloadRunnerTests
             foundRepo.Should().BeNull();
         }
     }
-
 }

--- a/test/TestUtilities/Test.Utility/FileSystemBackedV3MockServer.cs
+++ b/test/TestUtilities/Test.Utility/FileSystemBackedV3MockServer.cs
@@ -99,9 +99,21 @@ namespace Test.Utility
             }
             else if (path.StartsWith("/flat/") && path.EndsWith(".nupkg"))
             {
-                var file = new FileInfo(Path.Combine(_packageDirectory, parts.Last()));
+                var requestedFileName = parts.Last();
+                var directory = new DirectoryInfo(_packageDirectory);
+                FileInfo file = null;
 
-                if (file.Exists)
+                // Scan for file and ignore case to make sure this works in linux too
+                foreach (var candidate in directory.EnumerateFiles("*.nupkg", SearchOption.TopDirectoryOnly))
+                {
+                    if (string.Equals(candidate.Name, requestedFileName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        file = candidate;
+                        break;
+                    }
+                }
+
+                if (file != null && file.Exists)
                 {
                     return new Action<HttpListenerResponse>(response =>
                     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14607

## Description
This PR
* Adds package source mapping to the `package download` command
* Here is the design spec https://github.com/NuGet/Home/blob/dev-nyenework-install/accepted/2025/dotnet-package-download.md#source-selection-and-package-source-mapping
* Also update the test mock server to ignore file cases so that it is able to find files despite cases. Before this update the server was not able to find the package files in Linux if the casing is different.

TLDR
* When `--source` is specified, the command now prioritizes the provided source(s) and **skips package source mapping**
* When `--source` is not specified, the command reads sources from `nuget.config` and **applies package source mapping** to determine which source to use for each package.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
