### PR TITLE
Refactor SearchObject to eliminate duplicate code in search result handling

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SearchObject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SearchObject.cs
@@ -61,18 +61,12 @@ namespace NuGet.PackageManagement.VisualStudio
             _lastMainFeedSearchResult = feedResults; // Store this so we can ContinueSearch, we don't store recommended as we only do that on the first search
             _lastSearchFilter = filter;
 
-            var packageSearchMetadataContextInfoCollection = new List<PackageSearchMetadataContextInfo>(feedResults.Items.Count);
-            foreach (IPackageSearchMetadata packageSearchMetadata in feedResults.Items)
-            {
-                IPackageSearchMetadata? localPackageSearchMetadata = null;
-
-                // Attach local metadata in case we do not have an icon remotely, can try local metadata.
-                localPackageSearchMetadata = await _packageMetadataProvider.GetOnlyLocalPackageMetadataAsync(packageSearchMetadata.Identity, cancellationToken);
-
-                CacheBackgroundData(packageSearchMetadata, localPackageSearchMetadata, filter.IncludePrerelease);
-                var knownOwners = CreateKnownOwners(packageSearchMetadata);
-                packageSearchMetadataContextInfoCollection.Add(PackageSearchMetadataContextInfo.Create(packageSearchMetadata, knownOwners));
-            }
+            var packageSearchMetadataContextInfoCollection = await ProcessSearchResultsAsync(
+                feedResults.Items,
+                filter.IncludePrerelease,
+                includeLocalMetadata: true,
+                createKnownOwners: true,
+                cancellationToken);
 
             return new SearchResultContextInfo(
                 packageSearchMetadataContextInfoCollection,
@@ -91,13 +85,12 @@ namespace NuGet.PackageManagement.VisualStudio
                 cancellationToken);
             _lastMainFeedSearchResult = refreshSearchResult;
 
-            var packageItems = new List<PackageSearchMetadataContextInfo>(_lastMainFeedSearchResult.Items.Count);
-
-            foreach (IPackageSearchMetadata packageSearchMetadata in _lastMainFeedSearchResult.Items)
-            {
-                CacheBackgroundData(packageSearchMetadata, _lastSearchFilter.IncludePrerelease);
-                packageItems.Add(PackageSearchMetadataContextInfo.Create(packageSearchMetadata));
-            }
+            var packageItems = await ProcessSearchResultsAsync(
+                _lastMainFeedSearchResult.Items,
+                _lastSearchFilter.IncludePrerelease,
+                includeLocalMetadata: false,
+                createKnownOwners: false,
+                cancellationToken);
 
             return new SearchResultContextInfo(
                 packageItems,
@@ -141,14 +134,12 @@ namespace NuGet.PackageManagement.VisualStudio
                 cancellationToken);
             _lastMainFeedSearchResult = continueSearchResult;
 
-            var packageItems = new List<PackageSearchMetadataContextInfo>(_lastMainFeedSearchResult.Items.Count);
-
-            foreach (IPackageSearchMetadata packageSearchMetadata in _lastMainFeedSearchResult.Items)
-            {
-                CacheBackgroundData(packageSearchMetadata, _lastSearchFilter.IncludePrerelease);
-                var knownOwners = CreateKnownOwners(packageSearchMetadata);
-                packageItems.Add(PackageSearchMetadataContextInfo.Create(packageSearchMetadata, knownOwners));
-            }
+            var packageItems = await ProcessSearchResultsAsync(
+                _lastMainFeedSearchResult.Items,
+                _lastSearchFilter.IncludePrerelease,
+                includeLocalMetadata: false,
+                createKnownOwners: true,
+                cancellationToken);
 
             return new SearchResultContextInfo(
                 packageItems,
@@ -183,9 +174,41 @@ namespace NuGet.PackageManagement.VisualStudio
             return totalCount;
         }
 
-        private void CacheBackgroundData(IPackageSearchMetadata packageSearchMetadata, bool includesPrerelease)
+        /// <summary>
+        /// Processes search results by caching background data and creating PackageSearchMetadataContextInfo objects.
+        /// This method consolidates the common logic used across SearchAsync, RefreshSearchAsync, and ContinueSearchAsync.
+        /// </summary>
+        /// <param name="searchResults">The search results to process</param>
+        /// <param name="includePrerelease">Whether prerelease packages are included in the search</param>
+        /// <param name="includeLocalMetadata">Whether to include local package metadata for icons</param>
+        /// <param name="createKnownOwners">Whether to create known owners for the packages</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of processed PackageSearchMetadataContextInfo objects</returns>
+        private async ValueTask<List<PackageSearchMetadataContextInfo>> ProcessSearchResultsAsync(
+            IEnumerable<IPackageSearchMetadata> searchResults,
+            bool includePrerelease,
+            bool includeLocalMetadata,
+            bool createKnownOwners,
+            CancellationToken cancellationToken)
         {
-            CacheBackgroundData(packageSearchMetadata, localPackageSearchMetadata: null, includesPrerelease);
+            var packageSearchMetadataContextInfoCollection = new List<PackageSearchMetadataContextInfo>();
+
+            foreach (IPackageSearchMetadata packageSearchMetadata in searchResults)
+            {
+                IPackageSearchMetadata? localPackageSearchMetadata = null;
+
+                // Attach local metadata in case we do not have an icon remotely, can try local metadata.
+                if (includeLocalMetadata)
+                {
+                    localPackageSearchMetadata = await _packageMetadataProvider.GetOnlyLocalPackageMetadataAsync(packageSearchMetadata.Identity, cancellationToken);
+                }
+
+                CacheBackgroundData(packageSearchMetadata, localPackageSearchMetadata, includePrerelease);
+                IReadOnlyList<KnownOwner>? knownOwners = createKnownOwners ? CreateKnownOwners(packageSearchMetadata) : null;
+                packageSearchMetadataContextInfoCollection.Add(PackageSearchMetadataContextInfo.Create(packageSearchMetadata, knownOwners));
+            }
+
+            return packageSearchMetadataContextInfoCollection;
         }
 
         private void CacheBackgroundData(IPackageSearchMetadata packageSearchMetadata, IPackageSearchMetadata? localPackageSearchMetadata, bool includesPrerelease)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/2533

## Description
This refactoring addresses technical debt by eliminating duplicate code in the `SearchObject` class methods: `RefreshSearchAsync`, `ContinueSearchAsync`, and `SearchAsync`. These methods previously contained similar logic for handling and caching search results.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~

Manually validated the changes launching the Package Manager in the Solution and Project levels, cycling through the Browse, Installed, Updates tabs, and performing a search.
