### PR TITLE
[5.11] backport CI improvements around branch and drop names 

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -56,6 +56,7 @@ variables:
   RunTestsOnLinux: ${{ parameters.RunTestsOnLinux }}
   RunTestsOnMac: ${{ parameters.RunTestsOnMac }}
   RunMonoTestsOnMac: ${{ parameters.RunMonoTestsOnMac }}
+  SourceBranch: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
 
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -84,6 +84,16 @@ stages:
     - download: ComponentBuildUnderTest
       artifact: BuildInfo
       displayName: 'Download buildinfo.json'
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download RunSettings drop metadata'
+      inputs:
+        buildType: 'specific'
+        artifactName: 'DropMetadata-RunSettings'
+        targetPath: $(Pipeline.Workspace)\ComponentBuildUnderTest\DropMetadata-RunSettings
+        project: '$(System.TeamProjectId)'
+        definition: $(System.DefinitionId)
+        buildVersionToDownload: 'specific'
+        pipelineId: $(resources.pipeline.ComponentBuildUnderTest.runId)
     - powershell: |
         try {
           Write-Host "Set VSBranch variable"
@@ -118,15 +128,23 @@ stages:
       displayName: 'Set VSBranch variable'
     - powershell : |
         try {
-          $branchName = "$(resources.pipeline.ComponentBuildUnderTest.sourceBranch)"
-          $branchName = $branchName.Replace('refs/heads/', '')
-
-          $RunSettingsURI = "https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$branchName/$(resources.pipeline.ComponentBuildUnderTest.runID);NuGet.OptProfV2.runsettings"
-          Write-Host "RunSettingsURI: $RunSettingsURI"
-          # non-output variable for VS config in the configure machine job
-          # output variable for test execution job
-          Set-AzurePipelinesVariable 'RunSettingsURI' $RunSettingsURI
-          Set-AzurePipelinesVariable -IsOutput 'RunSettingsURI' $RunSettingsURI
+          $dropMetadata = ConvertFrom-Json (Get-Content "$(Pipeline.Workspace)\ComponentBuildUnderTest\DropMetadata-RunSettings\VSTSDrop.json" -Raw)
+          $dropUri = $dropMetadata.VstsDropBuildArtifact.VstsDropUrl
+          if ($dropUri)
+          {
+            $dropUri = $dropUri -replace '^(.*?)/RunSettings/', 'https://vsdrop.microsoft.com/file/v1/RunSettings/'
+            $RunSettingsURI = "$dropUri;NuGet.OptProfV2.runsettings"
+            Write-Host "RunSettingsURI: $RunSettingsURI"
+            # non-output variable for VS config in the configure machine job
+            # output variable for test execution job
+            Set-AzurePipelinesVariable 'RunSettingsURI' $RunSettingsURI
+            Set-AzurePipelinesVariable -IsOutput 'RunSettingsURI' $RunSettingsURI
+          }
+          else
+          {
+            Write-Error "Drop metadata: $dropMetadata"
+            throw "VSTSDropUrl not found in VSTSDrop.json"
+          }
         }
         catch {
           Write-Host $_

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -130,7 +130,7 @@ stages:
         }
         catch {
           Write-Host $_
-          Write-Error "Failed to set SourceBranchName pipeline variable"
+          Write-Error "Failed to set RunSettingsURI pipeline variable"
           throw
         }
       displayName: 'Set RunSettingsURI variable'
@@ -146,7 +146,7 @@ stages:
         arguments: -BootstrapperInfoJsonURI '$(Pipeline.Workspace)\ComponentBuildUnderTest\MicroBuildOutputs\BootstrapperInfo.json' -VSBranch '$(VSBranch)' -OutVariableName 'VisualStudio.InstallationUnderTest.BootstrapperURL'
     # Remove this step hook and it's task if you don't want LKG support
     prePublishOptimizationInputsDropStepList:
-    # Set parameter for PreviousOptimizationInputsDropName 
+    # Set parameter for PreviousOptimizationInputsDropName
     - powershell: |
         try {
           $artifactName = 'OptProf'
@@ -159,7 +159,7 @@ stages:
 
           Write-Host "The content of the metadata.json file was $json"
           $dropname = $json.OptimizationData
-          
+
           Write-Host "PreviousOptimizationInputsDropName: $dropname"
           Set-AzurePipelinesVariable 'PreviousOptimizationInputsDropName' $dropname
         }

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -45,6 +45,7 @@ resources:
       type: git
       name: 1ESPipelineTemplates/MicroBuildTemplate
       ref: refs/tags/release
+
 variables:
   BINLOG_DIRECTORY: $(Build.StagingDirectory)/binlog
   DOTNET_NOLOGO: 1
@@ -58,6 +59,8 @@ variables:
   RunTestsOnLinux: ${{ parameters.RunTestsOnLinux }}
   RunTestsOnMac: ${{ parameters.RunTestsOnMac }}
   RunMonoTestsOnMac: ${{ parameters.RunMonoTestsOnMac }}
+  SourceBranch: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
+
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -306,7 +306,7 @@ steps:
     displayName: "Generate .runsettings files"
     inputs:
       solution: 'build\runsettings.proj'
-      msbuildArguments: '/restore:false /property:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /property:TestDrop="RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)" /property:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)" /binarylogger:$(Build.StagingDirectory)\\binlog\\18.GenerateRunSettings.binlog'
+      msbuildArguments: '/restore:false /property:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /property:TestDrop="$(RunSettingsDropName)" /property:ProfilingInputsDrop="$(ProfilingInputsDropName)" /binarylogger:$(Build.StagingDirectory)\\binlog\\18.GenerateRunSettings.binlog'
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: PowerShell@1

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -15,7 +15,7 @@ steps:
   - task: PowerShell@1
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-      arguments: "-BuildRTM $(BuildRTM) -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(Build.SourceBranchName) -CommitHash $(Build.SourceVersion) -BuildNumber $(Build.BuildNumber)"
+      arguments: "-BuildRTM $(BuildRTM) -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(SourceBranch) -CommitHash $(Build.SourceVersion) -BuildNumber $(Build.BuildNumber)"
     displayName: "Configure VSTS CI Environment"
 
   - task: PowerShell@1
@@ -306,7 +306,7 @@ steps:
     displayName: "Generate .runsettings files"
     inputs:
       solution: 'build\runsettings.proj'
-      msbuildArguments: '/restore:false /property:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /property:TestDrop="RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" /property:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)" /binarylogger:$(Build.StagingDirectory)\\binlog\\18.GenerateRunSettings.binlog'
+      msbuildArguments: '/restore:false /property:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /property:TestDrop="RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)" /property:ProfilingInputsDrop="ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)" /binarylogger:$(Build.StagingDirectory)\\binlog\\18.GenerateRunSettings.binlog'
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: PowerShell@1

--- a/eng/pipelines/templates/Initialize_Build.yml
+++ b/eng/pipelines/templates/Initialize_Build.yml
@@ -36,11 +36,3 @@ steps:
         Write-Host "##vso[task.LogIssue type=error;]Unable to set build number"
         exit 1
       }
-
-- task: PowerShell@1
-  displayName: "Add Build Tags"
-  inputs:
-    scriptType: "inlineScript"
-    inlineScript: |
-      Write-Host "##vso[build.addbuildtag]${env:BUILD_SOURCEVERSIONAUTHOR}"
-      Write-Host "##vso[build.addbuildtag]${env:BUILD_SOURCEBRANCHNAME}"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -170,7 +170,7 @@ stages:
               displayName: "Publish the .runsettings files to artifact services"
               condition: "succeeded()"
               dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
-              buildNumber: "RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"
+              buildNumber: "RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)"
               sourcePath: 'artifacts\RunSettings'
               toLowerCase: false
               usePat: true
@@ -180,7 +180,7 @@ stages:
               displayName: "OptProfV2:  publish profiling inputs to artifact services"
               condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
               dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
-              buildNumber: "ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildId)"
+              buildNumber: "ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)"
               sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
               toLowerCase: false
               usePat: true
@@ -210,7 +210,7 @@ stages:
               displayName: "Upload VSTS Drop"
               condition: "succeeded()"
               dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
-              buildNumber: "Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)"
+              buildNumber: "Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)"
               sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
               toLowerCase: false
               usePat: true

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -113,6 +113,8 @@ stages:
           LocalizedLanguageCount: "13"
           BuildRTM: "false"
           SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
+          RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
+          ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
         pool:
           name: VSEngSS-MicroBuild2019-1ES
           os: windows
@@ -170,7 +172,7 @@ stages:
               displayName: "Publish the .runsettings files to artifact services"
               condition: "succeeded()"
               dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
-              buildNumber: "RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)"
+              buildNumber: "$(RunSettingsDropName)"
               sourcePath: 'artifacts\RunSettings'
               toLowerCase: false
               usePat: true
@@ -180,7 +182,7 @@ stages:
               displayName: "OptProfV2:  publish profiling inputs to artifact services"
               condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
               dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
-              buildNumber: "ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)"
+              buildNumber: "$(ProfilingInputsDropName)"
               sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
               toLowerCase: false
               usePat: true
@@ -210,7 +212,7 @@ stages:
               displayName: "Upload VSTS Drop"
               condition: "succeeded()"
               dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
-              buildNumber: "Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)"
+              buildNumber: "$(MicroBuild.ManifestDropName)"
               sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
               toLowerCase: false
               usePat: true


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Infrastructure

## Description

Backports two CI improvements. It's only needed if we end up renaming `release-5.11.x` to `release/5.11.x`, but it makes sure that OptProf works if we do.

**NOTE** The 5.11.x branch has a lot of differences than the other release branches, so there's higher risk of regression in this PR than the other backport PRs. If you're willing to spend a bit more effort than usual reviewing a backport PR, this is a good one to spend that effort on.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
