### PR TITLE
Exclude Microsoft.Extensions.DependencyInjection.* assemblies from VSIX

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -7,6 +7,8 @@ Azure.Core.dll
 Ben.Demystifier.dll
 Markdig.Signed.dll
 Microsoft.DataAI.NuGetRecommender.Contracts.dll
+Microsoft.Extensions.DependencyInjection.dll
+Microsoft.Extensions.DependencyInjection.Abstractions.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll
 Microsoft.IdentityModel.JsonWebTokens.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -9,6 +9,9 @@ Markdig.Signed.dll
 Microsoft.DataAI.NuGetRecommender.Contracts.dll
 Microsoft.Extensions.DependencyInjection.dll
 Microsoft.Extensions.DependencyInjection.Abstractions.dll
+Microsoft.Extensions.FileProviders.Abstractions.dll
+Microsoft.Extensions.FileSystemGlobbing.dll
+Microsoft.Extensions.Primitives.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll
 Microsoft.IdentityModel.JsonWebTokens.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -9,9 +9,6 @@ Markdig.Signed.dll
 Microsoft.DataAI.NuGetRecommender.Contracts.dll
 Microsoft.Extensions.DependencyInjection.dll
 Microsoft.Extensions.DependencyInjection.Abstractions.dll
-Microsoft.Extensions.FileProviders.Abstractions.dll
-Microsoft.Extensions.FileSystemGlobbing.dll
-Microsoft.Extensions.Primitives.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll
 Microsoft.IdentityModel.JsonWebTokens.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
@@ -58,8 +58,6 @@ NuGet.Versioning.dll
 NuGet.Versioning.resources.dll
 
 # 3rd party dlls to keep
-Microsoft.Extensions.DependencyInjection.dll
-Microsoft.Extensions.DependencyInjection.Abstractions.dll
 Microsoft.Extensions.FileProviders.Abstractions.dll
 Microsoft.Extensions.FileSystemGlobbing.dll
 Microsoft.Extensions.Primitives.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
@@ -58,9 +58,6 @@ NuGet.Versioning.dll
 NuGet.Versioning.resources.dll
 
 # 3rd party dlls to keep
-Microsoft.Extensions.FileProviders.Abstractions.dll
-Microsoft.Extensions.FileSystemGlobbing.dll
-Microsoft.Extensions.Primitives.dll
 Microsoft.Web.XmlTransform.dll
 Microsoft.Web.XmlTransform.resources.dll
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixinclude
@@ -58,6 +58,9 @@ NuGet.Versioning.dll
 NuGet.Versioning.resources.dll
 
 # 3rd party dlls to keep
+Microsoft.Extensions.FileProviders.Abstractions.dll
+Microsoft.Extensions.FileSystemGlobbing.dll
+Microsoft.Extensions.Primitives.dll
 Microsoft.Web.XmlTransform.dll
 Microsoft.Web.XmlTransform.resources.dll
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: engineering

## Description

While building, I was sure I got an error that this assembly was missing from the VSIX. However, after it was pointed out in comment https://github.com/NuGet/NuGet.Client/pull/6982#discussion_r2604814204, I tried excluding these assemblies from the VSIX and had no trouble. 

`Microsoft.Extensions.DependencyInjection.*` assemblies listed in our vsixinclude were part of my VS Installation folder's PublicAssemblies. Therefore, I'm moving the following to the `.vsixignore` which should reduce our VSIX size:
 - Microsoft.Extensions.DependencyInjection.dll
 - Microsoft.Extensions.DependencyInjection.Abstractions.dll


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
