### PR TITLE
Ensure stable order of files in the nuget package

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -1052,7 +1052,7 @@ namespace NuGet.Packaging
             var warningMessage = new StringBuilder();
 
             // Add files that might not come from expanding files on disk
-            foreach (IPackageFile file in new SortedSet<IPackageFile>(Files, new DirectorySeparatorAmbivalentComparer()))
+            foreach (IPackageFile file in new SortedSet<IPackageFile>(Files, new NormalizedPathComparer()))
             {
                 using (Stream stream = file.GetStream())
                 {
@@ -1379,7 +1379,7 @@ namespace NuGet.Packaging
             }
         }
 
-        private class DirectorySeparatorAmbivalentComparer : IComparer<IPackageFile>
+        private class NormalizedPathComparer : IComparer<IPackageFile>
         {
             public int Compare(IPackageFile x, IPackageFile y)
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -1052,7 +1052,7 @@ namespace NuGet.Packaging
             var warningMessage = new StringBuilder();
 
             // Add files that might not come from expanding files on disk
-            foreach (IPackageFile file in new HashSet<IPackageFile>(Files))
+            foreach (IPackageFile file in new SortedSet<IPackageFile>(Files, new DirectorySeparatorAmbivalentComparer()))
             {
                 using (Stream stream = file.GetStream())
                 {
@@ -1376,6 +1376,16 @@ namespace NuGet.Packaging
                 var hash = hashFunc.GetHashBytes();
                 var hex = EncodeHexString(hash);
                 return "R" + hex.Substring(0, 16);
+            }
+        }
+
+        private class DirectorySeparatorAmbivalentComparer : IComparer<IPackageFile>
+        {
+            public int Compare(IPackageFile x, IPackageFile y)
+            {
+                string xPathNormalized = x.Path.Replace('\\', '/');
+                string yPathNormalized = y.Path.Replace('\\', '/');
+                return String.CompareOrdinal(xPathNormalized, yPathNormalized);
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -81,7 +81,6 @@ namespace NuGet.Packaging.Test
                     var files = archive.Entries
                         .Where(file => file.Name == "_._")
                         .Select(file => file.FullName)
-                        .OrderBy(s => s)
                         .ToArray();
 
                     // Assert
@@ -150,7 +149,6 @@ namespace NuGet.Packaging.Test
                     var files = archive.Entries
                         .Where(file => file.Name.StartsWith("foo"))
                         .Select(file => file.FullName)
-                        .OrderBy(s => s)
                         .ToArray();
 
                     // Assert
@@ -2776,21 +2774,20 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
                 using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
                 {
                     // Get raw filenames without un-escaping.
-                    var files = archive.Entries.Select(e => e.FullName).OrderBy(s => s).ToArray();
+                    var files = archive.Entries.Select(e => e.FullName).ToArray();
 
-                    // Linux sorts the first two in different order than Windows
-                    Assert.Contains<string>(@"[Content_Types].xml", files);
-                    Assert.Contains<string>(@"_rels/.rels", files);
+                    Assert.Equal(@"_rels/.rels", files[0]);
+                    Assert.Equal(@"test.nuspec", files[1]);
                     Assert.Equal(@"content/images/bread&butter.jpg", files[2]);
                     Assert.Equal(@"content/images/logo123?#78.png", files[3]);
                     Assert.Equal(@"lib/C#/test.dll", files[4]);
                     Assert.Equal(@"lib/name with spaces.dll", files[5]);
                     Assert.Equal(@"lib/regular.file.dll", files[6]);
 
-                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[7]);
-                    Assert.EndsWith(@".psmdcp", files[7]);
+                    Assert.Equal(@"[Content_Types].xml", files[7]);
+                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[8]);
+                    Assert.EndsWith(@".psmdcp", files[8]);
 
-                    Assert.Equal(@"test.nuspec", files[8]);
                 }
             }
         }
@@ -2818,17 +2815,14 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
 
                 using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
                 {
-                    var files = archive.GetFiles().OrderBy(s => s).ToArray();
+                    var files = archive.GetFiles().ToArray();
 
-                    // Linux sorts the first two in different order than Windows
-                    Assert.Contains<string>(@"[Content_Types].xml", files);
-                    Assert.Contains<string>(@"_rels/.rels", files);
+                    Assert.Equal(@"_rels/.rels", files[0]);
+                    Assert.Equal(@"test.nuspec", files[1]);
                     Assert.Equal(@"myfile", files[2]);
-
-                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[3]);
-                    Assert.EndsWith(@".psmdcp", files[3]);
-
-                    Assert.Equal(@"test.nuspec", files[4]);
+                    Assert.Equal(@"[Content_Types].xml", files[3]);
+                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[4]);
+                    Assert.EndsWith(@".psmdcp", files[4]);
 
                     using (var contentTypesReader = new StreamReader(archive.Entries.Single(file => file.FullName == @"[Content_Types].xml").Open()))
                     {
@@ -3028,14 +3022,13 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
 
                 using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
                 {
-                    var files = archive.GetFiles().OrderBy(s => s).ToArray();
+                    var files = archive.GetFiles().ToArray();
 
-                    // Linux sorts the first two in different order than Windows
-                    Assert.Contains<string>(@"[Content_Types].xml", files);
-                    Assert.Contains<string>(@"_rels/.rels", files);
-                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[2]);
-                    Assert.Equal(@"test.nuspec", files[3]);
-                    Assert.Equal(outputFile, files[4]);
+                    Assert.Equal(@"_rels/.rels", files[0]);
+                    Assert.Equal(@"test.nuspec", files[1]);
+                    Assert.Equal(outputFile, files[2]);
+                    Assert.Equal(@"[Content_Types].xml", files[3]);
+                    Assert.StartsWith(@"package/services/metadata/core-properties/", files[4]);
                 }
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

Fixes: https://github.com/NuGet/Home/issues/14448

## Description

We can add files to the nuget package in any order. To provide more reproducibility/deterministicness, add the files in the archive in a well-defined order.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
