### PR TITLE
Fix false error for transitively pinned dependency with no version

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -557,7 +557,12 @@ namespace NuGet.Commands
                         currentGraphNode.InnerNodes.Add(newGraphNode);
                     }
 
-                    if (!childResolvedDependencyGraphItem.IsRootPackageReference && isCentralPackageTransitivePinningEnabled && childLibraryDependency.SuppressParent != LibraryIncludeFlags.All && !downgrades.ContainsKey(childResolvedLibraryRangeIndex) && !RemoteDependencyWalker.IsGreaterThanOrEqualTo(childResolvedDependencyGraphItem.LibraryDependency.LibraryRange.VersionRange, childLibraryDependency.LibraryRange.VersionRange))
+                    if (!childResolvedDependencyGraphItem.IsRootPackageReference
+                        && isCentralPackageTransitivePinningEnabled
+                        && childLibraryDependency.SuppressParent != LibraryIncludeFlags.All
+                        && !downgrades.ContainsKey(childResolvedLibraryRangeIndex)
+                        && childLibraryDependency.LibraryRange.VersionRange != VersionRange.All
+                        && !RemoteDependencyWalker.IsGreaterThanOrEqualTo(childResolvedDependencyGraphItem.LibraryDependency.LibraryRange.VersionRange, childLibraryDependency.LibraryRange.VersionRange))
                     {
                         // This is a downgrade if:
                         // 1. This is not a direct dependency
@@ -905,8 +910,7 @@ namespace NuGet.Commands
             FrameworkRuntimeDefinition pair,
             TargetFrameworkInformation projectTargetFramework,
             RuntimeGraph? runtimeGraph,
-            Dictionary<LibraryDependencyIndex,
-            VersionRange>? pinnedPackageVersions,
+            Dictionary<LibraryDependencyIndex, VersionRange>? pinnedPackageVersions,
             DependencyGraphItem rootProjectDependencyGraphItem,
             RemoteWalkContext context,
             CancellationToken token)

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -29,6 +29,8 @@ namespace NuGet.Test.Utility
 
     public static class SimpleTestPackageUtility
     {
+        private static NuGetVersion EmptyNuGetVersion = new NuGetVersion(0, 0, 0);
+
         public static async Task CreateFullPackagesAsync(string repositoryDir, IDictionary<string, IEnumerable<string>> packages)
         {
             if (packages == null)
@@ -222,7 +224,10 @@ namespace NuGet.Test.Utility
                             var node = new XElement(XName.Get("dependency"));
                             groupNode.Add(node);
                             node.Add(new XAttribute(XName.Get("id"), dependency.Id));
-                            node.Add(new XAttribute(XName.Get("version"), dependency.VersionRange.ToNormalizedString()));
+                            if (dependency.VersionRange.MinVersion != EmptyNuGetVersion)
+                            {
+                                node.Add(new XAttribute(XName.Get("version"), dependency.VersionRange.ToNormalizedString()));
+                            }
 
                             if (dependency.Include.Count > 0)
                             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14653

## Description
The new dependency resolver was falsely detecting a downgrade when a package version was missing from a nuspec because it would see that version `0.0.0` is less than what was resolved.  However, the version really is just `VersionRange.All`.

The fix is to never consider it a downgrade if the dependency version is `VersionRange.All`.

I also had to modify the test a little so I could create an environment where a package has a dependency with no version.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
