### PR TITLE
Package Item ToolTips show automatically when focusing on a package

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/InfiniteScrollListItemStyleSelector.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/InfiniteScrollListItemStyleSelector.cs
@@ -24,6 +24,7 @@ namespace NuGet.PackageManagement.UI
                 {
                     _packageItemStyle.Setters.Add(new Setter(InfiniteScrollList.FocusVisualStyleProperty, infiniteScrollList.FindResource("MarginFocusVisualStyle")));
                     _packageItemStyle.Setters.Add(new Setter(InfiniteScrollList.TemplateProperty, infiniteScrollList.FindResource("ListBoxItemTemplate")));
+                    _packageItemStyle.Setters.Add(new Setter(InfiniteScrollList.ToolTipProperty, infiniteScrollList.FindResource("PackageToolTipTemplate")));
                 }
             }
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Resources.xaml
@@ -173,11 +173,6 @@
 
   <Style x:Key="{x:Type ProgressBar}" TargetType="{x:Type ProgressBar}" BasedOn="{StaticResource {x:Static vs:VsResourceKeys.ProgressBarStyleKey}}"/>
 
-  <Style x:Key="TooltipStyle" TargetType="{x:Type TextBlock}">
-    <Setter Property="TextWrapping" Value="Wrap" />
-    <Setter Property="MaxWidth" Value="300" />
-  </Style>
-
   <Style x:Key="ToolBarButtonStyle" BasedOn="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" TargetType="{x:Type Button}">
     <Setter Property="FocusVisualStyle" Value="{StaticResource ControlsFocusVisualStyle}" />
   </Style>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -79,7 +79,7 @@ namespace NuGet.PackageManagement.UI
 
         public ImmutableList<KnownOwnerViewModel> KnownOwnerViewModels { get; internal set; }
 
-        public string Owner => string.Join(",", _packageModel.OwnersList ?? []);
+        public string Owner => string.Join(", ", _packageModel.OwnersList ?? []);
 
         public string Author => _packageModel.Authors;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -24,7 +24,10 @@
       x:Key="PackageLevelToGroupNameConverter" />
 
       <nuget:PackageLevelGroupToBooleanConverter
-       x:Key="PackageLevelGroupToBooleanConverter" />
+      x:Key="PackageLevelGroupToBooleanConverter" />
+
+      <nuget:NullToBooleanConverter
+      x:Key="NullToBooleanConverter" />
 
       <DataTemplate
       DataType="{x:Type nuget:PackageDependencyMetadata}">
@@ -236,7 +239,7 @@
       TargetType="{x:Type ListBoxItem}"
       BasedOn="{StaticResource listBoxItemStyle}">
         <!--
-            Note that we cannot set the template property in xaml list this:
+            Note that we cannot set the template property in xaml like this:
 
                <Setter Property="Template" Value="{StaticResource ListBoxItemTemplate}" />
 
@@ -245,6 +248,81 @@
             added by code when Standalone == false.
             -->
       </Style>
+
+      <Style x:Key="TooltipStyle" TargetType="{x:Type TextBlock}">
+        <Setter Property="TextWrapping" Value="Wrap" />
+        <Setter Property="MaxWidth" Value="300" />
+      </Style>
+
+      <Style x:Key="PackageDescriptionToolTipStyle" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource TooltipStyle}">
+        <Setter Property="Visibility" Value="Collapsed" />
+        <Style.Triggers>
+          <DataTrigger Binding="{Binding Path=PackageLevel}" Value="TopLevel">
+            <Setter Property="Visibility" Value="Visible" />
+          </DataTrigger>
+        </Style.Triggers>
+      </Style>
+
+      <Style x:Key="TransitiveInfoToolTipStyle" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource TooltipStyle}">
+        <Setter Property="Visibility" Value="Visible" />
+        <Style.Triggers>
+          <DataTrigger Binding="{Binding Path=TransitiveToolTipMessage, Converter={StaticResource NullToBooleanConverter}}" Value="True">
+            <Setter Property="Visibility" Value="Collapsed" />
+          </DataTrigger>
+        </Style.Triggers>
+      </Style>
+
+      <ToolTip x:Key="PackageToolTipTemplate">
+        <StackPanel>
+          <TextBlock Style="{StaticResource TooltipStyle}">
+           <Run
+             Text="{Binding Id, Mode=OneTime}"
+             FontWeight="Bold" /> <Run Text="{Binding ByOwnerOrAuthor, Mode=OneTime}"/>
+          </TextBlock>
+          <TextBlock Style="{StaticResource PackageDescriptionToolTipStyle}">
+           <Run Text="{Binding Summary, Mode=OneTime}" />
+              </TextBlock>
+              <TextBlock Style="{StaticResource TransitiveInfoToolTipStyle}">
+           <Run
+             Text="{x:Static nuget:Resources.ToolTip_TransitiveDependency}"
+             FontWeight="Bold" />
+           <Run Text="{Binding TransitiveToolTipMessage, Mode=OneTime}" />
+           <Run>
+             <Run.Style>
+               <Style TargetType="Run">
+                 <Style.Triggers>
+                   <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
+                     <Setter Property="Text" Value="&#x0a;&#x0a;" />
+                   </DataTrigger>
+                 </Style.Triggers>
+               </Style>
+             </Run.Style>
+           </Run><Run>
+             <Run.Style>
+               <Style TargetType="Run">
+                 <Style.Triggers>
+                   <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
+                     <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_TransitivePathHelp}" />
+                   </DataTrigger>
+                 </Style.Triggers>
+               </Style>
+             </Run.Style>
+           </Run>
+           <Run>
+             <Run.Style>
+               <Style TargetType="Run">
+                 <Style.Triggers>
+                   <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
+                     <Setter Property="Text" Value="aka.ms/dotnet/nuget/why"/>
+                     <Setter Property="FontWeight" Value="Bold"/>
+                   </DataTrigger>
+                 </Style.Triggers>
+               </Style>
+             </Run.Style>
+           </Run>
+          </TextBlock>
+        </StackPanel>
+      </ToolTip>
 
       <Style TargetType="FrameworkElement" x:Key="FadeAnimationStyle">
         <Setter Property="Visibility" Value="Hidden"/>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -23,8 +23,6 @@
         x:Key="SummaryToStringConverter" />
       <nuget:StringFormatConverter
         x:Key="StringFormatConverter" />
-      <nuget:NullToBooleanConverter
-        x:Key="NullToBooleanConverter" />
 
       <!--Style for warning tooltip text-->
       <Style TargetType="TextBlock" x:Key="VulnerabilitiesCountText">
@@ -86,24 +84,6 @@
             <Setter Property="Background" Value="{DynamicResource {x:Static nuget:Brushes.ToolWindowButtonDownKey}}" />
             <Setter Property="BorderBrush" Value="{DynamicResource {x:Static nuget:Brushes.ToolWindowButtonDownBorderKey}}" />
           </Trigger>
-        </Style.Triggers>
-      </Style>
-
-      <Style x:Key="PackageDescriptionToolTipStyle" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource TooltipStyle}">
-        <Setter Property="Visibility" Value="Collapsed" />
-        <Style.Triggers>
-          <DataTrigger Binding="{Binding Path=PackageLevel}" Value="TopLevel">
-            <Setter Property="Visibility" Value="Visible" />
-          </DataTrigger>
-        </Style.Triggers>
-      </Style>
-
-      <Style x:Key="TransitiveInfoToolTipStyle" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource TooltipStyle}">
-        <Setter Property="Visibility" Value="Visible" />
-        <Style.Triggers>
-          <DataTrigger Binding="{Binding Path=TransitiveToolTipMessage, Converter={StaticResource NullToBooleanConverter}}" Value="True">
-            <Setter Property="Visibility" Value="Collapsed" />
-          </DataTrigger>
         </Style.Triggers>
       </Style>
     </ResourceDictionary>
@@ -250,59 +230,6 @@
                         FormatStringAlternative="{x:Static nuget:Resources.Deprecation_PackageItemMessageAlternative}"
                         DataContext="{Binding DeprecationMetadata}" />
         </Grid>
-
-        <Grid.ToolTip>
-          <StackPanel>
-            <TextBlock
-              Style="{StaticResource TooltipStyle}">
-              <Run
-                Text="{Binding Id, Mode=OneTime}"
-                FontWeight="Bold" /> <Run Text="{Binding ByOwnerOrAuthor, Mode=OneTime}"/>
-            </TextBlock>
-            <TextBlock Style="{StaticResource PackageDescriptionToolTipStyle}">
-              <Run Text="{Binding Summary, Mode=OneTime}" />
-            </TextBlock>
-            <TextBlock Style="{StaticResource TransitiveInfoToolTipStyle}">
-              <Run
-                Text="{x:Static nuget:Resources.ToolTip_TransitiveDependency}"
-                FontWeight="Bold" />
-              <Run Text="{Binding TransitiveToolTipMessage, Mode=OneTime}" />
-              <Run>
-                <Run.Style>
-                  <Style TargetType="Run">
-                    <Style.Triggers>
-                      <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
-                        <Setter Property="Text" Value="&#x0a;&#x0a;" />
-                      </DataTrigger>
-                    </Style.Triggers>
-                  </Style>
-                </Run.Style>
-              </Run><Run>
-                <Run.Style>
-                  <Style TargetType="Run">
-                    <Style.Triggers>
-                      <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
-                        <Setter Property="Text" Value="{x:Static nuget:Resources.ToolTip_TransitivePathHelp}" />
-                      </DataTrigger>
-                    </Style.Triggers>
-                  </Style>
-                </Run.Style>
-              </Run>
-              <Run>
-                <Run.Style>
-                  <Style TargetType="Run">
-                    <Style.Triggers>
-                      <DataTrigger Binding="{Binding Path=PackageLevel}" Value="Transitive">
-                        <Setter Property="Text" Value="aka.ms/dotnet/nuget/why"/>
-                        <Setter Property="FontWeight" Value="Bold"/>
-                      </DataTrigger>
-                    </Style.Triggers>
-                  </Style>
-                </Run.Style>
-              </Run>
-            </TextBlock>
-          </StackPanel>
-        </Grid.ToolTip>
       </Grid>
 
       <Grid


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14683
Fixes: https://github.com/NuGet/Client.Engineering/issues/3558
Fixes: https://github.com/NuGet/Home/issues/14682

## Description

- Package Item ToolTips show when focusing on a package.
Now, tabbing to the packages list, using the arrow keys to select a package, within 1 second, the Tooltip automatically appears.
  - Moved the ToolTip up from the Grid within the PackageItemControl onto the parent ListBoxItem itself.
    - Adjusted the location of styles/resources to match the change.
  - `PackageToolTipTemplate` must be applied via the style selector to preserve Visual Studio styling on the ListBoxItem.
  This isn't new, and we have a comment explaining this reasoning.
  - Checked with Accessibility Insights to make sure no new errors appeared:
<img width="1282" height="548" alt="image" src="https://github.com/user-attachments/assets/b76e2f3c-4e91-4530-a1ef-9102e84acbe4" />


- Package Owners are once again separated with a space in the Package Item ToolTip.
Individual owner text is able to wrap, for example:
<img width="589" height="159" alt="image" src="https://github.com/user-attachments/assets/c0862112-1676-4cc3-abc4-018a256a397f" />

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests - Manually tested with keyboard. Also see AccessibilityInsights above.
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
