### PR TITLE
Prevent dictionary allocations in LockFileItem.Equals

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
@@ -54,7 +54,11 @@ namespace NuGet.ProjectModel
 
             if (string.Equals(Path, other.Path, StringComparison.OrdinalIgnoreCase))
             {
-                return Properties.OrderedEquals(other.Properties, pair => pair.Key, StringComparer.Ordinal);
+                // Cast to concrete Dictionary to avoid boxing the struct enumerator
+                // The cast is safe because Properties always returns the _properties field which is always Dictionary<string, string>
+                var thisDict = (Dictionary<string, string>)Properties;
+                var otherDict = (Dictionary<string, string>)other.Properties;
+                return thisDict.OrderedEquals(otherDict, pair => pair.Key, StringComparer.Ordinal);
             }
 
             return false;

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
@@ -54,11 +54,21 @@ namespace NuGet.ProjectModel
 
             if (string.Equals(Path, other.Path, StringComparison.OrdinalIgnoreCase))
             {
-                // Cast to concrete Dictionary to avoid boxing the struct enumerator
-                // The cast is safe because Properties always returns the _properties field which is always Dictionary<string, string>
-                var thisDict = (Dictionary<string, string>)Properties;
-                var otherDict = (Dictionary<string, string>)other.Properties;
-                return thisDict.OrderedEquals(otherDict, pair => pair.Key, StringComparer.Ordinal);
+                // Handle null/empty dictionaries (treat them as equal)
+                bool thisEmpty = _properties == null || _properties.Count == 0;
+                bool otherEmpty = other._properties == null || other._properties.Count == 0;
+
+                if (thisEmpty && otherEmpty)
+                {
+                    return true;
+                }
+
+                if (thisEmpty || otherEmpty)
+                {
+                    return false;
+                }
+
+                return _properties.OrderedEquals(other._properties, pair => pair.Key, StringComparer.Ordinal);
             }
 
             return false;


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: The hot path shows Dictionary<string, string> allocations in LockFileItem.get_Properties during equality comparisons
The source code reveals the root cause: In LockFileItem.Equals, it calls Properties.OrderedEquals even when the Properties dictionary is null/empty on both sides. The Properties getter lazy-initializes an empty Dictionary on every access causing unnecessary allocations. ETW traces show TypeAllocated!System.Collections.Generic.Dictionary`2[System.String,System.String] as an allocation hotspot.
- Issue type: AllocatingInGetHashCodeOrEquals
- Proposed fix: Use _properties instead of Properties for comparisons.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&failureHash=0aaacf93-f8f7-26f6-f2c9-a78a8a46eb47)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2672244)