### PR TITLE
[7.0.x] Vulnerability InfoBar now has "How to fix with GitHub Copilot" link to NuGet's MCP Server docs (#6959)

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/HyperlinkType.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/HyperlinkType.cs
@@ -14,6 +14,7 @@ namespace NuGet.PackageManagement.Telemetry
         DeprecationAlternativeDetails,
         DeprecationAlternativePackageItem,
         VulnerabilityAdvisory,
+        VulnerabilityAdvisoryGHCopilotDocs,
         OptionsBlocked,
         OwnerProfile,
         OwnerProfileDetailsPane

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigatedTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigatedTelemetryEvent.cs
@@ -73,6 +73,28 @@ namespace NuGet.PackageManagement.Telemetry
         }
 
         /// <summary>
+        /// Navigating from the Vulnerability InfoBar to the Manage Packages dialog.
+        /// </summary>
+        public static NavigatedTelemetryEvent CreateWithVulnerabilityInfoBarManagePackages()
+        {
+            NavigatedTelemetryEvent navigatedTelemetryEvent = new(NavigationType.Button, NavigationOrigin.VulnerabilityInfoBar_ManagePackages);
+            return navigatedTelemetryEvent;
+        }
+
+        /// <summary>
+        /// Navigating an External hyperlink from VS.
+        /// </summary>
+        /// <param name="hyperlinkType">Hyperlink origin</param>
+        public static NavigatedTelemetryEvent CreateWithExternalLink(HyperlinkType hyperlinkType)
+        {
+            NavigatedTelemetryEvent navigatedTelemetryEvent = new(NavigationType.Hyperlink, NavigationOrigin.PMUI_ExternalLink);
+
+            navigatedTelemetryEvent[HyperLinkTypePropertyName] = hyperlinkType;
+
+            return navigatedTelemetryEvent;
+        }
+
+        /// <summary>
         /// Navigating an External hyperlink from the PM UI.
         /// </summary>
         /// <param name="hyperlinkType">Hyperlink origin</param>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigationOrigin.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigationOrigin.cs
@@ -11,6 +11,7 @@ namespace NuGet.PackageManagement.Telemetry
         Options_PackageSourceMapping_RemoveAll,
         Options_LocalsCommand_ClearAll,
         PMUI_ExternalLink,
-        PMUI_PackageSourceMapping_Configure
+        PMUI_PackageSourceMapping_Configure,
+        VulnerabilityInfoBar_ManagePackages
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.SolutionRestoreManager {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -93,6 +93,15 @@ namespace NuGet.SolutionRestoreManager {
         internal static string ErrorOccurredRestoringPackages {
             get {
                 return ResourceManager.GetString("ErrorOccurredRestoringPackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to How to fix with GitHub Copilot.
+        /// </summary>
+        internal static string InfoBar_HyperlinkGHCopilotDocs {
+            get {
+                return ResourceManager.GetString("InfoBar_HyperlinkGHCopilotDocs", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
@@ -197,4 +197,7 @@ To prevent NuGet from restoring packages during build, open the Visual Studio Op
     <value>'{0}' items do not have the same value(s) across all target frameworks. Remove any condition from MSBuild files for '{0}' items.</value>
     <comment>{0} - MSBuild item type. For example, NuGetAuditSuppress</comment>
   </data>
+  <data name="InfoBar_HyperlinkGHCopilotDocs" xml:space="preserve">
+    <value>How to fix with GitHub Copilot</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VulnerablePackagesInfoBar.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VulnerablePackagesInfoBar.cs
@@ -13,7 +13,9 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.Common;
 using NuGet.PackageManagement;
+using NuGet.PackageManagement.Telemetry;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Telemetry;
 
@@ -23,12 +25,16 @@ namespace NuGet.SolutionRestoreManager
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class VulnerablePackagesInfoBar : IVulnerabilitiesNotificationService, IVsInfoBarUIEvents
     {
+        private const string LogEntrySource = "NuGet Package Manager";
+
         private IAsyncServiceProvider _asyncServiceProvider = AsyncServiceProvider.GlobalProvider;
         internal IVsInfoBarUIElement? _infoBarUIElement;
         internal bool _infoBarVisible = false; // InfoBar is currently being displayed in the Solution Explorer
         internal bool _wasInfoBarClosed = false; // InfoBar was closed by the user, using the 'x'(close) in the InfoBar
         internal bool _wasInfoBarHidden = false; // InfoBar was hid, this is caused because there are no more vulnerabilities to address
         private uint? _eventCookie; // To hold the connection cookie
+        private InfoBarHyperlink _hyperlinkPmui;
+        private InfoBarHyperlink _hyperlinkGHCopilotDocs;
 
         private Lazy<IPackageManagerLaunchService>? PackageManagerLaunchService { get; }
         private ISolutionManager? SolutionManager { get; }
@@ -36,6 +42,8 @@ namespace NuGet.SolutionRestoreManager
         [ImportingConstructor]
         public VulnerablePackagesInfoBar(ISolutionManager solutionManager, Lazy<IPackageManagerLaunchService> packageManagerLaunchService)
         {
+            _hyperlinkPmui = new InfoBarHyperlink(Resources.InfoBar_HyperlinkMessage);
+            _hyperlinkGHCopilotDocs = new InfoBarHyperlink(Resources.InfoBar_HyperlinkGHCopilotDocs, "https://aka.ms/nugetmcp/auditFix");
             SolutionManager = solutionManager;
             PackageManagerLaunchService = packageManagerLaunchService;
             SolutionManager.SolutionClosed += OnSolutionClosed;
@@ -157,7 +165,33 @@ namespace NuGet.SolutionRestoreManager
         public void OnActionItemClicked(IVsInfoBarUIElement infoBarUIElement, IVsInfoBarActionItem actionItem)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            PackageManagerLaunchService?.Value.LaunchSolutionPackageManager();
+            if (actionItem != null)
+            {
+                if (actionItem.ActionContext == _hyperlinkGHCopilotDocs.ActionContext)
+                {
+                    LaunchGitHubCopilotDocs();
+                }
+                else
+                {
+                    PackageManagerLaunchService?.Value.LaunchSolutionPackageManager();
+                    var evt = NavigatedTelemetryEvent.CreateWithVulnerabilityInfoBarManagePackages();
+                    TelemetryActivity.EmitTelemetryEvent(evt);
+                }
+            }
+        }
+
+        private void LaunchGitHubCopilotDocs()
+        {
+            try
+            {
+                System.Diagnostics.Process.Start(_hyperlinkGHCopilotDocs.ActionContext);
+                var evt = NavigatedTelemetryEvent.CreateWithExternalLink(HyperlinkType.VulnerabilityAdvisoryGHCopilotDocs);
+                TelemetryActivity.EmitTelemetryEvent(evt);
+            }
+            catch (System.ComponentModel.Win32Exception ex)
+            {
+                ActivityLog.LogError(LogEntrySource, ex.ToString());
+            }
         }
 
         protected InfoBarModel GetInfoBarModel()
@@ -165,7 +199,9 @@ namespace NuGet.SolutionRestoreManager
             IEnumerable<IVsInfoBarTextSpan> textSpans = new IVsInfoBarTextSpan[]
             {
                 new InfoBarTextSpan(Resources.InfoBar_TextMessage + " "),
-                new InfoBarHyperlink(Resources.InfoBar_HyperlinkMessage)
+                _hyperlinkPmui,
+                new InfoBarTextSpan(" | "),
+                _hyperlinkGHCopilotDocs
             };
 
             return new InfoBarModel(

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.cs.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Balíček {0} {1} nemá přesnou verzi, například [1.0.0]. S PackageDownload se povolují jenom přesné verze.</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">Spravovat balíčky NuGet</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.cs.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">Postup opravy pomocí GitHub Copilotu</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.de.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Das Paket "{0} {1}" weist keine genaue Version wie "[1.0.0]" auf. Nur exakte Versionen sind bei PackageDownload zulässig.</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">NuGet-Pakete verwalten</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.de.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">So beheben Sie Probleme mit GitHub Copilot</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.es.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">Cómo corregir con GitHub Copilot</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.es.xlf
@@ -22,6 +22,11 @@
         <target state="translated">El paquete "{0} {1}" no tiene una versión exacta, como "[1.0.0]". Solo se permiten versiones exactas con PackageDownload.</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">Administración de paquetes NuGet</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.fr.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">Comment résoudre un problème avec GitHub Copilot</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.fr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Le paquet '{0}' {1} n’a pas de version exacte comme '[1.0.0]'. Seules les versions exactes sont autorisées avec PackageDownload.</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">Gérer les packages NuGet</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.it.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">Come risolvere un problema con GitHub Copilot</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.it.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Il pacchetto '{0} {1}' non è una versione esatta come '[1.0.0]'. Con PackageDownload sono consentite solo versioni esatte.</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">Gestisci i pacchetti NuGet</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ja.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">GitHub Copilot で修正する方法</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ja.xlf
@@ -22,6 +22,11 @@
         <target state="translated">パッケージ '{0}{1}' に '[1.0.0]' のような正確なバージョンがありません。PackageDownload では、正確なバージョンのみが許可されます。</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">NuGet パッケージの管理</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ko.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">GitHub Copilot를 사용하여 해결하는 방법</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ko.xlf
@@ -22,6 +22,11 @@
         <target state="translated">'{0} {1}' 패키지에 '[1.0.0]'와 같은 정확한 버전이 없습니다. PackageDownload에는 정확한 버전만 허용됩니다.</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">NuGet 패키지</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.pl.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">Jak rozwiązać problem z funkcją GitHub Copilot</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.pl.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Pakiet „{0}{1}” nie ma dokładnej wersji, takiej jak „[1.0.0]”. Z elementem PackageDownload są dozwolone tylko dokładne wersje.</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">Zarządzaj pakietami NuGet</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.pt-BR.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">Como corrigir com o GitHub Copilot</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="translated">O pacote '{0} {1}' não possui uma versão exata como '[1.0.0]'. Somente versões exatas são permitidas com PackageDownload.</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">Gerenciar Pacotes do NuGet...</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ru.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">Исправление с помощью GitHub Copilot</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.ru.xlf
@@ -22,6 +22,11 @@
         <target state="translated">У пакета "{0}{1}" нет точной версии, такой как "[1.0.0]". С PackageDownload можно использовать только точные версии.</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">Управление пакетами NuGet</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.tr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">'{0} {1}' paketinin '[1.0.0]' gibi tam bir sürümü yok. PackageDownload'da yalnızca tam sürümlere izin verilir.</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">NuGet Paketlerini Yönet</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.tr.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">GitHub Copilot ile nasıl düzeltilir?</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="translated">包“{0} {1}”不是类似 "[1.0.0]" 的精确版本。仅可对 PackageDownload 使用精确版本。</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">管理 NuGet 程序包</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.zh-Hans.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">如何使用 GitHub Copilot 进行修复</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="translated">套件 '{0} {1}' 沒有如 '[1.0.0]' 的精確版本。只有精確版本才允許使用 PackageDownload。</target>
         <note>0 - The package that does not have an exact version. Do not translate 'PackageDownload'. 1 - the version string that's not exact.</note>
       </trans-unit>
+      <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
+        <source>How to fix with GitHub Copilot</source>
+        <target state="new">How to fix with GitHub Copilot</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">
         <source>Manage NuGet Packages</source>
         <target state="translated">管理 NuGet 套件</target>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/xlf/Resources.zh-Hant.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkGHCopilotDocs">
         <source>How to fix with GitHub Copilot</source>
-        <target state="new">How to fix with GitHub Copilot</target>
+        <target state="translated">如何使用 GitHub Copilot 修正</target>
         <note />
       </trans-unit>
       <trans-unit id="InfoBar_HyperlinkMessage">

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
@@ -69,6 +69,54 @@ namespace NuGet.PackageManagement.Test.Telemetry
         }
 
         [Fact]
+        public void CreateWithVulnerabilityInfoBarManagePackages_WithValidProperties_CreatedWithoutPiiData()
+        {
+            // Arrange
+            var nuGetTelemetryService = SetupTelemetryListener();
+
+            var navigationType = NavigationType.Button;
+            var navigationOrigin = NavigationOrigin.VulnerabilityInfoBar_ManagePackages;
+
+            var evt = NavigatedTelemetryEvent.CreateWithVulnerabilityInfoBarManagePackages();
+
+            // Act
+            nuGetTelemetryService.EmitTelemetryEvent(evt);
+
+            // Assert
+            Assert.NotNull(_lastTelemetryEvent);
+            Assert.Equal(navigationType, _lastTelemetryEvent[NavigatedTelemetryEvent.NavigationTypePropertyName]);
+            Assert.Equal(navigationOrigin, _lastTelemetryEvent[NavigatedTelemetryEvent.OriginPropertyName]);
+            Assert.Null(_lastTelemetryEvent[NavigatedTelemetryEvent.HyperLinkTypePropertyName]);
+            Assert.Null(_lastTelemetryEvent[NavigatedTelemetryEvent.CurrentTabPropertyName]);
+            Assert.Null(_lastTelemetryEvent[NavigatedTelemetryEvent.IsSolutionViewPropertyName]);
+            Assert.Empty(_lastTelemetryEvent.GetPiiData());
+        }
+
+        [Fact]
+        public void CreateWithExternalLink_VulnerabilityAdvisoryGHCopilotDocs_CreatedWithoutPiiData()
+        {
+            // Arrange
+            var nuGetTelemetryService = SetupTelemetryListener();
+
+            HyperlinkType hyperlinkType = HyperlinkType.VulnerabilityAdvisoryGHCopilotDocs;
+
+            var evt = NavigatedTelemetryEvent.CreateWithExternalLink(hyperlinkType);
+
+            // Act
+            nuGetTelemetryService.EmitTelemetryEvent(evt);
+
+            // Assert
+            Assert.NotNull(_lastTelemetryEvent);
+            Assert.Equal(3, _lastTelemetryEvent.Count);
+            Assert.Equal(NavigationType.Hyperlink, _lastTelemetryEvent[NavigatedTelemetryEvent.NavigationTypePropertyName]);
+            Assert.Equal(NavigationOrigin.PMUI_ExternalLink, _lastTelemetryEvent[NavigatedTelemetryEvent.OriginPropertyName]);
+            Assert.Equal(hyperlinkType, _lastTelemetryEvent[NavigatedTelemetryEvent.HyperLinkTypePropertyName]);
+            Assert.Null(_lastTelemetryEvent[NavigatedTelemetryEvent.CurrentTabPropertyName]);
+            Assert.Null(_lastTelemetryEvent[NavigatedTelemetryEvent.IsSolutionViewPropertyName]);
+            Assert.Empty(_lastTelemetryEvent.GetPiiData());
+        }
+
+        [Fact]
         public void CreateWithAddPackageSourceMapping_WithValidProperties_CreatedWithoutPiiData()
         {
             // Arrange


### PR DESCRIPTION
Cherry-pick of https://github.com/NuGet/NuGet.Client/pull/6959