### PR TITLE
[Feature]Add package download

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadArgs.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using NuGet.Common;
+
+namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload;
+
+internal record PackageDownloadArgs
+{
+    public IReadOnlyList<PackageWithNuGetVersion>? Packages { get; set; }
+    public IList<string>? Sources { get; set; }
+    public string? OutputDirectory { get; set; }
+    public string? ConfigFile { get; set; }
+    public bool IncludePrerelease { get; set; }
+    public bool AllowInsecureConnections { get; set; }
+    public bool Interactive { get; set; }
+    public LogLevel LogLevel { get; set; }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadCommand.cs
@@ -1,0 +1,97 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
+{
+    internal class PackageDownloadCommand
+    {
+        internal static void Register(Command packageCommand, Option<bool> interactiveOption)
+        {
+            Register(packageCommand, interactiveOption, PackageDownloadRunner.RunAsync);
+        }
+
+        public static void Register(Command packageCommand, Option<bool> interactiveOption, Func<PackageDownloadArgs, CancellationToken, Task<int>> action)
+        {
+            var downloadCommand = new DocumentedCommand(
+                "download",
+                Strings.PackageDownloadCommand_Description,
+                "https://aka.ms/dotnet/package/download");
+
+            // Arguments
+            var packagesArguments = new Argument<IReadOnlyList<PackageWithNuGetVersion>>("packages")
+            {
+                Description = Strings.PackageUpdate_PackageArgumentDescription,
+                Arity = ArgumentArity.OneOrMore,
+                CustomParser = PackageWithNuGetVersion.Parse
+            };
+
+            // Options
+            var allowInsecureConnections = new Option<bool>("--allow-insecure-connections")
+            {
+                Description = Strings.PackageDownloadCommand_AllowInsecureConnectionsDescription,
+                Arity = ArgumentArity.Zero
+            };
+
+            var configFile = new Option<string>("--configfile")
+            {
+                Description = Strings.Option_ConfigFile,
+                Arity = ArgumentArity.ExactlyOne
+            };
+
+            var outputDirectory = new Option<string>("--output", "-o")
+            {
+                Description = Strings.PackageDownloadCommand_OutputDirectoryDescription,
+                Arity = ArgumentArity.ExactlyOne
+            };
+
+            var prerelease = new Option<bool>("--prerelease")
+            {
+                Description = Strings.Prerelease_Description,
+                Arity = ArgumentArity.Zero
+            };
+
+            var sources = new Option<List<string>>("--source", "-s")
+            {
+                Description = Strings.PackageDownloadCommand_SourcesDescription,
+                Arity = ArgumentArity.OneOrMore
+            };
+
+            var verbosity = CommonOptions.GetVerbosityOption();
+
+            downloadCommand.Arguments.Add(packagesArguments);
+            downloadCommand.Options.Add(allowInsecureConnections);
+            downloadCommand.Options.Add(configFile);
+            downloadCommand.Options.Add(interactiveOption);
+            downloadCommand.Options.Add(outputDirectory);
+            downloadCommand.Options.Add(prerelease);
+            downloadCommand.Options.Add(sources);
+            downloadCommand.Options.Add(verbosity);
+
+            downloadCommand.SetAction(async (parserResult, cancellationToken) =>
+            {
+                IReadOnlyList<PackageWithNuGetVersion> packages = parserResult.GetValue(packagesArguments) ?? [];
+                var args = new PackageDownloadArgs()
+                {
+                    Packages = packages,
+                    Sources = parserResult.GetValue(sources),
+                    OutputDirectory = parserResult.GetValue(outputDirectory),
+                    IncludePrerelease = parserResult.GetValue(prerelease),
+                    AllowInsecureConnections = parserResult.GetValue(allowInsecureConnections),
+                    Interactive = parserResult.GetValue(interactiveOption),
+                    ConfigFile = parserResult.GetValue(configFile),
+                    LogLevel = (parserResult.GetValue(verbosity) ?? VerbosityEnum.normal).ToLogLevel()
+                };
+
+                return await action(args, cancellationToken);
+            });
+
+            packageCommand.Subcommands.Add(downloadCommand);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -48,18 +50,32 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
 
         public static async Task<int> RunAsync(PackageDownloadArgs args, ILoggerWithColor logger, IReadOnlyList<PackageSource> packageSources, ISettings settings, CancellationToken token)
         {
-            // Check for insecure sources
-            if (DetectAndReportInsecureSources(args.AllowInsecureConnections, packageSources, logger))
+            bool hasSourcesArg = args.Sources?.Count > 0;
+            PackageSourceMapping? packageSourceMapping = null;
+            if (!hasSourcesArg)
+            {
+                packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+            }
+
+            bool ignorePackageSourceMapping =
+                hasSourcesArg
+                || packageSourceMapping is null
+                || !packageSourceMapping.IsEnabled;
+
+            // When package source mapping is disabled, validate all configured sources upfront.
+            // When mapping is enabled, source validation is deferred to the per-package resolution step,
+            // since each package may map to a different subset of sources.
+            if (ignorePackageSourceMapping && DetectAndReportInsecureSources(args.AllowInsecureConnections, packageSources, logger))
             {
                 return ExitCodeError;
             }
 
             string outputDirectory = args.OutputDirectory ?? Directory.GetCurrentDirectory();
             var cache = new SourceCacheContext();
-            IReadOnlyList<SourceRepository> sourceRepositories = GetSourceRepositories(packageSources);
+            IReadOnlyList<SourceRepository> allRepositories = GetSourceRepositories(packageSources);
             bool downloadedAllSuccessfully = true;
 
-            foreach (var package in args.Packages)
+            foreach (var package in args.Packages ?? [])
             {
                 logger.LogMinimal(string.Format(
                     CultureInfo.CurrentCulture,
@@ -67,9 +83,29 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
                     package.Id,
                     string.IsNullOrEmpty(package.NuGetVersion?.ToNormalizedString()) ? Strings.PackageDownloadCommand_LatestVersion : package.NuGetVersion.ToNormalizedString()));
 
+                // Resolve which repositories to use for this package
+                IReadOnlyList<SourceRepository> sourceRepositories;
+                if (ignorePackageSourceMapping)
+                {
+                    sourceRepositories = allRepositories;
+                }
+                else
+                {
+                    if (!TryGetRepositoriesForPackage(
+                        package.Id,
+                        args,
+                        packageSourceMapping!,
+                        allRepositories,
+                        logger,
+                        out sourceRepositories))
+                    {
+                        return ExitCodeError;
+                    }
+                }
+
                 try
                 {
-                    (NuGetVersion version, SourceRepository downloadRepository) =
+                    (NuGetVersion? version, SourceRepository? downloadRepository) =
                         await ResolvePackageDownloadVersion(
                             package,
                             sourceRepositories,
@@ -88,7 +124,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
                     bool success = await DownloadPackageAsync(
                         package.Id,
                         version,
-                        downloadRepository,
+                        downloadRepository!,
                         cache,
                         settings,
                         outputDirectory,
@@ -127,16 +163,16 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             return downloadedAllSuccessfully ? ExitCodeSuccess : ExitCodeError;
         }
 
-        internal static async Task<(NuGetVersion, SourceRepository)> ResolvePackageDownloadVersion(
+        internal static async Task<(NuGetVersion?, SourceRepository?)> ResolvePackageDownloadVersion(
             PackageWithNuGetVersion packageWithNuGetVersion,
-            IEnumerable<SourceRepository> sourceRepositories,
+            IReadOnlyList<SourceRepository> sourceRepositories,
             SourceCacheContext cache,
             ILoggerWithColor logger,
             bool includePrerelease,
             CancellationToken token)
         {
-            NuGetVersion versionToDownload = null;
-            SourceRepository downloadSourceRepository = null;
+            NuGetVersion? versionToDownload = null;
+            SourceRepository? downloadSourceRepository = null;
             bool versionSpecified = packageWithNuGetVersion.NuGetVersion != null;
 
             foreach (var repo in sourceRepositories)
@@ -186,6 +222,69 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             }
 
             return (versionToDownload, downloadSourceRepository);
+        }
+
+        /// <summary>
+        /// Builds the set of SourceRepository objects to use for a given package,
+        /// applying package source mapping
+        /// validating HTTP usage only on the *effective* sources.
+        /// </summary>
+        private static bool TryGetRepositoriesForPackage(
+            string packageId,
+            PackageDownloadArgs args,
+            PackageSourceMapping packageSourceMapping,
+            IReadOnlyList<SourceRepository> allRepos,
+            ILoggerWithColor logger,
+            out IReadOnlyList<SourceRepository> repositories)
+        {
+            var mappedNames = packageSourceMapping.GetConfiguredPackageSources(packageId);
+
+            // Only validate insecure sources when mapping produced something
+            if (mappedNames.Count > 0)
+            {
+                var mappedRepos = new List<SourceRepository>(mappedNames.Count);
+                foreach (var mappedName in mappedNames)
+                {
+                    SourceRepository? repo = null;
+                    for (int i = 0; i < allRepos.Count; i++)
+                    {
+                        if (string.Equals(allRepos[i].PackageSource.Name, mappedName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            repo = allRepos[i];
+                            break;
+                        }
+                    }
+
+                    if (repo != null)
+                    {
+                        mappedRepos.Add(repo);
+                    }
+                    else
+                    {
+                        logger.LogVerbose(
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.PackageDownloadCommand_PackageSourceMapping_NoSuchSource,
+                                mappedName,
+                                packageId));
+                    }
+                }
+
+                if (DetectAndReportInsecureSources(args.AllowInsecureConnections, mappedRepos.Select(repo => repo.PackageSource), logger))
+                {
+                    repositories = [];
+                    return false;
+                }
+
+                repositories = mappedRepos;
+                return true;
+            }
+            else
+            {
+                // No mapping for this package: fall back to all sources
+                repositories = allRepos;
+                return true;
+            }
         }
 
         private static async Task<bool> DownloadPackageAsync(
@@ -239,7 +338,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             return success;
         }
 
-        private static IReadOnlyList<PackageSource> GetPackageSources(IList<string> sources, IPackageSourceProvider sourceProvider)
+        private static IReadOnlyList<PackageSource> GetPackageSources(IList<string>? sources, IPackageSourceProvider sourceProvider)
         {
             IEnumerable<PackageSource> configuredSources = sourceProvider.LoadPackageSources()
                 .Where(s => s.IsEnabled);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
@@ -1,0 +1,286 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.CommandLine.XPlat.Utility;
+using NuGet.Commands;
+using NuGet.Configuration;
+using NuGet.Credentials;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Repositories;
+using NuGet.Versioning;
+
+namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
+{
+    internal static class PackageDownloadRunner
+    {
+        internal const int ExitCodeError = 1;
+        internal const int ExitCodeSuccess = 0;
+
+        public static async Task<int> RunAsync(PackageDownloadArgs args, CancellationToken token)
+        {
+            ILoggerWithColor logger = new CommandOutputLogger(args.LogLevel)
+            {
+                HidePrefixForInfoAndMinimal = true
+            };
+
+            XPlatUtility.ConfigureProtocol();
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(logger, !args.Interactive);
+            ISettings settings = Settings.LoadDefaultSettings(
+                Directory.GetCurrentDirectory(),
+                args.ConfigFile,
+                new XPlatMachineWideSetting());
+            IReadOnlyList<PackageSource> packageSources = GetPackageSources(args.Sources, new PackageSourceProvider(settings));
+
+            return await RunAsync(args, logger, packageSources, settings, token);
+        }
+
+        public static async Task<int> RunAsync(PackageDownloadArgs args, ILoggerWithColor logger, IReadOnlyList<PackageSource> packageSources, ISettings settings, CancellationToken token)
+        {
+            // Check for insecure sources
+            if (DetectAndReportInsecureSources(args.AllowInsecureConnections, packageSources, logger))
+            {
+                return ExitCodeError;
+            }
+
+            string outputDirectory = args.OutputDirectory ?? Directory.GetCurrentDirectory();
+            var cache = new SourceCacheContext();
+            IReadOnlyList<SourceRepository> sourceRepositories = GetSourceRepositories(packageSources);
+            bool downloadedAllSuccessfully = true;
+
+            foreach (var package in args.Packages)
+            {
+                logger.LogMinimal(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.PackageDownloadCommand_Starting,
+                    package.Id,
+                    string.IsNullOrEmpty(package.NuGetVersion?.ToNormalizedString()) ? Strings.PackageDownloadCommand_LatestVersion : package.NuGetVersion.ToNormalizedString()));
+
+                try
+                {
+                    (NuGetVersion version, SourceRepository downloadRepository) =
+                        await ResolvePackageDownloadVersion(
+                            package,
+                            sourceRepositories,
+                            cache,
+                            logger,
+                            args.IncludePrerelease,
+                            token);
+
+                    if (version == null)
+                    {
+                        // Unable to find a valid version
+                        downloadedAllSuccessfully &= false;
+                        continue;
+                    }
+
+                    bool success = await DownloadPackageAsync(
+                        package.Id,
+                        version,
+                        downloadRepository,
+                        cache,
+                        settings,
+                        outputDirectory,
+                        logger,
+                        token);
+
+                    if (success)
+                    {
+                        logger.LogMinimal(string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.PackageDownloadCommand_Succeeded,
+                            package.Id,
+                            version,
+                            outputDirectory));
+                    }
+                    else
+                    {
+                        logger.LogError(string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.PackageDownloadCommand_Failed,
+                            package.Id,
+                            version));
+
+                        downloadedAllSuccessfully &= false;
+                    }
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception ex)
+                {
+                    logger.LogError(ex.ToString());
+                    downloadedAllSuccessfully &= false;
+                }
+#pragma warning restore CA1031 // Do not catch general exception types
+            }
+
+            return downloadedAllSuccessfully ? ExitCodeSuccess : ExitCodeError;
+        }
+
+        internal static async Task<(NuGetVersion, SourceRepository)> ResolvePackageDownloadVersion(
+            PackageWithNuGetVersion packageWithNuGetVersion,
+            IEnumerable<SourceRepository> sourceRepositories,
+            SourceCacheContext cache,
+            ILoggerWithColor logger,
+            bool includePrerelease,
+            CancellationToken token)
+        {
+            NuGetVersion versionToDownload = null;
+            SourceRepository downloadSourceRepository = null;
+            bool versionSpecified = packageWithNuGetVersion.NuGetVersion != null;
+
+            foreach (var repo in sourceRepositories)
+            {
+                var finder = await repo.GetResourceAsync<PackageMetadataResource>(token);
+                var packages = await finder.GetMetadataAsync(
+                    packageWithNuGetVersion.Id,
+                    includePrerelease,
+                    includeUnlisted: versionSpecified, // only load unlisted if an exact version is specified
+                    sourceCacheContext: cache,
+                    logger,
+                    token);
+
+                if (packages == null)
+                {
+                    continue;
+                }
+
+                if (versionSpecified)
+                {
+                    // If an exact version is specified, check if it exists at this source
+                    foreach (var package in packages)
+                    {
+                        if (package?.Identity?.Version == packageWithNuGetVersion.NuGetVersion)
+                        {
+                            return (packageWithNuGetVersion.NuGetVersion, repo);
+                        }
+                    }
+
+                    continue;
+                }
+
+                foreach (var package in packages)
+                {
+                    var version = package.Identity.Version;
+                    if (versionToDownload == null || version > versionToDownload)
+                    {
+                        versionToDownload = version;
+                        downloadSourceRepository = repo;
+                    }
+                }
+            }
+
+            if (versionToDownload == null)
+            {
+                logger.LogError(Strings.Error_PackageDownload_VersionNotFound);
+            }
+
+            return (versionToDownload, downloadSourceRepository);
+        }
+
+        private static async Task<bool> DownloadPackageAsync(
+            string id,
+            NuGetVersion version,
+            SourceRepository repo,
+            SourceCacheContext cache,
+            ISettings settings,
+            string outputDirectory,
+            Common.ILogger logger,
+            CancellationToken token)
+        {
+            var extractionContext = new PackageExtractionContext(
+                PackageSaveMode.Defaultv3,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                ClientPolicyContext.GetClientPolicy(settings, logger),
+                logger);
+
+            var resolver = new VersionFolderPathResolver(outputDirectory);
+            var userPackageFolder = new NuGetv3LocalRepository(outputDirectory);
+
+            // no-op if already installed
+            if (userPackageFolder.Exists(id, version))
+            {
+                logger.LogMinimal(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.PackageDownloadCommand_AlreadyInstalled,
+                    id,
+                    version.ToNormalizedString(),
+                    outputDirectory));
+
+                return true;
+            }
+
+            var packageIdentity = new PackageIdentity(id, version);
+            var provider = new SourceRepositoryDependencyProvider(sourceRepository: repo, logger: logger, cacheContext: cache, ignoreFailedSources: false, ignoreWarning: false);
+            using var downloader = await provider.GetPackageDownloaderAsync(packageIdentity, cache, logger, token);
+            bool success = await PackageExtractor.InstallFromSourceAsync(packageIdentity, downloader, resolver, extractionContext, token);
+
+            if (!success)
+            {
+                logger.LogError(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.PackageDownloadCommand_UnableToDownload,
+                    id,
+                    version.ToNormalizedString(),
+                    repo.PackageSource.Source));
+                return false;
+            }
+
+            return success;
+        }
+
+        private static IReadOnlyList<PackageSource> GetPackageSources(IList<string> sources, IPackageSourceProvider sourceProvider)
+        {
+            IEnumerable<PackageSource> configuredSources = sourceProvider.LoadPackageSources()
+                .Where(s => s.IsEnabled);
+
+            if (sources != null && sources.Count > 0)
+            {
+                // Use sources specified on command line
+                return [.. sources.Select(s => PackageSourceProviderExtensions.ResolveSource(configuredSources, s))];
+            }
+
+            return [.. configuredSources];
+        }
+
+        private static bool DetectAndReportInsecureSources(
+            bool allowInsecureConnections,
+            IEnumerable<PackageSource> packageSources,
+            ILoggerWithColor logger)
+        {
+            if (!allowInsecureConnections)
+            {
+                var insecureSources = HttpSourcesUtility.GetDisallowedInsecureHttpSources([.. packageSources]);
+                if (insecureSources.Any())
+                {
+                    logger.LogError(HttpSourcesUtility.BuildHttpSourceErrorMessage(insecureSources, "package download"));
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static IReadOnlyList<SourceRepository> GetSourceRepositories(IReadOnlyList<PackageSource> packageSources)
+        {
+            IEnumerable<Lazy<INuGetResourceProvider>> providers = Repository.Provider.GetCoreV3();
+            List<SourceRepository> sourceRepositories = [];
+            foreach (var source in packageSources)
+            {
+                sourceRepositories.Add(Repository.CreateSource(providers, source, FeedType.Undefined));
+            }
+
+            return sourceRepositories;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
@@ -72,7 +72,7 @@ namespace NuGet.CommandLine.XPlat
 
                 var prerelease = addpkg.Option(
                     "--prerelease",
-                    Strings.AddPkg_PackagePrerelease,
+                    Strings.Prerelease_Description,
                     CommandOptionType.NoValue);
 
                 addpkg.OnExecute(() =>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGetCommands.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGetCommands.cs
@@ -4,6 +4,7 @@
 using System;
 using System.CommandLine;
 using System.Linq;
+using NuGet.CommandLine.XPlat.Commands.Package.PackageDownload;
 using NuGet.CommandLine.XPlat.Commands.Package.Update;
 
 namespace NuGet.CommandLine.XPlat;
@@ -30,6 +31,7 @@ public static class NuGetCommands
         }
 
         PackageUpdateCommand.Register(packageCommand, interactiveOption);
+        PackageDownloadCommand.Register(packageCommand, interactiveOption);
     }
 
     // To delete once the SDK starts using the other overload. Joys of public APIs.

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -11,6 +11,9 @@ using Microsoft.Extensions.CommandLineUtils;
 using NuGet.CommandLine.XPlat.Commands.Package.Update;
 using NuGet.Commands;
 using NuGet.Common;
+#if DEBUG
+using NuGet.CommandLine.XPlat.Commands.Package.PackageDownload;
+#endif
 
 namespace NuGet.CommandLine.XPlat
 {
@@ -100,6 +103,9 @@ namespace NuGet.CommandLine.XPlat
 
                     PackageSearchCommand.Register(packageCommand, getHidePrefixLogger);
                     PackageUpdateCommand.Register(packageCommand, interactiveOption);
+#if DEBUG
+                    PackageDownloadCommand.Register(packageCommand, interactiveOption);
+#endif
                 }
                 else
                 {
@@ -246,7 +252,7 @@ namespace NuGet.CommandLine.XPlat
             if (args.Length >= 2 && arg0 == "package")
             {
                 string arg1 = args[1];
-                if (arg1 == "search" || arg1 == "update")
+                if (arg1 == "search" || arg1 == "update" || arg1 == "download")
                 {
                     return true;
                 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -1662,6 +1662,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The mapped source &apos;{0}&apos; for package &apos;{1}&apos; was not found among the configured sources..
+        /// </summary>
+        internal static string PackageDownloadCommand_PackageSourceMapping_NoSuchSource {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_PackageSourceMapping_NoSuchSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specifies one or more NuGet package sources to use..
         /// </summary>
         internal static string PackageDownloadCommand_SourcesDescription {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -151,15 +151,6 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allows prerelease packages to be installed..
-        /// </summary>
-        internal static string AddPkg_PackagePrerelease {
-            get {
-                return ResourceManager.GetString("AddPkg_PackagePrerelease", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Version of the package to be added..
         /// </summary>
         internal static string AddPkg_PackageVersionDescription {
@@ -760,6 +751,15 @@ namespace NuGet.CommandLine.XPlat {
         internal static string Error_NoVersionsAvailable {
             get {
                 return ResourceManager.GetString("Error_NoVersionsAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find a valid package version.
+        /// </summary>
+        internal static string Error_PackageDownload_VersionNotFound {
+            get {
+                return ResourceManager.GetString("Error_PackageDownload_VersionNotFound", resourceCulture);
             }
         }
         
@@ -1599,6 +1599,105 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allows downloading from HTTP (non-HTTPS) package sources..
+        /// </summary>
+        internal static string PackageDownloadCommand_AllowInsecureConnectionsDescription {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_AllowInsecureConnectionsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Skipping download. Package &apos;{0}&apos; version {1} already exists at &apos;{2}&apos;..
+        /// </summary>
+        internal static string PackageDownloadCommand_AlreadyInstalled {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_AlreadyInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Downloads a NuGet package to a local folder without requiring a project file..
+        /// </summary>
+        internal static string PackageDownloadCommand_Description {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package &apos;{0}&apos; ({1}) failed to download..
+        /// </summary>
+        internal static string PackageDownloadCommand_Failed {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_Failed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to latest version.
+        /// </summary>
+        internal static string PackageDownloadCommand_LatestVersion {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_LatestVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Directory where the package will be placed. Defaults to the current working directory..
+        /// </summary>
+        internal static string PackageDownloadCommand_OutputDirectoryDescription {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_OutputDirectoryDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package identifier (e.g. &apos;Newtonsoft.Json&apos;)..
+        /// </summary>
+        internal static string PackageDownloadCommand_PackageIdDescription {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_PackageIdDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specifies one or more NuGet package sources to use..
+        /// </summary>
+        internal static string PackageDownloadCommand_SourcesDescription {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_SourcesDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Downloading package {0}, version {1}..
+        /// </summary>
+        internal static string PackageDownloadCommand_Starting {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_Starting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package &apos;{0}&apos; ({1}) successfully downloaded to &apos;{2}&apos;..
+        /// </summary>
+        internal static string PackageDownloadCommand_Succeeded {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_Succeeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package download failed for `{0} {1}` from source `{2}`..
+        /// </summary>
+        internal static string PackageDownloadCommand_UnableToDownload {
+            get {
+                return ResourceManager.GetString("PackageDownloadCommand_UnableToDownload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All packages are already up to date..
         /// </summary>
         internal static string PackageUpdate_AllPackagesAlreadyUpToDate {
@@ -1847,6 +1946,15 @@ namespace NuGet.CommandLine.XPlat {
         internal static string pkgSearch_VerbosityDescription {
             get {
                 return ResourceManager.GetString("pkgSearch_VerbosityDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allows prerelease packages to be installed..
+        /// </summary>
+        internal static string Prerelease_Description {
+            get {
+                return ResourceManager.GetString("Prerelease_Description", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -1157,4 +1157,9 @@ Do not translate "PackageVersion"</comment>
   <data name="Error_PackageDownload_VersionNotFound" xml:space="preserve">
     <value>Unable to find a valid package version</value>
   </data>
+  <data name="PackageDownloadCommand_PackageSourceMapping_NoSuchSource" xml:space="preserve">
+    <value>The mapped source '{0}' for package '{1}' was not found among the configured sources.</value>
+    <comment>0 - package source name
+1 - package name</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -586,7 +586,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
     <value>Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</value>
     <comment>Please don't localize "q[uiet]", "m[inimal]", "n[ormal]", "d[etailed]", or "diag[nostic]"</comment>
   </data>
-  <data name="AddPkg_PackagePrerelease" xml:space="preserve">
+  <data name="Prerelease_Description" xml:space="preserve">
     <value>Allows prerelease packages to be installed.</value>
   </data>
   <data name="Error_PrereleaseWhenVersionSpecified" xml:space="preserve">
@@ -1107,5 +1107,54 @@ Do not translate "PackageVersion"</comment>
   <data name="Error_InvalidVersion" xml:space="preserve">
     <value>Invalid version value '{0}'.</value>
     <comment>0 - package version</comment>
+  </data>
+  <data name="PackageDownloadCommand_Description" xml:space="preserve">
+    <value>Downloads a NuGet package to a local folder without requiring a project file.</value>
+  </data>
+  <data name="PackageDownloadCommand_PackageIdDescription" xml:space="preserve">
+    <value>Package identifier (e.g. 'Newtonsoft.Json').</value>
+  </data>
+  <data name="PackageDownloadCommand_AllowInsecureConnectionsDescription" xml:space="preserve">
+    <value>Allows downloading from HTTP (non-HTTPS) package sources.</value>
+  </data>
+  <data name="PackageDownloadCommand_OutputDirectoryDescription" xml:space="preserve">
+    <value>Directory where the package will be placed. Defaults to the current working directory.</value>
+  </data>
+  <data name="PackageDownloadCommand_SourcesDescription" xml:space="preserve">
+    <value>Specifies one or more NuGet package sources to use.</value>
+  </data>
+  <data name="PackageDownloadCommand_Starting" xml:space="preserve">
+    <value>Downloading package {0}, version {1}.</value>
+    <comment>0- package id
+1- package version</comment>
+  </data>
+  <data name="PackageDownloadCommand_AlreadyInstalled" xml:space="preserve">
+    <value>Skipping download. Package '{0}' version {1} already exists at '{2}'.</value>
+    <comment>0 - package id
+1 - version
+2 - directory path where the package was downloaded</comment>
+  </data>
+  <data name="PackageDownloadCommand_Succeeded" xml:space="preserve">
+    <value>Package '{0}' ({1}) successfully downloaded to '{2}'.</value>
+    <comment>0 - package id
+1 - package version
+2 - package download location</comment>
+  </data>
+  <data name="PackageDownloadCommand_Failed" xml:space="preserve">
+    <value>Package '{0}' ({1}) failed to download.</value>
+    <comment>0 - package id
+1 - package version</comment>
+  </data>
+  <data name="PackageDownloadCommand_UnableToDownload" xml:space="preserve">
+    <value>Package download failed for `{0} {1}` from source `{2}`.</value>
+    <comment>0 package id
+1 package version
+2 package source</comment>
+  </data>
+  <data name="PackageDownloadCommand_LatestVersion" xml:space="preserve">
+    <value>latest version</value>
+  </data>
+  <data name="Error_PackageDownload_VersionNotFound" xml:space="preserve">
+    <value>Unable to find a valid package version</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
@@ -47,11 +47,6 @@
         <target state="translated">ID balíčku, který se má přidat</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">Umožňuje instalaci předběžných verzí balíčků.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">Verze balíčku, který se má přidat</target>
@@ -401,6 +396,11 @@ NuGet vyžaduje zdroje HTTPS. Pokud chcete používat zdroje HTTP, musíte v sou
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">Projekt {0} používá pro balíčky NuGet package.config, ale daný příkaz funguje jen s projekty odkazů na balíčky.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ Další informace najdete tady: https://docs.nuget.org/docs/reference/command-li
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">Aktualizujte odkazované balíčky v projektu nebo řešení.</target>
@@ -988,6 +1051,11 @@ Další informace najdete tady: https://docs.nuget.org/docs/reference/command-li
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">Nejsou k dispozici žádné stabilní verze, nejlepší dostupná verze je {0}. Zvažte možnost přidat --prerelease.</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
@@ -929,6 +929,12 @@ Další informace najdete tady: https://docs.nuget.org/docs/reference/command-li
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
@@ -929,6 +929,12 @@ Weitere Informationen finden Sie unter: https://docs.nuget.org/docs/reference/co
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
@@ -47,11 +47,6 @@
         <target state="translated">ID des hinzuzufügenden Pakets.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">Ermöglicht die Installation von Paketen mit Vorabversionen.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">Version des hinzuzufügenden Pakets.</target>
@@ -401,6 +396,11 @@ NuGet erfordert HTTPS-Quellen. Um HTTP-Quellen zu verwenden, müssen Sie „allo
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">Das Projekt "{0}" verwendet "package.config" für NuGet-Pakete, der Befehl funktioniert jedoch nur mit Projekten mit Paketverweis.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ Weitere Informationen finden Sie unter: https://docs.nuget.org/docs/reference/co
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">Referenzierte Pakete in einem Projekt oder einer Projektmappe aktualisieren.</target>
@@ -988,6 +1051,11 @@ Weitere Informationen finden Sie unter: https://docs.nuget.org/docs/reference/co
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">Es sind keine stabilen Versionen verfügbar. Beste verfügbare Version: {0}. Erwägen Sie, die Option "--prerelease" hinzuzufügen.</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Id. del paquete que se va a agregar.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">Permite que se instalen paquetes de versión preliminar.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">Versión del paquete que se agregará.</target>
@@ -401,6 +396,11 @@ NuGet requiere orígenes HTTPS. Para usar orígenes HTTP, es necesario establece
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">El proyecto "{0}" usa package.config para los paquetes NuGet, aunque el comando solo funciona con proyectos de referencia de paquetes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ Para obtener más información, visite https://docs.nuget.org/docs/reference/com
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">Actualizar los paquetes a los que se hace referencia en un proyecto o solución.</target>
@@ -988,6 +1051,11 @@ Para obtener más información, visite https://docs.nuget.org/docs/reference/com
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">No hay ninguna versión estable que se pueda seleccionar; {0} es la mejor opción disponible. Puede agregar la opción --prerelease.</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
@@ -929,6 +929,12 @@ Para obtener más información, visite https://docs.nuget.org/docs/reference/com
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
@@ -47,11 +47,6 @@
         <target state="translated">ID du package à ajouter.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">Permet d'installer les packages de préversion.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">Version du package à ajouter.</target>
@@ -401,6 +396,11 @@ NuGet nécessite des sources HTTPS. Pour utiliser des sources HTTP, vous devez d
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">Le projet '{0}' utilise package.config pour les packages NuGet, alors que la commande fonctionne uniquement avec les projets de référence de package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ Pour plus d'informations, visitez https://docs.nuget.org/docs/reference/command-
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">Mettre à jour les packages référencés dans un projet ou une solution.</target>
@@ -988,6 +1051,11 @@ Pour plus d'informations, visitez https://docs.nuget.org/docs/reference/command-
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">Aucune version stable n'est disponible, {0} est la meilleure version disponible. Ajoutez l'option --prerelease</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
@@ -929,6 +929,12 @@ Pour plus d'informations, visitez https://docs.nuget.org/docs/reference/command-
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
@@ -47,11 +47,6 @@
         <target state="translated">ID del pacchetto da aggiungere.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">Consente l'installazione di pacchetti non definitivi.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">Versione del pacchetto da aggiungere.</target>
@@ -401,6 +396,11 @@ NuGet richiede origini HTTPS. Per utilizzare origini HTTP, è necessario imposta
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">Il progetto `{0}` usa package.config per i pacchetti NuGet, mentre il comando funziona solo con progetti di riferimento al pacchetto.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ Per altre informazioni, vedere https://docs.nuget.org/docs/reference/command-lin
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">Aggiorna i pacchetti referenziati in un progetto o in una soluzione.</target>
@@ -988,6 +1051,11 @@ Per altre informazioni, vedere https://docs.nuget.org/docs/reference/command-lin
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">Non sono disponibili versioni stabili e {0} è la migliore versione disponibile. Provare ad aggiungere l'opzione --prerelease</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
@@ -929,6 +929,12 @@ Per altre informazioni, vedere https://docs.nuget.org/docs/reference/command-lin
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
@@ -929,6 +929,12 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
@@ -47,11 +47,6 @@
         <target state="translated">追加されるパッケージの ID。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">プレリリース パッケージのインストールを許可します。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">追加されるパッケージのバージョン。</target>
@@ -401,6 +396,11 @@ NuGet には HTTPS ソースが必要です。HTTP ソースを使用するに�
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">プロジェクト '{0}' では NuGet パッケージに package.config を使用しますが、コマンドはパッケージ参照プロジェクトでのみ動作します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">プロジェクトまたはソリューションで参照されているパッケージを更新します。</target>
@@ -988,6 +1051,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">利用可能な安定バージョンがありません。利用可能な中では {0} が最善です。--prerelease オプションを追加することをご検討ください</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
@@ -47,11 +47,6 @@
         <target state="translated">추가할 패키지의 ID입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">시험판 패키지를 설치할 수 있습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">추가할 패키지의 버전입니다.</target>
@@ -401,6 +396,11 @@ NuGet에는 HTTPS 원본이 필요합니다. HTTP 원본을 사용하려면 NuGe
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">`{0}` 프로젝트는 NuGet 패키지에 대한 package.config를 사용합니다. 명령은 패키지 참조 프로젝트에서만 작동합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">프로젝트 또는 솔루션에서 참조된 패키지를 업데이트합니다.</target>
@@ -988,6 +1051,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">사용할 수 있는 안정적인 버전이 없습니다. 사용할 수 있는 최상의 버전은 {0}입니다. --prerelease 옵션을 추가하는 것이 좋습니다.</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
@@ -929,6 +929,12 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Identyfikator pakietu do dodania.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">Zezwala na instalowanie pakietów wersji wstępnych.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">Wersja pakietu do dodania.</target>
@@ -401,6 +396,11 @@ Menedżer NuGet wymaga źródeł HTTPS. Aby użyć źródeł HTTP, musisz wyraź
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">Projekt „{0}” używa pliku package.config dla pakietów NuGet, podczas gdy polecenie działa tylko w przypadku projektów odwołania do pakietu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ Aby uzyskać więcej informacji, odwiedź stronę https://docs.nuget.org/docs/re
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">Zaktualizuj przywoływane pakiety w projekcie lub rozwiązaniu.</target>
@@ -988,6 +1051,11 @@ Aby uzyskać więcej informacji, odwiedź stronę https://docs.nuget.org/docs/re
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">Brak dostępnych stabilnych wersji. Najlepsza dostępna opcja to {0}. Rozważ dodanie opcji --prerelease</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
@@ -929,6 +929,12 @@ Aby uzyskać więcej informacji, odwiedź stronę https://docs.nuget.org/docs/re
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
@@ -929,6 +929,12 @@ Para obter mais informações, acesse https://docs.nuget.org/docs/reference/comm
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
@@ -47,11 +47,6 @@
         <target state="translated">ID do pacote a ser adicionado.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">Permite a instalação de pacotes de pré-lançamento.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">Versão do pacote a ser adicionado.</target>
@@ -401,6 +396,11 @@ O NuGet requer fontes HTTPS. Para usar fontes HTTP, você deve definir explicita
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">O projeto '{0}' usa package.config para pacotes do NuGet, enquanto o comando funciona somente com projetos de referência do pacote.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ Para obter mais informações, acesse https://docs.nuget.org/docs/reference/comm
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">Atualize os pacotes referenciados em um projeto ou solução.</target>
@@ -988,6 +1051,11 @@ Para obter mais informações, acesse https://docs.nuget.org/docs/reference/comm
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">Não há versões estáveis disponíveis. {0} é a melhor disponível. Considere a adição da opção --prerelease</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Идентификатор добавляемого пакета.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">Разрешает установку пакетов предварительного выпуска.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">Версия добавляемого пакета.</target>
@@ -401,6 +396,11 @@ NuGet requires HTTPS sources. To use HTTP sources, you must explicitly set 'allo
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">В проекте "{0}" используется файл package.config для пакетов NuGet, а команда работает только с проектами, содержащими ссылки на пакеты.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">Обновите пакеты, на которые ссылается проект или решение.</target>
@@ -988,6 +1051,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">Нет доступных стабильных версий. Наилучшей из доступных является {0}. Попробуйте добавить параметр --prerelease.</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
@@ -929,6 +929,12 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Eklenecek paketin kimliği.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">Ön sürüm paketlerinin yüklenmesini sağlar.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">Eklenecek paket sürümü.</target>
@@ -402,6 +397,11 @@ NuGet için HTTPS kaynakları gereklidir. HTTP kaynaklarını kullanmak için Nu
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">`{0}` projesi, NuGuet paketleri için package.config dosyasını kullanıyor fakat komut yalnızca paket başvurusu projeleriyle çalışır.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -892,6 +892,69 @@ Daha fazla bilgi için bkz. https://docs.nuget.org/docs/reference/command-line-r
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">Bir projede veya çözümde başvurulan paketleri güncelleştirin.</target>
@@ -989,6 +1052,11 @@ Daha fazla bilgi için bkz. https://docs.nuget.org/docs/reference/command-line-r
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">Kullanılabilir kararlı bir sürüm olmadığından {0} en iyi seçenektir. --prerelease seçeneğini eklemeyi göz önünde bulundurun</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
@@ -930,6 +930,12 @@ Daha fazla bilgi için bkz. https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
@@ -929,6 +929,12 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
@@ -47,11 +47,6 @@
         <target state="translated">要添加的包 ID。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">允许安装预发行包。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">要添加的包版本。</target>
@@ -401,6 +396,11 @@ NuGet 需要 HTTPS 源。要使用 HTTP 源，必须在 NuGet.Config 文件中�
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">项目“{0}”对 NuGet 包使用 package.config，但该命令仅适用于包引用项目。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">更新项目或解决方案中引用的包。</target>
@@ -988,6 +1051,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">没有可用的稳定版本，{0} 是可用的最佳版本。请考虑添加 --prerelease 选项</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
@@ -47,11 +47,6 @@
         <target state="translated">要新增的套件之識別碼。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AddPkg_PackagePrerelease">
-        <source>Allows prerelease packages to be installed.</source>
-        <target state="translated">允許安裝發行前版本套件。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddPkg_PackageVersionDescription">
         <source>Version of the package to be added.</source>
         <target state="translated">要新增的套件版本。</target>
@@ -401,6 +396,11 @@ NuGet 需要 HTTPS 來源。您必須在 NuGet.Config 檔案中將 'allowInsecur
       <trans-unit id="Error_NotPRProject">
         <source>The project `{0}` uses package.config for NuGet packages, while the command works only with package reference projects.</source>
         <target state="translated">專案 `{0}` 會使用 NuGet 套件的 package.config，且命令僅能搭配套件參考專案使用。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error_PackageDownload_VersionNotFound">
+        <source>Unable to find a valid package version</source>
+        <target state="new">Unable to find a valid package version</target>
         <note />
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingNotFound">
@@ -891,6 +891,69 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <note>{0}: App full name
 {1}: App version</note>
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AllowInsecureConnectionsDescription">
+        <source>Allows downloading from HTTP (non-HTTPS) package sources.</source>
+        <target state="new">Allows downloading from HTTP (non-HTTPS) package sources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_AlreadyInstalled">
+        <source>Skipping download. Package '{0}' version {1} already exists at '{2}'.</source>
+        <target state="new">Skipping download. Package '{0}' version {1} already exists at '{2}'.</target>
+        <note>0 - package id
+1 - version
+2 - directory path where the package was downloaded</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Description">
+        <source>Downloads a NuGet package to a local folder without requiring a project file.</source>
+        <target state="new">Downloads a NuGet package to a local folder without requiring a project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Failed">
+        <source>Package '{0}' ({1}) failed to download.</source>
+        <target state="new">Package '{0}' ({1}) failed to download.</target>
+        <note>0 - package id
+1 - package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_LatestVersion">
+        <source>latest version</source>
+        <target state="new">latest version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_OutputDirectoryDescription">
+        <source>Directory where the package will be placed. Defaults to the current working directory.</source>
+        <target state="new">Directory where the package will be placed. Defaults to the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageIdDescription">
+        <source>Package identifier (e.g. 'Newtonsoft.Json').</source>
+        <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_SourcesDescription">
+        <source>Specifies one or more NuGet package sources to use.</source>
+        <target state="new">Specifies one or more NuGet package sources to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Starting">
+        <source>Downloading package {0}, version {1}.</source>
+        <target state="new">Downloading package {0}, version {1}.</target>
+        <note>0- package id
+1- package version</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_Succeeded">
+        <source>Package '{0}' ({1}) successfully downloaded to '{2}'.</source>
+        <target state="new">Package '{0}' ({1}) successfully downloaded to '{2}'.</target>
+        <note>0 - package id
+1 - package version
+2 - package download location</note>
+      </trans-unit>
+      <trans-unit id="PackageDownloadCommand_UnableToDownload">
+        <source>Package download failed for `{0} {1}` from source `{2}`.</source>
+        <target state="new">Package download failed for `{0} {1}` from source `{2}`.</target>
+        <note>0 package id
+1 package version
+2 package source</note>
+      </trans-unit>
       <trans-unit id="PackageUpdateCommand_Description">
         <source>Update referenced packages in a project or solution.</source>
         <target state="translated">更新專案或解決方案中參照的套件。</target>
@@ -988,6 +1051,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <source>There are no stable versions available, {0} is the best available. Consider adding the --prerelease option</source>
         <target state="translated">沒有可用的穩定版本，{0} 是最適用的版本。請考慮新增 --prerelease 選項</target>
         <note>{0} - Package Version</note>
+      </trans-unit>
+      <trans-unit id="Prerelease_Description">
+        <source>Allows prerelease packages to be installed.</source>
+        <target state="new">Allows prerelease packages to be installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PushCommandSkipDuplicateDescription">
         <source>If a package and version already exists, skip it and continue with the next package in the push, if any.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
@@ -929,6 +929,12 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="new">Package identifier (e.g. 'Newtonsoft.Json').</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadCommand_PackageSourceMapping_NoSuchSource">
+        <source>The mapped source '{0}' for package '{1}' was not found among the configured sources.</source>
+        <target state="new">The mapped source '{0}' for package '{1}' was not found among the configured sources.</target>
+        <note>0 - package source name
+1 - package name</note>
+      </trans-unit>
       <trans-unit id="PackageDownloadCommand_SourcesDescription">
         <source>Specifies one or more NuGet package sources to use.</source>
         <target state="new">Specifies one or more NuGet package sources to use.</target>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
@@ -1,0 +1,429 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package;
+using NuGet.CommandLine.XPlat.Commands.Package.PackageDownload;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests;
+
+public class PackageDownloadRunnerTests
+{
+    public static IEnumerable<object[]> PackageTestData()
+    {
+        // Basic stable explicit versions
+        yield return new object[]
+        {
+            new List<(string, string)>
+            {
+                ("Contoso.Core", "1.0.0"),
+                ("Contoso.Core", "1.1.0"),
+                ("Contoso.Core", "2.0.0-beta")
+            },                                      // source packages
+            new List<(string, string)>
+            {
+                ("Contoso.Core", "1.1.0"),
+                ("Contoso.Core", "1.0.0"),
+            },                                      // argument packages
+            false,                               // enablePrerelease
+            "myOutput",                          // output directory subpath
+            new List<(string, string)>
+            {
+                ("Contoso.Core", "1.1.0"),
+                ("Contoso.Core", "1.0.0")
+            }                                    // expected
+        };
+
+        // Basic stable explicit versions with different ids
+        yield return new object[]
+        {
+            new List<(string, string)>
+            {
+                ("Contoso.Core", "1.0.0"),
+                ("Contoso.Core.Utils", "1.1.0"),
+                ("Contoso.Core", "2.0.0-beta")
+            },                                      // source packages
+            new List<(string, string)>
+            {
+                ("Contoso.Core.Utils", "1.1.0"),
+                ("Contoso.Core", "1.0.0"),
+            },                                      // argument packages
+            false,                               // enablePrerelease
+            "myOutput",                          // output directory subpath
+            new List<(string, string)>
+            {
+                ("Contoso.Core.Utils", "1.1.0"),
+                ("Contoso.Core", "1.0.0")
+            }                                    // expected
+        };
+
+        // Mixed casing on the ID in the *download* argument 
+        yield return new object[]
+        {
+            new List<(string, string)>
+            {
+                ("Contoso.Core", "1.1.0")
+            },                                       // source packages      
+            new List<(string, string)>
+            {
+                ("contoso.core", "1.1.0")
+            },                                      // download argument
+            false,                                  // enablePrerelease
+            "",                                     // output directory subpath
+            new List<(string, string)>
+            {
+                ("Contoso.Core", "1.1.0")
+            },                                      // expected
+        };
+
+        // prerelease with IncludePrerelease == true
+        yield return new object[]
+        {
+            new List<(string, string)>
+            {
+                ("Contoso.Preview", "1.3.0"),
+                ("Contoso.Preview", "2.0.0-beta.2")
+            },                                          // source packages
+            new List<(string, string)>
+            {
+                ("Contoso.Preview", null),
+            },                                          // download argument
+            true,                                    // enablePrerelease
+            "AnotherSubPath",                          // output directory subpath
+            new List<(string, string)>
+            {
+                ("Contoso.Preview", "2.0.0-beta.2")
+            },                                          // expected
+        };
+
+        // chose stable with IncludePrerelease == false
+        yield return new object[]
+        {
+            new List<(string, string)>
+            {
+                ("Contoso.Preview", "1.3.2"),
+                ("Contoso.Preview", "1.3.0"),
+                ("Contoso.Preview", "2.0.0-beta.2")
+            },                                                // source packages
+            new List<(string, string)>
+            {
+                ("Contoso.Preview", null)
+            },                                              // download argument
+            false,                                           // enablePrerelease
+            "SubPath",                                       // output directory subpath
+            new List <(string, string) > {
+                ("Contoso.Preview", "1.3.2")
+            }                                                // expected
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(PackageTestData))]
+    public async Task RunAsync_ExplicitVersionFromLocalFolderSource_SucceedsAsync(
+        IReadOnlyList<(string, string)> sourcePackages,
+        IReadOnlyList<(string, string)> argumentPackages,
+        bool enablePrerelease,
+        string outputDirectorySubPath,
+        IReadOnlyList<(string, string)> expectedPackages)
+    {
+        // Arrange
+        using var context = new SimpleTestPathContext();
+        var sourceDir = context.PackageSource;
+        var outputDir = Path.Combine(context.WorkingDirectory, outputDirectorySubPath);
+
+        foreach (var (id, version) in sourcePackages)
+        {
+            await SimpleTestPackageUtility.CreateFullPackageAsync(sourceDir, id, version);
+        }
+
+        var logger = new Mock<ILoggerWithColor>(MockBehavior.Loose);
+        var settings = new Mock<ISettings>(MockBehavior.Loose);
+        List<PackageWithNuGetVersion> packages = [];
+
+        foreach (var (id, version) in argumentPackages)
+        {
+            packages.Add(new PackageWithNuGetVersion
+            {
+                Id = id,
+                NuGetVersion = version == null ? null : NuGetVersion.Parse(version)
+            });
+        }
+
+        var args = new PackageDownloadArgs()
+        {
+            Packages = packages,
+            OutputDirectory = outputDir,
+            IncludePrerelease = enablePrerelease,
+        };
+
+        // Act
+        var result = await PackageDownloadRunner.RunAsync(
+            args,
+            logger.Object,
+            [new(sourceDir)],
+            settings.Object,
+            CancellationToken.None);
+
+        // Assert
+        foreach (var (expectedId, expectedVersion) in expectedPackages)
+        {
+            result.Should().Be(PackageDownloadRunner.ExitCodeSuccess);
+            var installDir = Path.Combine(outputDir, expectedId.ToLowerInvariant(), expectedVersion);
+            Directory.Exists(installDir).Should().BeTrue();
+            Directory.EnumerateFiles(installDir, "*.nupkg").Any().Should().BeTrue();
+            File.Exists(Path.Combine(installDir, $"{expectedId.ToLowerInvariant()}.{expectedVersion}.nupkg")).Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_NoVersion_PicksHighestAcrossMultipleSources()
+    {
+        // Arrange
+        using var contextA = new SimpleTestPathContext();
+        using var contextB = new SimpleTestPathContext();
+        var srcA = contextA.PackageSource;
+        var srcB = contextB.PackageSource;
+        var outputDir = contextA.WorkingDirectory;
+
+        var id = "Contoso.Toolkit";
+        await SimpleTestPackageUtility.CreateFullPackageAsync(srcA, id, "1.1.0");
+        await SimpleTestPackageUtility.CreateFullPackageAsync(srcB, id, "1.2.0");
+
+        var logger = new Mock<ILoggerWithColor>(MockBehavior.Loose);
+        var settings = new Mock<ISettings>(MockBehavior.Loose);
+
+        var args = new PackageDownloadArgs()
+        {
+            Packages = [new PackageWithNuGetVersion { Id = id, NuGetVersion = null }],
+            OutputDirectory = outputDir,
+        };
+
+        // Act
+        var result = await PackageDownloadRunner.RunAsync(
+            args,
+            logger.Object,
+            [new PackageSource(srcA), new PackageSource(srcB)],
+            settings.Object,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().Be(PackageDownloadRunner.ExitCodeSuccess);
+
+        var chosen = Path.Combine(outputDir, id.ToLowerInvariant(), "1.2.0");
+        Directory.Exists(chosen).Should().BeTrue("should choose the highest version found across all sources");
+        File.Exists(Path.Combine(chosen, $"{id.ToLowerInvariant()}.1.2.0.nupkg")).Should().BeTrue();
+    }
+
+    public static IEnumerable<object[]> ShortCircuitsPackageData =>
+        [
+        // single package already installed
+        [
+            new []
+            {
+                ("Contoso.Utils", "3.4.5")          // source packages
+            },
+            new[]
+            {
+                new PackageWithNuGetVersion              // argument packages
+                {
+                    Id = "Contoso.Utils",
+                    NuGetVersion = NuGetVersion.Parse("3.4.5")
+                }
+            },
+            new []
+            {
+                ("Contoso.Utils", "3.4.5")               // expected packages
+            }
+        ],
+
+        // multiple packages already installed
+        [
+            new []
+            {
+                ("Contoso.Utils", "3.4.5"),            // source packages
+                ("Contoso.Core", "3.0.5")
+            },
+            new []
+            {
+                new PackageWithNuGetVersion            // argument packages
+                {
+                    Id = "Contoso.Utils",
+                    NuGetVersion = NuGetVersion.Parse("3.4.5")
+                },
+                new PackageWithNuGetVersion
+                {
+                    Id = "Contoso.Core",
+                    NuGetVersion = NuGetVersion.Parse("3.0.5")
+                }
+            },
+            new []
+            {
+                ("Contoso.Utils", "3.4.5"),             // expected packages
+                ("Contoso.Core", "3.0.5")
+            }
+        ],
+
+        // no version specified, but latest version already installed
+        [
+            new []
+            {
+                ("Contoso.Utils", "3.4.5"),            // source packages
+                ("Contoso.Core", "3.0.5")
+            },
+            new []
+            {
+                new PackageWithNuGetVersion             // argument packages
+                {
+                    Id = "Contoso.Utils",
+                    NuGetVersion = null
+            },
+                new PackageWithNuGetVersion
+                {
+                    Id = "Contoso.Core",
+                    NuGetVersion = null
+                }
+            },
+            new []
+            {
+                ("Contoso.Utils", "3.4.5"),              // expected packages
+                ("Contoso.Core", "3.0.5")
+            }
+        ]];
+
+    [Theory]
+    [MemberData(nameof(ShortCircuitsPackageData))]
+    internal async Task RunAsync_VersionAlreadyInstalled_ShortCircuitsAndSucceeds(
+        IReadOnlyList<(string, string)> sourcePackages,
+        PackageWithNuGetVersion[] packageDownloadArgs,
+        IReadOnlyList<(string, string)> expectedPackages)
+    {
+        // Arrange
+        using var context = new SimpleTestPathContext();
+        var sourceDir = context.PackageSource;
+        var outputDir = context.WorkingDirectory;
+
+        List<PackageWithNuGetVersion> packagesToInstall = [];
+
+        foreach (var (id, version) in sourcePackages)
+        {
+            await SimpleTestPackageUtility.CreateFullPackageAsync(sourceDir, id, version);
+        }
+
+        var logger = new Mock<ILoggerWithColor>(MockBehavior.Loose);
+        var settings = new Mock<ISettings>(MockBehavior.Loose);
+
+        // First run: install explicit version
+        var args1 = new PackageDownloadArgs()
+        {
+            Packages = packageDownloadArgs,
+            LogLevel = LogLevel.Verbose,
+            OutputDirectory = outputDir,
+        };
+
+        var first = await PackageDownloadRunner.RunAsync(
+            args1,
+            logger.Object,
+            [new PackageSource(sourceDir)],
+            settings.Object,
+            CancellationToken.None);
+        first.Should().Be(ExitCodes.Success);
+
+        // Second run: should short-circuit because already installed
+        var args2 = new PackageDownloadArgs()
+        {
+            Packages = packageDownloadArgs,
+            OutputDirectory = outputDir,
+        };
+
+        // Act
+        var second = await PackageDownloadRunner.RunAsync(
+            args2,
+            logger.Object,
+            [new PackageSource(sourceDir)],
+            settings.Object,
+            CancellationToken.None);
+
+        // Assert
+        foreach (var (id, version) in expectedPackages)
+        {
+            second.Should().Be(PackageDownloadRunner.ExitCodeSuccess);
+            var installDir = Path.Combine(outputDir, id.ToLowerInvariant(), version);
+            Directory.Exists(installDir).Should().BeTrue();
+            File.Exists(Path.Combine(installDir, $"{id.ToLowerInvariant()}.{version}.nupkg")).Should().BeTrue();
+        }
+
+        logger.Verify(l => l.LogMinimal(It.Is<string>(s => s.Contains("Skipping", StringComparison.OrdinalIgnoreCase))), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenAllowInsecureConnectionsFalse_RejectsHttpSource()
+    {
+        // Arrange
+        using var context = new SimpleTestPathContext();
+        var httpSource = "http://contoso/v3/index.json";
+        var logger = new Mock<ILoggerWithColor>(MockBehavior.Loose);
+        var settings = new Mock<ISettings>(MockBehavior.Loose);
+
+        var args = new PackageDownloadArgs()
+        {
+            Packages = [new PackageWithNuGetVersion { Id = "Contoso.Lib", NuGetVersion = null }],
+        };
+
+        // Act
+        var result = await PackageDownloadRunner.RunAsync(
+            args,
+            logger.Object,
+            [new PackageSource(httpSource)],
+            settings.Object,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().Be(PackageDownloadRunner.ExitCodeError);
+        logger.Verify(l => l.LogError(It.Is<string>(s => s.Contains(httpSource, StringComparison.OrdinalIgnoreCase))), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task RunAsync_PackageDoesNotExist_ReturnsError()
+    {
+        // Arrange
+        using var context = new SimpleTestPathContext();
+        var id = "Missing.Package";
+        var v = "9.9.9";
+        var logger = new Mock<ILoggerWithColor>(MockBehavior.Loose);
+        var settings = new Mock<ISettings>(MockBehavior.Loose);
+
+        var args = new PackageDownloadArgs()
+        {
+            Packages = [new PackageWithNuGetVersion { Id = id, NuGetVersion = NuGetVersion.Parse(v) }],
+            OutputDirectory = context.WorkingDirectory,
+        };
+
+        // Act
+        var result = await PackageDownloadRunner.RunAsync(
+            args,
+            logger.Object,
+            [new PackageSource(context.PackageSource)],
+            settings.Object,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().Be(PackageDownloadRunner.ExitCodeError);
+        logger.Verify(l => l.LogError(It.IsAny<string>()), Times.AtLeastOnce);
+
+        File.Exists(Path.Combine(context.WorkingDirectory, $"{id.ToLowerInvariant()}.{v}.nupkg"))
+            .Should().BeFalse("Package does not exist in sources");
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -16,6 +17,7 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.CommandLine.Xplat.Tests;
@@ -425,5 +427,235 @@ public class PackageDownloadRunnerTests
 
         File.Exists(Path.Combine(context.WorkingDirectory, $"{id.ToLowerInvariant()}.{v}.nupkg"))
             .Should().BeFalse("Package does not exist in sources");
+    }
+
+    public static IEnumerable<object[]> Cases()
+    {
+        // Parameters:
+        // A-packages, B-packages, sourceMappings, sourcesArgs, downloadId, downloadVersion,
+        // allowInsecureConnections, expectSuccess, expectedInstalled
+
+        // --source specified, mapping ignored, package only in A -> success
+        yield return new object[]
+        {
+            new List<(string,string)> { ("Contoso.Lib", "1.0.0") }, // A
+            new List<(string,string)>(),                            // B
+            new List<(string,string)> { ("B", "Contoso.*") },       // mapping ignored
+            new List<string> { "A" },                               // --source A
+            "Contoso.Lib", "1.0.0",                                  // downloadId, downloadVersion
+            true,                                                   // allow insecure
+            true,                                                   // expect success
+            ("Contoso.Lib", "1.0.0")                                // expectedInstalled
+        };
+
+        // no --source, mapping -> B, package only in B -> success
+        yield return new object[]
+        {
+            new List<(string,string)>(),                            // A
+            new List<(string,string)> { ("Contoso.Mapped", "2.0.0") }, // B
+            new List<(string,string)> { ("B", "Contoso.*") },       // mapping -> B
+            null,                                                   // no --source
+            "Contoso.Mapped", "2.0.0",                              // downloadId, downloadVersion
+            true,                                                   // allow insecure
+            true,                                                   // expect success
+            ("Contoso.Mapped", "2.0.0")                             // expectedInstalled
+        };
+
+        // no --source, mapping -> A, package only in B -> fail
+        yield return new object[]
+        {
+            new List<(string,string)>(),                            // A
+            new List<(string,string)> { ("Contoso.Mapped", "2.0.0") },
+            new List<(string,string)> { ("A", "Contoso.*") },       // mapped to A
+            null,
+            "Contoso.Mapped", "2.0.0",
+            true,
+            false,
+            null!
+        };
+
+        // --source specified, no source mapping with an insecure source
+        yield return new object[]
+        {
+            new List<(string,string)> { ("Contoso.Lib", "1.0.0") }, // A
+            new List<(string,string)>(),
+            new List<(string,string)> { ("A", "Contoso.*") },
+            new List<string> { "A" },                               // --source
+            "Contoso.Lib", "1.0.0",
+            false,                                                  // allow insecure connections false / not set to true
+            false,
+            null!
+        };
+
+        // no --source, mapping -> B, allow insecure not enabled -> fail
+        yield return new object[]
+        {
+            new List<(string,string)>(),                            // A
+            new List<(string,string)> { ("Contoso.Mapped", "1.0.0") },
+            new List<(string,string)> { ("B", "Contoso.*") },
+            null,
+            "Contoso.Mapped", "1.0.0",
+            false,                                                   // allow insecure connections false / not set to true
+            false,
+            null!
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public async Task RunAsync_WithSourceMapping(
+        IReadOnlyList<(string id, string version)> sourceAPackages,
+        IReadOnlyList<(string id, string version)> sourceBPackages,
+        IReadOnlyList<(string source, string pattern)> sourceMappings,
+        IReadOnlyList<string> sourcesArgs,
+        string downloadId,
+        string downloadVersion,
+        bool allowInsecureConnections,
+        bool expectSuccess,
+        (string id, string version)? expectedInstalled)
+    {
+        // Arrange
+        using var context = new SimpleTestPathContext();
+        string srcADirectory = Path.Combine(context.PackageSource, "SourceA");
+        string srcBDirectory = Path.Combine(context.PackageSource, "SourceB");
+
+        using var serverA = new FileSystemBackedV3MockServer(srcADirectory);
+        using var serverB = new FileSystemBackedV3MockServer(srcBDirectory);
+
+        foreach (var (id, ver) in sourceAPackages)
+        {
+            await SimpleTestPackageUtility.CreateFullPackageAsync(srcADirectory, id, ver);
+        }
+
+        foreach (var (id, ver) in sourceBPackages)
+        {
+            await SimpleTestPackageUtility.CreateFullPackageAsync(srcBDirectory, id, ver);
+        }
+
+        serverA.Start();
+        serverB.Start();
+
+        // sources
+        context.Settings.AddSource("A", serverA.ServiceIndexUri);
+        context.Settings.AddSource("B", serverB.ServiceIndexUri);
+
+        // mapping
+        foreach (var (src, pattern) in sourceMappings)
+        {
+            context.Settings.AddPackageSourceMapping(src, pattern);
+        }
+
+        var settings = Settings.LoadSettingsGivenConfigPaths([context.Settings.ConfigPath]);
+
+        var packageSources = new List<PackageSource>
+        {
+            new(serverA.ServiceIndexUri, "A"),
+            new(serverB.ServiceIndexUri, "B")
+        };
+
+        // args
+        var args = new PackageDownloadArgs
+        {
+            Packages =
+            [
+                new PackageWithNuGetVersion
+                {
+                    Id = downloadId,
+                    NuGetVersion = downloadVersion is null ? null : NuGetVersion.Parse(downloadVersion)
+                }
+            ],
+            OutputDirectory = context.WorkingDirectory,
+            AllowInsecureConnections = allowInsecureConnections,
+            Sources = sourcesArgs == null ? [] : sourcesArgs.ToList()
+        };
+
+        string capturedLogs = string.Empty;
+        var logger = new Mock<ILoggerWithColor>(MockBehavior.Loose);
+        logger
+            .Setup(l => l.LogError(It.IsAny<string>()))
+            .Callback<string>(msg => capturedLogs += msg + Environment.NewLine);
+
+        // Act
+        var exit = await PackageDownloadRunner.RunAsync(
+            args,
+            logger.Object,
+            packageSources,
+            settings,
+            CancellationToken.None);
+
+        serverA.Stop();
+        serverB.Stop();
+
+        // Assert
+        if (expectSuccess)
+        {
+            exit.Should().Be(PackageDownloadRunner.ExitCodeSuccess, because: capturedLogs);
+            expectedInstalled.Should().NotBeNull();
+
+            var (expId, expVer) = expectedInstalled!.Value;
+            var installDir = Path.Combine(context.WorkingDirectory, expId.ToLowerInvariant(), expVer);
+            Directory.Exists(installDir).Should().BeTrue();
+            File.Exists(Path.Combine(installDir, $"{expId.ToLowerInvariant()}.{expVer}.nupkg")).Should().BeTrue();
+        }
+        else
+        {
+            exit.Should().Be(PackageDownloadRunner.ExitCodeError);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenMappedSourceMissing_LogsVerbose()
+    {
+        // Arrange
+        using var context = new SimpleTestPathContext();
+        string srcADirectory = Path.Combine(context.PackageSource, "SourceA");
+        using var serverA = new FileSystemBackedV3MockServer(srcADirectory);
+
+        await SimpleTestPackageUtility.CreateFullPackageAsync(srcADirectory, "Contoso.Utils", "1.0.0");
+        context.Settings.AddSource("A", serverA.ServiceIndexUri);
+
+        // Map the package to a NON-EXISTING source name "MissingSource"
+        context.Settings.AddPackageSourceMapping("MissingSource", "Contoso.*");
+        var settings = Settings.LoadSettingsGivenConfigPaths([context.Settings.ConfigPath]);
+
+        var args = new PackageDownloadArgs
+        {
+            Packages =
+            [
+                new PackageWithNuGetVersion
+                {
+                    Id = "Contoso.Utils",
+                    NuGetVersion = NuGetVersion.Parse("1.0.0")
+                }
+            ],
+            OutputDirectory = context.WorkingDirectory,
+            AllowInsecureConnections = true,
+            Sources = []
+        };
+        string capturedVerbose = string.Empty;
+        var logger = new Mock<ILoggerWithColor>(MockBehavior.Loose);
+        logger.Setup(l => l.LogVerbose(It.IsAny<string>()))
+              .Callback<string>(msg => capturedVerbose += msg + Environment.NewLine);
+
+        // Act
+        serverA.Start();
+
+        var exit = await PackageDownloadRunner.RunAsync(
+            args,
+            logger.Object,
+            [new(serverA.ServiceIndexUri, "A")],
+            settings,
+            CancellationToken.None);
+
+        serverA.Stop();
+
+        // Assert
+        var expected = string.Format(
+            CultureInfo.CurrentCulture,
+            Strings.PackageDownloadCommand_PackageSourceMapping_NoSuchSource,
+            "MissingSource",
+            "Contoso.Utils");
+
+        capturedVerbose.Should().Contain(expected, because: "a package mapped to a non-existing source name must log a verbose diagnostic");
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadCommandTests.cs
@@ -1,0 +1,288 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.CommandLine;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.CommandLine.XPlat.Commands.Package.PackageDownload;
+using NuGet.Common;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Download
+{
+    public class PackageDownloadCommandArgsTest
+    {
+        [Fact]
+        public async Task NoArguments_ThrowsAnExceptionForMissingArg()
+        {
+            // Arrange
+            string args = "package download";
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => RunAsync(args));
+        }
+
+        [Fact]
+        public async Task WithSinglePackage_ShouldParsePackageId()
+        {
+            // Arrange
+            string args = "package download Contoso.Utils";
+
+            // Act
+            var result = await RunAsync(args);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Packages.Should().HaveCount(1);
+            result.Packages[0].Id.Should().Be("Contoso.Utils");
+            result.Packages[0].NuGetVersion.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithMultiplePackages_ShouldParseAllPackageIds()
+        {
+            // Arrange
+            string args = "package download Contoso.Utils Contoso.Framework";
+
+            // Act
+            var result = await RunAsync(args);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Packages.Should().HaveCount(2);
+            result.Packages[0].Id.Should().Be("Contoso.Utils");
+            result.Packages[0].NuGetVersion.Should().BeNull();
+            result.Packages[1].Id.Should().Be("Contoso.Framework");
+            result.Packages[1].NuGetVersion.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithPackageAndVersion_ShouldParsePackageWithVersion()
+        {
+            // Arrange
+            string args = "package download Contoso.Utils@2.1.0";
+
+            // Act
+            var result = await RunAsync(args);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Packages.Should().HaveCount(1);
+            result.Packages[0].Id.Should().Be("Contoso.Utils");
+            result.Packages[0].NuGetVersion.Should().NotBeNull();
+            result.Packages[0].NuGetVersion!.ToString().Should().Be("2.1.0");
+        }
+
+        [Fact]
+        public async Task WithPackageAndVersionRange_ShouldFail()
+        {
+            // Arrange
+            string args = "package download Contoso.Utils@[2.0.0,3.0.0)";
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => RunAsync(args));
+        }
+
+        [Fact]
+        public async Task WithMixedPackages_ShouldParseMixedPackagesCorrectly()
+        {
+            // Arrange
+            string args = "package download Contoso.Utils@2.1.0 Contoso.Framework";
+
+            // Act
+            var result = await RunAsync(args);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Packages.Should().HaveCount(2);
+            result.Packages[0].Id.Should().Be("Contoso.Utils");
+            result.Packages[0].NuGetVersion.ToString().Should().Be("2.1.0");
+            result.Packages[1].Id.Should().Be("Contoso.Framework");
+            result.Packages[1].NuGetVersion.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithOutputAndConfig_ShouldBindPaths()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            string outDir = Path.Combine(pathContext.WorkingDirectory, "out");
+            string cfg = Path.Combine(pathContext.WorkingDirectory, "nuget.config");
+
+            string args = $"package download Contoso --output \"{outDir}\" --configfile \"{cfg}\"";
+
+            // Act
+            var result = await RunAsync(args);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.OutputDirectory.Should().Be(outDir);
+            result.ConfigFile.Should().Be(cfg);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WithInteractiveOption_ShouldSetCorrectInteractiveValue(bool value)
+        {
+            // Arrange
+            string args = $"package download Contoso --interactive:{value}";
+
+            // Act
+            var result = await RunAsync(args);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Interactive.Should().Be(value);
+        }
+
+        [Fact]
+        public async Task WithBooleanFlags_ShouldSetAllFlagsTrue()
+        {
+            // Arrange
+            string args = "package download contoso --prerelease --allow-insecure-connections --interactive";
+
+            // Act
+            var result = await RunAsync(args);
+
+            // Assert
+            result.IncludePrerelease.Should().BeTrue();
+            result.AllowInsecureConnections.Should().BeTrue();
+            result.Interactive.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("--verbosity quiet", LogLevel.Warning)]
+        [InlineData("--verbosity q", LogLevel.Warning)]
+        [InlineData("--verbosity minimal", LogLevel.Minimal)]
+        [InlineData("--verbosity m", LogLevel.Minimal)]
+        [InlineData("--verbosity normal", LogLevel.Information)]
+        [InlineData("--verbosity n", LogLevel.Information)]
+        [InlineData("--verbosity detailed", LogLevel.Verbose)]
+        [InlineData("--verbosity d", LogLevel.Verbose)]
+        [InlineData("--verbosity diagnostic", LogLevel.Debug)]
+        [InlineData("--verbosity diag", LogLevel.Debug)]
+        [InlineData("-v quiet", LogLevel.Warning)]
+        [InlineData("-v minimal", LogLevel.Minimal)]
+        [InlineData("-v normal", LogLevel.Information)]
+        [InlineData("-v detailed", LogLevel.Verbose)]
+        [InlineData("-v diagnostic", LogLevel.Debug)]
+        public async Task WithVerbosityOption_ShouldSetCorrectLogLevel(string verbosityArgs, LogLevel expectedLogLevel)
+        {
+            // Arrange
+            string args = $"package download contoso {verbosityArgs}";
+
+            // Act
+            var result = await RunAsync(args);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.LogLevel.Should().Be(expectedLogLevel);
+        }
+
+        [Fact]
+        public void WithInvalidVersion_ShouldHaveParseErrors()
+        {
+            // Arrange
+            string args = "package download Contoso.Utils@invalid-version";
+
+            // Act
+            var result = Parse(args);
+
+            // Assert
+            result.Errors.Count.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void WithEmptyVersionAfterAt_ShouldHaveParseErrors()
+        {
+            // Arrange
+            string args = "package download Contoso.Utils@";
+
+            // Act
+            var result = Parse(args);
+
+            // Assert
+            result.Errors.Count.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public async Task WithAllOptions_ShouldParseAllOptionsCorrectly()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            string outDir = Path.Combine(pathContext.WorkingDirectory, "out");
+            string cfg = Path.Combine(pathContext.WorkingDirectory, "nuget.config");
+
+            string args = $"package download Contoso.Utils@2.1.0 --output \"{outDir}\" --configfile \"{cfg}\" --prerelease --allow-insecure-connections --source s1 --source s2 --verbosity detailed --interactive";
+
+            // Act
+            var result = await RunAsync(args);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Packages.Should().HaveCount(1);
+            result.Packages[0].Id.Should().Be("Contoso.Utils");
+            result.Packages[0].NuGetVersion.ToString().Should().Be("2.1.0");
+            result.OutputDirectory.Should().Be(outDir);
+            result.ConfigFile.Should().Be(cfg);
+            result.IncludePrerelease.Should().BeTrue();
+            result.AllowInsecureConnections.Should().BeTrue();
+            result.Sources.Should().ContainInOrder("s1", "s2");
+            result.LogLevel.Should().Be(LogLevel.Verbose);
+            result.Interactive.Should().BeTrue();
+        }
+
+        private ParseResult Parse(string commandLine, Func<PackageDownloadArgs, CancellationToken, Task<int>> action = null)
+        {
+            RootCommand rootCommand = new RootCommand();
+
+            var packageCommand = new Command("package");
+            rootCommand.Subcommands.Add(packageCommand);
+
+            // Simulate SDK-provided interactive option
+            var interactiveOption = new Option<bool>("--interactive");
+
+            if (action == null)
+            {
+                action = (_, _) => throw new NotImplementedException("No action provided for command execution.");
+            }
+
+            PackageDownloadCommand.Register(packageCommand, interactiveOption, action);
+
+            var parser = rootCommand.Parse(commandLine);
+            return parser;
+        }
+
+        private async Task<PackageDownloadArgs> RunAsync(string commandLine)
+        {
+            PackageDownloadArgs commandArgs = null;
+
+            var parseResult = Parse(commandLine, (args, cancellationToken) =>
+            {
+                commandArgs = args;
+                return Task.FromResult(0);
+            });
+
+            using var output = new StringWriter();
+            var commandLineConfiguration = new InvocationConfiguration
+            {
+                Output = output,
+                Error = output,
+            };
+
+            await parseResult.InvokeAsync(commandLineConfiguration);
+
+            if (commandArgs is null)
+            {
+                throw new InvalidOperationException("Command arguments were not set during command execution. Output:" + output.ToString());
+            }
+
+            return commandArgs;
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadRunnerTests.cs
@@ -200,5 +200,4 @@ public class PackageDownloadRunnerTests
             foundRepo.Should().BeNull();
         }
     }
-
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadRunnerTests.cs
@@ -1,0 +1,204 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package;
+using NuGet.CommandLine.XPlat.Commands.Package.PackageDownload;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests;
+
+public class PackageDownloadRunnerTests
+{
+    public sealed record SourceSpec(string Name, params string[] Versions);
+
+    public sealed record ResolveScenario(
+        string Id,
+        IReadOnlyList<SourceSpec> Sources,
+        string RequestedVersion,
+        bool IncludePrerelease,
+        string ExpectedSource,   // null => expect no resolution
+        string ExpectedVersion); // null => expect no resolution
+
+    public sealed class ResolveVersionData : TheoryData<ResolveScenario>
+    {
+        public ResolveVersionData()
+        {
+            // Exact version at first source -> returns early
+            Add(new ResolveScenario(
+                Id: "Contoso",
+                Sources: [new SourceSpec("src", "1.2.3")],
+                RequestedVersion: "1.2.3",
+                IncludePrerelease: false,
+                ExpectedSource: "src",
+                ExpectedVersion: "1.2.3"));
+
+            // Exact version missing in first, present in second -> pick second
+            Add(new ResolveScenario(
+                "Contoso",
+                [new SourceSpec("srcA", "1.0.0"), new SourceSpec("srcB", "1.2.3")],
+                "1.2.3",
+                false,
+                "srcB",
+                "1.2.3"));
+
+            // No version; exclude prerelease -> highest stable across sources
+            Add(new ResolveScenario(
+                "Contoso",
+                [new SourceSpec("srcA", "1.0.0", "1.5.0-alpha"), new SourceSpec("srcB", "2.0.0")],
+                null,
+                false,
+                "srcB",
+                "2.0.0"));
+
+            // No version; include prerelease -> highest including prerelease
+            Add(new ResolveScenario(
+                "Contoso",
+                [new SourceSpec("srcA", "2.0.0"), new SourceSpec("srcB", "2.1.0-rc.1")],
+                null,
+                true,
+                "srcB",
+                "2.1.0-rc.1"));
+
+            // No matches anywhere -> null
+            Add(new ResolveScenario(
+                "Contoso",
+                [new SourceSpec("emptyA"), new SourceSpec("emptyB")],
+                null,
+                false,
+                ExpectedSource: null,
+                ExpectedVersion: null));
+
+            // Exact version requested, but not found anywhere -> null
+            Add(new ResolveScenario(
+                "Contoso",
+                [new SourceSpec("src", "1.0.0")],
+                "1.2.3",
+                false,
+                null,
+                null));
+        }
+    }
+
+    [Theory]
+    [ClassData(typeof(ResolveVersionData))]
+    public async Task ResolvePackageDownloadVersion_Scenarios(ResolveScenario scenario)
+    {
+        // Arrange
+        using var context = new SimpleTestPathContext();
+
+        // Create source folders and packages
+        var repos = new List<SourceRepository>();
+        foreach (var src in scenario.Sources)
+        {
+            var folder = Path.Combine(context.WorkingDirectory, src.Name);
+            Directory.CreateDirectory(folder);
+
+            foreach (var version in src.Versions)
+            {
+                await SimpleTestPackageUtility.CreateFullPackageAsync(folder, scenario.Id, version);
+            }
+
+            repos.Add(Repository.Factory.GetCoreV3(new PackageSource(folder)));
+        }
+
+        var logger = new Mock<ILoggerWithColor>(MockBehavior.Loose);
+        var package = new PackageWithNuGetVersion
+        {
+            Id = scenario.Id,
+            NuGetVersion = scenario.RequestedVersion is null ? null : NuGetVersion.Parse(scenario.RequestedVersion)
+        };
+
+        // Act
+        (NuGetVersion resolved, SourceRepository resolvedRepo) = await PackageDownloadRunner.ResolvePackageDownloadVersion(
+            package,
+            [.. repos],
+            new SourceCacheContext(),
+            logger.Object,
+            includePrerelease: scenario.IncludePrerelease,
+            CancellationToken.None);
+
+        // Assert
+        if (scenario.ExpectedVersion is null)
+        {
+            Assert.Null(resolved);
+            Assert.Null(resolvedRepo);
+            return;
+        }
+
+        Assert.Equal(new NuGetVersion(scenario.ExpectedVersion), resolved);
+        Assert.NotNull(resolvedRepo);
+
+        var expectedPath = Path.Combine(context.WorkingDirectory, scenario.ExpectedSource!);
+        Assert.Equal(expectedPath, resolvedRepo.PackageSource.Source);
+    }
+
+    [Theory]
+    [InlineData("1.0.0", true)]  // exact version specified -> should find even if unlisted
+    [InlineData(null, false)]     // no exact version -> should return null when unlisted
+    public async Task ResolvePackageDownloadVersion_UnlistedPackage_BehavesAsExpected(string requestedVersion, bool expectFound)
+    {
+        // Arrange
+        using var pathContext = new SimpleTestPathContext();
+        using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
+
+        var cache = new SourceCacheContext();
+        var logger = new Mock<ILoggerWithColor>();
+        var token = CancellationToken.None;
+
+        var sourceRepo = Repository.Factory.GetCoreV3(mockServer.ServiceIndexUri);
+
+        // Create the package and unlist it on the mock server.
+        var id = "Contoso.unlisted";
+        var createdVersion = "1.0.0";
+        var pkg = new SimpleTestPackageContext(id, createdVersion);
+        await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, pkg);
+        mockServer.UnlistedPackages.Add(pkg.Identity);
+
+        mockServer.Start();
+
+        var packageWithNuGetVersion = new PackageWithNuGetVersion
+        {
+            Id = id,
+            NuGetVersion = requestedVersion is null ? null : NuGetVersion.Parse(requestedVersion)
+        };
+
+        // Act
+        (NuGetVersion foundVersion, SourceRepository foundRepo) = await PackageDownloadRunner.ResolvePackageDownloadVersion(
+            packageWithNuGetVersion,
+            [sourceRepo],
+            cache,
+            logger.Object,
+            includePrerelease: false,
+            token);
+
+        mockServer.Stop();
+
+        // Assert
+        if (expectFound)
+        {
+            foundVersion.Should().NotBeNull();
+            foundVersion.OriginalVersion.Should().Be(requestedVersion);
+            foundRepo.Should().NotBeNull();
+            foundRepo.PackageSource.Name.Should().Be(sourceRepo.PackageSource.Name);
+        }
+        else
+        {
+            foundVersion.Should().BeNull();
+            foundRepo.Should().BeNull();
+        }
+    }
+
+}

--- a/test/TestUtilities/Test.Utility/FileSystemBackedV3MockServer.cs
+++ b/test/TestUtilities/Test.Utility/FileSystemBackedV3MockServer.cs
@@ -99,9 +99,21 @@ namespace Test.Utility
             }
             else if (path.StartsWith("/flat/") && path.EndsWith(".nupkg"))
             {
-                var file = new FileInfo(Path.Combine(_packageDirectory, parts.Last()));
+                var requestedFileName = parts.Last();
+                var directory = new DirectoryInfo(_packageDirectory);
+                FileInfo file = null;
 
-                if (file.Exists)
+                // Scan for file and ignore case to make sure this works in linux too
+                foreach (var candidate in directory.EnumerateFiles("*.nupkg", SearchOption.TopDirectoryOnly))
+                {
+                    if (string.Equals(candidate.Name, requestedFileName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        file = candidate;
+                        break;
+                    }
+                }
+
+                if (file != null && file.Exists)
                 {
                     return new Action<HttpListenerResponse>(response =>
                     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/12513
Fixes: https://github.com/NuGet/Home/issues/14606
## Description
This PR implements the following design spec https://github.com/NuGet/Home/pull/14495. It adds an implementation for the `dotnet package download` command. 
This is a feature branch compromised of the following commits: 
* https://github.com/NuGet/NuGet.Client/pull/6804
* https://github.com/NuGet/NuGet.Client/pull/6885
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14558
