### PR TITLE
Disable test execution and fix OptProf variable (release-5.11.x)

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -3,31 +3,26 @@ parameters:
   displayName: Build bits for publishing
   type: boolean
   default: true
-# Disable on this branch.
-# - name: RunCrossFrameworkTestsOnWindows
-#   displayName: Run cross framweork tests on Windows
-#   type: boolean
-#   default: true
-- name: RunFunctionalTestsOnWindows
-  displayName: Run functional tests on Windows
+- name: RunTestsOnWindows
+  displayName: Run tests on Windows
   type: boolean
-  default: true
+  default: false
 - name: RunSourceBuild
   displayName: Run source build
   type: boolean
-  default: true
+  default: false
 - name: RunTestsOnLinux
   displayName: Run tests on Linux
   type: boolean
-  default: true
+  default: false
 - name: RunTestsOnMac
   displayName: Run tests on Mac
   type: boolean
-  default: true
+  default: false
 - name: RunMonoTestsOnMac
   displayName: Run Mono tests on Mac
   type: boolean
-  default: true
+  default: false
 - name: SigningType
   displayName: Type of signing to use
   type: string
@@ -50,8 +45,7 @@ variables:
   Codeql.Enabled: false
   Codeql.TSAEnabled: false
   RunBuildForPublishing: ${{ parameters.RunBuildForPublishing }}
-  # Disable on this branch. RunCrossFrameworkTestsOnWindows: ${{ parameters.RunCrossFrameworkTestsOnWindows }}
-  RunFunctionalTestsOnWindows: ${{ parameters.RunFunctionalTestsOnWindows }}
+  RunTestsOnWindows: ${{ parameters.RunTestsOnWindows }}
   RunSourceBuild: ${{ parameters.RunSourceBuild }}
   RunTestsOnLinux: ${{ parameters.RunTestsOnLinux }}
   RunTestsOnMac: ${{ parameters.RunTestsOnMac }}
@@ -85,8 +79,7 @@ extends:
         isOfficialBuild: true
         NuGetLocalizationType: Full
         RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
-        # Disable on this branch. RunCrossFrameworkTestsOnWindows: ${{parameters.RunCrossFrameworkTestsOnWindows}}
-        RunFunctionalTestsOnWindows: ${{parameters.RunFunctionalTestsOnWindows}}
+        RunTestsOnWindows: ${{parameters.RunTestsOnWindows}}
         RunSourceBuild: ${{parameters.RunSourceBuild}}
         RunTestsOnLinux: ${{parameters.RunTestsOnLinux}}
         RunTestsOnMac: ${{parameters.RunTestsOnMac}}

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -10,12 +10,7 @@ parameters:
     displayName: Build bits for publishing
     type: boolean
     default: true
-  # Disable on this branch.
-  # - name: RunCrossFrameworkTestsOnWindows
-  #   displayName: Run cross framweork tests on Windows
-  #   type: boolean
-  #   default: true
-  - name: RunFunctionalTestsOnWindows
+  - name: RunTestsOnWindows
     displayName: Run functional tests on Windows
     type: boolean
     default: true
@@ -39,6 +34,7 @@ parameters:
     displayName: Type of signing to use
     type: string
     default: Test
+
 resources:
   repositories:
     - repository: MicroBuildTemplate
@@ -53,8 +49,7 @@ variables:
   Codeql.Enabled: false
   Codeql.TSAEnabled: false
   RunBuildForPublishing: ${{ parameters.RunBuildForPublishing }}
-  # Disable on this branch. RunCrossFrameworkTestsOnWindows: ${{ parameters.RunCrossFrameworkTestsOnWindows }}
-  RunFunctionalTestsOnWindows: ${{ parameters.RunFunctionalTestsOnWindows }}
+  RunTestsOnWindows: ${{ parameters.RunTestsOnWindows }}
   RunSourceBuild: ${{ parameters.RunSourceBuild }}
   RunTestsOnLinux: ${{ parameters.RunTestsOnLinux }}
   RunTestsOnMac: ${{ parameters.RunTestsOnMac }}
@@ -87,8 +82,7 @@ extends:
         parameters:
           NuGetLocalizationType: ${{parameters.NuGetLocalizationType}}
           RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
-          # Disable on this branch. RunCrossFrameworkTestsOnWindows: ${{parameters.RunCrossFrameworkTestsOnWindows}}
-          RunFunctionalTestsOnWindows: ${{parameters.RunFunctionalTestsOnWindows}}
+          RunTestsOnWindows: ${{parameters.RunTestsOnWindows}}
           RunSourceBuild: ${{parameters.RunSourceBuild}}
           RunTestsOnLinux: ${{parameters.RunTestsOnLinux}}
           RunTestsOnMac: ${{parameters.RunTestsOnMac}}

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -128,7 +128,7 @@ steps:
       solution: "test\\NuGet.Clients.Tests\\NuGet.CommandLine.Test\\NuGet.CommandLine.Test.csproj"
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:CopyFinalNuGetExeToOutputPath"
-    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+    condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'), not(eq(variables['RunMonoTestsOnMac'], 'false')))"
 
   - task: MSBuild@1
     displayName: "Run unit tests (stop on error)"
@@ -137,7 +137,7 @@ steps:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['RunTestsOnWindows'], 'false')), not(eq(variables['IsOfficialBuild'], 'true')))"
 
   - task: MSBuild@1
     displayName: "Run unit tests (continue on error)"
@@ -146,7 +146,7 @@ steps:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/t:CoreUnitTests;UnitTestsVS /p:BuildRTM=$(BuildRTM) /p:BuildNumber=$(BuildNumber) /p:TestResultOutputFormat=xml /p:SkipILMergeOfNuGetExe=true"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['RunTestsOnWindows'], 'false')), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: PublishTestResults@2
     displayName: "Publish Test Results"
@@ -157,7 +157,7 @@ steps:
       searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
       mergeTestResults: "true"
       publishRunAttachments: "false"
-    condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
+    condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'), not(eq(variables['RunTestsOnWindows'], 'false')))"
 
   - task: MSBuild@1
     displayName: "Sign Assemblies"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -13,12 +13,7 @@ parameters:
     displayName: Build bits for publishing
     type: boolean
     default: true
-  # Disable on this branch.
-  # - name: RunCrossFrameworkTestsOnWindows
-  #   displayName: Run cross framweork tests on Windows
-  #   type: boolean
-  #   default: true
-  - name: RunFunctionalTestsOnWindows
+  - name: RunTestsOnWindows
     displayName: Run functional tests on Windows
     type: boolean
     default: true
@@ -48,7 +43,7 @@ parameters:
     values:
       - Real
       - Test
-
+  
 stages:
   - stage: Initialize
     jobs:
@@ -109,7 +104,6 @@ stages:
           VsTargetChannelForTests: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetChannelForTests']]
           VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
           isOfficialBuild: ${{ parameters.isOfficialBuild }}
-          ShouldSkipOptimize: ${{ variables['ShouldSkipOptimize'] }}
           LocalizedLanguageCount: "13"
           BuildRTM: "false"
           SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
@@ -135,7 +129,7 @@ stages:
               enabled: ${{ variables['isOfficialBuild'] }}
               OptimizationInputsLookupMethod: DropPrefix
               DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-              ShouldSkipOptimize: ${{ variables['ShouldSkipOptimize'] }}
+              ShouldSkipOptimize: $(ShouldSkipOptimize)
               AccessToken: $(System.AccessToken)
           outputs:
             - output: pipelineArtifact
@@ -323,7 +317,7 @@ stages:
             $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
             # Set MSBuildEnableWorkloadResolver to work around https://github.com/dotnet/sdk/issues/17461
           MSBuildEnableWorkloadResolver: false
-        condition: "and(succeeded(), ne(variables['RunFunctionalTestsOnWindows'], 'false'))"
+        condition: "and(succeeded(), ne(variables['RunTestsOnWindows'], 'false'))"
         pool:
           name: VSEngSS-MicroBuild2019-1ES
           os: windows
@@ -437,36 +431,6 @@ stages:
               sbomEnabled: false
         steps:
           - template: /eng/pipelines/templates/Tests_On_Mac.yml@self
-
-    # Disable on this branch.
-    # - job: CrossFramework_Tests_On_Windows
-    #   displayName: "Windows CrossFrameworkTests"
-    #   condition: "and(succeeded(), ne(variables['RunCrossFrameworkTestsOnWindows'], 'false'))"
-    #   timeoutInMinutes: 30
-    #   variables:
-    #     BuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.BuildNumber']]
-    #     FullVstsBuildNumber: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.FullVstsBuildNumber']]
-    #   pool:
-    #     name: AzurePipelines-EO
-    #     image: 1ESPT-Windows2022
-    #     os: windows
-    #   templateContext:
-    #     outputs:
-    #     - output: pipelineArtifact
-    #       displayName: 'Publish Test Freeze Dump'
-    #       condition: "or(failed(), canceled())"
-    #       targetPath: "$(Build.Repository.LocalPath)/build/TestResults"
-    #       artifactName: "$(Agent.JobName) - Attempt $(System.JobAttempt)"
-    #       sbomEnabled: false
-
-    #     - output: pipelineArtifact
-    #       displayName: 'Publish binlogs'
-    #       condition: "or(failed(), eq(variables['System.debug'], 'true'))"
-    #       artifactName: binlog - $(System.JobDisplayName) - Attempt $(System.JobAttempt)
-    #       targetPath: $(Build.StagingDirectory)\binlog
-    #       sbomEnabled: false
-    #   steps:
-    #   - template: /eng/pipelines/templates/CrossFramework_Tests_On_Windows.yml@self
 
   - stage: MacTests
     displayName: "Mac Mono Tests"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Disables test execution in Official and PrivateDev builds for release-5.11.x and fixes the ShouldSkipOptimize option

I unified the `RunFunctionalTestsOnWindows` parameter to just `RunTestsOnWindows` and added the appropriate conditions to the tasks.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
