### PR TITLE
[7.0.x] dotnet nuget why: write target package in graph

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -84,6 +84,8 @@
     <PackageVersion Include="NuGet.Core" Version="2.14.0-rtm-832" />
     <PackageVersion Include="NuGetValidator" version="2.1.1" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
+    <PackageVersion Include="Spectre.Console" Version="0.54.0" />
+    <PackageVersion Include="Spectre.Console.Testing" Version="0.54.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="$(SystemComponentModelCompositionPackageVersion)" />
@@ -179,6 +181,7 @@
       <_allowBuildFromSourcePackage Include="Microsoft.Extensions.FileSystemGlobbing" />
       <_allowBuildFromSourcePackage Include="Microsoft.Web.Xdt" />
       <_allowBuildFromSourcePackage Include="Newtonsoft.Json" />
+      <_allowBuildFromSourcePackage Include="Spectre.Console" />
       <_allowBuildFromSourcePackage Include="System.Collections.Immutable" />
       <_allowBuildFromSourcePackage Include="System.CommandLine" />
       <_allowBuildFromSourcePackage Include="System.ComponentModel.Composition" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -41,6 +41,7 @@
       <package pattern="nuget.*" />
       <package pattern="runtime.*" />
       <package pattern="sharpziplib" />
+      <package pattern="Spectre.*" />
       <package pattern="streamjsonrpc" />
       <package pattern="system.*" />
       <package pattern="Validation" />

--- a/NuGet.sln
+++ b/NuGet.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build\config.props = build\config.props
 		Directory.Packages.props = Directory.Packages.props
 		build\DotNetSdkVersions.txt = build\DotNetSdkVersions.txt
+		NuGet.Config = NuGet.Config
 		build\sign.targets = build\sign.targets
 		spelling.dic = spelling.dic
 		build\test.targets = build\test.targets

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/DependencyGraphPrinter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/DependencyGraphPrinter.cs
@@ -7,19 +7,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Shared;
+using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace NuGet.CommandLine.XPlat.Commands.Why
 {
     internal static class DependencyGraphPrinter
     {
-        private const ConsoleColor TargetPackageColor = ConsoleColor.Cyan;
-
-        // Dependency graph console output symbols
-        private const string ChildNodeSymbol = "├─ ";
-        private const string LastChildNodeSymbol = "└─ ";
-
-        private const string ChildPrefixSymbol = "│  ";
-        private const string LastChildPrefixSymbol = "   ";
+        private static readonly Color TargetPackageColor = Color.Cyan;
 
         /// <summary>
         /// Prints the dependency graphs for all target frameworks.
@@ -27,10 +22,10 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         /// <param name="dependencyGraphPerFramework">A dictionary mapping target frameworks to their dependency graphs.</param>
         /// <param name="targetPackage">The package we want the dependency paths for.</param>
         /// <param name="logger"></param>
-        public static void PrintAllDependencyGraphs(Dictionary<string, List<DependencyNode>?> dependencyGraphPerFramework, string targetPackage, ILoggerWithColor logger)
+        public static void PrintAllDependencyGraphs(Dictionary<string, List<DependencyNode>?> dependencyGraphPerFramework, string targetPackage, IAnsiConsole logger)
         {
             // print empty line
-            logger.LogMinimal("");
+            logger.WriteLine();
 
             // deduplicate the dependency graphs
             List<List<string>> deduplicatedFrameworks = GetDeduplicatedFrameworks(dependencyGraphPerFramework);
@@ -51,29 +46,27 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         /// <param name="topLevelNodes">The top-level package nodes of the dependency graph.</param>
         /// <param name="targetPackage">The package we want the dependency paths for.</param>
         /// <param name="logger"></param>
-        private static void PrintDependencyGraphPerFramework(List<string> frameworks, List<DependencyNode>? topLevelNodes, string targetPackage, ILoggerWithColor logger)
+        private static void PrintDependencyGraphPerFramework(List<string> frameworks, List<DependencyNode>? topLevelNodes, string targetPackage, IAnsiConsole logger)
         {
-            // print framework header
-            foreach (var framework in frameworks)
-            {
-                logger.LogMinimal($"  [{framework}]");
-            }
-
-            logger.LogMinimal($"   {ChildPrefixSymbol}");
+            var tree = new Tree(string.Join("\n", frameworks.Select(f => $"[[{f}]]")));
 
             if (topLevelNodes == null || topLevelNodes.Count == 0)
             {
-                logger.LogMinimal($"   {LastChildNodeSymbol}{Strings.WhyCommand_Message_NoDependencyGraphsFoundForFramework}\n\n");
+                tree.AddNode(Strings.WhyCommand_Message_NoDependencyGraphsFoundForFramework);
+                logger.Write(PadTree(tree));
                 return;
             }
 
             var stack = new Stack<StackOutputData>();
 
             // initialize the stack with all top-level nodes
-            int counter = 0;
             foreach (var node in topLevelNodes.OrderByDescending(c => c.Id, StringComparer.OrdinalIgnoreCase))
             {
-                stack.Push(new StackOutputData(node, prefix: "   ", isLastChild: counter++ == 0));
+                stack.Push(new StackOutputData
+                {
+                    Node = node,
+                    ParentNode = tree
+                });
             }
 
             // print the dependency graph
@@ -81,41 +74,39 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             {
                 var current = stack.Pop();
 
-                string currentPrefix, childPrefix;
-                if (current.IsLastChild)
-                {
-                    currentPrefix = current.Prefix + LastChildNodeSymbol;
-                    childPrefix = current.Prefix + LastChildPrefixSymbol;
-                }
-                else
-                {
-                    currentPrefix = current.Prefix + ChildNodeSymbol;
-                    childPrefix = current.Prefix + ChildPrefixSymbol;
-                }
-
-                // print current node
-                if (current.Node.Id.Equals(targetPackage, StringComparison.OrdinalIgnoreCase))
-                {
-                    logger.LogMinimal($"{currentPrefix}", Console.ForegroundColor);
-                    logger.LogMinimal($"{current.Node.Id} (v{current.Node.Version})\n", TargetPackageColor);
-                }
-                else
-                {
-                    logger.LogMinimal($"{currentPrefix}{current.Node.Id} (v{current.Node.Version})");
-                }
+                var treeNodeText = GetNodeText(current.Node, targetPackage);
+                var treeNode = current.ParentNode.AddNode(treeNodeText);
 
                 if (current.Node.Children?.Count > 0)
                 {
-                    // push all the node's children onto the stack
-                    counter = 0;
                     foreach (var child in current.Node.Children.OrderByDescending(c => c.Id, StringComparer.OrdinalIgnoreCase))
                     {
-                        stack.Push(new StackOutputData(child, childPrefix, isLastChild: counter++ == 0));
+                        stack.Push(new StackOutputData
+                        {
+                            Node = child,
+                            ParentNode = treeNode
+                        });
                     }
                 }
             }
 
-            logger.LogMinimal("");
+            logger.Write(PadTree(tree));
+            logger.WriteLine();
+        }
+
+        private static IRenderable GetNodeText(DependencyNode node, string targetPackage)
+        {
+            string text = $"{node.Id} (v{node.Version})";
+            Style? style = node.Id.Equals(targetPackage, StringComparison.OrdinalIgnoreCase)
+                ? new Style(foreground: TargetPackageColor)
+                : null;
+
+            return new Text(text, style);
+        }
+
+        private static IRenderable PadTree(Tree tree)
+        {
+            return new Padder(tree, new Padding(left: 2, 0, 0, 0));
         }
 
         /// <summary>
@@ -173,16 +164,9 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
 
         private class StackOutputData
         {
-            public DependencyNode Node { get; set; }
-            public string Prefix { get; set; }
-            public bool IsLastChild { get; set; }
+            public required DependencyNode Node { get; init; }
 
-            public StackOutputData(DependencyNode node, string prefix, bool isLastChild)
-            {
-                Node = node;
-                Prefix = prefix;
-                IsLastChild = isLastChild;
-            }
+            public required IHasTreeNodes ParentNode { get; init; }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandArgs.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Spectre.Console;
 
 namespace NuGet.CommandLine.XPlat.Commands.Why
 {
@@ -14,7 +15,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         public string Path { get; }
         public string Package { get; }
         public List<string> Frameworks { get; }
-        public ILoggerWithColor Logger { get; }
+        public IAnsiConsole Logger { get; }
         public CancellationToken CancellationToken { get; }
 
         /// <summary>
@@ -29,7 +30,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             string path,
             string package,
             List<string> frameworks,
-            ILoggerWithColor logger,
+            IAnsiConsole logger,
             CancellationToken cancellationToken)
         {
             Path = path ?? throw new ArgumentNullException(nameof(path));

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommandRunner.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Build.Evaluation;
 using NuGet.ProjectModel;
+using Spectre.Console;
 
 namespace NuGet.CommandLine.XPlat.Commands.Why
 {
@@ -38,11 +39,11 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             }
             catch (ArgumentException ex)
             {
-                whyCommandArgs.Logger.LogError(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.WhyCommand_Error_ArgumentExceptionThrown,
-                        ex.Message));
+                string message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.WhyCommand_Error_ArgumentExceptionThrown,
+                    ex.Message);
+                whyCommandArgs.Logger.MarkupLine($"[red]{message}[/]");
 
                 return Task.FromResult(ExitCodes.InvalidArguments);
             }
@@ -63,7 +64,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
 
                     if (dependencyGraphPerFramework != null)
                     {
-                        whyCommandArgs.Logger.LogMinimal(
+                        whyCommandArgs.Logger.WriteLine(
                             string.Format(CultureInfo.CurrentCulture,
                                 Strings.WhyCommand_Message_DependencyGraphsFoundInProject,
                                 assetsFile.PackageSpec.Name,
@@ -73,7 +74,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                     }
                     else
                     {
-                        whyCommandArgs.Logger.LogMinimal(
+                        whyCommandArgs.Logger.WriteLine(
                             string.Format(CultureInfo.CurrentCulture,
                                 Strings.WhyCommand_Message_NoDependencyGraphsFoundInProject,
                                 assetsFile.PackageSpec.Name,
@@ -89,7 +90,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             return Task.FromResult(anyErrors ? ExitCodes.Error : ExitCodes.Success);
         }
 
-        private static IEnumerable<(string assetsFilePath, string? projectPath)> FindAssetsFiles(string path, ILoggerWithColor logger)
+        private static IEnumerable<(string assetsFilePath, string? projectPath)> FindAssetsFiles(string path, IAnsiConsole logger)
         {
             if (XPlatUtility.IsJsonFile(path))
             {
@@ -108,23 +109,22 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                     {
                         if (!MSBuildAPIUtility.IsPackageReferenceProject(project))
                         {
-                            logger.LogError(
-                                string.Format(
-                                    CultureInfo.CurrentCulture,
-                                    Strings.Error_NotPRProject,
-                                    project.FullPath));
-
+                            string message = string.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.Error_NotPRProject,
+                                project.FullPath);
+                            logger.MarkupLine($"[red]{message}[/]");
                             continue;
                         }
 
                         string? assetsFilePath = project.GetPropertyValue(ProjectAssetsFile);
                         if (string.IsNullOrEmpty(assetsFilePath) || !File.Exists(assetsFilePath))
                         {
-                            logger.LogError(
-                                string.Format(
-                                    CultureInfo.CurrentCulture,
-                                    Strings.Error_AssetsFileNotFound,
-                                    project.FullPath));
+                            string message = string.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.Error_AssetsFileNotFound,
+                                project.FullPath);
+                            logger.MarkupLine($"[red]{message}[/]");
                             continue;
                         }
 
@@ -132,7 +132,7 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                     }
                     else
                     {
-                        logger.LogMinimal(
+                        logger.WriteLine(
                                 string.Format(
                                     CultureInfo.CurrentCulture,
                                     Strings.WhyCommand_Message_NonSDKStyleProjectsAreNotSupported,
@@ -149,15 +149,15 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         /// <summary>
         /// Validates that the input 'path' argument is a valid path to a directory, solution file or project file.
         /// </summary>
-        private static bool ValidatePathArgument(string path, ILoggerWithColor logger)
+        private static bool ValidatePathArgument(string path, IAnsiConsole logger)
         {
             if (string.IsNullOrEmpty(path))
             {
-                logger.LogError(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.WhyCommand_Error_ArgumentCannotBeEmpty,
-                        "PROJECT|SOLUTION"));
+                string message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.WhyCommand_Error_ArgumentCannotBeEmpty,
+                    "PROJECT|SOLUTION");
+                logger.MarkupLine($"[red]{message}[/]");
                 return false;
             }
 
@@ -169,11 +169,11 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             }
             catch (ArgumentException)
             {
-                logger.LogError(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.WhyCommand_Error_ArgumentExceptionThrown,
-                        string.Format(CultureInfo.CurrentCulture, Strings.Error_PathIsMissingOrInvalid, path)));
+                string message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.WhyCommand_Error_ArgumentExceptionThrown,
+                    string.Format(CultureInfo.CurrentCulture, Strings.Error_PathIsMissingOrInvalid, path));
+                logger.MarkupLine($"[red]{message}[/]");
                 return false;
             }
 
@@ -186,24 +186,24 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             }
             else
             {
-                logger.LogError(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.WhyCommand_Error_ArgumentExceptionThrown,
-                        string.Format(CultureInfo.CurrentCulture, Strings.Error_PathIsMissingOrInvalid, path)));
+                string message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.WhyCommand_Error_ArgumentExceptionThrown,
+                    string.Format(CultureInfo.CurrentCulture, Strings.Error_PathIsMissingOrInvalid, path));
+                logger.MarkupLine($"[red]{message}[/]");
                 return false;
             }
         }
 
-        private static bool ValidatePackageArgument(string package, ILoggerWithColor logger)
+        private static bool ValidatePackageArgument(string package, IAnsiConsole logger)
         {
             if (string.IsNullOrEmpty(package))
             {
-                logger.LogError(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.WhyCommand_Error_ArgumentCannotBeEmpty,
-                        "PACKAGE"));
+                string message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.WhyCommand_Error_ArgumentCannotBeEmpty,
+                    "PACKAGE");
+                logger.MarkupLine($"[red]{message}[/]");
                 return false;
             }
 
@@ -213,19 +213,19 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         /// <summary>
         /// Validates that the input frameworks options have corresponding targets in the assets file. Outputs a warning message if a framework does not exist.
         /// </summary>
-        private static void ValidateFrameworksOptionsExistInAssetsFile(LockFile assetsFile, List<string> inputFrameworks, ILoggerWithColor logger)
+        private static void ValidateFrameworksOptionsExistInAssetsFile(LockFile assetsFile, List<string> inputFrameworks, IAnsiConsole logger)
         {
             foreach (var frameworkAlias in inputFrameworks)
             {
                 if (assetsFile.GetTarget(frameworkAlias, runtimeIdentifier: null) == null)
                 {
-                    logger.LogWarning(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.WhyCommand_Warning_AssetsFileDoesNotContainSpecifiedTarget,
-                            assetsFile.Path,
-                            assetsFile.PackageSpec.Name,
-                            frameworkAlias));
+                    string message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.WhyCommand_Warning_AssetsFileDoesNotContainSpecifiedTarget,
+                        assetsFile.Path,
+                        assetsFile.PackageSpec.Name,
+                        frameworkAlias);
+                    logger.MarkupLine($"[yellow]{message}[/]");
                 }
             }
         }
@@ -237,25 +237,25 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
         /// <param name="projectPath"></param>
         /// <param name="logger">Logger for the 'why' command</param>
         /// <returns>Assets file for the given project. Returns null if there was any issue finding or parsing the assets file.</returns>
-        private static LockFile? GetProjectAssetsFile(string assetsFilePath, string? projectPath, ILoggerWithColor logger)
+        private static LockFile? GetProjectAssetsFile(string assetsFilePath, string? projectPath, IAnsiConsole logger)
         {
             if (!File.Exists(assetsFilePath))
             {
                 if (!string.IsNullOrEmpty(projectPath))
                 {
-                    logger.LogError(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.Error_AssetsFileNotFound,
-                            projectPath));
+                    string message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.Error_AssetsFileNotFound,
+                        projectPath);
+                    logger.MarkupLine($"[red]{message}[/]");
                 }
                 else
                 {
-                    logger.LogError(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.Error_PathIsMissingOrInvalid,
-                            assetsFilePath));
+                    string message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.Error_PathIsMissingOrInvalid,
+                        assetsFilePath);
+                    logger.MarkupLine($"[red]{message}[/]");
                 }
 
                 return null;
@@ -271,20 +271,20 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
             {
                 if (string.IsNullOrEmpty(projectPath))
                 {
-                    logger.LogError(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.WhyCommand_Error_InvalidAssetsFile_WithoutProject,
-                            assetsFilePath));
+                    string message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.WhyCommand_Error_InvalidAssetsFile_WithoutProject,
+                        assetsFilePath);
+                    logger.MarkupLine($"[red]{message}[/]");
                 }
                 else
                 {
-                    logger.LogError(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.WhyCommand_Error_InvalidAssetsFile_WithProject,
-                            assetsFilePath,
-                            projectPath));
+                    string message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.WhyCommand_Error_InvalidAssetsFile_WithProject,
+                        assetsFilePath,
+                        projectPath);
+                    logger.MarkupLine($"[red]{message}[/]");
                 }
 
                 return null;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+    <PackageReference Include="Spectre.Console" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -108,8 +108,8 @@ namespace NuGet.CommandLine.XPlat
 
                     ConfigCommand.Register(nugetCommand, getHidePrefixLogger);
                     ConfigCommand.Register(rootCommand, getHidePrefixLogger);
-                    Commands.Why.WhyCommand.Register(nugetCommand, getHidePrefixLogger);
-                    Commands.Why.WhyCommand.Register(rootCommand, getHidePrefixLogger);
+                    Commands.Why.WhyCommand.Register(nugetCommand, Spectre.Console.AnsiConsole.Console);
+                    Commands.Why.WhyCommand.Register(rootCommand, Spectre.Console.AnsiConsole.Console);
                 }
 
                 CancellationTokenSource tokenSource = new CancellationTokenSource();

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -56,7 +56,7 @@ namespace Dotnet.Integration.Test
 
             // Assert
             Assert.Equal(ExitCodes.Success, result.ExitCode);
-            Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", result.AllOutput);
+            Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", result.AllOutput.Replace("\n", "").Replace("\r", ""));
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace Dotnet.Integration.Test
 
             // Assert
             Assert.Equal(ExitCodes.Success, result.ExitCode);
-            Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", result.AllOutput);
+            Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", result.AllOutput.Replace("\n", "").Replace("\r", ""));
         }
 
         [Fact]
@@ -150,7 +150,7 @@ namespace Dotnet.Integration.Test
 
             // Assert
             Assert.Equal(ExitCodes.Success, result.ExitCode);
-            Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", result.AllOutput);
+            Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", result.AllOutput.Replace("\n", "").Replace("\r", ""));
         }
 
         [Fact]
@@ -187,40 +187,6 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
-        public async Task WhyCommand_InvalidFrameworksOption_WarnsCorrectly()
-        {
-            // Arrange
-            var pathContext = new SimpleTestPathContext();
-            var inputFrameworksOption = "invalidFrameworkAlias";
-            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, Constants.ProjectTargetFramework);
-
-            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", Constants.ProjectTargetFramework);
-            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1", Constants.ProjectTargetFramework);
-
-            packageX.Dependencies.Add(packageY);
-
-            project.AddPackageToFramework(Constants.ProjectTargetFramework, packageX);
-
-            await SimpleTestPackageUtility.CreatePackagesAsync(
-                pathContext.PackageSource,
-                packageX,
-                packageY);
-
-            string addPackageCommandArgs = $"add {project.ProjectPath} package {packageX.Id}";
-            CommandRunnerResult addPackageResult = _testFixture.RunDotnetExpectSuccess(pathContext.SolutionRoot, addPackageCommandArgs, testOutputHelper: _testOutputHelper);
-
-            string whyCommandArgs = $"nuget why {project.ProjectPath} {packageY.Id} -f {inputFrameworksOption} -f {Constants.ProjectTargetFramework}";
-
-            // Act
-            CommandRunnerResult result = _testFixture.RunDotnetExpectSuccess(pathContext.SolutionRoot, whyCommandArgs, testOutputHelper: _testOutputHelper);
-
-            // Assert
-            Assert.Equal(ExitCodes.Success, result.ExitCode);
-            Assert.Contains($"warn : The assets file '{project.AssetsFileOutputPath}' for project '{ProjectName}' does not contain a target for the specified input framework '{inputFrameworksOption}'.", result.AllOutput);
-            Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", result.AllOutput);
-        }
-
-        [Fact]
         public async Task WhyCommand_DirectoryWithProject_HasTransitiveDependency_DependencyPathExists()
         {
             // Arrange
@@ -250,7 +216,7 @@ namespace Dotnet.Integration.Test
 
             // Assert
             Assert.Equal(ExitCodes.Success, result.ExitCode);
-            Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", result.AllOutput);
+            result.AllOutput.Replace("\n", "").Replace("\r", "").Should().Contain($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'");
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(LatestNETCoreTargetFramework)</TargetFramework>
     <Description>Functional tests for nuget in dotnet CLI scenarios, using the NuGet.CommandLine.XPlat assembly.</Description>
@@ -11,6 +11,10 @@
     <ProjectReference Include="..\..\..\src\NuGet.Core\Microsoft.Build.NuGetSdkResolver\Microsoft.Build.NuGetSdkResolver.csproj" />
     <ProjectReference Include="..\..\NuGet.Core.Tests\NuGet.CommandLine.Xplat.Tests\NuGet.CommandLine.Xplat.Tests.csproj" />
     <ProjectReference Include="..\..\NuGet.Core.Tests\NuGet.Configuration.Test\NuGet.Configuration.Test.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Spectre.Console.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
@@ -3,10 +3,12 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Why;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
+using Spectre.Console.Testing;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -50,23 +52,35 @@ namespace NuGet.XPlat.FuncTest
             var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
             var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger));
 
+            var console = new TestConsole();
+            console.Width(100);
+
             var whyCommandArgs = new WhyCommandArgs(
                     project.ProjectPath,
                     packageY.Id,
                     [projectFramework],
-                    logger,
+                    console,
                     CancellationToken.None);
 
             // Act
             var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
-            var output = logger.ShowMessages();
+            var output = console.Output;
+
+            string[] expected =
+                [
+                "Project 'Test.Project.DotnetNugetWhy' has the following dependency graph(s) for 'PackageY':",
+                "",
+                "  [net472]                                                                                          ",
+                "  └── PackageX (v1.0.0)                                                                             ",
+                "      └── PackageY (v1.0.1)                                                                         ",
+                "",
+                ""
+                ];
 
             Assert.Equal(ExitCodes.Success, result);
-            Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", output);
-            Assert.Contains($"{packageX.Id} (v{packageX.Version})", output);
-            Assert.Contains($"{packageY.Id} (v{packageY.Version})", output);
+            output.Should().Be(string.Join("\n", expected));
         }
 
         [Fact]
@@ -93,18 +107,21 @@ namespace NuGet.XPlat.FuncTest
             var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
             var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger));
 
+            var console = new TestConsole();
+            console.Width(500);
+
             var whyCommandArgs = new WhyCommandArgs(
                     project.ProjectPath,
                     packageZ.Id,
                     [projectFramework],
-                    logger,
+                    console,
                     CancellationToken.None);
 
             // Act
             var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
-            var output = logger.ShowMessages();
+            var output = console.Output;
 
             Assert.Equal(ExitCodes.Success, result);
             Assert.Contains($"Project '{ProjectName}' does not have a dependency on '{packageZ.Id}'", output);
@@ -114,7 +131,8 @@ namespace NuGet.XPlat.FuncTest
         public async Task WhyCommand_ProjectDidNotRunRestore_Fails()
         {
             // Arrange
-            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var logger = new TestConsole();
+            logger.Width(500);
 
             var pathContext = new SimpleTestPathContext();
             var projectFramework = "net472";
@@ -138,7 +156,7 @@ namespace NuGet.XPlat.FuncTest
             var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
-            var output = logger.ShowMessages();
+            var output = logger.Lines;
 
             Assert.Equal(ExitCodes.Success, result);
             Assert.Contains($"No assets file was found for `{project.ProjectPath}`. Please run restore before running this command.", output);
@@ -148,7 +166,8 @@ namespace NuGet.XPlat.FuncTest
         public async Task WhyCommand_EmptyProjectArgument_Fails()
         {
             // Arrange
-            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var logger = new TestConsole();
+            logger.Width(500);
 
             var whyCommandArgs = new WhyCommandArgs(
                     "",
@@ -161,17 +180,17 @@ namespace NuGet.XPlat.FuncTest
             var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
-            var errorOutput = logger.ShowErrors();
+            var errorOutput = logger.Lines;
 
             Assert.Equal(ExitCodes.InvalidArguments, result);
-            Assert.Contains($"Unable to run 'dotnet nuget why'. The 'PROJECT|SOLUTION' argument cannot be empty.", errorOutput);
+            errorOutput.Should().Contain($"Unable to run 'dotnet nuget why'. The 'PROJECT|SOLUTION' argument cannot be empty.");
         }
 
         [Fact]
         public async Task WhyCommand_EmptyPackageArgument_Fails()
         {
             // Arrange
-            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var logger = new TestConsole();
 
             var pathContext = new SimpleTestPathContext();
             var projectFramework = "net472";
@@ -188,7 +207,7 @@ namespace NuGet.XPlat.FuncTest
             var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
-            var errorOutput = logger.ShowErrors();
+            var errorOutput = logger.Lines;
 
             Assert.Equal(ExitCodes.InvalidArguments, result);
             Assert.Contains($"Unable to run 'dotnet nuget why'. The 'PACKAGE' argument cannot be empty.", errorOutput);
@@ -198,7 +217,8 @@ namespace NuGet.XPlat.FuncTest
         public async Task WhyCommand_InvalidProject_Fails()
         {
             // Arrange
-            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var logger = new TestConsole();
+            logger.Width(500);
 
             string fakeProjectPath = "FakeProjectPath.csproj";
 
@@ -213,7 +233,7 @@ namespace NuGet.XPlat.FuncTest
             var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
-            var errorOutput = logger.ShowErrors();
+            var errorOutput = logger.Lines;
 
             Assert.Equal(ExitCodes.InvalidArguments, result);
             Assert.Contains($"Unable to run 'dotnet nuget why'. Missing or invalid path '{fakeProjectPath}'. Please provide a path to a project, solution file, or directory.", errorOutput);
@@ -246,18 +266,21 @@ namespace NuGet.XPlat.FuncTest
             var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
             var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageCommandArgs, new MSBuildAPIUtility(logger));
 
+            var console = new TestConsole();
+            console.Width(500);
+
             var whyCommandArgs = new WhyCommandArgs(
                     project.ProjectPath,
                     packageY.Id,
                     [inputFrameworksOption, projectFramework],
-                    logger,
+                    console,
                     CancellationToken.None);
 
             // Act
             var result = await WhyCommandRunner.ExecuteCommand(whyCommandArgs);
 
             // Assert
-            var output = logger.ShowMessages();
+            var output = console.Output;
 
             Assert.Equal(ExitCodes.Success, result);
             Assert.Contains($"The assets file '{project.AssetsFileOutputPath}' for project '{ProjectName}' does not contain a target for the specified input framework '{inputFrameworksOption}'.", output);

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using NuGet.CommandLine.XPlat.Commands;
 using NuGet.CommandLine.XPlat.Commands.Why;
+using Spectre.Console.Testing;
 using Xunit;
 
 namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
@@ -20,7 +21,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
             Command rootCommand = new("nuget");
 
             // Act
-            WhyCommand.Register(rootCommand, NullLoggerWithColor.GetInstance);
+            WhyCommand.Register(rootCommand, new TestConsole());
 
             // Assert
             rootCommand.Subcommands[0].Should().BeAssignableTo<DocumentedCommand>();
@@ -33,7 +34,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
             // Arrange
             Command rootCommand = new("nuget");
 
-            WhyCommand.Register(rootCommand, NullLoggerWithColor.GetInstance, whyCommandArgs =>
+            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().Be(@"path\to\my.proj");
@@ -54,7 +55,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
             // Arrange
             Command rootCommand = new("nuget");
 
-            WhyCommand.Register(rootCommand, NullLoggerWithColor.GetInstance, whyCommandArgs =>
+            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().NotBeNull();
@@ -75,7 +76,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
             // Arrange
             Command rootCommand = new("nuget");
 
-            WhyCommand.Register(rootCommand, NullLoggerWithColor.GetInstance, whyCommandArgs =>
+            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
             {
                 // Assert
                 throw new Exception("Should not get here");
@@ -92,7 +93,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
             // Arrange
             Command rootCommand = new("nuget");
 
-            WhyCommand.Register(rootCommand, NullLoggerWithColor.GetInstance, whyCommandArgs =>
+            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
             {
                 // Assert
                 throw new Exception("Should not get here");
@@ -112,7 +113,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
             // Arrange
             Command rootCommand = new("nuget");
 
-            WhyCommand.Register(rootCommand, NullLoggerWithColor.GetInstance, whyCommandArgs =>
+            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().Be("my.proj");
@@ -135,7 +136,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
             // Arrange
             Command rootCommand = new("nuget");
 
-            WhyCommand.Register(rootCommand, NullLoggerWithColor.GetInstance, whyCommandArgs =>
+            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().Be("my.proj");
@@ -156,7 +157,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
             // Arrange
             Command rootCommand = new("nuget");
 
-            WhyCommand.Register(rootCommand, NullLoggerWithColor.GetInstance, whyCommandArgs =>
+            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().Be("my.proj");
@@ -177,7 +178,7 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
             // Arrange
             Command rootCommand = new("nuget");
 
-            WhyCommand.Register(rootCommand, NullLoggerWithColor.GetInstance, whyCommandArgs =>
+            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().Be("my.proj");

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/NuGet.CommandLine.Xplat.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="Spectre.Console.Testing" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -196,6 +196,63 @@ SDKs found: {string.Join(", ", Directory.EnumerateDirectories(SdkDirSource).Sele
             CopyPackSdkArtifacts(artifactsDirectory, pathToSdkInCli, configuration);
             CopyRestoreArtifacts(artifactsDirectory, pathToSdkInCli, configuration);
             CopyNuGetSdkResolverArtifacts(artifactsDirectory, pathToSdkInCli, configuration);
+            AddSpectreConsoleToDepsJson(pathToSdkInCli);
+        }
+
+        // Temporary. Can be removed once https://github.com/dotnet/dotnet/pull/3527 is merged and a new .NET SDK 
+        private static void AddSpectreConsoleToDepsJson(string pathToSdkInCli)
+        {
+            string[] depsFiles = ["NuGet.CommandLine.XPlat.deps.json", "dotnet.deps.json"];
+
+            foreach (var depsFile in depsFiles)
+            {
+                var depsFilePath = Path.Combine(pathToSdkInCli, depsFile);
+                JObject jObject = JObject.Parse(File.ReadAllText(depsFilePath));
+
+                var targetNode = (JObject)((JObject)jObject["targets"]).Properties().First().Value;
+                JProperty spectreConsoleProperty = targetNode.Properties()
+                    .FirstOrDefault(p => p.Name.StartsWith("Spectre.Console/"));
+
+                bool changed = false;
+
+                if (spectreConsoleProperty is null)
+                {
+                    spectreConsoleProperty = new JProperty("Spectre.Console/0.54.0", JObject.Parse("""{"runtime":{"lib/net9.0/Spectre.Console.dll":{"assemblyVersion":"0.0.0.0","fileVersion":"0.54.0.0"}}}"""));
+                    targetNode.Add(spectreConsoleProperty);
+                    changed = true;
+                }
+
+                JProperty library = (JProperty)((JObject)jObject["libraries"]).Properties()
+                    .FirstOrDefault(p => p.Name.StartsWith("Spectre.Console/"));
+                if (library is null)
+                {
+                    var value = JObject.Parse(
+                        """
+                        {
+                        "type": "package",
+                        "serviceable": true,
+                        "sha512": "sha512-StDXCFayfy0yB1xzUHT2tgEpV1/HFTiS4JgsAQS49EYTfMixSwwucaQs/bIOCwXjWwIQTMuxjUIxcB5XsJkFJA==",
+                        "path": "spectre.console/0.54.0",
+                        "hashPath": "spectre.console.0.54.0.nupkg.sha512"
+                        }
+                        """);
+                    library = new JProperty("Spectre.Console/0.54.0", value);
+                    ((JObject)jObject["libraries"]).Add(library);
+                    changed = true;
+                }
+
+                if (changed)
+                {
+                    using (StreamWriter streamWriter = File.CreateText(depsFilePath))
+                    using (JsonTextWriter writer = new JsonTextWriter(streamWriter)
+                    {
+                        Formatting = Formatting.Indented
+                    })
+                    {
+                        jObject.WriteTo(writer);
+                    }
+                }
+            }
         }
 
         private static void CopyRestoreArtifacts(string artifactsDirectory, string pathToSdkInCli, string configuration)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14664

## Description

Cherry-pick https://github.com/NuGet/NuGet.Client/pull/6975 to the release/7.0.x branch

But without some of the nullable changes, to reduce risk that it could introduce nullable warnings/errors when the dotnet/sdk repo uses it.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~


# .NET approval template:
## Customer Impact

Impacts customers using the `dotnet nuget why` command. 9.0.300 displays a package dependency graph using line characters, with the package names on the same line as the line. 10.0.100 puts the package ID searched for on a new line. There are screenshots in this issue: https://github.com/NuGet/Home/issues/14664

## Regression?

- [ ] Yes
- [x] No  

## Risk

- [ ] High
- [x] Medium
- [ ] Low  

Justification: The existing code to draw the package graph was replaced with Spectre.Console.

Addtionally, while another team had already caused Spectre.Console to be included in the upcoming 10.0.200 SDK, it's not currently part of the 10.0.100 SDK. I did validate with the source build team that adding it to 10.0.1xx servicing is acceptable from their point of view

## Verification

- [x] Manual (required)  
- [x] Automated  

## Packaging changes reviewed?

- [x] Yes
- [ ] No
- [ ] N/A  

I'm not sure what exactly is meant by "packaging changes", but as mentioned above, it will cause Spectre.Console.dll to ship in the SDK, which it did not before.