### PR TITLE
fix two warnings building NuGet vsix

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/Directory.Build.targets
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/Directory.Build.targets
@@ -1,4 +1,0 @@
-<Project>
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
-    <Import Project="$(PkgMicrosoft_VSSDK_BuildTools)\tools\VSSDK\Microsoft.VsSDK.targets" Condition="'$(PkgMicrosoft_VSSDK_BuildTools)' != ''" />
-</Project>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -357,7 +357,7 @@
     The VSSDK creates a VsixSourceItems item for each file to be copied into the VSIX. In this target, we remove all
     the files listed in our .vsixignore file, and error if any file listed in .vsixinclude is missing from the vsix.
   -->
-  <Target Name="RemoveUnsolicitedVsixAssemblies" AfterTargets="GetVsixSourceItems" Condition="'$(IncludeCopyLocalReferencesInVSIXContainer)'=='true'" DependsOnTargets="ReadVsixIncludeListFromFile;ReadVsixIgnoreListFromFile">
+  <Target Name="RemoveUnsolicitedVsixAssemblies" AfterTargets="GetVsixSourceItems" Condition="'$(IncludeCopyLocalReferencesInVSIXContainer)'=='true' And '$(DesignTimeBuild)'!='true'" DependsOnTargets="ReadVsixIncludeListFromFile;ReadVsixIgnoreListFromFile">
     <Message Text="Filtering VSIX package files..." Importance="high" />
     <ItemGroup>
       <AllVsixSymbols Include="@(VSIXSourceItem->'%(FileName)%(Extension)')" Condition=" '%(Extension)' == '.pdb' ">


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: local builds

## Description

Fixes two issues:

* Opening the repo in Visual Studio, the Error List window gets an error saying the Microsoft.Web.XmlTransform.dll is missing.  Updating our VS.Client targets to skip on design time build fixes this
* On CLI builds I was getting a warning that the VSSDK Build tools targets was being imported twice. Some other VSSDK package is now importing it automatically, so we no longer need to do it ourselves.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
