### PR TITLE
[5.11] Stop installing MicroBuild plugins explicitly

### DIFF
--- a/build/bootstrap.proj
+++ b/build/bootstrap.proj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageDownload Include="ILMerge" version="[3.0.21]" />
         <PackageDownload Include="Lucene.Net" version="[3.0.3]" />
-        <PackageDownload Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="[0.4.1]" />
+        <PackageDownload Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="[1.0.0]" />
         <PackageDownload Include="Microsoft.Web.Xdt" version="[3.0.0]" />
         <PackageDownload Include="Newtonsoft.Json" version="[9.0.1]" />
         <PackageDownload Include="NuGet.Build.Tasks.Pack" version="[5.8.0]" />

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" />
 
   <!-- Helper properties -->
   <PropertyGroup>
@@ -47,7 +47,7 @@
     <NuGetBuildLocalizationRepository>$(RepositoryRootDirectory)submodules\NuGet.Build.Localization\</NuGetBuildLocalizationRepository>
     <LocalizationRootDirectory>$(NuGetBuildLocalizationRepository)localize</LocalizationRootDirectory>
     <LocalizationWorkDirectory>$(RepositoryRootDirectory)localize</LocalizationWorkDirectory>
-    <MicroBuildDirectory>$(SolutionPackagesFolder)microsoft.visualstudioeng.microbuild.core\0.4.1\build\</MicroBuildDirectory>
+    <MicroBuildDirectory>$(SolutionPackagesFolder)Microsoft.VisualStudioEng.MicroBuild.Core\1.0.0\build\</MicroBuildDirectory>
     <MicrosoftDotNetBuildTasksFeedFilePath>$(SolutionPackagesFolder)microsoft.dotnet.build.tasks.feed\6.0.0-beta.20528.5\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
     <MicrosoftDotNetMaestroTasksFilePath>$(SolutionPackagesFolder)microsoft.dotnet.maestro.tasks\1.1.0-beta.21117.3\tools\netcoreapp3.1\Microsoft.DotNet.Maestro.Tasks.dll</MicrosoftDotNetMaestroTasksFilePath>
     <NoWarn>$(NoWarn);NU5105;MSB3277</NoWarn>

--- a/build/common.targets
+++ b/build/common.targets
@@ -394,6 +394,6 @@ Condition=" ('%(Extension)' == '.dll' OR '%(Filename)' == 'NuGet.CommandLine.XPl
       Condition=" '%(PackageReference.Version)' != '' AND '%(PackageReference.IsImplicitlyDefined)' != 'true' AND '%(PackageReference.Identity)' != 'Microsoft.NET.Test.Sdk' " />
   </Target>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), &quot;README.md&quot;))\packages\Microsoft.VisualStudioEng.MicroBuild.Core\1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
 
 </Project>

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -25,18 +25,6 @@ steps:
       inlineScript: |
         Get-ChildItem Env: | Sort-Object Name | Format-Table -Wrap -AutoSize
 
-  - task: MicroBuildLocalizationPlugin@1
-    displayName: "Install Localization Plugin"
-
-  - task: MicroBuildSigningPlugin@1
-    inputs:
-      signType: "$(SigningType)"
-      esrpSigning: "true"
-    displayName: "Install Signing Plugin"
-
-  - task: MicroBuildSwixPlugin@1
-    displayName: "Install Swix Plugin"
-
   # NuGet.Client's official repo is on github, hence the source link metadata should use the github URL.
   # However, our official builds are built from a mirror in Azure DevOps, hence without any extra help, the SourceLink.GitHub package
   # won't be able to determine the URL to embed in the pdbs.

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -187,6 +187,14 @@ steps:
           PackageName: "NuGet.Client"
           PackageVersion: "$(SemanticVersion)"
 
+  - task: PowerShell@1
+    displayName: "List vs15 directory"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        gci artifacts\VS15
+    condition: always()
+
   - task: MSBuild@1
     displayName: "Generate Build Tools package"
     inputs:
@@ -194,6 +202,14 @@ steps:
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\13.GenerateBuildToolsPackage.binlog"
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+  - task: PowerShell@1
+    displayName: "List vs15 directory 2"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        gci artifacts\VS15
+    condition: always()
 
   - task: MSBuild@1
     displayName: "Sign Nupkgs and VSIX"
@@ -224,6 +240,14 @@ steps:
       WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
     condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))) #skip this task for nonRTM in private build
 
+  - task: PowerShell@1
+    displayName: "List vs15 directory 3"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        gci artifacts\VS15
+    condition: always()
+
   - task: MSBuild@1
     displayName: "Generate VSMAN file for NuGet Core VSIX"
     inputs:
@@ -232,6 +256,14 @@ steps:
       msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\16.GenerateVSManifestForVSIX.binlog"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
+  - task: PowerShell@1
+    displayName: "List vs15 directory 4"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        gci artifacts\VS15
+    condition: always()
+
   - task: MSBuild@1
     displayName: "Generate VSMAN file for Build Tools VSIX"
     inputs:
@@ -239,6 +271,14 @@ steps:
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateVSManifestForToolsVSIX.binlog"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false')) "
+
+  - task: PowerShell@1
+    displayName: "List vs15 directory 5"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        gci artifacts\VS15
+    condition: always()
 
   - task: PowerShell@1
     displayName: "Create EndToEnd Test Package"

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -115,7 +115,7 @@ steps:
     inputs:
       solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:CopyFinalNuGetExeToOutputPath"
+      msbuildArguments: "/t:CopyFinalNuGetExeToOutputPath /binarylogger:$(Build.StagingDirectory)\\binlog\\07.CopyFinalNuGetExeToOutputPath.binlog"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'), not(eq(variables['RunMonoTestsOnMac'], 'false')))"
 
   - task: MSBuild@1
@@ -152,7 +152,7 @@ steps:
     inputs:
       solution: "build\\sign.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:AfterBuild"
+      msbuildArguments: "/t:AfterBuild /binarylogger:$(Build.StagingDirectory)\\binlog\\09.SignAssemblies.binlog"
       maximumCpuCount: true
     condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))) #skip this task for nonRTM in private build
 
@@ -161,7 +161,7 @@ steps:
     inputs:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber)"
+      msbuildArguments: "/t:Pack /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /binarylogger:$(Build.StagingDirectory)\\binlog\\10.PackNupkgs.binlog"
       maximumCpuCount: true
     condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))) #skip this task for nonRTM in private build
 
@@ -170,7 +170,7 @@ steps:
     inputs:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:EnsurePackagesExist /p:ExcludeTestProjects=$(BuildRTM)"
+      msbuildArguments: "/t:EnsurePackagesExist /p:ExcludeTestProjects=$(BuildRTM) /binarylogger:$(Build.StagingDirectory)\\binlog\\11.EnsurePackagesExist.binlog"
     condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))) #skip this task for nonRTM in private build
 
   - task: MSBuild@1
@@ -178,7 +178,7 @@ steps:
     inputs:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true"
+      msbuildArguments: "/t:BuildVSIX /p:BuildRTM=$(BuildRTM) /p:ExcludeTestProjects=$(BuildRTM) /p:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\12.PackVSIX.binlog"
       maximumCpuCount: true
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
   - ${{ if not(parameters.BuildRTM)}}:
@@ -192,7 +192,7 @@ steps:
     inputs:
       solution: "setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true"
+      msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\13.GenerateBuildToolsPackage.binlog"
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: MSBuild@1
@@ -200,7 +200,7 @@ steps:
     inputs:
       solution: "build\\sign.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/t:AfterBuild /p:SignPackages=true"
+      msbuildArguments: "/t:AfterBuild /p:SignPackages=true /binarylogger:$(Build.StagingDirectory)\\binlog\\14.SignNupkgsAndVSIX.binlog"
     condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))) #skip this task for nonRTM in private build
 
   - task: NuGetCommand@2

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -187,14 +187,6 @@ steps:
           PackageName: "NuGet.Client"
           PackageVersion: "$(SemanticVersion)"
 
-  - task: PowerShell@1
-    displayName: "List vs15 directory"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        gci artifacts\VS15
-    condition: always()
-
   - task: MSBuild@1
     displayName: "Generate Build Tools package"
     inputs:
@@ -202,14 +194,6 @@ steps:
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/p:BuildNumber=$(BuildNumber) /p:IsVsixBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\13.GenerateBuildToolsPackage.binlog"
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
-  - task: PowerShell@1
-    displayName: "List vs15 directory 2"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        gci artifacts\VS15
-    condition: always()
 
   - task: MSBuild@1
     displayName: "Sign Nupkgs and VSIX"
@@ -240,14 +224,6 @@ steps:
       WhiteListPathForSigs: '$(Build.Repository.LocalPath)\\build\\ignorecodesign.csv'
     condition: and(succeeded(), or(eq(variables['IsOfficialBuild'], 'true'), eq(variables['BuildRTM'], 'true'))) #skip this task for nonRTM in private build
 
-  - task: PowerShell@1
-    displayName: "List vs15 directory 3"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        gci artifacts\VS15
-    condition: always()
-
   - task: MSBuild@1
     displayName: "Generate VSMAN file for NuGet Core VSIX"
     inputs:
@@ -256,14 +232,6 @@ steps:
       msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\16.GenerateVSManifestForVSIX.binlog"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false')) "
 
-  - task: PowerShell@1
-    displayName: "List vs15 directory 4"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        gci artifacts\VS15
-    condition: always()
-
   - task: MSBuild@1
     displayName: "Generate VSMAN file for Build Tools VSIX"
     inputs:
@@ -271,14 +239,6 @@ steps:
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateVSManifestForToolsVSIX.binlog"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false')) "
-
-  - task: PowerShell@1
-    displayName: "List vs15 directory 5"
-    inputs:
-      scriptType: "inlineScript"
-      inlineScript: |
-        gci artifacts\VS15
-    condition: always()
 
   - task: PowerShell@1
     displayName: "Create EndToEnd Test Package"

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -26,7 +26,7 @@
     <ProjectReference Include="Microsoft.VisualStudio.NuGet.BuildTools.swixproj" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup  Condition="'$(IsVsixBuild)' != 'true'">
     <MergeManifest Include="$(OutputPath)$(MSBuildProjectName).json"
                    SBOMFileLocation="$(SBOMFileLocation)" />
   </ItemGroup>

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -11,6 +11,7 @@
     <TargetName>$(MSBuildProjectName)</TargetName>
     <DropFolder>$(VsixPublishDestination)</DropFolder>
     <OutputPath Condition="'$(IsVsixBuild)' != 'true'">$(DropFolder)</OutputPath>
+    <SBOMFileLocation>$(ManifestDirPath)\$(ARTIFACT_NAME)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsVsixBuild)' == 'true'">
@@ -26,7 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <MergeManifest Include="$(OutputPath)$(MSBuildProjectName).json" />
+    <MergeManifest Include="$(OutputPath)$(MSBuildProjectName).json"
+                   SBOMFileLocation="$(SBOMFileLocation)" />
   </ItemGroup>
 
   <Target Name="CopyToDropFolder" AfterTargets="Build" Condition="'$(IsVsixBuild)' == 'true'">

--- a/setup/Microsoft.VisualStudio.NuGet.Core.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.Core.vsmanproj
@@ -9,10 +9,13 @@
       <BuildNumber>$(SemanticVersion).$(BuildNumber)</BuildNumber>
       <TargetName>$(MSBuildProjectName)</TargetName>
       <OutputPath>$(VsixPublishDestination)</OutputPath>
+      <SBOMFileLocation>$(ManifestDirPath)\$(ARTIFACT_NAME)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
   </PropertyGroup>
 
   <ItemGroup>
-    <MergeManifest Include="$(VsixPublishDestination)Microsoft.VisualStudio.NuGet.Core.json" />
+    <MergeManifest Include="$(VsixPublishDestination)Microsoft.VisualStudio.NuGet.Core.json"
+                   SBOMFileLocation="$(SBOMFileLocation)" />
+
   </ItemGroup>
 
   <Import Project="$(MicroBuildDirectory)Microsoft.VisualStudioEng.MicroBuild.Core.targets"/>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Hopefully fixes 5.11 branch

## Description

Ever since the 5.11 branch migrated to 1ES templates, the pipeline has been failing signing. The templates already cause the loc, signing and swix plugins to be installed: https://github.com/NuGet/NuGet.Client/blob/a9e07c75027ca3e73752ab1a386b78542cb06a30/eng/pipelines/templates/pipeline.yml#L124-L133

So, there's no need to explicitly install them in our CI steps.  In fact, given we're using old `@1` versions of the tasks, it might be these old versions that are causing us problems. Let the template use the version that the VS Engineering team manage.

I don't know if this will fix the problem. The problem only occurs with real signing, so we can't test until this PR is merged.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
