### PR TITLE
Fix Static Source Analysis issue (release-6.11.x)

### DIFF
--- a/eng/pipelines/templates/Static_Source_Analysis.yml
+++ b/eng/pipelines/templates/Static_Source_Analysis.yml
@@ -23,31 +23,6 @@ steps:
     GdnBreakGdnToolCredScan: true
   continueOnError: ${{ parameters.isOfficialBuild }}
 
-- task: PowerShell@2
-  displayName: "Ensure all projects are in NuGet.sln"
-  inputs:
-    targetType: 'inline'
-    script: |
-      try {
-        $slnProjects = & dotnet sln list | Select-Object -Skip 2 | ForEach-Object { "$PWD\$_" } | sort
-        "Solution contains $($slnProjects.Length) projects"
-        $fsProjects = gci -Recurse -Filter *.csproj | ForEach-Object { $_.FullName } | Where-Object { $_ -notlike "*\EndToEnd\*" -and $_ -notlike "*\bin\*" -and $_ -notlike "*\compiler\resources\*" -and $_ -notlike "*\Assets\*" } | sort
-        "Repo contains $($fsProjects.Length) projects"
-        $diff = @(Compare-Object -ReferenceObject $fsProjects -DifferenceObject $slnProjects)
-        $diff
-        if ($diff.length -gt 0)
-        {
-          throw "Repo has project file(s) not in NuGet.sln"
-        }
-      }
-      catch
-      {
-        Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
-        exit 1
-      }
-  continueOnError: ${{ parameters.isOfficialBuild }}
-  condition: succeededOrFailed()
-
 - script: dotnet format whitespace --verify-no-changes NuGet.sln
   name: dotnetFormatWhitespace
   displayName: Check whitespace formatting


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3530

## Description
Static Source Analysis has a step to ensure all projects are in NuGet.sln and for some reason the PowerShell script is failing

```
Found more than one solution file in D:\a\_work\1\s\. Specify which one to use.
Solution contains 0 projects
Repo contains 93 projects
##[error]Cannot bind argument to parameter 'DifferenceObject' because it is null.[0]
##[error]PowerShell exited with code '1'.
```
We won't be changing the project set in this servicing branch so I just removed the task.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
