### PR TITLE
Introduce Audit Sources to package source VS options

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourceValidator.cs
@@ -22,7 +22,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             string name,
             bool isEnabled,
             bool allowInsecureConnections,
-            List<PackageSource> packageSources)
+            IReadOnlyList<PackageSource> packageSources)
         {
             string trimmedLookupName = lookupName?.Trim() ?? string.Empty;
             if (string.IsNullOrEmpty(trimmedLookupName))
@@ -169,7 +169,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             }
         }
 
-        private static PackageSource? FindByName(string packageSourceName, List<PackageSource> packageSources)
+        private static PackageSource? FindByName(string packageSourceName, IReadOnlyList<PackageSource> packageSources)
         {
             _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -212,7 +212,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                     string name = packageSourceDictionary[MonikerSourceName].ToString();
                     string lookupName;
 
-                    // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have a Package ID.
+                    // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have an ID.
                     if (packageSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageSourceIdObj))
                     {
                         lookupName = packageSourceIdObj.ToString();
@@ -223,7 +223,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                             hasAnyPackageSourceNameChanged = true;
                         }
                     }
-                    else // Newly added Package Sources will not have a Package ID yet.
+                    else // Newly added Package Sources will not have an ID yet.
                     {
                         lookupName = name;
                     }
@@ -281,7 +281,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                     string name = packageSourceDictionary[MonikerSourceName].ToString();
                     string lookupName;
 
-                    // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have a Package ID.
+                    // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have an ID.
                     if (packageSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageSourceIdObj))
                     {
                         lookupName = packageSourceIdObj.ToString();
@@ -292,7 +292,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                             hasAnyPackageSourceNameChanged = true;
                         }
                     }
-                    else // Newly added Package Sources will not have a Package ID yet.
+                    else // Newly added Package Sources will not have an ID yet.
                     {
                         lookupName = name;
                     }
@@ -334,12 +334,12 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             string name = packageSourceDictionary[MonikerSourceName].ToString().Trim();
             string? lookupName;
 
-            // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have a Package ID.
+            // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have an ID.
             if (packageSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageSourceIdObj))
             {
                 lookupName = packageSourceIdObj.ToString().Trim();
             }
-            else // Newly added Package Sources will not have a Package ID yet.
+            else // Newly added Package Sources will not have an ID yet.
             {
                 lookupName = name;
             }
@@ -361,12 +361,12 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             string name = auditSourceDictionary[MonikerSourceName].ToString().Trim();
             string? lookupName;
 
-            // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have a Package ID.
+            // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have an ID.
             if (auditSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageSourceIdObj))
             {
                 lookupName = packageSourceIdObj.ToString().Trim();
             }
-            else // Newly added Package Sources will not have a Package ID yet.
+            else // Newly added Package Sources will not have an ID yet.
             {
                 lookupName = name;
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -104,11 +104,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                 switch (moniker)
                 {
                     case MonikerPackageSources:
-                        var packageSourcesList = value as IReadOnlyList<IDictionary<string, object>>;
-                        if (packageSourcesList is null)
-                        {
-                            throw new InvalidOperationException();
-                        }
+                        var packageSourcesList = (IReadOnlyList<IDictionary<string, object>>)value;
                         return await Task.Run(
                             () =>
                             {
@@ -118,11 +114,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                             },
                             cancellationToken);
                     case MonikerAuditSources:
-                        var auditSourceList = value as IReadOnlyList<IDictionary<string, object>>;
-                        if (auditSourceList is null)
-                        {
-                            throw new InvalidOperationException();
-                        }
+                        var auditSourceList = (IReadOnlyList<IDictionary<string, object>>)value;
                         return await Task.Run(
                             () =>
                             {
@@ -132,11 +124,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                             },
                             cancellationToken);
                     case MonikerMachineWideSources:
-                        var machineWidePackageSourcesList = value as IReadOnlyList<IDictionary<string, object>>;
-                        if (machineWidePackageSourcesList is null)
-                        {
-                            throw new InvalidOperationException();
-                        }
+                        var machineWidePackageSourcesList = (IReadOnlyList<IDictionary<string, object>>)value;
                         return await Task.Run(
                             () => SetIsEnabledOnMachineWidePackageSources(machineWidePackageSourcesList, cancellationToken),
                             cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -17,7 +17,10 @@ namespace NuGet.PackageManagement.VisualStudio.Options
     [Guid("15C605EC-4FD7-446B-BA4A-75ECF0C0B2D0")]
     public class PackageSourcesPage : NuGetExternalSettingsProvider, IExternalSettingValidator
     {
+        internal const bool DefaultNuGetAudit = false;
         internal const string MonikerPackageSources = "packageSources";
+        internal const string MonikerAuditSources = "auditSources";
+        internal const string MonikerNuGetAudit = "nuGetAudit";
         internal const string MonikerMachineWideSources = "machineWidePackageSources";
         internal const string MonikerPackageSourceId = "packageSourceId"; // Unique identifier for the package source
         internal const string MonikerSourceName = "sourceName";
@@ -48,24 +51,51 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return filteredPackageSources;
         }
 
+        private List<PackageSource> LoadAuditSources()
+        {
+            IEnumerable<PackageSource> auditSources = _packageSourceProvider.LoadAuditSources();
+            return auditSources.ToList();
+        }
+
         public override async Task<ExternalSettingOperationResult<T>> GetValueAsync<T>(string moniker, CancellationToken cancellationToken)
         {
             switch (moniker)
             {
                 case MonikerPackageSources:
-                    var packageSources = await Task.Run(
-                        () => LoadPackageSources(isMachineWide: false),
-                        cancellationToken);
+                    {
+                        var packageSources = await Task.Run(
+                            () => LoadPackageSources(isMachineWide: false),
+                            cancellationToken);
 
-                    return GetValuePackageSources<T>(packageSources);
+                        return GetValuePackageSources<T>(packageSources);
+                    }
+                case MonikerNuGetAudit:
+                    {
+                        var auditSources = await Task.Run(
+                            () => LoadAuditSources(),
+                            cancellationToken);
+                        if (auditSources.Count > 0)
+                        {
+                            return await ConvertValueOrThrow<T>(true);
+                        }
+                        return await ConvertValueOrThrow<T>(DefaultNuGetAudit);
+                    }
+                case MonikerAuditSources:
+                    {
+                        var auditSources = await Task.Run(
+                            () => LoadAuditSources(),
+                            cancellationToken);
 
+                        return GetValuePackageSources<T>(auditSources);
+                    }
                 case MonikerMachineWideSources:
-                    var machineWidePackageSources = await Task.Run(
-                        () => LoadPackageSources(isMachineWide: true),
-                        cancellationToken);
+                    {
+                        var machineWidePackageSources = await Task.Run(
+                            () => LoadPackageSources(isMachineWide: true),
+                            cancellationToken);
 
-                    return GetValuePackageSources<T>(machineWidePackageSources);
-
+                        return GetValuePackageSources<T>(machineWidePackageSources);
+                    }
                 default: break;
             }
 
@@ -75,12 +105,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
         public override async Task<ExternalSettingOperationResult> SetValueAsync<T>(string moniker, T value, CancellationToken cancellationToken)
         {
-            var packageSourcesList = value as IReadOnlyList<IDictionary<string, object>>;
-            if (packageSourcesList is null)
-            {
-                throw new InvalidOperationException();
-            }
-
             bool hasAnyHiddenPropertyChanged = false;
 
             try
@@ -90,7 +114,14 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
                 switch (moniker)
                 {
+                    case MonikerNuGetAudit:
+                        return (ExternalSettingOperationResult)ExternalSettingOperationResult.Success.Instance;
                     case MonikerPackageSources:
+                        var packageSourcesList = value as IReadOnlyList<IDictionary<string, object>>;
+                        if (packageSourcesList is null)
+                        {
+                            throw new InvalidOperationException();
+                        }
                         return await Task.Run(
                             () =>
                             {
@@ -99,10 +130,28 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                                 return savePackageSourcesResult.result;
                             },
                             cancellationToken);
-
-                    case MonikerMachineWideSources:
+                    case MonikerAuditSources:
+                        var auditSourceList = value as IReadOnlyList<IDictionary<string, object>>;
+                        if (auditSourceList is null)
+                        {
+                            throw new InvalidOperationException();
+                        }
                         return await Task.Run(
-                            () => SetIsEnabledOnMachineWidePackageSources(packageSourcesList, cancellationToken),
+                            () =>
+                            {
+                                (ExternalSettingOperationResult result, bool hasAnyHiddenPropertyChanged) saveAuditSourcesResult = SaveAuditSources(auditSourceList, cancellationToken);
+                                hasAnyHiddenPropertyChanged = saveAuditSourcesResult.hasAnyHiddenPropertyChanged;
+                                return saveAuditSourcesResult.result;
+                            },
+                            cancellationToken);
+                    case MonikerMachineWideSources:
+                        var machineWidePackageSourcesList = value as IReadOnlyList<IDictionary<string, object>>;
+                        if (machineWidePackageSourcesList is null)
+                        {
+                            throw new InvalidOperationException();
+                        }
+                        return await Task.Run(
+                            () => SetIsEnabledOnMachineWidePackageSources(machineWidePackageSourcesList, cancellationToken),
                             cancellationToken);
 
                     default:
@@ -237,6 +286,74 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return (result, hasAnyHiddenPropertyChanged);
         }
 
+        private (ExternalSettingOperationResult result, bool hasAnyHiddenPropertyChanged) SaveAuditSources(
+            IReadOnlyList<IDictionary<string, object>> auditSourceDictionaryList,
+            CancellationToken cancellationToken)
+        {
+            bool hasAnyHiddenPropertyChanged = false;
+            ExternalSettingOperationResult result;
+
+            try
+            {
+                List<PackageSource> auditSources = new List<PackageSource>(capacity: auditSourceDictionaryList.Count);
+                List<PackageSource> existingAuditSources = LoadAuditSources();
+                bool hasAnyPackageSourceNameChanged = false;
+
+                foreach (Dictionary<string, object> packageSourceDictionary in auditSourceDictionaryList)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    string name = packageSourceDictionary[MonikerSourceName].ToString();
+                    string lookupName;
+
+                    // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have a Package ID.
+                    if (packageSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageSourceIdObj))
+                    {
+                        lookupName = packageSourceIdObj.ToString();
+
+                        if (!string.Equals(lookupName, name, StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            // Changing the ID needs to refresh Unified Settings since the ID is a hidden property.
+                            hasAnyPackageSourceNameChanged = true;
+                        }
+                    }
+                    else // Newly added Package Sources will not have a Package ID yet.
+                    {
+                        lookupName = name;
+                    }
+
+                    string source = packageSourceDictionary[MonikerSourceUrl].ToString();
+
+                    PackageSource packageSource =
+                        PackageSourceValidator.FindExistingOrCreate(
+                            lookupName,
+                            source,
+                            name,
+                            isEnabled: true,
+                            allowInsecureConnections: false,
+                            existingAuditSources);
+
+                    auditSources.Add(packageSource);
+                }
+
+                _packageSourceProvider.SaveAuditSources(auditSources);
+
+                hasAnyHiddenPropertyChanged = hasAnyPackageSourceNameChanged;
+
+                result = ExternalSettingOperationResult.Success.Instance;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                result = CreateSettingErrorResult(ex.Message, isTransient: true);
+                ActivityLog.LogError(ExceptionHelper.LogEntrySource, ex.ToString());
+            }
+
+            return (result, hasAnyHiddenPropertyChanged);
+        }
+
+
         private static PackageSource ParsePackageSource(IReadOnlyDictionary<string, object> packageSourceDictionary)
         {
             string name = packageSourceDictionary[MonikerSourceName].ToString().Trim();
@@ -260,6 +377,28 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             {
                 AllowInsecureConnections = allowInsecureConnections,
             };
+
+            return packageSource;
+        }
+
+        private static PackageSource ParseAuditSource(IReadOnlyDictionary<string, object> auditSourceDictionary)
+        {
+            string name = auditSourceDictionary[MonikerSourceName].ToString().Trim();
+            string? lookupName;
+
+            // Package Sources that were pre-existing in the NuGet.Config when GetValueAsync was called will have a Package ID.
+            if (auditSourceDictionary.TryGetValue(MonikerPackageSourceId, out object packageSourceIdObj))
+            {
+                lookupName = packageSourceIdObj.ToString().Trim();
+            }
+            else // Newly added Package Sources will not have a Package ID yet.
+            {
+                lookupName = name;
+            }
+
+            string source = auditSourceDictionary[MonikerSourceUrl].ToString().Trim();
+
+            var packageSource = new PackageSource(source, lookupName, isEnabled: true);
 
             return packageSource;
         }
@@ -317,7 +456,9 @@ namespace NuGet.PackageManagement.VisualStudio.Options
         {
             var settingMessages = new OneOrMany<SettingMessage>();
 
-            if (arraySettingMoniker != MonikerPackageSources)
+            bool isAuditSources = arraySettingMoniker == MonikerAuditSources;
+            bool isPackageSources = arraySettingMoniker == MonikerPackageSources;
+            if (!isPackageSources && !isAuditSources)
             {
                 return settingMessages;
             }
@@ -336,7 +477,9 @@ namespace NuGet.PackageManagement.VisualStudio.Options
                     case MonikerSourceUrl:
                         {
                             var packageSourceDictionary = arraySettingContent[arrayItemIndex];
-                            var result = ParsePackageSource(packageSourceDictionary);
+                            PackageSource result = isPackageSources
+                                ? ParsePackageSource(packageSourceDictionary)
+                                : ParseAuditSource(packageSourceDictionary);
 
                             var isValidSource = PackageSourceValidator.IsValidSource(result);
                             if (!isValidSource)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -42,18 +42,19 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             base.VsSettings_SettingsChanged(sender, e);
         }
 
-        private List<PackageSource> LoadPackageSources(bool isMachineWide)
+        private IReadOnlyList<PackageSource> LoadPackageSources(bool isMachineWide)
         {
-            IEnumerable<PackageSource> all = _packageSourceProvider.LoadPackageSources();
-            List<PackageSource> filteredPackageSources = all
-                .Where(packageSource => packageSource.IsMachineWide == isMachineWide).ToList();
+            IReadOnlyList<PackageSource> filteredPackageSources = _packageSourceProvider.LoadPackageSources()
+                .Where(packageSource => packageSource.IsMachineWide == isMachineWide)
+                .ToList()
+                .AsReadOnly();
             return filteredPackageSources;
         }
 
-        private List<PackageSource> LoadAuditSources()
+        private IReadOnlyList<PackageSource> LoadAuditSources()
         {
-            IEnumerable<PackageSource> auditSources = _packageSourceProvider.LoadAuditSources();
-            return auditSources.ToList();
+            var auditSources = _packageSourceProvider.LoadAuditSources();
+            return auditSources;
         }
 
         public override async Task<ExternalSettingOperationResult<T>> GetValueAsync<T>(string moniker, CancellationToken cancellationToken)
@@ -213,7 +214,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             try
             {
                 List<PackageSource> packageSources = new List<PackageSource>(capacity: packageSourceDictionaryList.Count);
-                List<PackageSource> existingPackageSources = LoadPackageSources(isMachineWide: false);
+                IReadOnlyList<PackageSource> existingPackageSources = LoadPackageSources(isMachineWide: false);
                 bool hasAnyPackageSourceNameChanged = false;
 
                 foreach (Dictionary<string, object> packageSourceDictionary in packageSourceDictionaryList)
@@ -282,7 +283,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             try
             {
                 List<PackageSource> auditSources = new List<PackageSource>(capacity: auditSourceDictionaryList.Count);
-                List<PackageSource> existingAuditSources = LoadAuditSources();
+                IReadOnlyList<PackageSource> existingAuditSources = LoadAuditSources();
                 bool hasAnyPackageSourceNameChanged = false;
 
                 foreach (Dictionary<string, object> packageSourceDictionary in auditSourceDictionaryList)
@@ -389,7 +390,7 @@ namespace NuGet.PackageManagement.VisualStudio.Options
             return packageSource;
         }
 
-        private static ExternalSettingOperationResult<T> GetValuePackageSources<T>(List<PackageSource> packageSources)
+        private static ExternalSettingOperationResult<T> GetValuePackageSources<T>(IReadOnlyList<PackageSource> packageSources)
         {
             ExternalSettingOperationResult<T> result;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Options/PackageSourcesPage.cs
@@ -20,7 +20,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
         internal const bool DefaultNuGetAudit = false;
         internal const string MonikerPackageSources = "packageSources";
         internal const string MonikerAuditSources = "auditSources";
-        internal const string MonikerNuGetAudit = "nuGetAudit";
         internal const string MonikerMachineWideSources = "machineWidePackageSources";
         internal const string MonikerPackageSourceId = "packageSourceId"; // Unique identifier for the package source
         internal const string MonikerSourceName = "sourceName";
@@ -69,17 +68,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
                         return GetValuePackageSources<T>(packageSources);
                     }
-                case MonikerNuGetAudit:
-                    {
-                        var auditSources = await Task.Run(
-                            () => LoadAuditSources(),
-                            cancellationToken);
-                        if (auditSources.Count > 0)
-                        {
-                            return await ConvertValueOrThrow<T>(true);
-                        }
-                        return await ConvertValueOrThrow<T>(DefaultNuGetAudit);
-                    }
                 case MonikerAuditSources:
                     {
                         var auditSources = await Task.Run(
@@ -114,8 +102,6 @@ namespace NuGet.PackageManagement.VisualStudio.Options
 
                 switch (moniker)
                 {
-                    case MonikerNuGetAudit:
-                        return (ExternalSettingOperationResult)ExternalSettingOperationResult.Success.Instance;
                     case MonikerPackageSources:
                         var packageSourcesList = value as IReadOnlyList<IDictionary<string, object>>;
                         if (packageSourcesList is null)

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -358,6 +358,15 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Audit sources.
+        /// </summary>
+        internal static string Text_AuditSources_Title {
+            get {
+                return ResourceManager.GetString("Text_AuditSources_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/).
         /// </summary>
         internal static string Text_ConfigurationFiles_CommonLink {

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -340,15 +340,6 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use separate sources for vulnerability audit.
-        /// </summary>
-        internal static string Text_AuditSources_Checkbox {
-            get {
-                return ResourceManager.GetString("Text_AuditSources_Checkbox", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources).
         /// </summary>
         internal static string Text_AuditSources_Description {

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -340,6 +340,33 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use separate sources for vulnerability audit.
+        /// </summary>
+        internal static string Text_AuditSources_Checkbox {
+            get {
+                return ResourceManager.GetString("Text_AuditSources_Checkbox", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources).
+        /// </summary>
+        internal static string Text_AuditSources_Description {
+            get {
+                return ResourceManager.GetString("Text_AuditSources_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove all audit sources to revert to using package sources for vulnerability data..
+        /// </summary>
+        internal static string Text_AuditSources_HowToRemove {
+            get {
+                return ResourceManager.GetString("Text_AuditSources_HowToRemove", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/).
         /// </summary>
         internal static string Text_ConfigurationFiles_CommonLink {
@@ -408,6 +435,15 @@ namespace NuGetVSExtension {
         internal static string Text_PackageSourceName_Header {
             get {
                 return ResourceManager.GetString("Text_PackageSourceName_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources).
+        /// </summary>
+        internal static string Text_PackageSources_Description {
+            get {
+                return ResourceManager.GetString("Text_PackageSources_Description", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -252,9 +252,6 @@
   <data name="Text_PackageSources_Description" xml:space="preserve">
     <value>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</value>
   </data>
-  <data name="Text_AuditSources_Checkbox" xml:space="preserve">
-    <value>Use separate sources for vulnerability audit</value>
-  </data>
   <data name="Text_AuditSources_HowToRemove" xml:space="preserve">
     <value>Remove all audit sources to revert to using package sources for vulnerability data.</value>
   </data>

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -249,4 +249,16 @@
   <data name="Text_AllowInsecureConnections_Header" xml:space="preserve">
     <value>Allow Insecure Connections</value>
   </data>
+  <data name="Text_PackageSources_Description" xml:space="preserve">
+    <value>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</value>
+  </data>
+  <data name="Text_AuditSources_Checkbox" xml:space="preserve">
+    <value>Use separate sources for vulnerability audit</value>
+  </data>
+  <data name="Text_AuditSources_HowToRemove" xml:space="preserve">
+    <value>Remove all audit sources to revert to using package sources for vulnerability data.</value>
+  </data>
+  <data name="Text_AuditSources_Description" xml:space="preserve">
+    <value>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -258,4 +258,7 @@
   <data name="Text_AuditSources_Description" xml:space="preserve">
     <value>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</value>
   </data>
+  <data name="Text_AuditSources_Title" xml:space="preserve">
+    <value>Audit sources</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Běžné konfigurace NuGet: [Způsob použití nastavení](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -132,6 +132,21 @@
         <target state="translated">Povolit nezabezpečená připojení</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Běžné konfigurace NuGet: [Způsob použití nastavení](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">Zdroj</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -132,11 +132,6 @@
         <target state="translated">Povolit nezabezpečená připojení</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Allgemeine NuGet-Konfigurationen: [Wie Einstellungen angewendet werden](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -132,11 +132,6 @@
         <target state="translated">Unsichere Verbindungen zulassen</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -132,6 +132,21 @@
         <target state="translated">Unsichere Verbindungen zulassen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Allgemeine NuGet-Konfigurationen: [Wie Einstellungen angewendet werden](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">Quelle</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Configuraciones comunes de NuGet: [cómo se aplican las opciones](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -132,6 +132,21 @@
         <target state="translated">Permitir conexiones no seguras</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Configuraciones comunes de NuGet: [cómo se aplican las opciones](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">Origen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -132,11 +132,6 @@
         <target state="translated">Permitir conexiones no seguras</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -132,11 +132,6 @@
         <target state="translated">Autorisez les connexions non sécurisées</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Configurations NuGet courantes : [Comment sont appliqués les paramètres](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -132,6 +132,21 @@
         <target state="translated">Autorisez les connexions non sécurisées</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Configurations NuGet courantes : [Comment sont appliqués les paramètres](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">Source</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Configurazioni NuGet comuni: [Modalità di applicazione delle impostazioni](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -132,11 +132,6 @@
         <target state="translated">Consentire connessioni non sicure</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -132,6 +132,21 @@
         <target state="translated">Consentire connessioni non sicure</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Configurazioni NuGet comuni: [Modalità di applicazione delle impostazioni](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">Origine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -132,6 +132,21 @@
         <target state="translated">安全ではない接続を許可する</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">一般的な NuGet 構成: [設定の適用方法](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">ソース</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">一般的な NuGet 構成: [設定の適用方法](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -132,11 +132,6 @@
         <target state="translated">安全ではない接続を許可する</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -132,11 +132,6 @@
         <target state="translated">안전하지 않은 연결 허용</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -132,6 +132,21 @@
         <target state="translated">안전하지 않은 연결 허용</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">일반적인 NuGet 구성: [설정 적용 방법](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">원본</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">일반적인 NuGet 구성: [설정 적용 방법](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Typowe konfiguracje NuGet: [Jak są stosowane ustawienia](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -132,6 +132,21 @@
         <target state="translated">Zezwalaj na niezabezpieczone połączenia</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Typowe konfiguracje NuGet: [Jak są stosowane ustawienia](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">Źródło</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -132,11 +132,6 @@
         <target state="translated">Zezwalaj na niezabezpieczone połączenia</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -132,6 +132,21 @@
         <target state="translated">Permitir Conexões Inseguras</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Configurações comuns do NuGet: [Como as configurações são aplicadas](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">Origem</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Configurações comuns do NuGet: [Como as configurações são aplicadas](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -132,11 +132,6 @@
         <target state="translated">Permitir Conexões Inseguras</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -132,6 +132,21 @@
         <target state="translated">Разрешить небезопасные подключения</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Общие конфигурации NuGet: [Как применяются параметры](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">Источник</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -132,11 +132,6 @@
         <target state="translated">Разрешить небезопасные подключения</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Общие конфигурации NuGet: [Как применяются параметры](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -132,11 +132,6 @@
         <target state="translated">Güvenli Olmayan Bağlantılara İzin Ver</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -132,6 +132,21 @@
         <target state="translated">Güvenli Olmayan Bağlantılara İzin Ver</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Ortak NuGet yapılandırmaları: [Ayarların uygulanması](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">Kaynak</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">Ortak NuGet yapılandırmaları: [Ayarların uygulanması](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -132,6 +132,21 @@
         <target state="translated">允许不安全的连接</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">常用 NuGet 配置：[如何应用设置](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">源</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">常用 NuGet 配置：[如何应用设置](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -132,11 +132,6 @@
         <target state="translated">允许不安全的连接</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -142,6 +142,11 @@
         <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Title">
+        <source>Audit sources</source>
+        <target state="new">Audit sources</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">常見的 NuGet 設定：[如何套用設定](https://aka.ms/nuget/how-settings-are-applied/)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -132,6 +132,21 @@
         <target state="translated">允許不安全連線</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_AuditSources_Checkbox">
+        <source>Use separate sources for vulnerability audit</source>
+        <target state="new">Use separate sources for vulnerability audit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_Description">
+        <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
+        <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_AuditSources_HowToRemove">
+        <source>Remove all audit sources to revert to using package sources for vulnerability data.</source>
+        <target state="new">Remove all audit sources to revert to using package sources for vulnerability data.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Text_ConfigurationFiles_CommonLink">
         <source>Common NuGet configurations: [How settings are applied](https://aka.ms/nuget/how-settings-are-applied/)</source>
         <target state="translated">常見的 NuGet 設定：[如何套用設定](https://aka.ms/nuget/how-settings-are-applied/)</target>
@@ -175,6 +190,11 @@
       <trans-unit id="Text_PackageSourceUrl_Header">
         <source>Source</source>
         <target state="translated">來源</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Text_PackageSources_Description">
+        <source>Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</source>
+        <target state="new">Package sources define where NuGet retrieves packages for install, restore, audit, and update operations. [Learn more about package sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#packagesources)</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSources_MachineWide">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -132,11 +132,6 @@
         <target state="translated">允許不安全連線</target>
         <note />
       </trans-unit>
-      <trans-unit id="Text_AuditSources_Checkbox">
-        <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
         <source>Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</source>
         <target state="new">Audit sources provide vulnerability data during restore without acting as package sources. If no audit sources are configured, NuGet Audit uses package sources and suppresses warning NU1905. [Learn more about audit sources](https://learn.microsoft.com/nuget/reference/nuget-config-file#auditsources)</target>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -209,7 +209,7 @@
         },
         "auditSources": {
           "type": "array",
-          "title": "Audit Sources",
+          "title": "@Text_AuditSources_Title;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
           "description": "@Text_AuditSources_Description;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
           "helpUri": "https://learn.microsoft.com/nuget/concepts/auditing-packages",
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -140,6 +140,7 @@
         "packageSources": {
           "type": "array",
           "title": "@Text_PackageSources_NotMachineWide;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+          "description": "@Text_PackageSources_Description;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
 
           // Metadata about items in this array
           "items": {
@@ -156,7 +157,7 @@
                 "type": "string",
                 "title": "@Text_PackageSourceName_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
                 "uniqueness": "caseInsensitive",
-                "default":  "",
+                "default": "",
                 "example": "Package source",
                 "messages": [
                   {
@@ -206,6 +207,63 @@
           "allowItemEditing": true,
           "allowAdditionsAndRemovals": true
         },
+        "auditSources": {
+          "type": "array",
+          "title": "Audit Sources",
+          "description": "@Text_AuditSources_Description;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+          "helpUri": "https://learn.microsoft.com/nuget/concepts/auditing-packages",
+
+          // Metadata about items in this array
+          "items": {
+            "type": "object",
+
+            // The properties of items in this array
+            "properties": {
+              "sourceName": {
+                "type": "string",
+                "title": "@Text_PackageSourceName_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                "uniqueness": "caseInsensitive",
+                "default": "",
+                "example": "Package source",
+                "messages": [
+                  {
+                    "text": "@Error_PackageSourceName_Missing;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                    "visibleWhen": "${config:sourceName} ~= '^\\\\s*$'",
+                    "severity": "error"
+                  }
+                ]
+              },
+              "sourceUrl": {
+                "type": "string",
+                "format": "path",
+                "pathKind": "folderOrUri",
+                "title": "@Text_PackageSourceUrl_Header;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                "uniqueness": "caseInsensitive",
+                "default": "",
+                "example": "https://packagesource",
+                "messages": [
+                  {
+                    "text": "@Error_PackageSourceUri_Missing;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                    "visibleWhen": "${config:sourceUrl} ~= '^\\\\s*$'",
+                    "severity": "error"
+                  }
+                ]
+              }
+            }
+          },
+
+          // The actual items that appear by default; in most cases, you'd leave this array empty.
+          "default": [],
+          "allowItemEditing": true,
+          "allowAdditionsAndRemovals": true,
+          "messages": [
+            {
+              "text": "@Text_AuditSources_HowToRemove;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+              "visibleWhen": "${config:auditSources} != '[]'"
+            }
+          ]
+        },
+
         "machineWidePackageSources": {
           "type": "array",
           "title": "@Text_PackageSources_MachineWide;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/IPackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/IPackageSourceProvider.cs
@@ -83,6 +83,13 @@ namespace NuGet.Configuration
         void SavePackageSources(IEnumerable<PackageSource> sources);
 
         /// <summary>
+        /// Compares the given list of AuditSources with the current AuditSources in the configuration
+        /// and adds, removes or updates each source as needed.
+        /// </summary>
+        /// <param name="sources">PackageSources to be saved</param>
+        void SaveAuditSources(IEnumerable<PackageSource> sources);
+
+        /// <summary>
         /// Checks if a package source with a given name is part of the disabled sources configuration
         /// </summary>
         /// <param name="name">Name of the source to be queried</param>

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -227,6 +227,9 @@ namespace NuGet.Configuration
             loadedPackageSources.InsertRange(defaultSourcesInsertIndex, defaultPackageSourcesToBeAdded);
         }
 
+        /// <summary>
+        /// Create a package source from the package source or audit source setting.
+        /// </summary>
         internal static PackageSource ReadPackageSource(SourceItem setting, bool isEnabled, ISettings settings, IEnvironmentVariableReader environmentVariableReader)
         {
             var name = setting.Key;
@@ -613,6 +616,31 @@ namespace NuGet.Configuration
                     isDirty: ref isDirty);
             }
         }
+        private void UpdateAuditSource(
+            PackageSource newSource,
+            PackageSource existingSource,
+            bool shouldSkipSave,
+            ref bool isDirty)
+        {
+            if (string.Equals(newSource.Name, existingSource.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                if ((!string.Equals(newSource.Source, existingSource.Source, StringComparison.OrdinalIgnoreCase) ||
+                    newSource.ProtocolVersion != existingSource.ProtocolVersion ||
+                    newSource.AllowInsecureConnections != existingSource.AllowInsecureConnections ||
+                    newSource.DisableTLSCertificateValidation != existingSource.DisableTLSCertificateValidation) && newSource.IsPersistable)
+                {
+                    Settings.AddOrUpdate(ConfigurationConstants.AuditSources, newSource.AsSourceItem());
+                    isDirty = true;
+                }
+
+                if (!shouldSkipSave && isDirty)
+                {
+                    Settings.SaveToDisk();
+                    OnPackageSourcesChanged();
+                    isDirty = false;
+                }
+            }
+        }
 
         private void UpdatePackageSource(
             PackageSource newSource,
@@ -689,6 +717,22 @@ namespace NuGet.Configuration
 
             var isDirty = false;
             AddPackageSource(source, shouldSkipSave: false, isDirty: ref isDirty);
+        }
+
+        private void AddAuditSource(PackageSource source, bool shouldSkipSave, ref bool isDirty)
+        {
+            if (source.IsPersistable)
+            {
+                Settings.AddOrUpdate(ConfigurationConstants.AuditSources, source.AsSourceItem());
+                isDirty = true;
+            }
+
+            if (!shouldSkipSave && isDirty)
+            {
+                Settings.SaveToDisk();
+                OnPackageSourcesChanged();
+                isDirty = false;
+            }
         }
 
         private void AddPackageSource(PackageSource source, bool shouldSkipSave, ref bool isDirty)
@@ -830,9 +874,71 @@ namespace NuGet.Configuration
             }
         }
 
+        public void SaveAuditSources(IEnumerable<PackageSource> sources)
+        {
+            SaveAuditSources(sources, EnvironmentVariableWrapper.Instance);
+        }
+
+        internal void SaveAuditSources(IEnumerable<PackageSource> sources, IEnvironmentVariableReader environmentVariableReader)
+        {
+            if (sources == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            var isDirty = false;
+            var existingSettingsLookup = GetExistingSettingsLookup(ConfigurationConstants.AuditSources);
+
+            foreach (var source in sources)
+            {
+                SourceItem? existingSourceItem = null;
+
+                if (existingSettingsLookup.TryGetValue(source.Name, out existingSourceItem))
+                {
+                    var oldPackageSource = ReadPackageSource(existingSourceItem, isEnabled: true, Settings, environmentVariableReader);
+
+                    UpdateAuditSource(
+                        source,
+                        oldPackageSource,
+                        shouldSkipSave: true,
+                        isDirty: ref isDirty);
+                }
+                else
+                {
+                    AddAuditSource(source, shouldSkipSave: true, isDirty: ref isDirty);
+                }
+
+                if (existingSourceItem != null)
+                {
+                    existingSettingsLookup.Remove(source.Name);
+                }
+            }
+
+            if (existingSettingsLookup != null)
+            {
+                foreach (var sourceItem in existingSettingsLookup)
+                {
+                    Settings.Remove(ConfigurationConstants.AuditSources, sourceItem.Value);
+                    isDirty = true;
+                }
+            }
+
+            if (isDirty)
+            {
+                Settings.SaveToDisk();
+                OnPackageSourcesChanged();
+                isDirty = false;
+            }
+        }
+
         private Dictionary<string, SourceItem> GetExistingSettingsLookup()
         {
-            SettingSection? sourcesSection = Settings.GetSection(ConfigurationConstants.PackageSources);
+            return GetExistingSettingsLookup(ConfigurationConstants.PackageSources);
+        }
+
+        private Dictionary<string, SourceItem> GetExistingSettingsLookup(string sectionName)
+        {
+            SettingSection? sourcesSection = Settings.GetSection(sectionName);
             List<SourceItem>? existingSettings = sourcesSection?.Items.OfType<SourceItem>().Where(
                 c => !(c.Origin == null || c.Origin.IsReadOnly || c.Origin.IsMachineWide))
                 .ToList();

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -886,6 +886,11 @@ namespace NuGet.Configuration
                 throw new ArgumentNullException(nameof(sources));
             }
 
+            if (environmentVariableReader == null)
+            {
+                throw new ArgumentNullException(nameof(environmentVariableReader));
+            }
+
             var isDirty = false;
             var existingSettingsLookup = GetExistingSettingsLookup(ConfigurationConstants.AuditSources);
 

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+NuGet.Configuration.IPackageSourceProvider.SaveAuditSources(System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>! sources) -> void
+NuGet.Configuration.PackageSourceProvider.SaveAuditSources(System.Collections.Generic.IEnumerable<NuGet.Configuration.PackageSource!>! sources) -> void

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
@@ -23,7 +23,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         private IEnumerable<PackageSource> _packageSources;
         private IEnumerable<PackageSource> _savedPackageSources;
         private IEnumerable<PackageSource> _auditSources;
-        private IEnumerable<PackageSource> _savedAuditSources;
         private int _countEnablePackageSourceCalled = 0;
         private int _countDisablePackageSourceCalled = 0;
 
@@ -34,7 +33,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             _packageSources = Enumerable.Empty<PackageSource>();
             _auditSources = Enumerable.Empty<PackageSource>();
             _savedPackageSources = Enumerable.Empty<PackageSource>();
-            _savedAuditSources = Enumerable.Empty<PackageSource>();
         }
 
         protected override PackageSourcesPage CreateInstance(VSSettings? vsSettings)
@@ -51,13 +49,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
                     .Callback<IEnumerable<PackageSource>>(sources =>
                     {
                         _savedPackageSources = sources;
-                    });
-
-            mockedPackageSourceProvider.Setup(packageSourceProvider =>
-                packageSourceProvider.SaveAuditSources(It.IsAny<IEnumerable<PackageSource>>()))
-                    .Callback<IEnumerable<PackageSource>>(sources =>
-                    {
-                        _savedAuditSources = sources;
                     });
 
             mockedPackageSourceProvider.Setup(packageSourceProvider =>
@@ -89,11 +80,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             string newSourceUrl = isNameChanging ? originalSourceUrl : "https://auditTestingSourceEdited";
 
             bool wasVsSettingsSettingsChangedCalled = false;
-
-            _savedAuditSources =
-            [
-                new PackageSource(originalSourceUrl, originalSourceName)
-            ];
 
             PackageSourcesPage instance = CreateInstance(_vsSettings);
             instance.SettingValuesChanged += (sender, e) =>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
@@ -22,6 +22,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
     {
         private IEnumerable<PackageSource> _packageSources;
         private IEnumerable<PackageSource> _savedPackageSources;
+        private IEnumerable<PackageSource> _auditSources;
+        private IEnumerable<PackageSource> _savedAuditSources;
         private int _countEnablePackageSourceCalled = 0;
         private int _countDisablePackageSourceCalled = 0;
 
@@ -30,7 +32,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             sp.Reset();
             NuGetUIThreadHelper.SetCustomJoinableTaskFactory(ThreadHelper.JoinableTaskFactory);
             _packageSources = Enumerable.Empty<PackageSource>();
+            _auditSources = Enumerable.Empty<PackageSource>();
             _savedPackageSources = Enumerable.Empty<PackageSource>();
+            _savedAuditSources = Enumerable.Empty<PackageSource>();
         }
 
         protected override PackageSourcesPage CreateInstance(VSSettings? vsSettings)
@@ -39,11 +43,21 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             mockedPackageSourceProvider.Setup(packageSourceProvider => packageSourceProvider.LoadPackageSources())
                 .Returns(_packageSources);
 
+            mockedPackageSourceProvider.Setup(packageSourceProvider => packageSourceProvider.LoadAuditSources())
+                .Returns(_auditSources.ToList().AsReadOnly());
+
             mockedPackageSourceProvider.Setup(packageSourceProvider =>
                 packageSourceProvider.SavePackageSources(It.IsAny<IEnumerable<PackageSource>>()))
                     .Callback<IEnumerable<PackageSource>>(sources =>
                     {
                         _savedPackageSources = sources;
+                    });
+
+            mockedPackageSourceProvider.Setup(packageSourceProvider =>
+                packageSourceProvider.SaveAuditSources(It.IsAny<IEnumerable<PackageSource>>()))
+                    .Callback<IEnumerable<PackageSource>>(sources =>
+                    {
+                        _savedAuditSources = sources;
                     });
 
             mockedPackageSourceProvider.Setup(packageSourceProvider =>
@@ -61,6 +75,139 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
                 });
 
             return new PackageSourcesPage(vsSettings!, mockedPackageSourceProvider.Object);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SetValueAsync_AuditSources_WhenNameChanging_RaisesSettingValuesChangedAsync(bool isNameChanging)
+        {
+            // Arrange
+            string originalSourceName = "auditTestingSourceName";
+            string originalSourceUrl = "https://auditTestingSource";
+            string newSourceName = isNameChanging ? "auditTestingSourceNameEdited" : originalSourceName;
+            string newSourceUrl = isNameChanging ? originalSourceUrl : "https://auditTestingSourceEdited";
+
+            bool wasVsSettingsSettingsChangedCalled = false;
+
+            _savedAuditSources =
+            [
+                new PackageSource(originalSourceUrl, originalSourceName)
+            ];
+
+            PackageSourcesPage instance = CreateInstance(_vsSettings);
+            instance.SettingValuesChanged += (sender, e) =>
+            {
+                wasVsSettingsSettingsChangedCalled = true;
+            };
+
+            Dictionary<string, object> auditSourceDictionary = new Dictionary<string, object>();
+            auditSourceDictionary[PackageSourcesPage.MonikerSourceName] = newSourceName;
+            auditSourceDictionary[PackageSourcesPage.MonikerSourceUrl] = newSourceUrl;
+
+            IList<IDictionary<string, object>> auditSourceDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 1)
+                {
+                    auditSourceDictionary
+                };
+
+            // Act
+            ExternalSettingOperationResult result = await instance.SetValueAsync(
+                PackageSourcesPage.MonikerAuditSources,
+                auditSourceDictionaryList,
+                CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<ExternalSettingOperationResult.Success>();
+            // VS refresh event isn't needed for audit sources name changes.
+            wasVsSettingsSettingsChangedCalled.Should().Be(false);
+        }
+
+        [Theory]
+        [InlineData(@"http://")]
+        [InlineData(@"https://")]
+        [InlineData(@"https:// ")]
+        [InlineData(@" https://")]
+        [InlineData(@"ftp://")]
+        [InlineData(@"http:/")]
+        public async Task SetValueAsync_AuditSources_WithInvalidRemoteSource_ReturnsFailureResultTaskAsync(string invalidSource)
+        {
+            // Arrange
+            PackageSourcesPage instance = CreateInstance(_vsSettings);
+            Dictionary<string, object> auditSourceDictionary = new Dictionary<string, object>();
+
+            auditSourceDictionary[PackageSourcesPage.MonikerSourceName] = "auditTestingSourceName";
+            auditSourceDictionary[PackageSourcesPage.MonikerSourceUrl] = invalidSource;
+            auditSourceDictionary[PackageSourcesPage.MonikerIsEnabled] = true;
+            auditSourceDictionary[PackageSourcesPage.MonikerAllowInsecureConnections] = false;
+
+            IList<IDictionary<string, object>> auditSourceDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 1)
+                {
+                    auditSourceDictionary
+                };
+
+            // Act
+            ExternalSettingOperationResult result = await instance.SetValueAsync(
+                PackageSourcesPage.MonikerAuditSources,
+                auditSourceDictionaryList,
+                CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<ExternalSettingOperationResult.Failure>();
+
+            var failure = result as ExternalSettingOperationResult.Failure;
+            failure.Should().NotBeNull();
+            failure.IsTransient.Should().BeTrue();
+            failure.Scope.Should().Be(ExternalSettingsErrorScope.SingleSettingOnly);
+            failure.ErrorMessage.Should().StartWith(Strings.Error_PackageSource_InvalidSource);
+        }
+
+        [Theory]
+        [InlineData(@"C")]
+        [InlineData(@"http")] // Missing :// causes this to be treated as a file path.
+        [InlineData(@"http:")]
+        [InlineData(@"ftp")] // Missing :// causes this to be treated as a file path.
+        [InlineData(@"C:")]
+        [InlineData(@"C:\\invalid\\*\\'\\chars")]
+        [InlineData(@"\\\\server\\invalid\\*\\")]
+        [InlineData(@"..\\packages")]
+        [InlineData(@"./configs/source.config")]
+        [InlineData(@"../local-packages/")]
+        public async Task SetValueAsync_AuditSources_WithInvalidUncPath_ReturnsFailureResultTaskAsync(string invalidSource)
+        {
+            // Arrange
+            PackageSourcesPage instance = CreateInstance(_vsSettings);
+            Dictionary<string, object> auditSourceDictionary = new Dictionary<string, object>();
+
+            auditSourceDictionary[PackageSourcesPage.MonikerSourceName] = "auditTestingSourceName";
+            auditSourceDictionary[PackageSourcesPage.MonikerSourceUrl] = invalidSource;
+            auditSourceDictionary[PackageSourcesPage.MonikerIsEnabled] = true;
+            auditSourceDictionary[PackageSourcesPage.MonikerAllowInsecureConnections] = false;
+
+            IList<IDictionary<string, object>> auditSourceDictionaryList =
+                new List<IDictionary<string, object>>(capacity: 1)
+                {
+                    auditSourceDictionary
+                };
+
+            // Act
+            ExternalSettingOperationResult result = await instance.SetValueAsync(
+                PackageSourcesPage.MonikerAuditSources,
+                auditSourceDictionaryList,
+                CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<ExternalSettingOperationResult.Failure>();
+
+            var failure = result as ExternalSettingOperationResult.Failure;
+            failure.Should().NotBeNull();
+            failure.IsTransient.Should().BeTrue();
+            failure.Scope.Should().Be(ExternalSettingsErrorScope.SingleSettingOnly);
+            failure.ErrorMessage.Should().StartWith(Strings.Error_PackageSource_InvalidSource);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TestPackageSourceProvider.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TestPackageSourceProvider.cs
@@ -54,5 +54,7 @@ namespace NuGet.Commands.Test
         public void AddPackageSource(PackageSource source) => throw new NotImplementedException();
 
         public bool IsPackageSourceEnabled(string name) => throw new NotImplementedException();
+
+        public void SaveAuditSources(IEnumerable<PackageSource> sources) => throw new NotImplementedException();
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -2556,6 +2556,304 @@ namespace NuGet.Configuration.Test
             auditSource.Subject.IsEnabled.Should().BeTrue();
         }
 
+        [Fact]
+        public void SaveAuditSources_AddsNewAuditSources()
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+
+            const string contents = @"<configuration />";
+            var path = Path.Combine(testDirectory.Path, Settings.DefaultSettingsFileName);
+            File.WriteAllText(path, contents);
+
+            Settings settings = new Settings(testDirectory.Path);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            var auditSources = new[]
+            {
+                new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso"),
+                new PackageSource("https://fabrikam.test/nuget/v3/index.json", "fabrikam")
+            };
+
+            // Act
+            psp.SaveAuditSources(auditSources);
+
+            // Assert
+            IReadOnlyList<PackageSource> loadedSources = psp.LoadAuditSources();
+            loadedSources.Should().HaveCount(2);
+            loadedSources[0].Name.Should().Be("contoso");
+            loadedSources[0].Source.Should().Be("https://contoso.test/nuget/v3/index.json");
+            loadedSources[1].Name.Should().Be("fabrikam");
+            loadedSources[1].Source.Should().Be("https://fabrikam.test/nuget/v3/index.json");
+        }
+
+        [Fact]
+        public void SaveAuditSources_UpdatesExistingAuditSource()
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+
+            const string contents = @"<configuration>
+    <auditSources>
+        <add key=""contoso"" value=""https://contoso.test/nuget/v2/index.json"" />
+    </auditSources>
+</configuration>";
+            var path = Path.Combine(testDirectory.Path, Settings.DefaultSettingsFileName);
+            File.WriteAllText(path, contents);
+
+            Settings settings = new Settings(testDirectory.Path);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            var auditSources = new[]
+            {
+                new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso") { ProtocolVersion = 3 }
+            };
+
+            // Act
+            psp.SaveAuditSources(auditSources);
+
+            // Assert
+            IReadOnlyList<PackageSource> loadedSources = psp.LoadAuditSources();
+            loadedSources.Should().ContainSingle();
+            loadedSources[0].Name.Should().Be("contoso");
+            loadedSources[0].Source.Should().Be("https://contoso.test/nuget/v3/index.json");
+            loadedSources[0].ProtocolVersion.Should().Be(3);
+        }
+
+        [Fact]
+        public void SaveAuditSources_RemovesAuditSourcesNotInList()
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+
+            const string contents = @"<configuration>
+    <auditSources>
+        <add key=""contoso"" value=""https://contoso.test/nuget/v3/index.json"" />
+        <add key=""fabrikam"" value=""https://fabrikam.test/nuget/v3/index.json"" />
+    </auditSources>
+</configuration>";
+            var path = Path.Combine(testDirectory.Path, Settings.DefaultSettingsFileName);
+            File.WriteAllText(path, contents);
+
+            Settings settings = new Settings(testDirectory.Path);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            // Only include contoso, fabrikam should be removed
+            var auditSources = new[]
+            {
+                new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso")
+            };
+
+            // Act
+            psp.SaveAuditSources(auditSources);
+
+            // Assert
+            IReadOnlyList<PackageSource> loadedSources = psp.LoadAuditSources();
+            loadedSources.Should().ContainSingle();
+            loadedSources[0].Name.Should().Be("contoso");
+        }
+
+        [Fact]
+        public void SaveAuditSources_HandlesEmptyList()
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+
+            const string contents = @"<configuration>
+    <auditSources>
+        <add key=""contoso"" value=""https://contoso.test/nuget/v3/index.json"" />
+    </auditSources>
+</configuration>";
+            var path = Path.Combine(testDirectory.Path, Settings.DefaultSettingsFileName);
+            File.WriteAllText(path, contents);
+
+            Settings settings = new Settings(testDirectory.Path);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            // Act
+            psp.SaveAuditSources(Array.Empty<PackageSource>());
+
+            // Assert
+            IReadOnlyList<PackageSource> loadedSources = psp.LoadAuditSources();
+            loadedSources.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void SaveAuditSources_PreservesClearStatement()
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+
+            const string contents = @"<configuration>
+    <auditSources>
+        <clear />
+        <add key=""contoso"" value=""https://contoso.test/nuget/v3/index.json"" />
+    </auditSources>
+</configuration>";
+            var path = Path.Combine(testDirectory.Path, Settings.DefaultSettingsFileName);
+            File.WriteAllText(path, contents);
+
+            Settings settings = new Settings(testDirectory.Path);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            var auditSources = new[]
+            {
+                new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso"),
+                new PackageSource("https://fabrikam.test/nuget/v3/index.json", "fabrikam")
+            };
+
+            // Act
+            psp.SaveAuditSources(auditSources);
+
+            // Assert
+            var configContent = File.ReadAllText(path);
+            configContent.Should().Contain("<clear />");
+
+            IReadOnlyList<PackageSource> loadedSources = psp.LoadAuditSources();
+            loadedSources.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void SaveAuditSources_WithProtocolVersion()
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+
+            const string contents = @"<configuration />";
+            var path = Path.Combine(testDirectory.Path, Settings.DefaultSettingsFileName);
+            File.WriteAllText(path, contents);
+
+            Settings settings = new Settings(testDirectory.Path);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            var auditSources = new[]
+            {
+                new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso") { ProtocolVersion = 3 }
+            };
+
+            // Act
+            psp.SaveAuditSources(auditSources);
+
+            // Assert
+            IReadOnlyList<PackageSource> loadedSources = psp.LoadAuditSources();
+            loadedSources.Should().ContainSingle();
+            loadedSources[0].Name.Should().Be("contoso");
+            loadedSources[0].ProtocolVersion.Should().Be(3);
+        }
+
+        [Fact]
+        public void SaveAuditSources_NonPersistableSourceNotSaved()
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+
+            const string contents = @"<configuration />";
+            var path = Path.Combine(testDirectory.Path, Settings.DefaultSettingsFileName);
+            File.WriteAllText(path, contents);
+
+            Settings settings = new Settings(testDirectory.Path);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            var auditSources = new[]
+            {
+                new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso", isEnabled: true, isOfficial: false, isPersistable: true),
+                new PackageSource("https://fabrikam.test/nuget/v3/index.json", "fabrikam", isEnabled: true, isOfficial: false, isPersistable: false)
+            };
+
+            // Act
+            psp.SaveAuditSources(auditSources);
+
+            // Assert
+            IReadOnlyList<PackageSource> loadedSources = psp.LoadAuditSources();
+            loadedSources.Should().ContainSingle();
+            loadedSources[0].Name.Should().Be("contoso");
+        }
+
+        [Fact]
+        public void SaveAuditSources_ThrowsOnNull()
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+
+            const string contents = @"<configuration />";
+            var path = Path.Combine(testDirectory.Path, Settings.DefaultSettingsFileName);
+            File.WriteAllText(path, contents);
+
+            Settings settings = new Settings(testDirectory.Path);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => psp.SaveAuditSources(null));
+        }
+
+        [Fact]
+        public void SaveAuditSources_UpdatesProtocolVersion()
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+
+            const string contents = @"<configuration>
+    <auditSources>
+        <add key=""contoso"" value=""https://contoso.test/nuget/v3/index.json"" protocolVersion=""2"" />
+    </auditSources>
+</configuration>";
+            var path = Path.Combine(testDirectory.Path, Settings.DefaultSettingsFileName);
+            File.WriteAllText(path, contents);
+
+            Settings settings = new Settings(testDirectory.Path);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            var auditSources = new[]
+            {
+                new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso") { ProtocolVersion = 3 }
+            };
+
+            // Act
+            psp.SaveAuditSources(auditSources);
+
+            // Assert
+            IReadOnlyList<PackageSource> loadedSources = psp.LoadAuditSources();
+            loadedSources.Should().ContainSingle();
+            loadedSources[0].ProtocolVersion.Should().Be(3);
+        }
+
+        [Fact]
+        public void SaveAuditSources_DoesNotAffectPackageSources()
+        {
+            // Arrange
+            using TestDirectory testDirectory = TestDirectory.Create();
+
+            const string contents = @"<configuration>
+    <packageSources>
+        <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" />
+    </packageSources>
+</configuration>";
+            var path = Path.Combine(testDirectory.Path, Settings.DefaultSettingsFileName);
+            File.WriteAllText(path, contents);
+
+            Settings settings = new Settings(testDirectory.Path);
+            PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            var auditSources = new[]
+            {
+                new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso")
+            };
+
+            // Act
+            psp.SaveAuditSources(auditSources);
+
+            // Assert
+            // Verify audit sources are saved
+            IReadOnlyList<PackageSource> loadedAuditSources = psp.LoadAuditSources();
+            loadedAuditSources.Should().ContainSingle();
+            loadedAuditSources[0].Name.Should().Be("contoso");
+
+            // Verify package sources are not affected
+            IReadOnlyList<PackageSource> loadedPackageSources = psp.LoadPackageSources().ToList();
+            loadedPackageSources.Should().ContainSingle();
+            loadedPackageSources[0].Name.Should().Be("nuget.org");
+        }
+
         private string CreateNuGetConfigContent(string enabledReplacement = "", string disabledReplacement = "", string activeSourceReplacement = "")
         {
             var nugetConfigBaseString = new StringBuilder();

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -2572,7 +2572,7 @@ namespace NuGet.Configuration.Test
             var auditSources = new[]
             {
                 new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso"),
-                new PackageSource("https://fabrikam.test/nuget/v3/index.json", "fabrikam")
+                new PackageSource("https://test2.test/nuget/v3/index.json", "test2")
             };
 
             // Act
@@ -2583,8 +2583,8 @@ namespace NuGet.Configuration.Test
             loadedSources.Should().HaveCount(2);
             loadedSources[0].Name.Should().Be("contoso");
             loadedSources[0].Source.Should().Be("https://contoso.test/nuget/v3/index.json");
-            loadedSources[1].Name.Should().Be("fabrikam");
-            loadedSources[1].Source.Should().Be("https://fabrikam.test/nuget/v3/index.json");
+            loadedSources[1].Name.Should().Be("test2");
+            loadedSources[1].Source.Should().Be("https://test2.test/nuget/v3/index.json");
         }
 
         [Fact]
@@ -2629,7 +2629,7 @@ namespace NuGet.Configuration.Test
             const string contents = @"<configuration>
     <auditSources>
         <add key=""contoso"" value=""https://contoso.test/nuget/v3/index.json"" />
-        <add key=""fabrikam"" value=""https://fabrikam.test/nuget/v3/index.json"" />
+        <add key=""test2"" value=""https://test2.test/nuget/v3/index.json"" />
     </auditSources>
 </configuration>";
             var path = Path.Combine(testDirectory.Path, Settings.DefaultSettingsFileName);
@@ -2638,7 +2638,7 @@ namespace NuGet.Configuration.Test
             Settings settings = new Settings(testDirectory.Path);
             PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
-            // Only include contoso, fabrikam should be removed
+            // Only include contoso, test2 should be removed
             var auditSources = new[]
             {
                 new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso")
@@ -2699,7 +2699,7 @@ namespace NuGet.Configuration.Test
             var auditSources = new[]
             {
                 new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso"),
-                new PackageSource("https://fabrikam.test/nuget/v3/index.json", "fabrikam")
+                new PackageSource("https://test2.test/nuget/v3/index.json", "test2")
             };
 
             // Act
@@ -2757,7 +2757,7 @@ namespace NuGet.Configuration.Test
             var auditSources = new[]
             {
                 new PackageSource("https://contoso.test/nuget/v3/index.json", "contoso", isEnabled: true, isOfficial: false, isPersistable: true),
-                new PackageSource("https://fabrikam.test/nuget/v3/index.json", "fabrikam", isEnabled: true, isOfficial: false, isPersistable: false)
+                new PackageSource("https://test2.test/nuget/v3/index.json", "test2", isEnabled: true, isOfficial: false, isPersistable: false)
             };
 
             // Act
@@ -2783,7 +2783,7 @@ namespace NuGet.Configuration.Test
             PackageSourceProvider psp = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
 
             // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => psp.SaveAuditSources(null));
+            Assert.Throws<ArgumentNullException>(() => psp.SaveAuditSources(null!));
         }
 
         [Fact]

--- a/test/TestUtilities/Test.Utility/SourceRepository/TestSourceRepositoryUtility.cs
+++ b/test/TestUtilities/Test.Utility/SourceRepository/TestSourceRepositoryUtility.cs
@@ -142,6 +142,8 @@ namespace Test.Utility
         public void AddPackageSource(PackageSource source) => throw new NotImplementedException();
 
         public bool IsPackageSourceEnabled(string name) => throw new NotImplementedException();
+
+        public void SaveAuditSources(IEnumerable<PackageSource> sources) => throw new NotImplementedException();
     }
 
     public static class TestPackageSourceSettings


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/13955

## Description

Adds a table to the package source VS Options page with audit sources.
When any audit source is configured, a message is shown explaining that removing all audit sources reverts to using package sources for vulnerability data.

- Update the SDK to support adding audit sources in the `PackageSourceProvider`.
  - I've omitted properties not currently configurable like the Enabled and AllowInsecureConnections properties.

<img width="1246" height="379" alt="image" src="https://github.com/user-attachments/assets/909dc848-298f-4429-b906-cc662a0b0464" />

Help Links:
- Audit Sources (?): https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages
- Learn more about audit sources: https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#auditsources

<img width="570" height="399" alt="image" src="https://github.com/user-attachments/assets/46da238e-25bf-4052-ae33-dcaad1b56f1b" />



## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
