### PR TITLE
Remove DefaultInvisible for Clear NuGet Local Resources Command

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
@@ -94,7 +94,6 @@
       </Button>
 
       <Button guid="guidClearNuGetLocalResourcesCmdSet" id="cmdidClearNuGetLocalResources" priority="0x0100" type="Button">
-        <CommandFlag>DefaultInvisible</CommandFlag>
         <Strings>
           <CommandName>cmdidClearNuGetLocalResources</CommandName>
           <!--This button text is not visible to the user as the command is invoked from Unified Settings-->


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14625
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2617172

## Description

Unified Settings bases the visibility of Commands on the VSCT Command visibility.
In legacy Options, our AsyncPackage was always loaded and initialized as the options were opening, and this is not the case in USX.

NuGet's Clear command was set to DefaultInvisible, so I've disabled that here and, in my testing, it resolves the issue
Before the NuGet Package loads, this means the button could be hidden until some arbitrary action loads our AsyncPackage (time passes, restore is triggered, any NuGet command is executed). With this change, make the command always visible, as at any time, clearing these NuGet resources is applicable.

<img width="600" height="199" alt="image" src="https://github.com/user-attachments/assets/21802ab6-d9db-4b78-8e20-fa8342b109f4" />

Manually tested that the button appears and functions immediately after opening VS without loading a solution.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ 
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
