### PR TITLE
Resize PM UI checkbox texts to correct size

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -189,23 +189,9 @@
         <Grid.ColumnDefinitions>
           <ColumnDefinition MaxWidth="320" MinWidth="118"/>
           <ColumnDefinition Width="auto" />
-          <ColumnDefinition MaxWidth="{Binding ActualWidth, ElementName=_measurerPrerelease}" />
-          <ColumnDefinition MaxWidth="{Binding ActualWidth, ElementName=_measurerVulnerabilities}" />
+          <ColumnDefinition MaxWidth="{Binding ActualWidth, ElementName=_checkboxPrerelease}" />
+          <ColumnDefinition MaxWidth="{Binding ActualWidth, ElementName=_checkboxVulnerabilities}" />
         </Grid.ColumnDefinitions>
-
-        <!-- hidden text measurers mirror the checkbox labels so we can bind MaxWidth -->
-        <TextBlock
-          x:Name="_measurerPrerelease"
-          Visibility="Hidden"
-          Text="{x:Static nuget:Resources.Checkbox_IncludePrerelease}"
-          FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl}}"
-          FontFamily="{Binding FontFamily, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
-        <TextBlock
-          x:Name="_measurerVulnerabilities"
-          Visibility="Hidden"
-          Text="{x:Static nuget:Resources.Checkbox_Show_Vulnerable_Only}"
-          FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl}}"
-          FontFamily="{Binding FontFamily, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
 
         <!-- container of the search control -->
         <Border

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -189,9 +189,24 @@
         <Grid.ColumnDefinitions>
           <ColumnDefinition MaxWidth="320" MinWidth="118"/>
           <ColumnDefinition Width="auto" />
-          <ColumnDefinition MaxWidth="125" />
-          <ColumnDefinition MaxWidth="150"/>
+          <ColumnDefinition MaxWidth="{Binding ActualWidth, ElementName=_measurerPrerelease}" />
+          <ColumnDefinition MaxWidth="{Binding ActualWidth, ElementName=_measurerVulnerabilities}" />
         </Grid.ColumnDefinitions>
+
+        <!-- hidden text measurers mirror the checkbox labels so we can bind MaxWidth -->
+        <TextBlock
+          x:Name="_measurerPrerelease"
+          Visibility="Hidden"
+          Text="{x:Static nuget:Resources.Checkbox_IncludePrerelease}"
+          FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl}}"
+          FontFamily="{Binding FontFamily, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+        <TextBlock
+          x:Name="_measurerVulnerabilities"
+          Visibility="Hidden"
+          Text="{x:Static nuget:Resources.Checkbox_Show_Vulnerable_Only}"
+          FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl}}"
+          FontFamily="{Binding FontFamily, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+
         <!-- container of the search control -->
         <Border
           Grid.Column="0"

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
@@ -43,6 +43,51 @@ namespace NuGet.PackageManagement.UI
             var cvs = Resources["cvsPackageSources"] as CollectionViewSource;
             cvs.Culture = CultureInfo.DefaultThreadCurrentUICulture;
             cvs.Source = PackageSources;
+
+            // Hook Loaded so we can measure hidden text measurers and set column MaxWidth.
+            Loaded += PackageManagerTopPanel_Loaded;
+        }
+
+        private void PackageManagerTopPanel_Loaded(object sender, RoutedEventArgs e)
+        {
+            // Perform an immediate measurement to initialize column widths.
+            UpdateMeasuredColumnWidths();
+        }
+
+        private void UpdateMeasuredColumnWidths()
+        {
+            try
+            {
+                if (_measurerPrerelease == null || _measurerVulnerabilities == null || _checkboxPrerelease == null)
+                {
+                    return;
+                }
+
+                // Measure the hidden TextBlocks with infinite available width so they compute their natural width.
+                _measurerPrerelease.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                _measurerVulnerabilities.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+
+                double w1 = _measurerPrerelease.DesiredSize.Width;
+                double w2 = _measurerVulnerabilities.DesiredSize.Width;
+
+                // Add some slack to account for the checkbox glyph and margins.
+                const double extra = 28.0;
+
+                var parentGrid = _checkboxPrerelease.Parent as Grid;
+                if (parentGrid != null && parentGrid.ColumnDefinitions.Count > 3)
+                {
+                    parentGrid.ColumnDefinitions[2].MaxWidth = w1 + extra;
+                    parentGrid.ColumnDefinitions[3].MaxWidth = w2 + extra;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Swallow exceptions from layout/measure to avoid breaking UI initialization.
+            }
+            catch (ArgumentException)
+            {
+                // Swallow exceptions from layout/measure to avoid breaking UI initialization.
+            }
         }
 
         public void CreateAndAddConsolidateTab()

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
@@ -58,26 +58,23 @@ namespace NuGet.PackageManagement.UI
         {
             try
             {
-                if (_measurerPrerelease == null || _measurerVulnerabilities == null || _checkboxPrerelease == null)
+                if (_checkboxPrerelease == null || _checkboxVulnerabilities == null)
                 {
                     return;
                 }
 
                 // Measure the hidden TextBlocks with infinite available width so they compute their natural width.
-                _measurerPrerelease.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
-                _measurerVulnerabilities.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                _checkboxPrerelease.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                _checkboxVulnerabilities.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
 
-                double w1 = _measurerPrerelease.DesiredSize.Width;
-                double w2 = _measurerVulnerabilities.DesiredSize.Width;
-
-                // Add some slack to account for the checkbox glyph and margins.
-                const double extra = 28.0;
+                double w1 = _checkboxPrerelease.DesiredSize.Width;
+                double w2 = _checkboxVulnerabilities.DesiredSize.Width;
 
                 var parentGrid = _checkboxPrerelease.Parent as Grid;
                 if (parentGrid != null && parentGrid.ColumnDefinitions.Count > 3)
                 {
-                    parentGrid.ColumnDefinitions[2].MaxWidth = w1 + extra;
-                    parentGrid.ColumnDefinitions[3].MaxWidth = w2 + extra;
+                    parentGrid.ColumnDefinitions[2].MaxWidth = w1;
+                    parentGrid.ColumnDefinitions[3].MaxWidth = w2;
                 }
             }
             catch (InvalidOperationException)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13002
Fixes: https://github.com/NuGet/Home/issues/13002

## Description
We added text trimming to the PM UI checkbox texts when the size of the window is too small, but in XAML, you need to specify a minWidth or maxWidth to ave the trimming working. 

Currently, we set a fixed maxWidth size these texts that fit perfectly in most scales and resolutions, but if you have a different configuration the texts are trimmed since we don't do any custom calculations.

This PR tries to fix that by adding a "ghost" TextBlock that contains the text and help us to calculate the MaxWidth of the Column when we render the PM UI.

This implementation only calculates the size of the column on load to avoid doing recalculations when resizing the PM UI or VS, if there is a change in scale, DPI or text size during PMUI session, users would need to reopen the PM UI to recalculate.

"Normal" scale in small window
<img width="586" height="88" alt="image" src="https://github.com/user-attachments/assets/4a34251c-86ba-4f7f-9520-c8e9058de72d" />

Increased system font no longer trims the text
<img width="1509" height="142" alt="image" src="https://github.com/user-attachments/assets/11e692dd-c535-495e-826a-46d243205621" />

Increased font and small window
<img width="781" height="154" alt="image" src="https://github.com/user-attachments/assets/a968fb19-930f-4aca-b318-803e689342cb" />


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[ ] Added tests~ Manually tested
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
