### PR TITLE
Fix version conflict detection in new dependency resolver

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -512,7 +512,15 @@ namespace NuGet.Commands
                             continue;
                         }
 
-                        if (TryDetectVersionConflict(currentGraphNode, childResolvedDependencyGraphItem, versionConflicts, downgrades, childLibraryDependency, currentRangeIndex, childResolvedLibraryRangeIndex, out GraphNode<RemoteResolveResult>? nodeWithConflict))
+                        if (TryDetectVersionConflict(
+                            currentGraphNode,
+                            childResolvedDependencyGraphItem,
+                            versionConflicts,
+                            downgrades,
+                            childLibraryDependency,
+                            currentRangeIndex,
+                            childResolvedLibraryRangeIndex,
+                            out GraphNode<RemoteResolveResult>? nodeWithConflict))
                         {
                             currentGraphNode.InnerNodes.Add(nodeWithConflict);
 
@@ -589,7 +597,14 @@ namespace NuGet.Commands
                             ));
                     }
 
-                    if (TryDetectVersionConflict(currentGraphNode, childResolvedDependencyGraphItem, versionConflicts, downgrades, childLibraryDependency, currentRangeIndex, childResolvedLibraryRangeIndex, out GraphNode<RemoteResolveResult>? conflictingNode))
+                    if (TryDetectVersionConflict(
+                        currentGraphNode,
+                        childResolvedDependencyGraphItem,
+                        versionConflicts, downgrades,
+                        childLibraryDependency,
+                        currentRangeIndex,
+                        childResolvedLibraryRangeIndex,
+                        out GraphNode<RemoteResolveResult>? conflictingNode))
                     {
                         // Remove the existing node so it can be replaced with a node representing the conflict
                         currentGraphNode.InnerNodes.Remove(newGraphNode);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -396,6 +396,7 @@ namespace NuGet.Commands
                     }
 
                     LibraryDependencyIndex childLibraryDependencyIndex = resolvedDependencyGraphItem.GetDependencyIndexForDependencyAt(i);
+                    LibraryRangeIndex currentRangeIndex = resolvedDependencyGraphItem.GetRangeIndexForDependencyAt(i);
 
                     if (!resolvedDependencyGraphItems.TryGetValue(childLibraryDependencyIndex, out ResolvedDependencyGraphItem? childResolvedDependencyGraphItem))
                     {
@@ -409,8 +410,6 @@ namespace NuGet.Commands
                     // Determine if this dependency has already been visited
                     if (!visitedItems.Add(childLibraryDependencyIndex))
                     {
-                        LibraryRangeIndex currentRangeIndex = resolvedDependencyGraphItem.GetRangeIndexForDependencyAt(i);
-
                         if (resolvedDependencyGraphItem.Path.Contains(currentRangeIndex))
                         {
                             // If the dependency exists in the its own path, then a cycle exists
@@ -513,10 +512,19 @@ namespace NuGet.Commands
                             continue;
                         }
 
+                        if (TryDetectVersionConflict(currentGraphNode, childResolvedDependencyGraphItem, versionConflicts, downgrades, childLibraryDependency, currentRangeIndex, childResolvedLibraryRangeIndex, out GraphNode<RemoteResolveResult>? nodeWithConflict))
+                        {
+                            currentGraphNode.InnerNodes.Add(nodeWithConflict);
+
+                            nodesById.Add(currentRangeIndex, nodeWithConflict);
+
+                            continue;
+                        }
+
                         // If it wasn't a downgrade, then it was a version conflict like A -> B [1.0.0] but B 1.0.0 was not in the resolved graph
                         if (versionConflicts.ContainsKey(childResolvedLibraryRangeIndex) && !nodesById.ContainsKey(currentRangeIndex))
                         {
-                            GraphNode<RemoteResolveResult> nodeWithConflict = new(childResolvedLibraryDependency.LibraryRange)
+                            nodeWithConflict = new(childResolvedLibraryDependency.LibraryRange)
                             {
                                 Item = childResolvedDependencyGraphItem.Item,
                                 Disposition = Disposition.Acceptable,
@@ -581,43 +589,19 @@ namespace NuGet.Commands
                             ));
                     }
 
-                    // This is a version conflict if:
-                    // 1. The node is not a project and isn't unresolved
-                    // 2. The conflict has not already been detected
-                    // 3. The dependency is transitive and doesn't have PrivateAssets=All
-                    // 4. The dependency has a version specified
-                    // 5. The version range is not satisfied by the resolved version
-                    // 6. A corresponding downgrade was not detected
-                    if (newGraphNode.Item.Key.Type != LibraryType.Project
-                        && newGraphNode.Item.Key.Type != LibraryType.ExternalProject
-                        && newGraphNode.Item.Key.Type != LibraryType.Unresolved
-                        && !versionConflicts.ContainsKey(childResolvedLibraryRangeIndex)
-                        && childLibraryDependency.SuppressParent != LibraryIncludeFlags.All
-                        && childLibraryDependency.LibraryRange.VersionRange != null
-                        && !childLibraryDependency.LibraryRange.VersionRange!.Satisfies(newGraphNode.Item.Key.Version)
-                        && !downgrades.ContainsKey(childResolvedLibraryRangeIndex))
+                    if (TryDetectVersionConflict(currentGraphNode, childResolvedDependencyGraphItem, versionConflicts, downgrades, childLibraryDependency, currentRangeIndex, childResolvedLibraryRangeIndex, out GraphNode<RemoteResolveResult>? conflictingNode))
                     {
                         // Remove the existing node so it can be replaced with a node representing the conflict
                         currentGraphNode.InnerNodes.Remove(newGraphNode);
 
-                        GraphNode<RemoteResolveResult> conflictingNode = new(childLibraryDependency.LibraryRange)
-                        {
-                            Disposition = Disposition.Acceptable,
-                            Item = new GraphItem<RemoteResolveResult>(
-                                new LibraryIdentity(
-                                    childLibraryDependency.Name,
-                                    childLibraryDependency.LibraryRange.VersionRange.MinVersion!,
-                                    LibraryType.Package)),
-                            OuterNode = currentGraphNode,
-                        };
-
                         // Add the conflict node to the parent
                         currentGraphNode.InnerNodes.Add(conflictingNode);
 
-                        // Track the version conflict for later
-                        versionConflicts.Add(childResolvedLibraryRangeIndex, conflictingNode);
+                        nodesById.Add(currentRangeIndex, conflictingNode);
 
-                        // Process the next child
+                        // This node conflicts and won't be included in the final graph
+                        visitedItems.Remove(childLibraryDependencyIndex);
+
                         continue;
                     }
 
@@ -752,6 +736,59 @@ namespace NuGet.Commands
                 resolvedDependencies: resolvedPackages);
 
             return (success, restoreTargetGraph);
+
+            static bool TryDetectVersionConflict(
+                GraphNode<RemoteResolveResult> currentGraphNode,
+                ResolvedDependencyGraphItem resolvedDependencyGraphItem,
+                Dictionary<LibraryRangeIndex, GraphNode<RemoteResolveResult>> versionConflicts,
+                Dictionary<LibraryRangeIndex, (LibraryRangeIndex FromParentLibraryRangeIndex, LibraryDependency FromLibraryDependency, LibraryRangeIndex ToParentLibraryRangeIndex, LibraryDependencyIndex ToLibraryDependencyIndex, bool IsCentralTransitive)> downgrades,
+                LibraryDependency childLibraryDependency,
+                LibraryRangeIndex childLibraryDependencyIndex,
+                LibraryRangeIndex childResolvedLibraryRangeIndex,
+                [NotNullWhen(true)] out GraphNode<RemoteResolveResult>? conflictingNode)
+            {
+                conflictingNode = null;
+
+                if (resolvedDependencyGraphItem.IsRootPackageReference)
+                {
+                    return false;
+                }
+
+                // This is a version conflict if:
+                // 1. The node is not a project and isn't unresolved
+                // 2. The conflict has not already been detected
+                // 3. The dependency is transitive and doesn't have PrivateAssets=All
+                // 4. The dependency has a version specified
+                // 5. The version range is not satisfied by the resolved version
+                // 6. A corresponding downgrade was not detected
+                if (resolvedDependencyGraphItem.Item.Key.Type != LibraryType.Project
+                    && resolvedDependencyGraphItem.Item.Key.Type != LibraryType.ExternalProject
+                    && resolvedDependencyGraphItem.Item.Key.Type != LibraryType.Unresolved
+                    && !versionConflicts.ContainsKey(childResolvedLibraryRangeIndex)
+                    && childLibraryDependency.SuppressParent != LibraryIncludeFlags.All
+                    && childLibraryDependency.LibraryRange.VersionRange != null
+                    && !childLibraryDependency.LibraryRange.VersionRange!.Satisfies(resolvedDependencyGraphItem.Item.Key.Version)
+                    && !downgrades.ContainsKey(childResolvedLibraryRangeIndex))
+                {
+                    conflictingNode = new(childLibraryDependency.LibraryRange)
+                    {
+                        Disposition = Disposition.Rejected,
+                        Item = new GraphItem<RemoteResolveResult>(
+                            new LibraryIdentity(
+                                childLibraryDependency.Name,
+                                childLibraryDependency.LibraryRange.VersionRange.MinVersion!,
+                                LibraryType.Package)),
+                        OuterNode = currentGraphNode,
+                    };
+
+                    // Track the version conflict for later
+                    versionConflicts.Add(childResolvedLibraryRangeIndex, conflictingNode);
+
+                    return true;
+                }
+
+                return false;
+            }
         }
 
         private static bool EvaluateRuntimeDependencies(ref LibraryDependency libraryDependency, RuntimeGraph? runtimeGraph, string? runtimeIdentifier, ref HashSet<LibraryDependency>? runtimeDependencies)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -2805,16 +2805,16 @@ namespace NuGet.Commands.FuncTest
 
 
             // Switch the order in which A & B are declared
-            var projectSpec = @"
-            {
-              ""frameworks"": {
-                ""net10.0"": {
-                    ""dependencies"": {
-                            DEPS
-                    }
-                }
-              }
-            }".Replace("DEPS", deps);
+            var projectSpec = @$"
+            {{
+              ""frameworks"": {{
+                ""net10.0"": {{
+                    ""dependencies"": {{
+                      {deps}
+                    }}
+                }}
+              }}
+            }}";
 
             var packageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project", pathContext.SolutionRoot, projectSpec);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -2822,6 +2822,73 @@ namespace NuGet.Commands.FuncTest
             (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, packageSpec);
         }
 
+        // Project -> B 1.0.0
+        //              -> C [1.0.0, 2.0.0)
+        //              -> D [1.0.0, 2.0.0)
+        //              -> A [1.0.0, 2.0.0)
+        //         -> A 2.0.0 -> C 2.0.0 -> D 2.0.0
+        //         -> C 2.0.0
+        //         -> D 2.0.0
+        [Fact]
+        public async Task RestoreCommand_WithConflictsOverridenByADirectDependencyRaisesNU1608_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            var D = new SimpleTestPackageContext("D", "2.0.0");
+
+            var C = new SimpleTestPackageContext("C", "2.0.0")
+            {
+                Dependencies =
+                [
+                    D,
+                ]
+            };
+
+            var B = new SimpleTestPackageContext("B", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("C", "[1.0.0, 2.0.0)"),
+                    new SimpleTestPackageContext("D", "[1.0.0, 2.0.0)"),
+                    new SimpleTestPackageContext("A", "[1.0.0, 2.0.0)"),
+                ]
+            };
+
+            var A = new SimpleTestPackageContext("A", "2.0.0")
+            {
+                Dependencies =
+                [
+                    C,
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreatePackagesWithoutDependenciesAsync(pathContext.PackageSource,
+                B,
+                A,
+                C,
+                D);
+
+            var projectSpec = @"
+            {
+              ""frameworks"": {
+                ""net10.0"": {
+                    ""dependencies"": {
+                            ""D"":  ""2.0.0"",
+                            ""C"":  ""2.0.0"",
+                            ""A"":  ""2.0.0"",
+                            ""B"":  ""1.0.0"",
+                    }
+                }
+              }
+            }";
+
+            var packageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project", pathContext.SolutionRoot, projectSpec);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, packageSpec);
+        }
+
         // P -> A 1.0.0
         //      -> B (no version)
         // B is pinned to 1.0.0

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -2745,6 +2745,83 @@ namespace NuGet.Commands.FuncTest
             result2.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("1.0.0"));
         }
 
+        [Theory]
+        // Project -> D 2.0.0
+        //         -> A 2.0.0
+        //             -> C >= 2.0.0
+        //                 -> D 2.0.0
+        //         -> B 1.0.0
+        //              -> C >= 1.0.0 & < 2.0.0
+        //              -> D [1.0.0, 2.0.0)
+        //              -> A [1.0.0, 2.0.0)
+        [InlineData("\"D\":\"2.0.0\",\r\n\"A\":\"2.0.0\",\r\n\"B\":\"1.0.0\",")]
+        // Project -> D 2.0.0
+        //         -> B 1.0.0
+        //              -> C >= 1.0.0 & < 2.0.0
+        //              -> D >= 1.0.0 & < 2.0.0)
+        //              -> A >= 1.0.0 & < 2.0.0)
+        //         -> A 2.0.0
+        //             -> C >= 2.0.0
+        //                 -> D 2.0.0
+        [InlineData("\"D\":\"2.0.0\",\r\n\"B\":\"1.0.0\",\r\n\"A\":\"2.0.0\",")]
+        public async Task RestoreCommand_WhenGraphHasAnUnresolvableRangeConflict_RaisesNU1107_VerifiesEquivalency(string deps)
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            var D = new SimpleTestPackageContext("D", "2.0.0");
+
+            var C = new SimpleTestPackageContext("C", "2.0.0")
+            {
+                Dependencies =
+                [
+                    D,
+                ]
+            };
+
+            var B = new SimpleTestPackageContext("B", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("C", "[1.0.0, 2.0.0)"),
+                    new SimpleTestPackageContext("D", "[1.0.0, 2.0.0)"),
+                    new SimpleTestPackageContext("A", "[1.0.0, 2.0.0)"),
+                ]
+            };
+
+            var A = new SimpleTestPackageContext("A", "2.0.0")
+            {
+                Dependencies =
+                [
+                    C,
+                ]
+            };
+
+            await SimpleTestPackageUtility.CreatePackagesWithoutDependenciesAsync(pathContext.PackageSource,
+                B,
+                A,
+                C,
+                D);
+
+
+            // Switch the order in which A & B are declared
+            var projectSpec = @"
+            {
+              ""frameworks"": {
+                ""net10.0"": {
+                    ""dependencies"": {
+                            DEPS
+                    }
+                }
+              }
+            }".Replace("DEPS", deps);
+
+            var packageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project", pathContext.SolutionRoot, projectSpec);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, packageSpec);
+        }
+
         // P -> A 1.0.0
         //      -> B (no version)
         // B is pinned to 1.0.0


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14675

## Description
The new dependency resolver loops through the defined graph looking for cycles and conflicts.  If a good node is walked first, a version conflict is detected later and works just fine.  However, if the conflicting node is walked first, it is added to the graph as a conflict but then the good node is never walked because the conflicting node was walked first.

This change updates the version conflict detection logic to handle the case where the ordering of the conflict would cause it to not work correctly.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
