### PR TITLE
Fix unhandled exception in restore with transitive pinning and an unresolved dependency

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -543,12 +543,14 @@ namespace NuGet.Commands
                         // This should never happen, if the package was resolved there should be a calculated include type for it
                         // There have been bugs in the past where getting a value from the dictionary was throwing a KeyNotFoundException
                         // Log an error with the info needed asking the user to file an issue
-                        logger.LogError(
-                            string.Format(
-                                CultureInfo.CurrentCulture,
-                                Strings.Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType,
-                                centralPackageVersion.Name,
-                                node.Item.Key));
+                        logger.Log(
+                            LogMessage.CreateError(
+                                NuGetLogCode.NU1000,
+                                string.Format(
+                                    CultureInfo.CurrentCulture,
+                                    Strings.Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType,
+                                    centralPackageVersion.Name,
+                                    node.Item.Key)));
 
                         continue;
                     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -283,7 +283,7 @@ namespace NuGet.Commands
 
             PopulatePackageFolders(localRepositories.Select(repo => repo.RepositoryRoot).Distinct(), lockFile);
 
-            AddCentralTransitiveDependencyGroupsForPackageReference(project, lockFile, targetGraphs);
+            AddCentralTransitiveDependencyGroupsForPackageReference(project, lockFile, targetGraphs, _logger);
 
             // Add the original package spec to the lock file.
             lockFile.PackageSpec = project;
@@ -453,7 +453,7 @@ namespace NuGet.Commands
             }
         }
 
-        private void AddCentralTransitiveDependencyGroupsForPackageReference(PackageSpec project, LockFile lockFile, IEnumerable<RestoreTargetGraph> targetGraphs)
+        private void AddCentralTransitiveDependencyGroupsForPackageReference(PackageSpec project, LockFile lockFile, IEnumerable<RestoreTargetGraph> targetGraphs, ILogger logger)
         {
             if (project.RestoreMetadata == null || !project.RestoreMetadata.CentralPackageVersionsEnabled || !project.RestoreMetadata.CentralPackageTransitivePinningEnabled)
             {
@@ -472,7 +472,7 @@ namespace NuGet.Commands
                 }
 
                 // The transitive dependencies enforced by the central package version management file are written to the assets to be used by the pack task.
-                List<LibraryDependency> centralEnforcedTransitiveDependencies = GetLibraryDependenciesForCentralTransitiveDependencies(targetGraph, targetFrameworkInformation).ToList();
+                List<LibraryDependency> centralEnforcedTransitiveDependencies = GetLibraryDependenciesForCentralTransitiveDependencies(targetGraph, targetFrameworkInformation, logger).ToList();
 
                 if (centralEnforcedTransitiveDependencies.Any())
                 {
@@ -492,8 +492,9 @@ namespace NuGet.Commands
         /// </summary>
         /// <param name="targetGraph">The <see cref="RestoreTargetGraph" /> to get centrally defined transitive dependencies for.</param>
         /// <param name="targetFrameworkInformation">The <see cref="TargetFrameworkInformation" /> for the target framework to get centrally defined transitive dependencies for.</param>
+        /// <param name="logger">An <see cref="ILogger" /> to use for logging.</param>
         /// <returns>An <see cref="IEnumerable{LibraryDependency}" /> representing the centrally defined transitive dependencies for the specified <see cref="RestoreTargetGraph" />.</returns>
-        private IEnumerable<LibraryDependency> GetLibraryDependenciesForCentralTransitiveDependencies(RestoreTargetGraph targetGraph, TargetFrameworkInformation targetFrameworkInformation)
+        private IEnumerable<LibraryDependency> GetLibraryDependenciesForCentralTransitiveDependencies(RestoreTargetGraph targetGraph, TargetFrameworkInformation targetFrameworkInformation, ILogger logger)
         {
             HashSet<GraphNode<RemoteResolveResult>> visitedNodes = new HashSet<GraphNode<RemoteResolveResult>>();
             Queue<GraphNode<RemoteResolveResult>> queue = new Queue<GraphNode<RemoteResolveResult>>();
@@ -504,8 +505,12 @@ namespace NuGet.Commands
 
                 foreach (GraphNode<RemoteResolveResult> node in rootNode.InnerNodes)
                 {
-                    // Only consider nodes that are Accepted, IsCentralTransitive, and have a centrally defined package version
-                    if (node?.Item == null || node.Disposition != Disposition.Accepted || !node.Item.IsCentralTransitive || !targetFrameworkInformation.CentralPackageVersions?.ContainsKey(node.Item.Key.Name) == true)
+                    // Only consider nodes that are not unresolved, Accepted, IsCentralTransitive, and have a centrally defined package version
+                    if (node?.Item == null
+                        || node.Item.Key.Type == LibraryType.Unresolved
+                        || node.Disposition != Disposition.Accepted
+                        || !node.Item.IsCentralTransitive
+                        || !targetFrameworkInformation.CentralPackageVersions?.ContainsKey(node.Item.Key.Name) == true)
                     {
                         continue;
                     }
@@ -528,18 +533,34 @@ namespace NuGet.Commands
                     }
 
                     // If all assets are suppressed then the dependency should not be added
-                    if (suppressParent != LibraryIncludeFlags.All
-                        && dependenciesIncludeFlags.TryGetValue(centralPackageVersion.Name, out LibraryIncludeFlags includeType)) // Check if an include type was calculated, a value can be missing when during dependency resolution a package was not found
+                    if (suppressParent == LibraryIncludeFlags.All)
                     {
-                        yield return new LibraryDependency()
-                        {
-                            LibraryRange = new LibraryRange(centralPackageVersion.Name, centralPackageVersion.VersionRange, LibraryDependencyTarget.Package),
-                            ReferenceType = LibraryDependencyReferenceType.Transitive,
-                            VersionCentrallyManaged = true,
-                            IncludeType = includeType,
-                            SuppressParent = suppressParent,
-                        };
+                        continue;
                     }
+
+                    if (!dependenciesIncludeFlags.TryGetValue(centralPackageVersion.Name, out LibraryIncludeFlags includeType))
+                    {
+                        // This should never happen, if the package was resolved there should be a calculated include type for it
+                        // There have been bugs in the past where getting a value from the dictionary was throwing a KeyNotFoundException
+                        // Log an error with the info needed asking the user to file an issue
+                        logger.LogError(
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType,
+                                centralPackageVersion.Name,
+                                node.Item.Key));
+
+                        continue;
+                    }
+
+                    yield return new LibraryDependency()
+                    {
+                        LibraryRange = new LibraryRange(centralPackageVersion.Name, centralPackageVersion.VersionRange, LibraryDependencyTarget.Package),
+                        ReferenceType = LibraryDependencyReferenceType.Transitive,
+                        VersionCentrallyManaged = true,
+                        IncludeType = includeType,
+                        SuppressParent = suppressParent,
+                    };
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -528,14 +528,9 @@ namespace NuGet.Commands
                     }
 
                     // If all assets are suppressed then the dependency should not be added
-                    if (suppressParent != LibraryIncludeFlags.All)
+                    if (suppressParent != LibraryIncludeFlags.All
+                        && dependenciesIncludeFlags.TryGetValue(centralPackageVersion.Name, out LibraryIncludeFlags includeType)) // Check if an include type was calculated, a value can be missing when during dependency resolution a package was not found
                     {
-                        if (!dependenciesIncludeFlags.TryGetValue(centralPackageVersion.Name, out LibraryIncludeFlags includeType))
-                        {
-                            // This can happen when during dependency resolution a package was not found, so there will be no way to calculate its include type
-                            includeType = LibraryIncludeFlags.All;
-                        }
-
                         yield return new LibraryDependency()
                         {
                             LibraryRange = new LibraryRange(centralPackageVersion.Name, centralPackageVersion.VersionRange, LibraryDependencyTarget.Package),

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -530,12 +530,18 @@ namespace NuGet.Commands
                     // If all assets are suppressed then the dependency should not be added
                     if (suppressParent != LibraryIncludeFlags.All)
                     {
+                        if (!dependenciesIncludeFlags.TryGetValue(centralPackageVersion.Name, out LibraryIncludeFlags includeType))
+                        {
+                            // This can happen when during dependency resolution a package was not found, so there will be no way to calculate its include type
+                            includeType = LibraryIncludeFlags.All;
+                        }
+
                         yield return new LibraryDependency()
                         {
                             LibraryRange = new LibraryRange(centralPackageVersion.Name, centralPackageVersion.VersionRange, LibraryDependencyTarget.Package),
                             ReferenceType = LibraryDependencyReferenceType.Transitive,
                             VersionCentrallyManaged = true,
-                            IncludeType = dependenciesIncludeFlags[centralPackageVersion.Name],
+                            IncludeType = includeType,
                             SuppressParent = suppressParent,
                         };
                     }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.Commands {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -246,6 +246,15 @@ namespace NuGet.Commands {
         internal static string Error_CentralPackageManagement_MissingPackageVersion {
             get {
                 return ResourceManager.GetString("Error_CentralPackageManagement_MissingPackageVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The centrally pinned dependency &apos;{0}&apos; was not found in the resolved graph unexpectedly for node &apos;{1}&apos;. Please file an issue at https://github.com/NuGet/Home.
+        /// </summary>
+        internal static string Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType {
+            get {
+                return ResourceManager.GetString("Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType", resourceCulture);
             }
         }
         
@@ -754,7 +763,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project.json project type is deprecated. Migrate to PackageReference..
+        ///   Looks up a localized string similar to Managing packages with project.json is deprecated. Migrate to PackageReference..
         /// </summary>
         internal static string Error_ProjectJson_Deprecated {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -828,6 +828,9 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
       Do not localize `VersionOverride`
     </comment>
   </data>
+  <data name="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType" xml:space="preserve">
+    <value>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</value>
+  </data>
   <data name="Warning_CentralPackageManagement_MultipleSourcesWithoutPackageSourceMapping" xml:space="preserve">
     <value>There are {0} package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: {1}</value>
     <comment>0 - The number of package sources, 1 - The URL of the package sources, comma separated.</comment>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.cs.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">Následující položky PackageReference nemohou definovat hodnotu parametru Version: {0}. Projekty využívající CPM (Central Package Management) musí definovat hodnotu parametru Version pro položku PackageVersion. Další informace najdete na https://aka.ms/nuget/cpm/gettingstarted</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.de.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">Die folgenden PackageReference-Elemente können keinen Wert definieren für Version: {0}. Projekte, die die zentrale Paketverwaltung verwenden, müssen einen Versionswert für ein PackageVersion-Element definieren. Weitere Informationen finden Sie unter https://aka.ms/nuget/cpm/gettingstarted</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.es.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">Los siguientes elementos PackageReference no pueden definir un valor para la versión: {0}. Los proyectos que usan la Administración central de paquetes deben definir un valor de versión en un elemento PackageVersion. Para obtener más información, visite https://aka.ms/nuget/cpm/gettingstarted</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.fr.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">Les éléments PackageReference suivants ne peuvent pas définir de valeur pour la version : {0}. Les projets utilisant Package Management central doivent définir une valeur de version sur un élément PackageVersion. Pour plus d’informations, visitez https://aka.ms/nuget/cpm/gettingstarted</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.it.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">I seguenti elementi PackageReference non possono definire un valore per Version: {0}. I progetti che utilizzano la Gestione pacchetti centrale devono definire un valore Version in un elemento PackageVersion. Per altre informazioni, visita https://aka.ms/nuget/cpm/gettingstarted</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.ja.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">次の PackageReference 項目では、Version の値を定義できません: {0}。Central Package Management を使用するプロジェクトでは、PackageVersion 項目で Version 値を定義する必要があります。詳細情報については、https://aka.ms/nuget/cpm/gettingstarted を参照してください</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.ko.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">다음 PackageReference 항목은 버전에 대한 값을 정의할 수 없습니다. {0}. 중앙 패키지 관리를 사용하는 프로젝트는 PackageVersion 항목에 버전 값을 정의해야 합니다. 자세한 내용은 https://aka.ms/nuget/cpm/gettingstarted를 방문하세요.</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.pl.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">Następujące elementy PackageReference nie mogą definiować wartości dla wersji: {0}. Projekty korzystające z centralnego zarządzania pakietami muszą definiować wartość version w elemencie PackageVersion. Aby uzyskać więcej informacji, odwiedź witrynę https://aka.ms/nuget/cpm/gettingstarted</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.pt-BR.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">Os seguintes itens PackageReference não podem definir um valor para Versão: {0}. Projetos que usam o Gerenciamento Central de Pacotes devem definir um valor para a versão em um item PackageVersion. Para obter mais informações, visite https://aka.ms/nuget/cpm/gettingstarted</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.ru.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">Следующие элементы PackageReference не могут определять значение для версии: {0}. Проекты, использующие централизованное управление пакетами, должны определять значение версии в элементе PackageVersion. Дополнительные сведения см. на странице https://aka.ms/nuget/cpm/gettingstarted</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.tr.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">Aşağıdaki PackageReference öğeleri Sürüm için bir değer tanımlayamaz {0}. Merkezi Paket Yönetimi kullanan projeler, PackageVersion öğesinde bir Sürüm değeri tanımlamalıdır. Daha fazla bilgi için şu adresi ziyaret edin: https://aka.ms/nuget/cpm/gettingstarted</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hans.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">以下 PackageReference 项无法定义版本的值: {0}。使用中央包管理的项目必须在 PackageVersion 项上定义版本值。有关详细信息，请访问 https://aka.ms/nuget/cpm/gettingstarted</target>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hant.xlf
@@ -129,6 +129,11 @@
       Do not localize `PackageVersion`
     </note>
       </trans-unit>
+      <trans-unit id="Error_CentralPackageManagement_MissingTransitivelyPinnedIncludeType">
+        <source>The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</source>
+        <target state="new">The centrally pinned dependency '{0}' was not found in the resolved graph unexpectedly for node '{1}'. Please file an issue at https://github.com/NuGet/Home</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_CentralPackageManagement_PackageReferenceWithVersionNotAllowed">
         <source>The following PackageReference items cannot define a value for Version: {0}. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted</source>
         <target state="translated">下列 PackageReference 項目無法定義 Version: {0} 的值。使用中央套件管理的專案必須在 PackageVersion 項目上定義 Version 值。如需詳細資訊，請造訪 https://aka.ms/nuget/cpm/gettingstarted</target>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2751,6 +2751,113 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             }
         }
 
+        [Fact]
+        public async Task RestoreCommand_CentralVersion_AssetsFile_UnresolvedPackage()
+        {
+            // Arrange
+            var framework = new NuGetFramework("net46");
+
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var projectInfo = new
+                {
+                    Name = "ProjectA",
+                    Directory = Directory.CreateDirectory(Path.Combine(pathContext.SolutionRoot, "ProjectA")),
+                    Path = new FileInfo(Path.Combine(pathContext.SolutionRoot, "ProjectA", "Project1.csproj")).FullName
+                };
+
+                var logger = new TestLogger();
+
+                // PackageA 1.0.0 -> PackageB 1.0.0 -> PackageC 1.0.0 -> PackageD 1.0.0
+                var packageA = new PackageIdentity("PackageA", new NuGetVersion("1.0.0"));
+                var packageB = new PackageIdentity("PackageB", new NuGetVersion("1.0.0"));
+                var packageC = new PackageIdentity("PackageC", new NuGetVersion("1.0.0"));
+                var packageD = new PackageIdentity("PackageD", new NuGetVersion("1.0.0"));
+
+                var packageDContext = new SimpleTestPackageContext(packageD);
+                packageDContext.AddFile("lib/net46/PackageD.dll");
+                //await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, packageDContext);
+
+                var packageCContext = new SimpleTestPackageContext(packageC);
+                packageCContext.AddFile("lib/net46/PackageC.dll");
+                packageCContext.Dependencies.Add(packageDContext);
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, packageCContext);
+
+                var packageBContext = new SimpleTestPackageContext(packageB);
+                packageBContext.AddFile("lib/net46/PackageB.dll");
+                packageBContext.Dependencies.Add(packageCContext);
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, packageBContext);
+
+                var packageAContext = new SimpleTestPackageContext(packageA);
+                packageAContext.AddFile("lib/net46/PackageA.dll");
+                packageAContext.Dependencies.Add(packageBContext);
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, packageAContext);
+
+                var tfi = CreateTargetFrameworkInformation(
+                    [
+                        new LibraryDependency()
+                        {
+                            LibraryRange = new LibraryRange()
+                            {
+                                Name = packageA.Id,
+                                TypeConstraint = LibraryDependencyTarget.Package,
+                            },
+                            VersionCentrallyManaged = true,
+                            SuppressParent = LibraryIncludeFlags.Runtime | LibraryIncludeFlags.Compile
+                        },
+                    ],
+                    new List<CentralPackageVersion>
+                    {
+                        new CentralPackageVersion(packageA.Id, new VersionRange(packageA.Version)),
+                        new CentralPackageVersion(packageB.Id, new VersionRange(packageB.Version)),
+                        new CentralPackageVersion(packageD.Id, new VersionRange(packageD.Version))
+                    },
+                    framework);
+
+                PackageSpec packageSpec = CreatePackageSpec(
+                    new List<TargetFrameworkInformation>() { tfi },
+                    framework,
+                    projectInfo.Name,
+                    projectInfo.Path,
+                    centralPackageManagementEnabled: true,
+                    centralPackageTransitivePinningEnabled: true);
+
+
+                var dgspec = new DependencyGraphSpec();
+                dgspec.AddProject(packageSpec);
+
+                var request = new TestRestoreRequest(dgspec.GetProjectSpec(projectInfo.Name), new[] { new PackageSource(pathContext.PackageSource) }, pathContext.PackagesV2, logger)
+                {
+                    LockFilePath = Path.Combine(projectInfo.Directory.FullName, "project.assets.json"),
+                    ProjectStyle = ProjectStyle.PackageReference
+                };
+
+                var restoreCommand = new RestoreCommand(request);
+                var result = await restoreCommand.ExecuteAsync();
+                var lockFile = result.LockFile;
+
+                var targetLib = lockFile.Targets.First().Libraries.FirstOrDefault(l => l.Name == packageA.Id);
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal(1, lockFile.CentralTransitiveDependencyGroups.Count);
+
+                List<LibraryDependency> transitiveDependencies = lockFile.CentralTransitiveDependencyGroups.First().TransitiveDependencies.ToList();
+
+                Assert.Equal(2, transitiveDependencies.Count);
+
+                LibraryDependency transitiveDependencyB = transitiveDependencies.Single(i => i.Name.Equals(packageB.Id));
+
+                Assert.Equal(LibraryIncludeFlags.Runtime | LibraryIncludeFlags.Compile, transitiveDependencyB.SuppressParent);
+
+                LibraryDependency transitiveDependencyD = transitiveDependencies.Single(i => i.Name.Equals(packageD.Id));
+
+                Assert.Equal(LibraryIncludeFlags.All, transitiveDependencyD.IncludeType);
+
+                Assert.Equal(LibraryIncludeFlags.Runtime | LibraryIncludeFlags.Compile, transitiveDependencyD.SuppressParent);
+            }
+        }
+
         /// <summary>
         /// Verifies an error is logged when a user attempts to specify a VersionOverride but the feature is disabled and that restore succeeds if the feature is enabled.
         /// </summary>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2752,7 +2752,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
 
         [Fact]
-        public async Task RestoreCommand_CentralVersion_AssetsFile_UnresolvedPackage()
+        public async Task RestoreCommand_CentralVersion_AssetsFile_UnresolvedTransitivelyPinnedPackage()
         {
             // Arrange
             var framework = new NuGetFramework("net46");
@@ -2768,25 +2768,12 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
                 var logger = new TestLogger();
 
-                // PackageA 1.0.0 -> PackageB 1.0.0 -> PackageC 1.0.0 -> PackageD 1.0.0
+                // PackageA 1.0.0 -> PackageB 1.0.0
                 var packageA = new PackageIdentity("PackageA", new NuGetVersion("1.0.0"));
                 var packageB = new PackageIdentity("PackageB", new NuGetVersion("1.0.0"));
-                var packageC = new PackageIdentity("PackageC", new NuGetVersion("1.0.0"));
-                var packageD = new PackageIdentity("PackageD", new NuGetVersion("1.0.0"));
-
-                var packageDContext = new SimpleTestPackageContext(packageD);
-                packageDContext.AddFile("lib/net46/PackageD.dll");
-                //await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, packageDContext);
-
-                var packageCContext = new SimpleTestPackageContext(packageC);
-                packageCContext.AddFile("lib/net46/PackageC.dll");
-                packageCContext.Dependencies.Add(packageDContext);
-                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, packageCContext);
 
                 var packageBContext = new SimpleTestPackageContext(packageB);
                 packageBContext.AddFile("lib/net46/PackageB.dll");
-                packageBContext.Dependencies.Add(packageCContext);
-                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, packageBContext);
 
                 var packageAContext = new SimpleTestPackageContext(packageA);
                 packageAContext.AddFile("lib/net46/PackageA.dll");
@@ -2810,7 +2797,6 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                     {
                         new CentralPackageVersion(packageA.Id, new VersionRange(packageA.Version)),
                         new CentralPackageVersion(packageB.Id, new VersionRange(packageB.Version)),
-                        new CentralPackageVersion(packageD.Id, new VersionRange(packageD.Version))
                     },
                     framework);
 
@@ -2840,21 +2826,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
                 // Assert
                 Assert.False(result.Success);
-                Assert.Equal(1, lockFile.CentralTransitiveDependencyGroups.Count);
-
-                List<LibraryDependency> transitiveDependencies = lockFile.CentralTransitiveDependencyGroups.First().TransitiveDependencies.ToList();
-
-                Assert.Equal(2, transitiveDependencies.Count);
-
-                LibraryDependency transitiveDependencyB = transitiveDependencies.Single(i => i.Name.Equals(packageB.Id));
-
-                Assert.Equal(LibraryIncludeFlags.Runtime | LibraryIncludeFlags.Compile, transitiveDependencyB.SuppressParent);
-
-                LibraryDependency transitiveDependencyD = transitiveDependencies.Single(i => i.Name.Equals(packageD.Id));
-
-                Assert.Equal(LibraryIncludeFlags.All, transitiveDependencyD.IncludeType);
-
-                Assert.Equal(LibraryIncludeFlags.Runtime | LibraryIncludeFlags.Compile, transitiveDependencyD.SuppressParent);
+                Assert.Equal(0, lockFile.CentralTransitiveDependencyGroups.Count);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -2759,65 +2759,51 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectInfo = new
-                {
-                    Name = "ProjectA",
-                    Directory = Directory.CreateDirectory(Path.Combine(pathContext.SolutionRoot, "ProjectA")),
-                    Path = new FileInfo(Path.Combine(pathContext.SolutionRoot, "ProjectA", "Project1.csproj")).FullName
-                };
-
-                var logger = new TestLogger();
+                var projectDirectory = new DirectoryInfo(Path.Combine(pathContext.SolutionRoot, "Project1"));
 
                 // PackageA 1.0.0 -> PackageB 1.0.0
-                var packageA = new PackageIdentity("PackageA", new NuGetVersion("1.0.0"));
-                var packageB = new PackageIdentity("PackageB", new NuGetVersion("1.0.0"));
+                var packageA = new SimpleTestPackageContext { Id = "PackageA", Version = "1.0.0", };
+                var packageB = new SimpleTestPackageContext { Id = "PackageB", Version = "1.0.0", };
 
-                var packageBContext = new SimpleTestPackageContext(packageB);
-                packageBContext.AddFile("lib/net46/PackageB.dll");
+                packageA.Dependencies.Add(packageB);
 
-                var packageAContext = new SimpleTestPackageContext(packageA);
-                packageAContext.AddFile("lib/net46/PackageA.dll");
-                packageAContext.Dependencies.Add(packageBContext);
-                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, packageAContext);
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, packageA);
 
-                var tfi = CreateTargetFrameworkInformation(
+                var projectSpec = PackageReferenceSpecBuilder.Create("Project1", projectDirectory.FullName)
+                    .WithTargetFrameworks(
                     [
-                        new LibraryDependency()
+                        new TargetFrameworkInformation
                         {
-                            LibraryRange = new LibraryRange()
+                            FrameworkName = NuGetFramework.Parse("net46"),
+                            Dependencies =
+                            [
+                                new LibraryDependency
+                                {
+                                    LibraryRange = new LibraryRange(packageA.PackageName, VersionRange.Parse(packageA.Version), LibraryDependencyTarget.All),
+                                    VersionCentrallyManaged = true,
+                                },
+                            ],
+                            CentralPackageVersions = new Dictionary<string, CentralPackageVersion>(StringComparer.OrdinalIgnoreCase)
                             {
-                                Name = packageA.Id,
-                                TypeConstraint = LibraryDependencyTarget.Package,
-                            },
-                            VersionCentrallyManaged = true,
-                            SuppressParent = LibraryIncludeFlags.Runtime | LibraryIncludeFlags.Compile
-                        },
-                    ],
-                    new List<CentralPackageVersion>
-                    {
-                        new CentralPackageVersion(packageA.Id, new VersionRange(packageA.Version)),
-                        new CentralPackageVersion(packageB.Id, new VersionRange(packageB.Version)),
-                    },
-                    framework);
+                                { packageA.PackageName, new CentralPackageVersion(packageA.PackageName, VersionRange.Parse(packageA.Version)) },
+                                { packageB.PackageName, new CentralPackageVersion(packageB.PackageName, VersionRange.Parse(packageB.Version)) }
+                            }
+                        }
+                    ])
+                    .WithCentralPackageVersionsEnabled()
+                    .WithCentralPackageTransitivePinningEnabled()
+                    .Build()
+                    .WithTestRestoreMetadata();
 
-                PackageSpec packageSpec = CreatePackageSpec(
-                    new List<TargetFrameworkInformation>() { tfi },
-                    framework,
-                    projectInfo.Name,
-                    projectInfo.Path,
-                    centralPackageManagementEnabled: true,
-                    centralPackageTransitivePinningEnabled: true);
-
-
-                var dgspec = new DependencyGraphSpec();
-                dgspec.AddProject(packageSpec);
-
-                var request = new TestRestoreRequest(dgspec.GetProjectSpec(projectInfo.Name), new[] { new PackageSource(pathContext.PackageSource) }, pathContext.PackagesV2, logger)
+                // Act
+                var restoreContext = new RestoreArgs()
                 {
-                    LockFilePath = Path.Combine(projectInfo.Directory.FullName, "project.assets.json"),
-                    ProjectStyle = ProjectStyle.PackageReference
+                    Sources = new List<string> { pathContext.PackageSource },
+                    GlobalPackagesFolder = pathContext.UserPackagesFolder,
+                    Log = NullLogger.Instance,
+                    CacheContext = new TestSourceCacheContext(),
                 };
-
+                var request = await ProjectTestHelpers.GetRequestAsync(restoreContext, projectSpec);
                 var restoreCommand = new RestoreCommand(request);
                 var result = await restoreCommand.ExecuteAsync();
                 var lockFile = result.LockFile;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14198
Fixes: https://github.com/NuGet/Home/issues/11028

## Description
During restore, a package can be unresolved but an assets file is still written. When transitive pinning is enabled, the resolver calculates the `IncludeAssets` as the intersection of all of the packages that referenced that one.  However, when a package is unresolved, the restore will fail and there's no information about the package to calculate the include, leading to an error about the unresolved package as well as an unhandled exception related to a dictionary lookup.

This change skips any package that is unresolved since the restore will fail anyway.  Subsequent restores will correctly calculate the include type.

I also added a new error to log asking the user to file an issue since this bug should be fixed as far as we know but we don't want to throw a `KeyNotFoundException`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
