### PR TITLE
dotnet list package --format=json - remove redundant auto-referenced packages warning

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/ListPackage/ListPackageJsonRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/ListPackage/ListPackageJsonRenderer.cs
@@ -102,11 +102,6 @@ namespace NuGet.CommandLine.XPlat.ListPackage
             writer.WritePropertyName(ParametersProperty);
             writer.WriteValue(PathUtility.GetPathWithForwardSlashes(listPackageArgs.ArgumentText));
 
-            if (listPackageReportModel.Projects.Any(p => p.AutoReferenceFound))
-            {
-                _problems.Add(new ReportProblem(ProblemType.Warning, string.Empty, Strings.ListPkg_AutoReferenceDescription));
-            }
-
             if (_problems?.Count > 0)
             {
                 WriteProblems(writer, _problems);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPackageJsonRendererTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPackageJsonRendererTests.cs
@@ -1403,6 +1403,13 @@ namespace NuGet.XPlat.FuncTest
             {
                 var projectModel = new ListPackageProjectModel(project.projectPath);
                 projectModel.TargetFrameworkPackages = project.listPackageReportFrameworks;
+                var hasAutoReferencedTopLevelPackage = project.listPackageReportFrameworks?.Any(packageReportFramework =>
+                                                           packageReportFramework.TopLevelPackages?.Any(topLevelPackage => topLevelPackage.AutoReference) ?? false) ??
+                                                       false;
+                var hasAutoReferencedTransitivePackage = project.listPackageReportFrameworks?.Any(packageReportFramework =>
+                                                             packageReportFramework.TransitivePackages?.Any(transitivePackage => transitivePackage.AutoReference) ?? false) ??
+                                                         false;
+                projectModel.AutoReferenceFound = hasAutoReferencedTopLevelPackage || hasAutoReferencedTransitivePackage;
 
                 if (project.projectProblems != null)
                 {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPackageJsonRendererTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPackageJsonRendererTests.cs
@@ -1406,10 +1406,8 @@ namespace NuGet.XPlat.FuncTest
                 var hasAutoReferencedTopLevelPackage = project.listPackageReportFrameworks?.Any(packageReportFramework =>
                                                            packageReportFramework.TopLevelPackages?.Any(topLevelPackage => topLevelPackage.AutoReference) ?? false) ??
                                                        false;
-                var hasAutoReferencedTransitivePackage = project.listPackageReportFrameworks?.Any(packageReportFramework =>
-                                                             packageReportFramework.TransitivePackages?.Any(transitivePackage => transitivePackage.AutoReference) ?? false) ??
-                                                         false;
-                projectModel.AutoReferenceFound = hasAutoReferencedTopLevelPackage || hasAutoReferencedTransitivePackage;
+
+                projectModel.AutoReferenceFound = hasAutoReferencedTopLevelPackage;
 
                 if (project.projectProblems != null)
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13080

## Description
The discussion in NuGet/Home#13080 could not find a reason to have the information about auto-referenced packages twice. This PR removes the redundant information.

There is already a test in JsonRenderer_ListPackage_PackageWithAutoReference_SucceedsAsync, but it wasn't being activated correctly since the autoreference property wasn't being set. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
