### PR TITLE
Stop running test in official build and PrivateDev (release-6.10.x)

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -3,14 +3,18 @@ parameters:
   displayName: Build bits for publishing
   type: boolean
   default: true
+- name: RunUnitTestsOnWindows
+  displayName: Run unit tests on Windows
+  type: boolean
+  default: false
 - name: RunCrossFrameworkTestsOnWindows
   displayName: Run cross framweork tests on Windows
   type: boolean
-  default: true
+  default: false
 - name: RunFunctionalTestsOnWindows
   displayName: Run functional tests on Windows
   type: boolean
-  default: true
+  default: false
 - name: RunSourceBuild
   displayName: Run source build
   type: boolean
@@ -18,11 +22,11 @@ parameters:
 - name: RunTestsOnLinux
   displayName: Run tests on Linux
   type: boolean
-  default: true
+  default: false
 - name: RunTestsOnMac
   displayName: Run tests on Mac
   type: boolean
-  default: true
+  default: false
 - name: RunMonoTestsOnMac
   displayName: Run Mono tests on Mac
   type: boolean
@@ -49,6 +53,7 @@ variables:
   Codeql.Enabled: false
   Codeql.TSAEnabled: false
   RunBuildForPublishing: ${{ parameters.RunBuildForPublishing }}
+  RunUnitTestsOnWindows: ${{ parameters.RunUnitTestsOnWindows }}
   RunCrossFrameworkTestsOnWindows: ${{ parameters.RunCrossFrameworkTestsOnWindows }}
   RunFunctionalTestsOnWindows: ${{ parameters.RunFunctionalTestsOnWindows }}
   RunSourceBuild: ${{ parameters.RunSourceBuild }}

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -10,26 +10,30 @@ parameters:
   displayName: Build bits for publishing
   type: boolean
   default: true
+- name: RunUnitTestsOnWindows
+  displayName: Run unit tests on Windows
+  type: boolean
+  default: false
 - name: RunCrossFrameworkTestsOnWindows
   displayName: Run cross framweork tests on Windows
   type: boolean
-  default: true
+  default: false
 - name: RunFunctionalTestsOnWindows
   displayName: Run functional tests on Windows
   type: boolean
-  default: true
+  default: false
 - name: RunSourceBuild
   displayName: Run source build
   type: boolean
-  default: true
+  default: false
 - name: RunTestsOnLinux
   displayName: Run tests on Linux
   type: boolean
-  default: true
+  default: false
 - name: RunTestsOnMac
   displayName: Run tests on Mac
   type: boolean
-  default: true
+  default: false
 - name: RunMonoTestsOnMac
   displayName: Run Mono tests on Mac
   type: boolean
@@ -57,6 +61,7 @@ variables:
   Codeql.Enabled: false
   Codeql.TSAEnabled: false
   RunBuildForPublishing: ${{ parameters.RunBuildForPublishing }}
+  RunUnitTestsOnWindows: ${{ parameters.RunUnitTestsOnWindows }}
   RunCrossFrameworkTestsOnWindows: ${{ parameters.RunCrossFrameworkTestsOnWindows }}
   RunFunctionalTestsOnWindows: ${{ parameters.RunFunctionalTestsOnWindows }}
   RunSourceBuild: ${{ parameters.RunSourceBuild }}

--- a/eng/pipelines/templates/Build_and_UnitTest.yml
+++ b/eng/pipelines/templates/Build_and_UnitTest.yml
@@ -133,7 +133,7 @@ steps:
     solution: "build\\build.proj"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.RunUnitTests.binlog"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), not(eq(variables['IsOfficialBuild'], 'true')), not(eq(variables['RunUnitTestsOnWindows'], 'false')))"
 
 - task: MSBuild@1
   displayName: "Run unit tests (continue on error)"
@@ -142,7 +142,7 @@ steps:
     solution: "build\\build.proj"
     configuration: "$(BuildConfiguration)"
     msbuildArguments: "/restore:false /target:CoreUnitTests;UnitTestsVS /property:BuildRTM=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /property:SkipILMergeOfNuGetExe=true /binarylogger:$(Build.StagingDirectory)\\binlog\\08.RunUnitTests.binlog"
-  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'))"
+  condition: "and(succeeded(), eq(variables['BuildRTM'], 'true'), eq(variables['IsOfficialBuild'], 'true'), not(eq(variables['RunUnitTestsOnWindows'], 'false')))"
 
 - task: PublishTestResults@2
   displayName: "Publish Test Results"
@@ -152,7 +152,7 @@ steps:
     testRunTitle: "NuGet.Client Unit Tests On Windows"
     searchFolder: "$(Build.Repository.LocalPath)\\build\\TestResults"
     publishRunAttachments: "false"
-  condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'))"
+  condition: "and(succeededOrFailed(),eq(variables['BuildRTM'], 'true'), not(eq(variables['RunUnitTestsOnWindows'], 'false')))"
 
 - task: MSBuild@1
   displayName: "Sign Assemblies"

--- a/eng/pipelines/templates/Static_Source_Analysis.yml
+++ b/eng/pipelines/templates/Static_Source_Analysis.yml
@@ -23,31 +23,6 @@ steps:
     GdnBreakGdnToolCredScan: true
   continueOnError: ${{ parameters.isOfficialBuild }}
 
-- task: PowerShell@2
-  displayName: "Ensure all projects are in NuGet.sln"
-  inputs:
-    targetType: 'inline'
-    script: |
-      try {
-        $slnProjects = & dotnet sln list | Select-Object -Skip 2 | ForEach-Object { "$PWD\$_" } | sort
-        "Solution contains $($slnProjects.Length) projects"
-        $fsProjects = gci -Recurse -Filter *.csproj | ForEach-Object { $_.FullName } | Where-Object { $_ -notlike "*\EndToEnd\*" -and $_ -notlike "*\bin\*" -and $_ -notlike "*\compiler\resources\*" -and $_ -notlike "*\Assets\*" } | sort
-        "Repo contains $($fsProjects.Length) projects"
-        $diff = @(Compare-Object -ReferenceObject $fsProjects -DifferenceObject $slnProjects)
-        $diff
-        if ($diff.length -gt 0)
-        {
-          throw "Repo has project file(s) not in NuGet.sln"
-        }
-      }
-      catch
-      {
-        Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
-        exit 1
-      }
-  continueOnError: ${{ parameters.isOfficialBuild }}
-  condition: succeededOrFailed()
-
 - script: dotnet format whitespace --verify-no-changes NuGet.sln
   name: dotnetFormatWhitespace
   displayName: Check whitespace formatting


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3532

## Description
This is mostly a cherry-pick from the same commit in `release-6.8.x` which disables the test execution by default in Official and PrivateDev.  It also removes some logic in the static source analysis that we don't need.
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
