### PR TITLE
[7.0.x] Stop using /WarnAsError in source-build CI

### DIFF
--- a/eng/dotnet-build/build.ps1
+++ b/eng/dotnet-build/build.ps1
@@ -9,7 +9,6 @@ param (
   [switch][Alias('nobl')]$excludeCIBinarylog,
   [switch][Alias('pb')]$productBuild,
   [switch]$fromVMR,
-  [bool]$warnAsError = $true,
   [bool]$nodeReuse = $true,
   [Parameter(ValueFromRemainingArguments = $true)][string[]]$properties
 )

--- a/eng/dotnet-build/build.sh
+++ b/eng/dotnet-build/build.sh
@@ -14,7 +14,6 @@ source_build=false
 product_build=false
 from_vmr=false
 ci=false
-warn_as_error=true
 node_reuse=true
 binary_log=false
 
@@ -57,10 +56,6 @@ while [[ $# > 0 ]]; do
       ;;
     --from-vmr|--fromvmr)
       from_vmr=true
-      ;;
-    --warnaserror)
-      warn_as_error=$2
-      shift
       ;;
     --nodereuse)
       node_reuse=$2
@@ -133,9 +128,4 @@ if [[ "$ci" == true ]]; then
   node_reuse=false
 fi
 
-local warnaserror_switch=""
-if [[ $warn_as_error == true ]]; then
-  warnaserror_switch="/warnaserror"
-fi
-
-"$DOTNET" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci $bl ${dotnetArguments[@]+"${dotnetArguments[@]}"} ${args[@]+"${args[@]}"}
+"$DOTNET" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse /p:ContinuousIntegrationBuild=$ci $bl ${dotnetArguments[@]+"${dotnetArguments[@]}"} ${args[@]+"${args[@]}"}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Infrastructure

## Description

Backports https://github.com/NuGet/NuGet.Client/pull/6867 to release/7.0.x branch

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
