### PR TITLE
Fixes resizing behavior of the filters in the PMUI top panel

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -239,7 +239,8 @@
             VerticalContentAlignment="Center"
             Checked="_checkboxPrerelease_Checked"
             Unchecked="_checkboxPrerelease_Unchecked"
-            IsChecked="True">
+            IsChecked="True"
+            ToolTip="{x:Static nuget:Resources.Checkbox_IncludePrerelease}">
               <TextBlock TextTrimming="CharacterEllipsis" Text="{x:Static nuget:Resources.Checkbox_IncludePrerelease}" />
             </CheckBox>
 
@@ -255,8 +256,9 @@
             Checked="_checkboxVulnerabilities_Checked"
             Unchecked="_checkboxVulnerabilities_Unchecked"
             Visibility="Hidden"
-            IsChecked="False">
-            <TextBlock TextTrimming="CharacterEllipsis" Text="{x:Static nuget:Resources.Checkbox_Show_Vulnerable_Only}" />
+            IsChecked="False"
+            ToolTip="{x:Static nuget:Resources.Checkbox_Show_Vulnerable_Only}">
+              <TextBlock TextTrimming="CharacterEllipsis" Text="{x:Static nuget:Resources.Checkbox_Show_Vulnerable_Only}" />
           </CheckBox>
         </Grid>
       </Grid>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -189,8 +189,7 @@
         <Grid.ColumnDefinitions>
           <ColumnDefinition MaxWidth="320" MinWidth="118"/>
           <ColumnDefinition Width="auto" />
-          <ColumnDefinition MaxWidth="125" />
-          <ColumnDefinition MaxWidth="150"/>
+          <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <!-- container of the search control -->
         <Border
@@ -218,39 +217,52 @@
             Width="16" />
         </Button>
 
-        <!-- prerelease checkbox -->
-        <CheckBox
+        <!-- grid for filters -->
+        <Grid
           Grid.Column="2"
-          x:Name="_checkboxPrerelease"
-          AutomationProperties.AutomationId="CheckBox_Prerelease"
-          Margin="3,0"
           VerticalAlignment="Center"
-          Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
-          VerticalContentAlignment="Center"
-          Checked="_checkboxPrerelease_Checked"
-          Unchecked="_checkboxPrerelease_Unchecked"
-          IsChecked="True">
-          <TextBlock TextTrimming="CharacterEllipsis" Text="{x:Static nuget:Resources.Checkbox_IncludePrerelease}" />
-        </CheckBox>
+          HorizontalAlignment="Left">
 
-        <!-- show vulnerabilities checkbox -->
-        <CheckBox
-          Grid.Column="3"
-          x:Name="_checkboxVulnerabilities"
-          AutomationProperties.AutomationId="CheckBox_Vulnerabilities"
-          Margin="3,0"
-          VerticalAlignment="Center"
-          Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
-          VerticalContentAlignment="Center"
-          Checked="_checkboxVulnerabilities_Checked"
-          Unchecked="_checkboxVulnerabilities_Unchecked"
-          Visibility="Hidden"
-          IsChecked="False">
-          <TextBlock TextTrimming="CharacterEllipsis" Text="{x:Static nuget:Resources.Checkbox_Show_Vulnerable_Only}" />
-        </CheckBox>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+          </Grid.ColumnDefinitions>
+
+          <!-- prerelease checkbox -->
+          <CheckBox
+            Grid.Column="0"
+            x:Name="_checkboxPrerelease"
+            AutomationProperties.AutomationId="CheckBox_Prerelease"
+            Margin="3,0"
+            VerticalAlignment="Center"
+            Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
+            VerticalContentAlignment="Center"
+            Checked="_checkboxPrerelease_Checked"
+            Unchecked="_checkboxPrerelease_Unchecked"
+            IsChecked="True">
+              <TextBlock TextTrimming="CharacterEllipsis" Text="{x:Static nuget:Resources.Checkbox_IncludePrerelease}" />
+            </CheckBox>
+
+          <!-- show vulnerabilities checkbox -->
+          <CheckBox
+            Grid.Column="1"
+            x:Name="_checkboxVulnerabilities"
+            AutomationProperties.AutomationId="CheckBox_Vulnerabilities"
+            Margin="3,0"
+            VerticalAlignment="Center"
+            Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
+            VerticalContentAlignment="Center"
+            Checked="_checkboxVulnerabilities_Checked"
+            Unchecked="_checkboxVulnerabilities_Unchecked"
+            Visibility="Hidden"
+            IsChecked="False">
+            <TextBlock TextTrimming="CharacterEllipsis" Text="{x:Static nuget:Resources.Checkbox_Show_Vulnerable_Only}" />
+          </CheckBox>
+        </Grid>
       </Grid>
+      
       <Grid
-        Grid.Column="2"
+        Grid.Column="1"
         VerticalAlignment="Center"
         HorizontalAlignment="Right">
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13002
https://github.com/NuGet/Home/issues/14221

## Description
The filters in the PM UI top panel (include prerelease and show only vulnerable packages) are set to trim the text if the window size is too small or if the font is too large for the text to fit. As part of that change, a max width was set on the columns containing the checkboxes but that prevents the checkbox text from growing past that point if the text size is increased, even if there's additional room for the checkbox text to grow.

The proposed fix #6908 offers a solution for this issue using a custom computation in codebehind. This fix is an alternative to that solution that resolves the issue exclusively in WPF and reacts to text size changes and window resizing.

Some of the principal features of this fix are that each of the filter checkboxes will collapse proportionally, they will be left justified and will not "float" away from each other as the screen size is increased, and they will resize dynamically along with window resizing and text scaling changes.

Additionally, I added tooltips to the filter checkboxes so the full text will display when hovered over. This will help in cases where the full text is truncated and also with keyboard navigation and accessibility.

Here are some screenshots demonstrating the behavior:

Starting text sizing (120%):
<img width="1263" height="228" alt="image" src="https://github.com/user-attachments/assets/b097c490-e6cb-4d48-8216-f9e6c27f7aec" />

Starting text sizing (120%), shrunken window size:
<img width="864" height="190" alt="image" src="https://github.com/user-attachments/assets/21f1baac-0c39-4777-af9c-27f321c2d118" />

Starting text sizing (120%), even smaller window size:
<img width="704" height="140" alt="image" src="https://github.com/user-attachments/assets/a563798f-e665-4111-be32-e1ccbf3a53aa" />

Increased text size (185%) with same screen size:
<img width="1614" height="207" alt="image" src="https://github.com/user-attachments/assets/a2ff9c04-ddc3-4d19-84f6-be7206768f81" />

Large text size (185%) with VS maximized:
<img width="3080" height="228" alt="image" src="https://github.com/user-attachments/assets/94e4109b-72e3-426c-bdf0-b7ecd5fc460a" />

Tooltip example (both filters now have tooltips):
<img width="695" height="140" alt="image" src="https://github.com/user-attachments/assets/cb044301-e492-4713-926d-e811519ad638" />

Note: I also included a fix for the grid column number for the Package Sources grid. It was previously specified as 2 when it should be 1.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ Manually tested
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
