### PR TITLE
Fix item dedupe in PackageSpecFactory

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ProjectItemIdentityComparer.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ProjectItemIdentityComparer.cs
@@ -12,13 +12,15 @@ namespace NuGet.Commands.Restore.Utility
     {
         internal static ProjectItemIdentityComparer Default { get; } = new();
 
+        private IEqualityComparer<string> _identityComparer = StringComparer.OrdinalIgnoreCase;
+
         public bool Equals(IItem x, IItem y)
         {
-            return StringComparer.OrdinalIgnoreCase.Equals(x.Identity, y.Identity);
+            return _identityComparer.Equals(x.Identity, y.Identity);
         }
         public int GetHashCode(IItem obj)
         {
-            return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Identity);
+            return _identityComparer.GetHashCode(obj.Identity);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ProjectItemIdentityComparer.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ProjectItemIdentityComparer.cs
@@ -14,11 +14,11 @@ namespace NuGet.Commands.Restore.Utility
 
         public bool Equals(IItem x, IItem y)
         {
-            return StringComparer.InvariantCultureIgnoreCase.Equals(x.Identity, y.Identity);
+            return StringComparer.OrdinalIgnoreCase.Equals(x.Identity, y.Identity);
         }
         public int GetHashCode(IItem obj)
         {
-            return obj.Identity.GetHashCode();
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Identity);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/ProjectItemIdentityComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/ProjectItemIdentityComparerTests.cs
@@ -9,16 +9,54 @@ using NuGet.Commands.Restore;
 using NuGet.Commands.Restore.Utility;
 using Xunit;
 
-namespace NuGet.Commands.Test.Utility;
+namespace NuGet.Commands.Test.RestoreCommandTests.Utility;
 
 public class ProjectItemIdentityComparerTests
 {
+    [Fact]
+    public void Distinct_WithDifferentPackageNames_DoesNotDeduplicate()
+    {
+        // Arrange
+        var item1 = new TestItem("packagea", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            { { "Version", "1.0.0" } }
+        );
+        var item2 = new TestItem("packageb", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            { { "Version", "1.0.0" } }
+        );
+        List<IItem> items = [item1, item2];
+
+        // Act
+        var result = items.Distinct(ProjectItemIdentityComparer.Default).ToList();
+
+        // Assert
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Distinct_WithSamePackageNameDifferentVersions_Deduplicates()
+    {
+        // Arrange
+        var item1 = new TestItem("packagea", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            { { "Version", "1.0.0" } }
+        );
+        var item2 = new TestItem("packagea", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            { { "Version", "2.0.0" } }
+        );
+        List<IItem> items = [item1, item2];
+
+        // Act
+        var result = items.Distinct(ProjectItemIdentityComparer.Default).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+    }
+
     [Fact]
     public void Distinct_WithDuplicateMixedCasePackageName_Deduplicates()
     {
         // Arrange
         var item1 = new TestItem("packagea", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            { {"Version", "1.0.0"} }
+            { { "Version", "1.0.0" } }
         );
         var item2 = new TestItem("PackageA", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             { { "Version", "1.0.0" } }
@@ -29,7 +67,7 @@ public class ProjectItemIdentityComparerTests
         var result = items.Distinct(ProjectItemIdentityComparer.Default).ToList();
 
         // Assert
-        result.Count.Should().Be(1);
+        result.Should().HaveCount(1);
     }
 
     private class TestItem : IItem

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/Utility/ProjectItemIdentityComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/Utility/ProjectItemIdentityComparerTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NuGet.Commands.Restore;
+using NuGet.Commands.Restore.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test.Utility;
+
+public class ProjectItemIdentityComparerTests
+{
+    [Fact]
+    public void Distinct_WithDuplicateMixedCasePackageName_Deduplicates()
+    {
+        // Arrange
+        var item1 = new TestItem("packagea", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            { {"Version", "1.0.0"} }
+        );
+        var item2 = new TestItem("PackageA", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            { { "Version", "1.0.0" } }
+        );
+        List<IItem> items = [item1, item2];
+
+        // Act
+        var result = items.Distinct(ProjectItemIdentityComparer.Default).ToList();
+
+        // Assert
+        result.Count.Should().Be(1);
+    }
+
+    private class TestItem : IItem
+    {
+        private readonly IReadOnlyDictionary<string, string> _metadata;
+
+        public TestItem(string identity, IReadOnlyDictionary<string, string> metadata)
+        {
+            Identity = identity;
+            _metadata = metadata;
+        }
+        public string Identity { get; }
+
+        public string GetMetadata(string name)
+        {
+            if (_metadata.TryGetValue(name, out string? value))
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value.Trim();
+                }
+            }
+            return null!;
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14676

## Description

The implementation of the comparer PackageSpecFactory uses didn't implement `GetHashCode` and `Equals` consistently. They both need to ignore case.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
