### PR TITLE
Wrap all accesses to cancellation token source in PackageItemViewModel in try-catch blocks to handle ObjectDisposedException gracefully

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -494,14 +494,38 @@ namespace NuGet.PackageManagement.UI
         {
             var identity = new PackageIdentity(Id, Version);
             var isTransitive = PackageLevel == PackageLevel.Transitive;
-            return await _searchService.GetPackageVersionsAsync(identity, Sources, IncludePrerelease, isTransitive, _cancellationTokenSource.Token);
+
+            CancellationToken cancellationToken;
+            try
+            {
+                cancellationToken = _cancellationTokenSource.Token;
+            }
+            catch (ObjectDisposedException)
+            {
+                // If the CancellationTokenSource is disposed, return empty collection
+                return Array.Empty<VersionInfoContextInfo>();
+            }
+
+            return await _searchService.GetPackageVersionsAsync(identity, Sources, IncludePrerelease, isTransitive, cancellationToken);
         }
 
         public async Task<IReadOnlyCollection<VersionInfoContextInfo>> GetVersionsAsync(IEnumerable<IProjectContextInfo> projects)
         {
             var identity = new PackageIdentity(Id, Version);
             var isTransitive = PackageLevel == PackageLevel.Transitive;
-            return await _searchService.GetPackageVersionsAsync(identity, Sources, IncludePrerelease, isTransitive, projects, _cancellationTokenSource.Token);
+
+            CancellationToken cancellationToken;
+            try
+            {
+                cancellationToken = _cancellationTokenSource.Token;
+            }
+            catch (ObjectDisposedException)
+            {
+                // If the CancellationTokenSource is disposed, return empty collection
+                return Array.Empty<VersionInfoContextInfo>();
+            }
+
+            return await _searchService.GetPackageVersionsAsync(identity, Sources, IncludePrerelease, isTransitive, projects, cancellationToken);
         }
 
         // This Lazy/AsyncLazy is just because DetailControlModel calls GetDetailedPackageSearchMetadataAsync directly,
@@ -513,7 +537,19 @@ namespace NuGet.PackageManagement.UI
             new Common.AsyncLazy<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo)>(async () =>
             {
                 var identity = new PackageIdentity(Id, Version);
-                return await _searchService.GetPackageMetadataAsync(identity, Sources, IncludePrerelease, _cancellationTokenSource.Token);
+
+                CancellationToken cancellationToken;
+                try
+                {
+                    cancellationToken = _cancellationTokenSource.Token;
+                }
+                catch (ObjectDisposedException)
+                {
+                    // If the CancellationTokenSource is disposed, throw OperationCanceledException
+                    throw new OperationCanceledException();
+                }
+
+                return await _searchService.GetPackageMetadataAsync(identity, Sources, IncludePrerelease, cancellationToken);
             });
         public Task<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo)> GetDetailedPackageSearchMetadataAsync()
         {
@@ -687,7 +723,17 @@ namespace NuGet.PackageManagement.UI
 
         private async Task ReloadPackageVersionsAsync()
         {
-            CancellationToken cancellationToken = _cancellationTokenSource.Token;
+            CancellationToken cancellationToken;
+            try
+            {
+                cancellationToken = _cancellationTokenSource.Token;
+            }
+            catch (ObjectDisposedException)
+            {
+                // If the CancellationTokenSource is disposed, treat it as cancellation
+                return;
+            }
+
             try
             {
                 IReadOnlyCollection<VersionInfoContextInfo> packageVersions = await GetVersionsAsync();
@@ -744,7 +790,17 @@ namespace NuGet.PackageManagement.UI
 
         private async Task RunOperationAsync(Func<CancellationToken, Task> func)
         {
-            CancellationToken cancellationToken = _cancellationTokenSource.Token;
+            CancellationToken cancellationToken;
+            try
+            {
+                cancellationToken = _cancellationTokenSource.Token;
+            }
+            catch (ObjectDisposedException)
+            {
+                // If the CancellationTokenSource is disposed, treat it as cancellation
+                return;
+            }
+
             try
             {
                 await func(cancellationToken);
@@ -823,7 +879,16 @@ namespace NuGet.PackageManagement.UI
 
         public void UpdateInstalledPackagesVulnerabilities(PackageIdentity packageIdentity)
         {
-            CancellationToken cancellationToken = _cancellationTokenSource.Token;
+            CancellationToken cancellationToken;
+            try
+            {
+                cancellationToken = _cancellationTokenSource.Token;
+            }
+            catch (ObjectDisposedException)
+            {
+                // If the CancellationTokenSource is disposed, don't start the operation
+                return;
+            }
 
             NuGetUIThreadHelper.JoinableTaskFactory
                 .RunAsync(() => UpdatePackageMaxVulnerabilityAsync(packageIdentity, cancellationToken))

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageItemViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageItemViewModelTests.cs
@@ -632,5 +632,68 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
                 Assert.Equal(IconBitmapStatus.FetchedIcon, packageItemViewModel.BitmapStatus);
             }
         }
+
+        [Fact]
+        public async Task GetVersionsAsync_AfterDispose_DoesNotThrowObjectDisposedException()
+        {
+            // Arrange
+            var packageModel = CreateLocalPackageModel();
+            var packageItemViewModel = new PackageItemViewModel(_searchService.Object, packageModel: packageModel);
+
+            // Act
+            packageItemViewModel.Dispose();
+
+            // Assert - should not throw ObjectDisposedException
+            var versions = await packageItemViewModel.GetVersionsAsync();
+            Assert.NotNull(versions);
+            Assert.Empty(versions); // Should return empty collection when disposed
+        }
+
+        [Fact]
+        public async Task GetVersionsAsync_WithProjects_AfterDispose_DoesNotThrowObjectDisposedException()
+        {
+            // Arrange
+            var packageModel = CreateLocalPackageModel();
+            var packageItemViewModel = new PackageItemViewModel(_searchService.Object, packageModel: packageModel);
+            var projects = new List<IProjectContextInfo>();
+
+            // Act
+            packageItemViewModel.Dispose();
+
+            // Assert - should not throw ObjectDisposedException
+            var versions = await packageItemViewModel.GetVersionsAsync(projects);
+            Assert.NotNull(versions);
+            Assert.Empty(versions); // Should return empty collection when disposed
+        }
+
+        [Fact]
+        public void UpdateInstalledPackagesVulnerabilities_AfterDispose_DoesNotThrowObjectDisposedException()
+        {
+            // Arrange
+            var packageModel = CreateLocalPackageModel();
+            var packageItemViewModel = new PackageItemViewModel(_searchService.Object, packageModel: packageModel);
+            var packageIdentity = new PackageIdentity("TestPackage", new NuGetVersion("1.0.0"));
+
+            // Act
+            packageItemViewModel.Dispose();
+
+            // Assert - should not throw ObjectDisposedException
+            packageItemViewModel.UpdateInstalledPackagesVulnerabilities(packageIdentity);
+        }
+
+        [Fact]
+        public async Task GetDetailedPackageSearchMetadataAsync_AfterDispose_ThrowsOperationCanceledException()
+        {
+            // Arrange
+            var packageModel = CreateLocalPackageModel();
+            var packageItemViewModel = new PackageItemViewModel(_searchService.Object, packageModel: packageModel);
+
+            // Act
+            packageItemViewModel.Dispose();
+
+            // Assert - should throw OperationCanceledException (not ObjectDisposedException)
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await packageItemViewModel.GetDetailedPackageSearchMetadataAsync());
+        }
     }
 }


### PR DESCRIPTION
Wrap all accesses to `_cancellationTokenSource.Token` in try-catch blocks to handle ObjectDisposedException gracefully

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3499

## Description
The PackageItemViewModel class was throwing ObjectDisposedException when code attempted to access the CancellationTokenSource after the ViewModel had been disposed. This exception was being logged as a fault in telemetry.

## Root Cause
The issue occurred when:
1. The PackageItemViewModel's `Dispose()` method was called, which disposed the `_cancellationTokenSource`
2. Async methods that had already started (or were about to start) attempted to access `_cancellationTokenSource.Token`
3. Accessing the `Token` property of a disposed CancellationTokenSource throws `ObjectDisposedException`

## Solution
The fix wraps all accesses to `_cancellationTokenSource.Token` in try-catch blocks to handle ObjectDisposedException gracefully. When the CancellationTokenSource is disposed:

1. **GetVersionsAsync methods**: Return empty collections instead of throwing
2. **Async operations (ReloadPackageVersionsAsync, RunOperationAsync)**: Exit gracefully as if cancelled
3. **GetDetailedPackageSearchMetadataAsync**: Throws OperationCanceledException (which is already handled by callers)
4. **UpdateInstalledPackagesVulnerabilities**: Does not start new operations

This approach ensures that:
- ObjectDisposedException is never propagated to telemetry
- The behavior is semantically correct (treating disposed state as cancelled)
- No existing functionality is broken

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
