### PR TITLE
Fix issue with centralPackageFloatingVersionsEnabled not being read from the dgspec (release/7.0.x)

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -14,7 +14,7 @@
     <!-- when changing any of the NuGetVersion props below, run tools-local\ship-public-apis -->
     <MajorNuGetVersion Condition="'$(MajorNuGetVersion)' == ''">7</MajorNuGetVersion>
     <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">0</MinorNuGetVersion>
-    <PatchNuGetVersion Condition="'$(PatchNuGetVersion)' == ''">0</PatchNuGetVersion>
+    <PatchNuGetVersion Condition="'$(PatchNuGetVersion)' == ''">1</PatchNuGetVersion>
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
 
     <!-- ** Change for each new preview/rc -->

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -44,6 +44,7 @@ namespace NuGet.ProjectModel
         private static readonly byte[] CentralPackageVersionsManagementEnabledPropertyName = Encoding.UTF8.GetBytes("centralPackageVersionsManagementEnabled");
         private static readonly byte[] CentralPackageVersionOverrideDisabledPropertyName = Encoding.UTF8.GetBytes("centralPackageVersionOverrideDisabled");
         private static readonly byte[] CentralPackageTransitivePinningEnabledPropertyName = Encoding.UTF8.GetBytes("CentralPackageTransitivePinningEnabled");
+        private static readonly byte[] CentralPackageFloatingVersionsEnabledPropertyName = Encoding.UTF8.GetBytes("centralPackageFloatingVersionsEnabled");
         private static readonly byte[] ConfigFilePathsPropertyName = Encoding.UTF8.GetBytes("configFilePaths");
         private static readonly byte[] CrossTargetingPropertyName = Encoding.UTF8.GetBytes("crossTargeting");
         private static readonly byte[] FallbackFoldersPropertyName = Encoding.UTF8.GetBytes("fallbackFolders");
@@ -755,6 +756,7 @@ namespace NuGet.ProjectModel
             var centralPackageVersionsManagementEnabled = false;
             var centralPackageVersionOverrideDisabled = false;
             var CentralPackageTransitivePinningEnabled = false;
+            var centralPackageFloatingVersionsEnabled = false;
             List<string> configFilePaths = null;
             var crossTargeting = false;
             List<string> fallbackFolders = null;
@@ -797,6 +799,10 @@ namespace NuGet.ProjectModel
                     else if (jsonReader.ValueTextEquals(CentralPackageTransitivePinningEnabledPropertyName))
                     {
                         CentralPackageTransitivePinningEnabled = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
+                    else if (jsonReader.ValueTextEquals(CentralPackageFloatingVersionsEnabledPropertyName))
+                    {
+                        centralPackageFloatingVersionsEnabled = jsonReader.ReadNextTokenAsBoolOrFalse();
                     }
                     else if (jsonReader.ValueTextEquals(ConfigFilePathsPropertyName))
                     {
@@ -1058,6 +1064,7 @@ namespace NuGet.ProjectModel
             msbuildMetadata.CentralPackageVersionsEnabled = centralPackageVersionsManagementEnabled;
             msbuildMetadata.CentralPackageVersionOverrideDisabled = centralPackageVersionOverrideDisabled;
             msbuildMetadata.CentralPackageTransitivePinningEnabled = CentralPackageTransitivePinningEnabled;
+            msbuildMetadata.CentralPackageFloatingVersionsEnabled = centralPackageFloatingVersionsEnabled;
             msbuildMetadata.RestoreAuditProperties = auditProperties;
             msbuildMetadata.SdkAnalysisLevel = sdkAnalysisLevel;
             msbuildMetadata.UsingMicrosoftNETSdk = usingMicrosoftNetSdk;

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -2117,17 +2117,41 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
-        [InlineData(null, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void GetPackageSpec_WhenCentralPackageVersionsManagementEnabledValueIsValid_ReturnsCentralPackageVersionsManagementEnabled(
+        [InlineData("centralPackageVersionsManagementEnabled", null, false)]
+        [InlineData("centralPackageVersionsManagementEnabled", true, true)]
+        [InlineData("centralPackageVersionsManagementEnabled", false, false)]
+        [InlineData("centralPackageVersionOverrideDisabled", null, false)]
+        [InlineData("centralPackageVersionOverrideDisabled", true, true)]
+        [InlineData("centralPackageVersionOverrideDisabled", false, false)]
+        [InlineData("CentralPackageTransitivePinningEnabled", null, false)]
+        [InlineData("CentralPackageTransitivePinningEnabled", true, true)]
+        [InlineData("CentralPackageTransitivePinningEnabled", false, false)]
+        [InlineData("centralPackageFloatingVersionsEnabled", null, false)]
+        [InlineData("centralPackageFloatingVersionsEnabled", true, true)]
+        [InlineData("centralPackageFloatingVersionsEnabled", false, false)]
+        public void GetPackageSpec_WhenCentralPackageManagementPropertyIsSet_ReturnsCorrectValue(
+            string propertyName,
             bool? value,
             bool expectedValue)
         {
-            var json = $"{{\"restore\":{{\"centralPackageVersionsManagementEnabled\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
+            var json = $"{{\"restore\":{{\"{propertyName}\":{(value.HasValue ? value.ToString().ToLowerInvariant() : "null")}}}}}";
             PackageSpec packageSpec = GetPackageSpec(json);
 
-            Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageVersionsEnabled);
+            switch (propertyName)
+            {
+                case "centralPackageVersionsManagementEnabled":
+                    Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageVersionsEnabled);
+                    break;
+                case "centralPackageVersionOverrideDisabled":
+                    Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageVersionOverrideDisabled);
+                    break;
+                case "CentralPackageTransitivePinningEnabled":
+                    Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageTransitivePinningEnabled);
+                    break;
+                case "centralPackageFloatingVersionsEnabled":
+                    Assert.Equal(expectedValue, packageSpec.RestoreMetadata.CentralPackageFloatingVersionsEnabled);
+                    break;
+            }
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Cherry-pick of debe5cc7ba5fcda6abcb2bed0b0693f33da5bbba on the `release/7.0.x` branch.
It also bumps the patch version to 7.0.1
## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
