### PR TITLE
Reduce unnecessary usage of mockserver

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Package/Download/PackageDownloadRunnerTests.cs
@@ -564,7 +564,7 @@ public class PackageDownloadRunnerTests
     }
 
     [Fact]
-    public async Task RunAsync_WhenPsmMapsToInsecureSource_AndAllowInsecureConnectionsFalse_LogsErrorForMappedSource()
+    public async Task RunAsync_WhenSourceMappingMapsToInsecureSource_AndAllowInsecureConnectionsFalse_LogsErrorForMappedSource()
     {
         // Arrange
         using var context = new SimpleTestPathContext();
@@ -608,7 +608,7 @@ public class PackageDownloadRunnerTests
     }
 
     [Fact]
-    public async Task RunAsync_WhenPsmMapsToSecureLocalSource_DoesNotLogErrorEvenWhenOtherSourceIsHttp()
+    public async Task RunAsync_WhenSourceMappingMapsToSecureLocalSource_DoesNotLogErrorEvenWhenOtherSourceIsHttp()
     {
         // Arrange
         using var context = new SimpleTestPathContext();
@@ -662,7 +662,7 @@ public class PackageDownloadRunnerTests
     }
 
     [Fact]
-    public async Task RunAsync_WhenPsmMapsToInsecureSource_AndAllowInsecureConnectionsTrue_DownloadsWithoutError()
+    public async Task RunAsync_WhenSourceMappingMapsToInsecureSource_AndAllowInsecureConnectionsTrue_DownloadsWithoutError()
     {
         // Arrange
         using var context = new SimpleTestPathContext();
@@ -730,10 +730,9 @@ public class PackageDownloadRunnerTests
         // Arrange
         using var context = new SimpleTestPathContext();
         string srcADirectory = Path.Combine(context.PackageSource, "SourceA");
-        using var serverA = new FileSystemBackedV3MockServer(srcADirectory);
 
         await SimpleTestPackageUtility.CreateFullPackageAsync(srcADirectory, "Contoso.Utils", "1.0.0");
-        context.Settings.AddSource("A", serverA.ServiceIndexUri);
+        context.Settings.AddSource("A", srcADirectory);
 
         // Map the package to a NON-EXISTING source name "MissingSource"
         context.Settings.AddPackageSourceMapping("MissingSource", "Contoso.*");
@@ -759,16 +758,12 @@ public class PackageDownloadRunnerTests
               .Callback<string>(msg => capturedVerbose += msg + Environment.NewLine);
 
         // Act
-        serverA.Start();
-
         var exit = await PackageDownloadRunner.RunAsync(
             args,
             logger.Object,
-            [new(serverA.ServiceIndexUri, "A")],
+            [new(srcADirectory, "A")],
             settings,
             CancellationToken.None);
-
-        serverA.Stop();
 
         // Assert
         var expected = string.Format(


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

This PR fixes a test that was using a MockServer to not use it. It is not a need. Help reduce flakiness of the test.

Related: https://github.com/NuGet/NuGet.Client/pull/6948
Related discussion: https://github.com/NuGet/Client.Engineering/issues/3542#issuecomment-3534603684

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
