### PR TITLE
remove .NET SDK version from global.json

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -59,9 +59,10 @@
       does it.
     -->
     <ItemGroup>
-      <_BuildOutputInPackage Remove="$(IntermediateOutputPath)%(_TargetFramework.Identity)\**\$(AssemblyName).resources.dll" />
+      <_BuildOutputInPackage Remove="@(_BuildOutputInPackage)"
+                             Condition="'%(Filename)%(Extension)' == '*.resources.dll'" />
     </ItemGroup>
   </Target>
-  
+
   <Import Project="eng\dotnet-build\ExcludeFromDotNetBuild.AfterCommonTargets.targets" Condition="'$(DotNetBuild)' == 'true'" />
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -54,7 +54,8 @@
   <Target Name="RemoveSatelliteDllsFromBuildOutputInPackage"
           BeforeTargets="GenerateNuspec"
           Condition="'$(IncludeSatelliteOutputInPack)' != 'true'">
-    <Message Text="Build Output before: %(_BuildOutputInPackage)" Importance="high" />
+    <Message Text="Build Output before: %(_BuildOutputInPackage.Identity)" Importance="high" />
+    <Message Text="_TargetFramework: %(_TargetFramework.Identity)" Importance="high" />
 
     <!--
       Could not find a way to tell NuGet to exclude the satellite assemblies from the NuGet package so this target
@@ -64,7 +65,7 @@
       <_BuildOutputInPackage Remove="$(IntermediateOutputPath)%(_TargetFramework.Identity)\**\$(AssemblyName).resources.dll" />
     </ItemGroup>
 
-    <Message Text="Build Output after: %(_BuildOutputInPackage)" Importance="high" />
+    <Message Text="Build Output after: %(_BuildOutputInPackage.Identity)" Importance="high" />
   </Target>
 
   <Import Project="eng\dotnet-build\ExcludeFromDotNetBuild.AfterCommonTargets.targets" Condition="'$(DotNetBuild)' == 'true'" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -54,14 +54,17 @@
   <Target Name="RemoveSatelliteDllsFromBuildOutputInPackage"
           BeforeTargets="GenerateNuspec"
           Condition="'$(IncludeSatelliteOutputInPack)' != 'true'">
+    <Message Text="Build Output before: %(_BuildOutputInPackage)" Importance="high" />
+
     <!--
       Could not find a way to tell NuGet to exclude the satellite assemblies from the NuGet package so this target
       does it.
     -->
     <ItemGroup>
-      <_BuildOutputInPackage Remove="@(_BuildOutputInPackage)"
-                             Condition="'%(Filename)%(Extension)' == '*.resources.dll'" />
+      <_BuildOutputInPackage Remove="$(IntermediateOutputPath)%(_TargetFramework.Identity)\**\$(AssemblyName).resources.dll" />
     </ItemGroup>
+
+    <Message Text="Build Output after: %(_BuildOutputInPackage)" Importance="high" />
   </Target>
 
   <Import Project="eng\dotnet-build\ExcludeFromDotNetBuild.AfterCommonTargets.targets" Condition="'$(DotNetBuild)' == 'true'" />

--- a/eng/dotnet-build/build.sh
+++ b/eng/dotnet-build/build.sh
@@ -74,7 +74,7 @@ function ReadGlobalVersion {
   local global_json_file="$repo_root/global.json"
 
   if command -v jq &> /dev/null; then
-    _ReadGlobalVersion="$(jq -r ".[] | select(has(\"$key\")) | .\"$key\"" "$global_json_file")"
+    _ReadGlobalVersion="$(cat "$global_json_file" | sed 's|//.*||' | jq -r ".[] | select(has(\"$key\")) | .\"$key\"")"
   elif [[ "$(cat "$global_json_file")" =~ \"$key\"[[:space:]\:]*\"([^\"]+) ]]; then
     _ReadGlobalVersion=${BASH_REMATCH[1]}
   fi

--- a/eng/dotnet-build/build.sh
+++ b/eng/dotnet-build/build.sh
@@ -88,19 +88,7 @@ function ReadGlobalVersion {
 if [[ "$DOTNET" == "" && "$DOTNET_PATH" != "" ]]; then
   export DOTNET="$DOTNET_PATH/dotnet"
 else
-  ReadGlobalVersion dotnet
-  export SDK_VERSION=$_ReadGlobalVersion
-
-  mkdir -p "${repo_root}cli"
-  curl -o "${repo_root}cli/dotnet-install.sh" -L https://dot.net/v1/dotnet-install.sh
-
-  if (( $? )); then
-    echo "Could not download 'dotnet-install.sh' script. Please check your network and try again!"
-    exit 1
-  fi
-  chmod +x "${repo_root}cli/dotnet-install.sh"
-
-  "${repo_root}cli/dotnet-install.sh" -v $SDK_VERSION -i "${repo_root}cli"
+  "${repo_root}configure.sh"
   export DOTNET=${repo_root}cli/dotnet
 fi
 

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -268,7 +268,14 @@ stages:
           inputs:
             targetType: "inline"
             script: |
-              ./eng/dotnet-build/build.sh --source-build
+              ./eng/dotnet-build/build.sh --source-build -bl
+        - task: PublishBuildArtifacts@1
+          displayName: "Publish binlog"
+          inputs:
+            PathtoPublish: "$(Build.SourcesDirectory)/artifacts/log"
+            ArtifactName: "binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)"
+            publishLocation: "Container"
+          condition: "always()"
     - ${{ if eq(parameters.RunStaticAnalysis, true) }}:
       - job:
         displayName: Run Static Analysis

--- a/global.json
+++ b/global.json
@@ -9,10 +9,6 @@
   "sdk": {
     "allowPrerelease": true
   },
-  "tools": {
-    "dotnet": "9.0.300",
-    "pinned": true
-  },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25479.115",
     "Microsoft.Build.NoTargets": "3.7.0"

--- a/global.json
+++ b/global.json
@@ -1,7 +1,12 @@
 {
+  // This empty file has no effect and is here to support Arcade-powered dotnet-build.
+  // The Arcade build process requires a global.json at the root of the repo and normally
+  // uses it to restore the necessary SDK and tools to build the repo.
+  // However, NuGet explitcly wants to use the ambient SDK (normally latest), not any particular
+  // version.  We also don't want to introduce MS.DN.Arcade.SDK into the non-dotnet-build build.
+  // eng/dotnet-build/global.json has the entry for the Arcade version we need for
+  // Arcade-powered dotnet-build.
   "sdk": {
-    "version": "9.0.300",
-    "rollForward": "latestMajor",
     "allowPrerelease": true
   },
   "tools": {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

VS often warns me I'm missing the .NET 9.0 SDK, I'm guessing because it sees global.json, even though I have the .NET 10 SDK installed and the product builds fine.  Also, our internal mirror is getting dependabot updates for global.json even though our build doesn't care what version of the SDK is used.

Our build used to work this way (without the SDK version in the global.json) before https://github.com/NuGet/NuGet.Client/pull/5764.  That PR added the SDK version into global.json, but our build scripts install a new SDK, so I don't feel like global.json is a good way to enforce a minimum SDK version given all the undesirable side effects it causes.

I validated that the dotnet VMR builds correctly with this change: https://github.com/dotnet/dotnet/pull/3105

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
