### PR TITLE
Set ExcludeRestorePackageImports when reading PackageReference for list package

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -907,7 +907,10 @@ namespace NuGet.CommandLine.XPlat
         private static IEnumerable<InstalledPackageReference> GetPackageReferencesFromTargets(string projectPath, string framework)
         {
             var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                { { "TargetFramework", framework } };
+                {
+                    { "TargetFramework", framework },
+                    { "ExcludeRestorePackageImports", "true" }
+                };
             var newProject = new ProjectInstance(projectPath, globalProperties, null);
             newProject.Build(new[] { CollectPackageReferences, CollectCentralPackageVersions }, new List<Microsoft.Build.Framework.ILogger> { }, out var targetOutputs);
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -909,7 +909,7 @@ namespace NuGet.CommandLine.XPlat
             var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "TargetFramework", framework },
-                    { "ExcludeRestorePackageImports", "true" }
+                    { "ExcludeRestorePackageImports", bool.TrueString }
                 };
             var newProject = new ProjectInstance(projectPath, globalProperties, null);
             newProject.Build(new[] { CollectPackageReferences, CollectCentralPackageVersions }, new List<Microsoft.Build.Framework.ILogger> { }, out var targetOutputs);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -1094,6 +1094,48 @@ namespace Dotnet.Integration.Test
             projects[0]["path"].ToString().Should().Be(PathUtility.GetPathWithForwardSlashes(projectA.ProjectPath));
         }
 
+        [PlatformFact(Platform.Windows)]
+        public async Task DotnetListPackage_PackageWithTargetsFileThatErrorsForNonNet50_ReturnsCorrectResults()
+        {
+            // Arrange
+            using var pathContext = _fixture.CreateSimpleTestPathContext();
+            _fixture.CreateDotnetNewProject(pathContext.SolutionRoot, ProjectName, args: "classlib", _testOutputHelper);
+            string projectPath = Path.Combine(pathContext.SolutionRoot, ProjectName, $"{ProjectName}.csproj");
+
+            // Create a package with a .targets file that logs an error when TargetFramework is not net5.0
+            var packageX = new SimpleTestPackageContext("PackageX", "1.0.0");
+            packageX.Files.Clear();
+            packageX.AddFile("lib/net5.0/_._");
+            packageX.AddFile("lib/net6.0/_._");
+
+            var targetsContent = @"
+<Project InitialTargets=""ErrorForNonNet50"">
+  <Target Name=""ErrorForNonNet50"">
+    <Error Condition=""'$(TargetFramework)' != 'net5.0'"" Text=""This is a failure within a package targets, to ensure list package is able to handle it."" />
+  </Target>
+</Project>";
+            packageX.AddFile("build/PackageX.targets", targetsContent);
+
+            // Generate Package
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageX);
+
+            // Pre-Req
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectPath).FullName,
+                $"add {projectPath} package PackageX --version 1.0.0",
+                testOutputHelper: _testOutputHelper);
+
+            // Act - dotnet list package should succeed despite the MSBuild error in the .targets file
+            CommandRunnerResult listResult = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectPath).FullName,
+                $"list {projectPath} package",
+                testOutputHelper: _testOutputHelper);
+
+            // Assert - Verify the package is listed correctly
+            Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "PackageX1.0.01.0.0"));
+        }
+
         private static string CollapseSpaces(string input)
         {
             return Regex.Replace(input, " +", " ");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -1095,23 +1095,21 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
-        public async Task DotnetListPackage_PackageWithTargetsFileThatErrorsForNonNet50_ReturnsCorrectResults()
+        public async Task DotnetListPackage_PackageWithTargetsFileErrors_ReturnsCorrectResults()
         {
             // Arrange
             using var pathContext = _fixture.CreateSimpleTestPathContext();
             _fixture.CreateDotnetNewProject(pathContext.SolutionRoot, ProjectName, args: "classlib", _testOutputHelper);
             string projectPath = Path.Combine(pathContext.SolutionRoot, ProjectName, $"{ProjectName}.csproj");
 
-            // Create a package with a .targets file that logs an error when TargetFramework is not net5.0
+            // Create a package with a .targets file that logs an error
             var packageX = new SimpleTestPackageContext("PackageX", "1.0.0");
-            packageX.Files.Clear();
             packageX.AddFile("lib/net5.0/_._");
-            packageX.AddFile("lib/net6.0/_._");
 
             var targetsContent = @"
-<Project InitialTargets=""ErrorForNonNet50"">
-  <Target Name=""ErrorForNonNet50"">
-    <Error Condition=""'$(TargetFramework)' != 'net5.0'"" Text=""This is a failure within a package targets, to ensure list package is able to handle it."" />
+<Project InitialTargets=""ErrorToFailBuild"">
+  <Target Name=""ErrorToFailBuild"">
+    <Error Text=""This is a failure within a package targets, to ensure list package is able to handle it."" />
   </Target>
 </Project>";
             packageX.AddFile("build/PackageX.targets", targetsContent);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/nuget/home/issues/14670

## Description

If there's a package with content that specifically fails running the collect* targets, list package may fial. 

The correct thing is to set ExcludeRestorePackageImports whenever we run any of the collect* targets.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
