### PR TITLE
Update all projects in solution with dotnet package update

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
@@ -6,8 +6,8 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Configuration;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Model;
 using NuGet.Versioning;
@@ -112,10 +112,11 @@ internal interface IPackageUpdateIO
 
     /// <summary>Gets the assets file for a project.</summary>
     /// <param name="dgSpec">The restore inputs for the project.</param>
+    /// <param name="projectPath">The path to the project to get the assets file for.</param>
     /// <param name="logger">The output logger</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The assets file for the project.</returns>
-    Task<LockFile> GetProjectAssetsFileAsync(DependencyGraphSpec dgSpec, ILogger logger, CancellationToken cancellationToken);
+    Task<LockFile> GetProjectAssetsFileAsync(DependencyGraphSpec dgSpec, string projectPath, ILogger logger, CancellationToken cancellationToken);
 
     /// <summary>Gets the package source mapping configuration for the current settins context.</summary>
     /// <returns>The package source mapping settings.</returns>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -108,7 +108,7 @@ internal static class PackageUpdateCommandRunner
 
             foreach (var packageResult in packagesToUpdate)
             {
-                logger.LogInformation($"    " + Format.PackageUpdate_UpdatedMessage(packageResult.Package.Id, packageResult.Package.CurrentVersion.ToShortString(), packageResult.Package.NewVersion.ToShortString()));
+                logger.LogInformation($"    {Format.PackageUpdate_UpdatedMessage(packageResult.Package.Id, packageResult.Package.CurrentVersion.ToShortString(), packageResult.Package.NewVersion.ToShortString())}");
                 packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageResult.TargetFrameworkAliases, packageResult.Package, logger);
                 uniquePackagesUpdated.Add(packageResult.Package.Id);
             }
@@ -258,19 +258,21 @@ internal static class PackageUpdateCommandRunner
 
         if (args.Vulnerable)
         {
+            foreach (var projectPath in dgSpec.Restore)
+            {
+                PackageSpec projectSpec = dgSpec.GetProjectSpec(projectPath);
+                if (!NuGetAuditEnabled(projectSpec))
+                {
+                    logger.LogError(Strings.PackageUpdate_AuditDisabled);
+                    return (ExitCodes.InvalidArgs, projectPackageUpdates, 0);
+                }
+            }
+
             (exitCode, totalPackagesScanned) = await ProcessProjectsInParallelAsync(
                 dgSpec,
                 projectPackageUpdates,
                 async (projectPath, ct) =>
                 {
-                    PackageSpec projectSpec = dgSpec.GetProjectSpec(projectPath);
-
-                    if (!NuGetAuditEnabled(projectSpec))
-                    {
-                        logger.LogError(Strings.PackageUpdate_AuditDisabled);
-                        return (null, new HashSet<string>(StringComparer.OrdinalIgnoreCase), ExitCodes.InvalidArgs);
-                    }
-
                     (List<PackageUpdateResult> packagesToUpdate, HashSet<string> scannedPackages) =
                         await SelectVulnerablePackagesToUpdateAsync(args.Packages, dgSpec, projectPath, logger, packageUpdateIO, ct);
 
@@ -313,12 +315,18 @@ internal static class PackageUpdateCommandRunner
                 async (projectPath, ct) =>
                 {
                     PackageSpec projectSpec = dgSpec.GetProjectSpec(projectPath);
-                    (List<PackageUpdateResult> packagesToUpdate, HashSet<string> scannedPackages) =
+                    (List<PackageUpdateResult>? packagesToUpdate, HashSet<string> scannedPackages) =
                         await SelectSpecificPackagesToUpdateAsync(args.Packages!, projectSpec, logger, packageUpdateIO, ct);
 
-                    return (packagesToUpdate, scannedPackages, null);
+                    int? errorCode = packagesToUpdate is null ? ExitCodes.Error : null;
+                    return (packagesToUpdate, scannedPackages, errorCode);
                 },
                 cancellationToken);
+
+            if (exitCode.HasValue)
+            {
+                return (exitCode.Value, projectPackageUpdates, totalPackagesScanned);
+            }
         }
 
         // Check if any packages were found to update
@@ -329,14 +337,10 @@ internal static class PackageUpdateCommandRunner
                 logger.LogMinimal(Strings.PackageUpdate_NoVulnerablePackages, ConsoleColor.Green);
                 return (ExitCodes.Success, projectPackageUpdates, totalPackagesScanned);
             }
-            else if (noPackagesSpecified)
+            else
             {
                 logger.LogMinimal(Strings.PackageUpdate_AlreadyUpToDate, ConsoleColor.Green);
                 return (ExitCodes.NoPackagesNeedUpdating, projectPackageUpdates, totalPackagesScanned);
-            }
-            else
-            {
-                return (ExitCodes.Error, projectPackageUpdates, totalPackagesScanned);
             }
         }
 
@@ -384,7 +388,7 @@ internal static class PackageUpdateCommandRunner
         return (exitCode, scannedPackages.Count);
     }
 
-    internal static async Task<(List<PackageUpdateResult>, HashSet<string> scannedPackages)> SelectSpecificPackagesToUpdateAsync(
+    internal static async Task<(List<PackageUpdateResult>?, HashSet<string> scannedPackages)> SelectSpecificPackagesToUpdateAsync(
         IReadOnlyList<PackageWithVersionRange> packages,
         PackageSpec project,
         ILoggerWithColor logger,
@@ -465,7 +469,7 @@ internal static class PackageUpdateCommandRunner
             });
         }
 
-        return (hasErrors ? [] : packagesToUpdate, scannedPackages);
+        return (hasErrors ? null : packagesToUpdate, scannedPackages);
     }
 
     /// <summary>Gets the package's referenced version range and TFMs which it's referenced in.</summary>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -11,9 +11,9 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Configuration;
 using NuGet.CommandLine.XPlat.Utility;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Credentials;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
@@ -75,84 +75,19 @@ internal static class PackageUpdateCommandRunner
             logger.LogInformation(Format.PackageUpdate_UpdatingOutdatedPackages(args.Project));
         }
 
-        if (dgSpec.Restore.Count > 1)
-        {
-            logger.LogMinimal(Strings.Unsupported_UpdatingMoreThanOneProject, ConsoleColor.Red);
-            return ExitCodes.Error;
-        }
-
-        PackageSpec projectSpec = dgSpec.GetProjectSpec(dgSpec.Restore[0]);
-
         // 2. Find suitable version of package(s) to update
         // Source provider will be needed to find the package version and to restore, so create it here.
         logger.LogVerbose(Strings.PackageUpdate_FindingUpdateVersions);
 
-        bool noPackagesSpecified = args.Packages is null || args.Packages.Count == 0;
-        int totalPackagesScanned = 0;
-        List<PackageUpdateResult> packagesToUpdateResult;
-
-        if (args.Vulnerable)
+        var (exitCode, projectPackageUpdates, totalPackagesScanned) = await SelectPackagesToUpdateAsync(args, dgSpec, logger, packageUpdateIO, cancellationToken);
+        if (exitCode.HasValue)
         {
-            if (!NuGetAuditEnabled(projectSpec))
-            {
-                logger.LogError(Strings.PackageUpdate_AuditDisabled);
-                return ExitCodes.InvalidArgs;
-            }
-
-            if (!IsNuGetAuditModeSetToAll(projectSpec))
-            {
-                logger.LogWarning(Strings.PackageUpdate_AuditModeIsDirect);
-            }
-
-            (packagesToUpdateResult, totalPackagesScanned) = await SelectVulnerablePackagesToUpdateAsync(args.Packages, dgSpec, logger, packageUpdateIO, cancellationToken);
-
-            if (packagesToUpdateResult.Count == 0)
-            {
-                logger.LogMinimal(Strings.PackageUpdate_NoVulnerablePackages, ConsoleColor.Green);
-                return ExitCodes.Success;
-            }
+            return exitCode.Value;
         }
-        else if (noPackagesSpecified)
-        {
-            (var selectedPackages, totalPackagesScanned) = await SelectAllPackagesWithUpdatesAsync(projectSpec, logger, packageUpdateIO, cancellationToken);
-            if (selectedPackages is null)
-            {
-                // SelectAllPackagesWithUpdatesAsync logs the error.
-                return ExitCodes.Error;
-            }
-            else if (selectedPackages.Count == 0)
-            {
-                // When no packages are specified and all packages are already up to date, return exit code 2
-                logger.LogMinimal(Strings.PackageUpdate_AlreadyUpToDate, ConsoleColor.Green);
-                return ExitCodes.NoPackagesNeedUpdating;
-            }
-            packagesToUpdateResult = selectedPackages;
-        }
-        else
-        {
-            totalPackagesScanned = args.Packages!.Count;
-            packagesToUpdateResult = await SelectPackagesToUpdateAsync(args.Packages, projectSpec, logger, packageUpdateIO, cancellationToken);
-            if (packagesToUpdateResult.Count == 0)
-            {
-                // SelectPackagesToUpdateAsync logs the error.
-                return ExitCodes.Error;
-            }
-        }
-
-        var projectName = Path.GetFileNameWithoutExtension(projectSpec.FilePath);
-        logger.LogInformation($"  {projectName}:");
-
-        foreach (var packageResult in packagesToUpdateResult)
-        {
-            logger.LogInformation($"    " + Format.PackageUpdate_UpdatedMessage(packageResult.Package.Id, packageResult.Package.CurrentVersion.ToShortString(), packageResult.Package.NewVersion.ToShortString()));
-        }
-
-        // New line in between projects, or before the final summary.
-        logger.LogInformation("");
 
         // 3. Preview restore to validate changes
         logger.LogDebug(Strings.PackageUpdate_PreviewRestore);
-        var updatedDgSpec = GetUpdatedDependencyGraphSpec(projectSpec, dgSpec, packagesToUpdateResult);
+        var updatedDgSpec = GetUpdatedDependencyGraphSpec(dgSpec, projectPackageUpdates);
         var restorePreviewResult = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(updatedDgSpec, logger, cancellationToken);
 
         if (!restorePreviewResult.Success)
@@ -162,33 +97,49 @@ internal static class PackageUpdateCommandRunner
         }
 
         // 4. Update MSBuild files
+        HashSet<string> uniquePackagesUpdated = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        var updatedPackageSpec = updatedDgSpec.GetProjectSpec(projectSpec.FilePath);
-        int updatedCount = 0;
-
-        foreach (var packageResult in packagesToUpdateResult)
+        foreach (var (projectPath, packagesToUpdate) in projectPackageUpdates)
         {
-            packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageResult.TargetFrameworkAliases, packageResult.Package, logger);
-            updatedCount++;
+            var projectName = Path.GetFileNameWithoutExtension(projectPath);
+            logger.LogInformation($"  {projectName}:");
+
+            var updatedPackageSpec = updatedDgSpec.GetProjectSpec(projectPath);
+
+            foreach (var packageResult in packagesToUpdate)
+            {
+                logger.LogInformation($"    " + Format.PackageUpdate_UpdatedMessage(packageResult.Package.Id, packageResult.Package.CurrentVersion.ToShortString(), packageResult.Package.NewVersion.ToShortString()));
+                packageUpdateIO.UpdatePackageReference(updatedPackageSpec, restorePreviewResult, packageResult.TargetFrameworkAliases, packageResult.Package, logger);
+                uniquePackagesUpdated.Add(packageResult.Package.Id);
+            }
         }
 
         // 5. Commit restore if everything successful
         await packageUpdateIO.CommitAsync(restorePreviewResult, CancellationToken.None);
 
-        int scannedCount = totalPackagesScanned;
-        logger.LogMinimal(Format.PackageUpdate_FinalSummary(updatedCount, scannedCount), ConsoleColor.Green);
+        int uniquePackageCount = uniquePackagesUpdated.Count;
+        logger.LogInformation("");
+        logger.LogMinimal(Format.PackageUpdate_FinalSummary(uniquePackageCount, totalPackagesScanned), ConsoleColor.Green);
 
         return ExitCodes.Success;
     }
 
-    private static async Task<(List<PackageUpdateResult> vulnerablePackages, int packagesScanned)> SelectVulnerablePackagesToUpdateAsync(
+    private static async Task<(List<PackageUpdateResult> vulnerablePackages, HashSet<string> packagesScanned)> SelectVulnerablePackagesToUpdateAsync(
         IReadOnlyList<PackageWithVersionRange>? packages,
         DependencyGraphSpec dgSpec,
+        string projectPath,
         ILoggerWithColor logger,
         IPackageUpdateIO packageUpdateIO,
         CancellationToken cancellationToken)
     {
-        LockFile assetsFile = await packageUpdateIO.GetProjectAssetsFileAsync(dgSpec, logger, cancellationToken);
+        LockFile assetsFile = await packageUpdateIO.GetProjectAssetsFileAsync(dgSpec, projectPath, logger, cancellationToken);
+        PackageSpec projectSpec = assetsFile.PackageSpec;
+
+        bool auditModeAll = IsNuGetAuditModeSetToAll(projectSpec);
+        if (!auditModeAll)
+        {
+            logger.LogWarning(Strings.PackageUpdate_AuditModeIsDirect);
+        }
 
         // Log messages don't have package version in a usable way, so we have to first find the list of package ids,
         // then check each TFM's package list against that list.
@@ -199,7 +150,19 @@ internal static class PackageUpdateCommandRunner
             .Where(id => packages is null || packages.Count == 0 || packages.Any(p => string.Equals(p.Id, id, StringComparison.OrdinalIgnoreCase)))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        int scannedPackages = assetsFile.Libraries.Count(l => l.Type == "package" && (packages is null || packages.Count == 0 || packages.Any(p => string.Equals(p.Id, l.Name, StringComparison.OrdinalIgnoreCase))));
+        HashSet<string> scannedPackages =
+            auditModeAll
+            ? assetsFile.Libraries
+                .Where(l => l.Type == "package" && (packages is null || packages.Count == 0 || packages.Any(p => string.Equals(p.Id, l.Name, StringComparison.OrdinalIgnoreCase))))
+                .Select(l => l.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase)
+            : assetsFile.PackageSpec.TargetFrameworks
+                .SelectMany(tfm => tfm.Dependencies)
+                .Where(d => d.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package && (packages is null || packages.Count == 0 || packages.Any(p => string.Equals(p.Id, d.Name, StringComparison.OrdinalIgnoreCase))))
+                .Select(d => d.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var packagesToUpdateResult = new List<PackageUpdateResult>();
 
         if (packageIdsWithVulnerabilities.Count > 0)
         {
@@ -223,7 +186,6 @@ internal static class PackageUpdateCommandRunner
                 .ToList();
 
             PackageSourceMapping sourceMapping = packageUpdateIO.GetPackageSourceMapping();
-            var packagesToUpdateResult = new List<PackageUpdateResult>(packagesToUpdate.Count);
             foreach (var (packageIdentity, tfmAliases) in packagesToUpdate)
             {
                 IReadOnlyList<string>? mappedSources = sourceMapping.IsEnabled ? sourceMapping.GetConfiguredPackageSources(packageIdentity.Id) : null;
@@ -252,11 +214,9 @@ internal static class PackageUpdateCommandRunner
                     });
                 }
             }
-
-            return (packagesToUpdateResult, scannedPackages);
         }
 
-        return ([], scannedPackages);
+        return (packagesToUpdateResult, scannedPackages);
 
         bool PackageHasVulnerability(string packageId, NuGetVersion version, IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities)
         {
@@ -282,7 +242,149 @@ internal static class PackageUpdateCommandRunner
         }
     }
 
-    internal static async Task<List<PackageUpdateResult>> SelectPackagesToUpdateAsync(
+    private static async Task<(int? exitCode, Dictionary<string, List<PackageUpdateResult>> projectPackageUpdates, int totalPackagesScanned)>
+        SelectPackagesToUpdateAsync(
+            PackageUpdateArgs args,
+            DependencyGraphSpec dgSpec,
+            ILoggerWithColor logger,
+            IPackageUpdateIO packageUpdateIO,
+            CancellationToken cancellationToken)
+    {
+        bool noPackagesSpecified = args.Packages is null || args.Packages.Count == 0;
+        var projectPackageUpdates = new Dictionary<string, List<PackageUpdateResult>>(StringComparer.OrdinalIgnoreCase);
+
+        int? exitCode;
+        int totalPackagesScanned;
+
+        if (args.Vulnerable)
+        {
+            (exitCode, totalPackagesScanned) = await ProcessProjectsInParallelAsync(
+                dgSpec,
+                projectPackageUpdates,
+                async (projectPath, ct) =>
+                {
+                    PackageSpec projectSpec = dgSpec.GetProjectSpec(projectPath);
+
+                    if (!NuGetAuditEnabled(projectSpec))
+                    {
+                        logger.LogError(Strings.PackageUpdate_AuditDisabled);
+                        return (null, new HashSet<string>(StringComparer.OrdinalIgnoreCase), ExitCodes.InvalidArgs);
+                    }
+
+                    (List<PackageUpdateResult> packagesToUpdate, HashSet<string> scannedPackages) =
+                        await SelectVulnerablePackagesToUpdateAsync(args.Packages, dgSpec, projectPath, logger, packageUpdateIO, ct);
+
+                    return (packagesToUpdate, scannedPackages, null);
+                },
+                cancellationToken);
+
+            if (exitCode.HasValue)
+            {
+                return (exitCode.Value, projectPackageUpdates, totalPackagesScanned);
+            }
+        }
+        else if (noPackagesSpecified)
+        {
+            (exitCode, totalPackagesScanned) = await ProcessProjectsInParallelAsync(
+                dgSpec,
+                projectPackageUpdates,
+                async (projectPath, ct) =>
+                {
+                    PackageSpec projectSpec = dgSpec.GetProjectSpec(projectPath);
+                    (List<PackageUpdateResult>? packagesToUpdate, HashSet<string> scannedPackages) =
+                        await SelectAllPackagesWithUpdatesAsync(projectSpec, logger, packageUpdateIO, ct);
+
+                    // SelectAllPackagesWithUpdatesAsync logs the error when returning null
+                    int? errorCode = packagesToUpdate is null ? ExitCodes.Error : null;
+                    return (packagesToUpdate, scannedPackages, errorCode);
+                },
+                cancellationToken);
+
+            if (exitCode.HasValue)
+            {
+                return (exitCode.Value, projectPackageUpdates, totalPackagesScanned);
+            }
+        }
+        else
+        {
+            (exitCode, totalPackagesScanned) = await ProcessProjectsInParallelAsync(
+                dgSpec,
+                projectPackageUpdates,
+                async (projectPath, ct) =>
+                {
+                    PackageSpec projectSpec = dgSpec.GetProjectSpec(projectPath);
+                    (List<PackageUpdateResult> packagesToUpdate, HashSet<string> scannedPackages) =
+                        await SelectSpecificPackagesToUpdateAsync(args.Packages!, projectSpec, logger, packageUpdateIO, ct);
+
+                    return (packagesToUpdate, scannedPackages, null);
+                },
+                cancellationToken);
+        }
+
+        // Check if any packages were found to update
+        if (projectPackageUpdates.Count == 0)
+        {
+            if (args.Vulnerable)
+            {
+                logger.LogMinimal(Strings.PackageUpdate_NoVulnerablePackages, ConsoleColor.Green);
+                return (ExitCodes.Success, projectPackageUpdates, totalPackagesScanned);
+            }
+            else if (noPackagesSpecified)
+            {
+                logger.LogMinimal(Strings.PackageUpdate_AlreadyUpToDate, ConsoleColor.Green);
+                return (ExitCodes.NoPackagesNeedUpdating, projectPackageUpdates, totalPackagesScanned);
+            }
+            else
+            {
+                return (ExitCodes.Error, projectPackageUpdates, totalPackagesScanned);
+            }
+        }
+
+        return (null, projectPackageUpdates, totalPackagesScanned);
+    }
+
+    private static async Task<(int? exitCode, int totalPackagesScanned)> ProcessProjectsInParallelAsync(
+        DependencyGraphSpec dgSpec,
+        Dictionary<string, List<PackageUpdateResult>> projectPackageUpdates,
+        Func<string, CancellationToken, Task<(List<PackageUpdateResult>? packagesToUpdate, HashSet<string> scannedPackages, int? errorExitCode)>> processProject,
+        CancellationToken cancellationToken)
+    {
+        var scannedPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var lockObject = new object();
+        int? exitCode = null;
+
+        var parallelOptions = new ParallelOptions
+        {
+            MaxDegreeOfParallelism = Environment.ProcessorCount,
+            CancellationToken = cancellationToken
+        };
+
+        await Parallel.ForEachAsync(dgSpec.Restore, parallelOptions, async (projectPath, ct) =>
+        {
+            (List<PackageUpdateResult>? packagesToUpdate, HashSet<string> projectScannedPackages, int? errorExitCode) =
+                await processProject(projectPath, ct);
+
+            lock (lockObject)
+            {
+                if (errorExitCode.HasValue)
+                {
+                    exitCode = errorExitCode.Value;
+                    return;
+                }
+
+                scannedPackages.UnionWith(projectScannedPackages);
+
+                if (packagesToUpdate is not null && packagesToUpdate.Count > 0)
+                {
+                    projectPackageUpdates[projectPath] = packagesToUpdate;
+                }
+            }
+        });
+
+        return (exitCode, scannedPackages.Count);
+    }
+
+    internal static async Task<(List<PackageUpdateResult>, HashSet<string> scannedPackages)> SelectSpecificPackagesToUpdateAsync(
         IReadOnlyList<PackageWithVersionRange> packages,
         PackageSpec project,
         ILoggerWithColor logger,
@@ -296,6 +398,7 @@ internal static class PackageUpdateCommandRunner
 
         var sourceMapping = packageUpdateIO.GetPackageSourceMapping();
         var packagesToUpdate = new List<PackageUpdateResult>();
+        var scannedPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         bool hasErrors = false;
 
         foreach (var package in packages)
@@ -317,6 +420,8 @@ internal static class PackageUpdateCommandRunner
                 }
                 continue;
             }
+
+            scannedPackages.Add(package.Id);
 
             VersionRange upgradeVersion;
             if (package.VersionRange is not null)
@@ -360,7 +465,7 @@ internal static class PackageUpdateCommandRunner
             });
         }
 
-        return hasErrors ? [] : packagesToUpdate;
+        return (hasErrors ? [] : packagesToUpdate, scannedPackages);
     }
 
     /// <summary>Gets the package's referenced version range and TFMs which it's referenced in.</summary>
@@ -438,7 +543,7 @@ internal static class PackageUpdateCommandRunner
         return (existingVersion, frameworks);
     }
 
-    internal static async Task<(List<PackageUpdateResult>? packagesToUpdate, int packagesInProject)> SelectAllPackagesWithUpdatesAsync(
+    internal static async Task<(List<PackageUpdateResult>? packagesToUpdate, HashSet<string> scannedPackages)> SelectAllPackagesWithUpdatesAsync(
         PackageSpec project,
         ILoggerWithColor logger,
         IPackageUpdateIO packageUpdateIO,
@@ -447,11 +552,12 @@ internal static class PackageUpdateCommandRunner
         var allProjectPackages = GetAllPackagesReferencedByProject(project, logger);
         if (allProjectPackages is null)
         {
-            return (null, 0);
+            return (null, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
         }
 
         var sourceMapping = packageUpdateIO.GetPackageSourceMapping();
         var packagesToUpdate = new List<PackageUpdateResult>();
+        var scannedPackages = new HashSet<string>(allProjectPackages.Select(p => p.identity.Id), StringComparer.OrdinalIgnoreCase);
         bool successful = true;
 
         foreach (var package in allProjectPackages)
@@ -496,7 +602,7 @@ internal static class PackageUpdateCommandRunner
             packagesToUpdate.Add(result);
         }
 
-        return successful ? (packagesToUpdate, allProjectPackages.Count) : (null, allProjectPackages.Count);
+        return successful ? (packagesToUpdate, scannedPackages) : (null, scannedPackages);
     }
 
     private static List<(PackageWithVersionRange identity, List<string> tfms)>? GetAllPackagesReferencedByProject(PackageSpec project, ILoggerWithColor logger)
@@ -553,18 +659,38 @@ internal static class PackageUpdateCommandRunner
         return result;
     }
 
-    private static DependencyGraphSpec GetUpdatedDependencyGraphSpec(PackageSpec projectSpec, DependencyGraphSpec currentDgSpec, List<PackageUpdateResult> packagesToUpdate)
+    private static DependencyGraphSpec GetUpdatedDependencyGraphSpec(DependencyGraphSpec currentDgSpec, Dictionary<string, List<PackageUpdateResult>> projectPackageUpdates)
     {
-        var updatedPackageSpec = projectSpec.Clone();
+        var updatedDgSpec = new DependencyGraphSpec();
 
-        foreach (var packageResult in packagesToUpdate)
+        // Add all projects from the current dgSpec, replacing those with updates
+        foreach (var project in currentDgSpec.Projects)
         {
-            PackageDependency packageDependency = new PackageDependency(packageResult.Package.Id, packageResult.Package.NewVersion);
-            PackageSpecOperations.AddOrUpdateDependency(updatedPackageSpec, packageDependency);
+            if (projectPackageUpdates.TryGetValue(project.FilePath, out var packagesToUpdate))
+            {
+                // Clone and update this project
+                var updatedPackageSpec = project.Clone();
+
+                foreach (var packageResult in packagesToUpdate)
+                {
+                    PackageDependency packageDependency = new PackageDependency(packageResult.Package.Id, packageResult.Package.NewVersion);
+                    PackageSpecOperations.AddOrUpdateDependency(updatedPackageSpec, packageDependency);
+                }
+
+                updatedDgSpec.AddProject(updatedPackageSpec);
+            }
+            else
+            {
+                // Keep the original project unchanged
+                updatedDgSpec.AddProject(project);
+            }
         }
 
-        var updatedDgSpec = currentDgSpec.WithReplacedSpec(updatedPackageSpec).WithoutRestores();
-        updatedDgSpec.AddRestore(updatedPackageSpec.RestoreMetadata.ProjectUniqueName);
+        // Add restore entries for all projects from the current dgSpec
+        foreach (var restorePath in currentDgSpec.Restore)
+        {
+            updatedDgSpec.AddRestore(restorePath);
+        }
 
         return updatedDgSpec;
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -134,7 +134,7 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
                 new DependencyGraphSpecRequestProvider(providerCache, dgSpec)
             };
 
-        var globalPackagesFolder = dgSpec.GetProjectSpec(dgSpec.Restore.Single()).RestoreMetadata.PackagesPath;
+        var globalPackagesFolder = dgSpec.GetProjectSpec(dgSpec.Restore.First()).RestoreMetadata.PackagesPath;
 
         var restoreContext = new RestoreArgs()
         {
@@ -146,15 +146,12 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
             // Sources : No need to pass it, because SourceRepositories contains the already built SourceRepository objects
         };
 
-        // Generate Restore Requests. There will always be 1 request here since we are restoring for 1 project.
         var restoreRequests = await RestoreRunner.GetRequests(restoreContext);
-
-        // Run restore without commit. This will always return 1 Result pair since we are restoring for 1 request.
         var restoreResult = await RestoreRunner.RunWithoutCommitAsync(restoreRequests, restoreContext, cancellationToken);
 
         var result = new RestoreResult
         {
-            RestoreResultPair = restoreResult.Single()
+            RestoreResultPairs = restoreResult
         };
         return result;
     }
@@ -162,7 +159,11 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
     /// <inheritdoc cref="IPackageUpdateIO.CommitAsync(IPackageUpdateIO.RestoreResult, CancellationToken)"/>
     public async Task CommitAsync(IPackageUpdateIO.RestoreResult restorePreviewResult, CancellationToken none)
     {
-        await RestoreRunner.CommitAsync(((RestoreResult)restorePreviewResult).RestoreResultPair, CancellationToken.None);
+        var restoreResult = (RestoreResult)restorePreviewResult;
+        foreach (var restoreResultPair in restoreResult.RestoreResultPairs)
+        {
+            await RestoreRunner.CommitAsync(restoreResultPair, CancellationToken.None);
+        }
     }
 
     /// <inheritdoc cref="IPackageUpdateIO.UpdatePackageReference(PackageSpec, IPackageUpdateIO.RestoreResult, List{string}, PackageToUpdate, ILogger)"/>
@@ -177,9 +178,15 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
             packageTfms.Add(targetFramework.FrameworkName);
         }
 
+        var restoreResult = (RestoreResult)restorePreviewResult;
+        var restoreResultPair = restoreResult.RestoreResultPairs.Single(pair =>
+            string.Equals(pair.SummaryRequest.Request.Project.FilePath, updatedPackageSpec.FilePath, StringComparison.OrdinalIgnoreCase));
+
         if (!AddPackageReferenceCommandRunner.TryFindResolvedVersion(packageTfms,
             packageDependency.Id,
-            ((RestoreResult)restorePreviewResult).RestoreResultPair.Result, logger, out NuGetVersion resolvedVersion))
+            restoreResultPair.Result,
+            logger,
+            out NuGetVersion resolvedVersion))
         {
             return;
         }
@@ -450,7 +457,9 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
             throw new NotSupportedException();
         }
 
-        LockFile? assetsFile = previewRestoreResult.RestoreResultPair.Result.LockFile;
+        var restoreResultPair = previewRestoreResult.RestoreResultPairs.Single(pair =>
+            string.Equals(pair.SummaryRequest.Request.Project.FilePath, projectPath, StringComparison.OrdinalIgnoreCase));
+        LockFile? assetsFile = restoreResultPair.Result.LockFile;
         if (assetsFile is null)
         {
             var packageSpec = dgSpec.GetProjectSpec(projectPath);
@@ -461,10 +470,10 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
         return assetsFile;
     }
 
-    private class RestoreResult : IPackageUpdateIO.RestoreResult
+    internal class RestoreResult : IPackageUpdateIO.RestoreResult
     {
-        internal required RestoreResultPair RestoreResultPair { get; init; }
+        internal required IReadOnlyList<RestoreResultPair> RestoreResultPairs { get; init; }
 
-        public override bool Success => RestoreResultPair.Result.Success;
+        public override bool Success => RestoreResultPairs.All(pair => pair.Result.Success);
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -436,9 +436,10 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
         return highestVersion;
     }
 
-    /// <inheritdoc cref="IPackageUpdateIO.GetProjectAssetsFileAsync(DependencyGraphSpec, ILogger, CancellationToken)"/>
+    /// <inheritdoc cref="IPackageUpdateIO.GetProjectAssetsFileAsync(DependencyGraphSpec, string, ILogger, CancellationToken)"/>
     public async Task<LockFile> GetProjectAssetsFileAsync(
         DependencyGraphSpec dgSpec,
+        string projectPath,
         ILogger logger,
         CancellationToken cancellationToken)
     {
@@ -452,7 +453,7 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
         LockFile? assetsFile = previewRestoreResult.RestoreResultPair.Result.LockFile;
         if (assetsFile is null)
         {
-            var packageSpec = dgSpec.GetProjectSpec(dgSpec.Restore.Single());
+            var packageSpec = dgSpec.GetProjectSpec(projectPath);
             var assetsFilePath = Path.Combine(packageSpec.RestoreMetadata.OutputPath, LockFileFormat.AssetsFileName);
             assetsFile = new LockFileFormat().Read(assetsFilePath);
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
@@ -6,11 +6,13 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using FluentAssertions;
 using NuGet.CommandLine.Xplat.Tests;
+using NuGet.Frameworks;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -89,10 +91,8 @@ namespace Dotnet.Integration.Test
             // Assert
             result.ExitCode.Should().Be(0);
 
-            XDocument csproj = XDocument.Load(csprojPath);
-            var packageReferenceA = csproj.XPathSelectElements("//PackageReference[@Include='NuGet.Internal.Test.a']").ToList();
-            packageReferenceA.Count.Should().Be(1);
-            packageReferenceA[0].Attribute("Version").Value.Should().Be("2.0.0");
+            string version = GetPackageReferenceVersion(csprojPath, "NuGet.Internal.Test.a");
+            version.Should().Be("2.0.0");
         }
 
         [Fact]
@@ -144,15 +144,11 @@ namespace Dotnet.Integration.Test
             // Assert
             result.ExitCode.Should().Be(0);
 
-            XDocument csproj = XDocument.Load(csprojPath);
-            var packageReferenceA = csproj.XPathSelectElements("//PackageReference[@Include='NuGet.Internal.Test.a']").ToList();
-            packageReferenceA.Count.Should().Be(1);
-            packageReferenceA[0].Attribute("Version").Should().BeNull();
+            string packageReferenceVersion = GetPackageReferenceVersion(csprojPath, "NuGet.Internal.Test.a");
+            packageReferenceVersion.Should().BeNullOrEmpty();
 
-            XDocument packagesProps = XDocument.Load(packagesPropsPath);
-            var packageVersionA = packagesProps.XPathSelectElements("//PackageVersion[@Include='NuGet.Internal.Test.a']").ToList();
-            packageVersionA.Count.Should().Be(1);
-            packageVersionA[0].Attribute("Version").Value.Should().Be("2.0.0");
+            string packageVersionVersion = GetPackageVersionVersion(csprojPath, "NuGet.Internal.Test.a");
+            packageVersionVersion.Should().Be("2.0.0");
         }
 
         [Fact]
@@ -191,10 +187,8 @@ namespace Dotnet.Integration.Test
             // Assert
             result.ExitCode.Should().Be(0);
 
-            XDocument csproj = XDocument.Load(csprojPath);
-            var packageReferenceA = csproj.XPathSelectElements("//PackageReference[@Include='NuGet.Internal.Test.a']").ToList();
-            packageReferenceA.Count.Should().Be(1);
-            packageReferenceA[0].Attribute("Version").Value.Should().Be("2.0.0");
+            string version = GetPackageReferenceVersion(csprojPath, "NuGet.Internal.Test.a");
+            version.Should().Be("2.0.0");
         }
 
         [Fact]
@@ -301,6 +295,96 @@ namespace Dotnet.Integration.Test
 
             // Assert
             result.Output.Should().Contain("MSB4025").And.Contain(csprojPath);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SolutionWithTwoProjects_UpdateAll_UpdatesBothProjects(bool useSlnx)
+        {
+            // Arrange
+            using var testContext = new SimpleTestPathContext();
+            File.WriteAllText(testContext.NuGetConfig, string.Format(NugetConfigFormat, testContext.PackageSource));
+
+            var a1 = new SimpleTestPackageContext("NuGet.Internal.Test.a", "1.0.0");
+            var a2 = new SimpleTestPackageContext("NuGet.Internal.Test.a", "2.0.0");
+
+            SimpleTestPackageContext[] packages = [a1, a2];
+            await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packages);
+
+            var solution = new SimpleTestSolutionContext(testContext.SolutionRoot, useSlnx);
+
+            var project1 = SimpleTestProjectContext.CreateNETCore(
+                "Project1",
+                testContext.SolutionRoot,
+                NuGetFramework.Parse("net9.0"));
+            project1.AddPackageToAllFrameworks(a1);
+
+            var project2 = SimpleTestProjectContext.CreateNETCore(
+                "Project2",
+                testContext.SolutionRoot,
+                NuGetFramework.Parse("net9.0"));
+            project2.AddPackageToAllFrameworks(a1);
+
+            solution.Projects.Add(project1);
+            solution.Projects.Add(project2);
+            solution.Create();
+
+            // Act
+            var result = _testFixture.RunDotnetExpectSuccess(
+                workingDirectory: testContext.SolutionRoot,
+                args: $"package update",
+                testOutputHelper: _testOutputHelper,
+                environmentVariables: _envVars);
+
+            // Assert
+            result.ExitCode.Should().Be(0);
+
+            string version1 = GetPackageReferenceVersion(project1.ProjectPath, "NuGet.Internal.Test.a");
+            version1.Should().Be("2.0.0");
+
+            string version2 = GetPackageReferenceVersion(project2.ProjectPath, "NuGet.Internal.Test.a");
+            version2.Should().Be("2.0.0");
+        }
+
+        private string GetItemVersion(string projectPath, string itemType, string packageName)
+        {
+            var result = _testFixture.RunDotnetExpectSuccess(
+                workingDirectory: Path.GetDirectoryName(projectPath),
+                args: $"msbuild {Path.GetFileName(projectPath)} -getItem:{itemType}",
+                testOutputHelper: _testOutputHelper,
+                environmentVariables: _envVars);
+
+            using JsonDocument document = JsonDocument.Parse(result.Output);
+            JsonElement root = document.RootElement;
+
+            if (root.TryGetProperty("Items", out JsonElement items) &&
+                items.TryGetProperty(itemType, out JsonElement itemElements))
+            {
+                foreach (JsonElement item in itemElements.EnumerateArray())
+                {
+                    if (item.TryGetProperty("Identity", out JsonElement identity) &&
+                        identity.GetString() == packageName)
+                    {
+                        if (item.TryGetProperty("Version", out JsonElement version))
+                        {
+                            return version.GetString();
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private string GetPackageReferenceVersion(string projectPath, string packageName)
+        {
+            return GetItemVersion(projectPath, "PackageReference", packageName);
+        }
+
+        private string GetPackageVersionVersion(string projectPath, string packageName)
+        {
+            return GetItemVersion(projectPath, "PackageVersion", packageName);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/AddPackageCommandUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/AddPackageCommandUtilityTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace NuGet.XPlat.FuncTest
 {
-    [Collection("NuGet XPlat Test Collection")]
+    [Collection(XPlatCollection.Name)]
     public class AddPackageCommandUtilityTests
     {
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/CommitAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/CommitAsyncTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Common;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest.Commands.Package.Update.PackageUpdateIOTests;
+
+public class CommitAsyncTests
+{
+    private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
+    {
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
+        return packageUpdateIO;
+    }
+
+    [Fact]
+    public async Task CommitAsync_AfterSuccessfulPreview_CreatesAssetsFile()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+
+        var packageA = new SimpleTestPackageContext("PackageA", "1.0.0");
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packageA);
+
+        var projectA = SimpleTestProjectContext.CreateNETCore(
+            "ProjectA",
+            testContext.SolutionRoot,
+            "net9.0");
+        projectA.AddPackageToAllFrameworks(packageA);
+        projectA.GlobalPackagesFolder = testContext.UserPackagesFolder;
+        projectA.Sources = new List<NuGet.Configuration.PackageSource> { new NuGet.Configuration.PackageSource(testContext.PackageSource) };
+        projectA.FallbackFolders = new List<string> { testContext.FallbackFolder };
+        projectA.Save();
+
+        var projectB = SimpleTestProjectContext.CreateNETCore(
+            "ProjectB",
+            testContext.SolutionRoot,
+            "net9.0");
+        projectB.AddPackageToAllFrameworks(packageA);
+        projectB.GlobalPackagesFolder = testContext.UserPackagesFolder;
+        projectB.Sources = new List<NuGet.Configuration.PackageSource> { new NuGet.Configuration.PackageSource(testContext.PackageSource) };
+        projectB.FallbackFolders = new List<string> { testContext.FallbackFolder };
+        projectB.Save();
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+        var dgSpec = new DependencyGraphSpec();
+        dgSpec.AddProject(projectA.PackageSpec);
+        dgSpec.AddProject(projectB.PackageSpec);
+        dgSpec.AddRestore(projectA.PackageSpec.RestoreMetadata.ProjectUniqueName);
+        dgSpec.AddRestore(projectB.PackageSpec.RestoreMetadata.ProjectUniqueName);
+
+        var previewResult = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(
+            dgSpec,
+            NullLogger.Instance,
+            CancellationToken.None);
+        previewResult.Success.Should().BeTrue();
+
+        var assetsFilePathA = projectA.AssetsFileOutputPath;
+        if (File.Exists(assetsFilePathA))
+        {
+            File.Delete(assetsFilePathA);
+        }
+
+        var assetsFilePathB = projectB.AssetsFileOutputPath;
+        if (File.Exists(assetsFilePathB))
+        {
+            File.Delete(assetsFilePathB);
+        }
+
+        // Act
+        await packageUpdateIO.CommitAsync(previewResult, CancellationToken.None);
+
+        // Assert
+        File.Exists(assetsFilePathA).Should().BeTrue();
+
+        var lockFileA = new LockFileFormat().Read(assetsFilePathA);
+        lockFileA.Should().NotBeNull();
+        lockFileA.Libraries.Should().ContainSingle(lib => lib.Name == "PackageA" && lib.Version.ToString() == "1.0.0");
+
+        File.Exists(assetsFilePathB).Should().BeTrue();
+
+        var lockFileB = new LockFileFormat().Read(assetsFilePathB);
+        lockFileB.Should().NotBeNull();
+        lockFileB.Libraries.Should().ContainSingle(lib => lib.Name == "PackageA" && lib.Version.ToString() == "1.0.0");
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetDependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetDependencyGraphSpecTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Common;
+using NuGet.Test.Utility;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest.Commands.Package.Update.PackageUpdateIOTests;
+
+[Collection(XPlatCollection.Name)]
+public class GetDependencyGraphSpecTests
+{
+    private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
+    {
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
+        return packageUpdateIO;
+    }
+
+    [Fact]
+    public void GetDependencyGraphSpec_WithValidProjectFile_ReturnsDgSpec()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+
+        var projectName = "TestProject";
+        var projectPath = Path.Combine(testContext.SolutionRoot, $"{projectName}.csproj");
+
+        var projectContent = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+</Project>";
+
+        File.WriteAllText(projectPath, projectContent);
+
+        var envVars = new Dictionary<string, string>
+        {
+            ["DOTNET_HOST_PATH"] = TestFileSystemUtility.GetDotnetCli()
+        };
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = packageUpdateIO.GetDependencyGraphSpec(projectPath);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Projects.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void GetDependencyGraphSpec_WithInvalidProjectFile_ReturnsNull()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+        var nonExistentProject = Path.Combine(testContext.SolutionRoot, "NonExistent.csproj");
+
+        var envVars = new Dictionary<string, string>
+        {
+            ["DOTNET_HOST_PATH"] = TestFileSystemUtility.GetDotnetCli()
+        };
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = packageUpdateIO.GetDependencyGraphSpec(nonExistentProject);
+
+        // Assert
+        result.Should().BeNull();
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetKnownVulnerabilitiesAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetKnownVulnerabilitiesAsyncTests.cs
@@ -1,0 +1,172 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Common;
+using NuGet.Protocol;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest.Commands.Package.Update.PackageUpdateIOTests;
+
+public class GetKnownVulnerabilitiesAsyncTests
+{
+    private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
+    {
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
+        return packageUpdateIO;
+    }
+
+    [Fact]
+    public async Task GetKnownVulnerabilitiesAsync_WithNoSources_ReturnsEmptyList()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+
+        var nugetConfig = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <clear />
+  </packageSources>
+</configuration>";
+        File.WriteAllText(Path.Combine(testContext.SolutionRoot, "nuget.config"), nugetConfig);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = await packageUpdateIO.GetKnownVulnerabilitiesAsync(
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetKnownVulnerabilitiesAsync_WithMockServerSource_ReturnsVulnerabilities()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+        var packageId = "TestPackage.Vulnerable";
+
+        using var mockServer = new FileSystemBackedV3MockServer(
+            testContext.PackageSource,
+            isPrivateFeed: false,
+            sourceReportsVulnerabilities: true);
+
+        mockServer.Vulnerabilities.Add(packageId, new List<(Uri, PackageVulnerabilitySeverity, VersionRange)>
+        {
+            (new Uri("https://example.com/vuln1"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 1.1.0]")),
+            (new Uri("https://example.com/vuln2"), PackageVulnerabilitySeverity.Moderate, VersionRange.Parse("[2.0.0]"))
+        });
+
+        mockServer.Start();
+
+        var nugetConfig = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key=""testSource"" value=""{mockServer.ServiceIndexUri}"" allowInsecureConnections=""true"" />
+  </packageSources>
+</configuration>";
+        File.WriteAllText(Path.Combine(testContext.SolutionRoot, "nuget.config"), nugetConfig);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = await packageUpdateIO.GetKnownVulnerabilitiesAsync(
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty();
+        result.Should().HaveCount(1);
+
+        var vulnerabilityDict = result[0];
+        vulnerabilityDict.Should().ContainKey(packageId);
+
+        var packageVulnerabilities = vulnerabilityDict[packageId];
+        packageVulnerabilities.Should().HaveCount(2);
+
+        packageVulnerabilities[0].Url.Should().Be(new Uri("https://example.com/vuln1"));
+        packageVulnerabilities[0].Severity.Should().Be(PackageVulnerabilitySeverity.High);
+        packageVulnerabilities[0].Versions.Should().Be(VersionRange.Parse("[1.0.0, 1.1.0]"));
+
+        packageVulnerabilities[1].Url.Should().Be(new Uri("https://example.com/vuln2"));
+        packageVulnerabilities[1].Severity.Should().Be(PackageVulnerabilitySeverity.Moderate);
+        packageVulnerabilities[1].Versions.Should().Be(VersionRange.Parse("[2.0.0]"));
+    }
+
+    [Fact]
+    public async Task GetKnownVulnerabilitiesAsync_WithAuditSource_ReturnsVulnerabilities()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+        var packageId = "TestPackage.WithAudit";
+
+        var packages = new[]
+        {
+            new SimpleTestPackageContext(packageId, "1.0.0"),
+            new SimpleTestPackageContext(packageId, "2.0.0")
+        };
+
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packages);
+
+        using var mockServer = new FileSystemBackedV3MockServer(
+            testContext.PackageSource,
+            isPrivateFeed: false,
+            sourceReportsVulnerabilities: true);
+
+        mockServer.Vulnerabilities.Add(packageId, new List<(Uri, PackageVulnerabilitySeverity, VersionRange)>
+        {
+            (new Uri("https://example.com/security-advisory"), PackageVulnerabilitySeverity.Critical, VersionRange.Parse("[1.0.0]"))
+        });
+
+        mockServer.Start();
+
+        var nugetConfig = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key=""mainSource"" value=""{testContext.PackageSource}"" />
+  </packageSources>
+  <auditSources>
+    <clear />
+    <add key=""auditSource"" value=""{mockServer.ServiceIndexUri}"" allowInsecureConnections=""true"" />
+  </auditSources>
+</configuration>";
+        File.WriteAllText(Path.Combine(testContext.SolutionRoot, "nuget.config"), nugetConfig);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = await packageUpdateIO.GetKnownVulnerabilitiesAsync(
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBeEmpty();
+
+        var vulnerabilityDict = result[0];
+        vulnerabilityDict.Should().ContainKey(packageId);
+
+        var packageVulnerabilities = vulnerabilityDict[packageId];
+        packageVulnerabilities.Should().HaveCount(1);
+        packageVulnerabilities[0].Url.Should().Be(new Uri("https://example.com/security-advisory"));
+        packageVulnerabilities[0].Severity.Should().Be(PackageVulnerabilitySeverity.Critical);
+        packageVulnerabilities[0].Versions.Should().Be(VersionRange.Parse("[1.0.0]"));
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetLatestVersionAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetLatestVersionAsyncTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Common;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest.Commands.Package.Update.PackageUpdateIOTests;
+
+public class GetLatestVersionAsyncTests
+{
+    private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
+    {
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
+        return packageUpdateIO;
+    }
+
+    [Fact]
+    public async Task GetLatestVersionAsync_WithMultipleVersions_ReturnsHighestStableVersion()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+        var packageId = "TestPackage.A";
+
+        var packages = new[]
+        {
+            new SimpleTestPackageContext(packageId, "1.0.0"),
+            new SimpleTestPackageContext(packageId, "2.0.0"),
+            new SimpleTestPackageContext(packageId, "2.1.0-beta"),
+        };
+
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packages);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = await packageUpdateIO.GetLatestVersionAsync(
+            packageId,
+            includePrerelease: false,
+            allowedSources: null,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(new NuGetVersion("2.0.0"));
+    }
+
+    [Fact]
+    public async Task GetLatestVersionAsync_WithPrereleaseVersions_WhenIncludePrereleaseTrue_ReturnsPrereleaseVersion()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+        var packageId = "TestPackage.B";
+
+        var packages = new[]
+        {
+            new SimpleTestPackageContext(packageId, "1.0.0"),
+            new SimpleTestPackageContext(packageId, "2.0.0-beta")
+        };
+
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packages);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = await packageUpdateIO.GetLatestVersionAsync(
+            packageId,
+            includePrerelease: true,
+            allowedSources: null,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(new NuGetVersion("2.0.0-beta"));
+    }
+
+    [Fact]
+    public async Task GetLatestVersionAsync_WithNonExistentPackage_ReturnsNull()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = await packageUpdateIO.GetLatestVersionAsync(
+            "NonExistent.Package",
+            includePrerelease: false,
+            allowedSources: null,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetLatestVersionAsync_WithAllowedSources_RespectsSourceFilter()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+        var packageId = "TestPackage.D";
+
+        var source1 = Path.Combine(testContext.SolutionRoot, "source1");
+        var source2 = Path.Combine(testContext.SolutionRoot, "source2");
+        Directory.CreateDirectory(source1);
+        Directory.CreateDirectory(source2);
+
+        var packagesSource1 = new[]
+        {
+            new SimpleTestPackageContext(packageId, "1.0.0")
+        };
+        await SimpleTestPackageUtility.CreatePackagesAsync(source1, packagesSource1);
+
+        var packagesSource2 = new[]
+        {
+            new SimpleTestPackageContext(packageId, "2.0.0")
+        };
+        await SimpleTestPackageUtility.CreatePackagesAsync(source2, packagesSource2);
+
+        var nugetConfig = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""source1"" value=""{source1}"" />
+    <add key=""source2"" value=""{source2}"" />
+  </packageSources>
+</configuration>";
+        File.WriteAllText(Path.Combine(testContext.SolutionRoot, "nuget.config"), nugetConfig);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act - only use source1
+        var result = await packageUpdateIO.GetLatestVersionAsync(
+            packageId,
+            includePrerelease: false,
+            allowedSources: new[] { "source1" },
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(new NuGetVersion("1.0.0"));
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetNonVulnerableAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetNonVulnerableAsyncTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Common;
+using NuGet.Protocol;
+using NuGet.Protocol.Model;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest.Commands.Package.Update.PackageUpdateIOTests;
+
+public class GetNonVulnerableAsyncTests
+{
+    private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
+    {
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
+        return packageUpdateIO;
+    }
+
+    [Fact]
+    public async Task GetNonVulnerableAsync_WithVulnerableMinVersion_ReturnsNextNonVulnerableVersion()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+        var packageId = "TestPackage.F";
+
+        var packages = new[]
+        {
+            new SimpleTestPackageContext(packageId, "1.0.0"),
+            new SimpleTestPackageContext(packageId, "1.1.0"),
+            new SimpleTestPackageContext(packageId, "2.0.0")
+        };
+
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packages);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        var vulnerabilities = new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
+        {
+            [packageId] = new List<PackageVulnerabilityInfo>
+            {
+                new PackageVulnerabilityInfo(
+                    url: new Uri("https://example.com/vuln"),
+                    severity: PackageVulnerabilitySeverity.High,
+                    versions: VersionRange.Parse("[1.0.0, 1.1.0]"))
+            }
+        };
+
+        var knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>
+        {
+            vulnerabilities
+        };
+
+        // Act
+        var result = await packageUpdateIO.GetNonVulnerableAsync(
+            packageId,
+            allowedSources: null,
+            new NuGetVersion("1.0.0"),
+            NullLogger.Instance,
+            knownVulnerabilities,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(new NuGetVersion("2.0.0"));
+    }
+
+    [Fact]
+    public async Task GetNonVulnerableAsync_WithAllVersionsVulnerable_ReturnsNull()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+        var packageId = "TestPackage.G";
+
+        var packages = new[]
+        {
+            new SimpleTestPackageContext(packageId, "1.0.0"),
+            new SimpleTestPackageContext(packageId, "1.1.0")
+        };
+
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packages);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        var vulnerabilities = new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
+        {
+            [packageId] = new List<PackageVulnerabilityInfo>
+            {
+                new PackageVulnerabilityInfo(
+                    url: new Uri("https://example.com/vuln"),
+                    severity: PackageVulnerabilitySeverity.High,
+                    versions: VersionRange.Parse("[1.0.0, 2.0.0]"))
+            }
+        };
+
+        var knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>
+        {
+            vulnerabilities
+        };
+
+        // Act
+        var result = await packageUpdateIO.GetNonVulnerableAsync(
+            packageId,
+            allowedSources: null,
+            new NuGetVersion("1.0.0"),
+            NullLogger.Instance,
+            knownVulnerabilities,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetPackageSourceMappingTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetPackageSourceMappingTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using FluentAssertions;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Common;
+using NuGet.Test.Utility;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest.Commands.Package.Update.PackageUpdateIOTests;
+
+public class GetPackageSourceMappingTests
+{
+    private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
+    {
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
+        return packageUpdateIO;
+    }
+
+    [Fact]
+    public void GetPackageSourceMapping_WithNoMapping_ReturnsDisabledMapping()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = packageUpdateIO.GetPackageSourceMapping();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetPackageSourceMapping_WithMapping_ReturnsConfiguredMapping()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+
+        var nugetConfig = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key=""nuget.org"">
+      <package pattern=""TestPackage.*"" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>";
+        File.WriteAllText(Path.Combine(testContext.SolutionRoot, "nuget.config"), nugetConfig);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = packageUpdateIO.GetPackageSourceMapping();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsEnabled.Should().BeTrue();
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetProjectAssetsFileAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetProjectAssetsFileAsyncTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Common;
+using NuGet.Test.Utility;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest.Commands.Package.Update.PackageUpdateIOTests;
+
+public class GetProjectAssetsFileAsyncTests
+{
+    private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
+    {
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
+        return packageUpdateIO;
+    }
+
+    [Fact]
+    public async Task GetProjectAssetsFileAsync_WithValidProject_ReturnsLockFile()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+
+        var packageA = new SimpleTestPackageContext("PackageA", "1.0.0");
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packageA);
+
+        var project = SimpleTestProjectContext.CreateNETCore(
+            "TestProject",
+            testContext.SolutionRoot,
+            "net9.0");
+
+        project.AddPackageToAllFrameworks(packageA);
+        project.Save();
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+        var dgSpec = packageUpdateIO.GetDependencyGraphSpec(project.ProjectPath);
+        dgSpec.Should().NotBeNull();
+
+        // Act
+        var lockFile = await packageUpdateIO.GetProjectAssetsFileAsync(
+            dgSpec!,
+            project.ProjectPath,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // Assert
+        lockFile.Should().NotBeNull();
+        lockFile.Libraries.Should().ContainSingle(lib => lib.Name == "PackageA" && lib.Version.ToString() == "1.0.0");
+        lockFile.PackageSpec.Should().NotBeNull();
+        lockFile.PackageSpec.Name.Should().Be("TestProject");
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/PreviewUpdatePackageReferenceAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/PreviewUpdatePackageReferenceAsyncTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Common;
+using NuGet.Test.Utility;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest.Commands.Package.Update.PackageUpdateIOTests;
+
+public class PreviewUpdatePackageReferenceAsyncTests
+{
+    private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
+    {
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
+        return packageUpdateIO;
+    }
+
+    [Fact]
+    public async Task PreviewUpdatePackageReferenceAsync_WithValidProjects_ReturnsSuccessfulResult()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+
+        var packageA = new SimpleTestPackageContext("PackageA", "1.0.0");
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packageA);
+
+        var projectA = SimpleTestProjectContext.CreateNETCore(
+            "ProjectA",
+            testContext.SolutionRoot,
+            "net9.0");
+        projectA.AddPackageToAllFrameworks(packageA);
+        projectA.GlobalPackagesFolder = testContext.UserPackagesFolder;
+        projectA.Sources = new List<NuGet.Configuration.PackageSource> { new NuGet.Configuration.PackageSource(testContext.PackageSource) };
+        projectA.FallbackFolders = new List<string> { testContext.FallbackFolder };
+        projectA.Save();
+
+        var projectB = SimpleTestProjectContext.CreateNETCore(
+            "ProjectB",
+            testContext.SolutionRoot,
+            "net9.0");
+        projectB.AddPackageToAllFrameworks(packageA);
+        projectB.GlobalPackagesFolder = testContext.UserPackagesFolder;
+        projectB.Sources = new List<NuGet.Configuration.PackageSource> { new NuGet.Configuration.PackageSource(testContext.PackageSource) };
+        projectB.FallbackFolders = new List<string> { testContext.FallbackFolder };
+        projectB.Save();
+
+        var dgSpec = new NuGet.ProjectModel.DependencyGraphSpec();
+        var projectSpecA = projectA.PackageSpec;
+        var projectSpecB = projectB.PackageSpec;
+        dgSpec.AddProject(projectSpecA);
+        dgSpec.AddProject(projectSpecB);
+        dgSpec.AddRestore(projectSpecA.RestoreMetadata.ProjectUniqueName);
+        dgSpec.AddRestore(projectSpecB.RestoreMetadata.ProjectUniqueName);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(
+            dgSpec,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+
+        var restoreResult = result.Should().BeOfType<PackageUpdateIO.RestoreResult>().Subject;
+        restoreResult.RestoreResultPairs.Should().HaveCount(2);
+        restoreResult.RestoreResultPairs.Should().Contain(pair =>
+            pair.SummaryRequest.Request.Project.Name == "ProjectA");
+        restoreResult.RestoreResultPairs.Should().Contain(pair =>
+            pair.SummaryRequest.Request.Project.Name == "ProjectB");
+    }
+
+    [Fact]
+    public async Task PreviewUpdatePackageReferenceAsync_WithMissingPackage_ReturnsFailedResult()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+
+        var packageA = new SimpleTestPackageContext("MissingPackage", "1.0.0");
+
+        var project = SimpleTestProjectContext.CreateNETCore(
+            "TestProject",
+            testContext.SolutionRoot,
+            "net9.0");
+
+        project.AddPackageToAllFrameworks(packageA);
+        project.GlobalPackagesFolder = testContext.UserPackagesFolder;
+        project.Sources = new List<NuGet.Configuration.PackageSource> { new NuGet.Configuration.PackageSource(testContext.PackageSource) };
+        project.FallbackFolders = new List<string> { testContext.FallbackFolder };
+        project.Save();
+
+        var dgSpec = new NuGet.ProjectModel.DependencyGraphSpec();
+        var projectSpec = project.PackageSpec;
+        dgSpec.AddProject(projectSpec);
+        dgSpec.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(
+            dgSpec,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Success.Should().BeFalse();
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/UpdatePackageReferenceTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/UpdatePackageReferenceTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using FluentAssertions;
+using NuGet.CommandLine.XPlat;
+using NuGet.CommandLine.XPlat.Commands.Package.Update;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+using static NuGet.CommandLine.XPlat.Commands.Package.Update.PackageUpdateCommandRunner;
+
+namespace NuGet.XPlat.FuncTest.Commands.Package.Update.PackageUpdateIOTests;
+
+// PackageUpdateIO uses MSBuildAPIUtility, so just use a few integration tests here, and assume that
+// MSBuildAPIUtility is tested extensively elsewhere.
+[Collection(XPlatCollection.Name)]
+public class UpdatePackageReferenceTests
+{
+    private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
+    {
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
+        return packageUpdateIO;
+    }
+
+    [Fact]
+    public async Task UpdatePackageReference_DgSpecWithTwoProjects_UpdatesOneProject()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+
+        var packageA_v1 = new SimpleTestPackageContext("PackageA", "1.0.0");
+        var packageA_v2 = new SimpleTestPackageContext("PackageA", "2.0.0");
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packageA_v1, packageA_v2);
+
+        var project1 = SimpleTestProjectContext.CreateNETCore(
+            "TestProject1",
+            testContext.SolutionRoot,
+            "net9.0");
+
+        project1.AddPackageToAllFrameworks(packageA_v1);
+        project1.Properties.Add("RestorePackagesPath", testContext.UserPackagesFolder);
+        project1.Sources = new List<PackageSource> { new PackageSource(testContext.PackageSource) };
+        project1.FallbackFolders = new List<string> { testContext.FallbackFolder };
+        project1.GlobalPackagesFolder = testContext.UserPackagesFolder;
+        project1.Save();
+
+        var project2 = SimpleTestProjectContext.CreateNETCore(
+            "TestProject2",
+            testContext.SolutionRoot,
+            "net9.0");
+
+        project2.AddPackageToAllFrameworks(packageA_v1);
+        project2.Properties.Add("RestorePackagesPath", testContext.UserPackagesFolder);
+        project2.Sources = new List<PackageSource> { new PackageSource(testContext.PackageSource) };
+        project2.FallbackFolders = new List<string> { testContext.FallbackFolder };
+        project2.GlobalPackagesFolder = testContext.UserPackagesFolder;
+        project2.Save();
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        var updatedDgSpec = new ProjectModel.DependencyGraphSpec();
+        var originalProjectSpec1 = project1.PackageSpec;
+        var projectSpec1 = originalProjectSpec1.Clone();
+        projectSpec1.RestoreMetadata.Sources = new List<PackageSource> { new PackageSource(testContext.PackageSource) };
+        projectSpec1.RestoreMetadata.FallbackFolders = new List<string> { testContext.FallbackFolder };
+        projectSpec1.RestoreMetadata.PackagesPath = testContext.UserPackagesFolder;
+        var framework1 = projectSpec1.TargetFrameworks.First();
+        framework1.Dependencies.Clear();
+        framework1.Dependencies.Add(new LibraryModel.LibraryDependency
+        {
+            LibraryRange = new LibraryModel.LibraryRange(
+                "PackageA",
+                VersionRange.Parse("2.0.0"),
+                NuGet.LibraryModel.LibraryDependencyTarget.Package)
+        });
+        updatedDgSpec.AddProject(projectSpec1);
+        updatedDgSpec.AddRestore(projectSpec1.RestoreMetadata.ProjectUniqueName);
+
+        var originalProjectSpec2 = project2.PackageSpec;
+        var projectSpec2 = originalProjectSpec2.Clone();
+        projectSpec2.RestoreMetadata.Sources = new List<PackageSource> { new PackageSource(testContext.PackageSource) };
+        projectSpec2.RestoreMetadata.FallbackFolders = new List<string> { testContext.FallbackFolder };
+        projectSpec2.RestoreMetadata.PackagesPath = testContext.UserPackagesFolder;
+        updatedDgSpec.AddProject(projectSpec2);
+        updatedDgSpec.AddRestore(projectSpec2.RestoreMetadata.ProjectUniqueName);
+
+        var previewResult = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(
+            updatedDgSpec,
+            NullLogger.Instance,
+            CancellationToken.None);
+        previewResult.Success.Should().BeTrue();
+
+        var packageToUpdate = new PackageToUpdate
+        {
+            Id = "PackageA",
+            CurrentVersion = VersionRange.Parse("1.0.0"),
+            NewVersion = VersionRange.Parse("2.0.0")
+        };
+
+        var tfmAliases = projectSpec1.TargetFrameworks.Select(tf => tf.TargetAlias).ToList();
+
+        // Act
+        packageUpdateIO.UpdatePackageReference(
+            projectSpec1,
+            previewResult,
+            tfmAliases,
+            packageToUpdate,
+            NullLogger.Instance);
+
+        // Assert
+        var project1Xml = XDocument.Load(project1.ProjectPath);
+        var ns = project1Xml.Root!.GetDefaultNamespace();
+        var project1PackageReferences = project1Xml.Descendants(ns + "PackageReference")
+            .Where(e => e.Attribute("Include")?.Value == "PackageA")
+            .ToList();
+
+        project1PackageReferences.Should().ContainSingle();
+        var project1PackageRef = project1PackageReferences.First();
+        project1PackageRef.Attribute("Version")?.Value.Should().Be("2.0.0");
+
+        var project2Xml = XDocument.Load(project2.ProjectPath);
+        var project2PackageReferences = project2Xml.Descendants(ns + "PackageReference")
+            .Where(e => e.Attribute("Include")?.Value == "PackageA")
+            .ToList();
+
+        project2PackageReferences.Should().ContainSingle();
+        var project2PackageRef = project2PackageReferences.First();
+        project2PackageRef.Attribute("Version")?.Value.Should().Be("1.0.0");
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -32,7 +32,7 @@ using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
-    [Collection("NuGet XPlat Test Collection")]
+    [Collection(XPlatCollection.Name)]
     public class ListPackageTests
     {
         private readonly ITestOutputHelper _testOutputHelper;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -24,7 +24,7 @@ using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
-    [Collection("NuGet XPlat Test Collection")]
+    [Collection(XPlatCollection.Name)]
     public class XPlatAddPkgTests
     {
         private static readonly string ProjectName = "test_project_addpkg";

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatClientCertTests.cs
@@ -18,7 +18,7 @@ using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
-    [Collection("NuGet XPlat Test Collection")]
+    [Collection(XPlatCollection.Name)]
     public class XPlatClientCertTests
     {
         private readonly ITestOutputHelper _testOutputHelper;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatCollection.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatCollection.cs
@@ -5,11 +5,13 @@ using Xunit;
 
 namespace NuGet.XPlat.FuncTest
 {
-    [CollectionDefinition("NuGet XPlat Test Collection")]
+    [CollectionDefinition(Name)]
     public class XPlatCollection : ICollectionFixture<XPlatMsbuildTestFixture>
     {
         // This class has no code, and is never created. Its purpose is simply
         // to be the place to apply [CollectionDefinition] and all the
         // ICollectionFixture<> interfaces.
+
+        public const string Name = "NuGet XPlat Test Collection";
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatVerifyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatVerifyTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
-    [Collection("NuGet XPlat Test Collection")]
+    [Collection(XPlatCollection.Name)]
     public class XPlatVerifyTests
     {
         private readonly ITestOutputHelper _testOutputHelper;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
-    [Collection("NuGet XPlat Test Collection")]
+    [Collection(XPlatCollection.Name)]
     public class XPlatWhyTests
     {
         private static readonly string ProjectName = "Test.Project.DotnetNugetWhy";

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPackageJsonRendererTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPackageJsonRendererTests.cs
@@ -21,7 +21,7 @@ using Xunit;
 
 namespace NuGet.XPlat.FuncTest
 {
-    [Collection("NuGet XPlat Test Collection")]
+    [Collection(XPlatCollection.Name)]
     public class XplatListPackageJsonRendererTests
     {
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
@@ -16,7 +16,7 @@ using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
-    [Collection("NuGet XPlat Test Collection")]
+    [Collection(XPlatCollection.Name)]
     public class XPlatRemovePkgTests
     {
         private static readonly string ProjectName = "test_project_removepkg";

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
@@ -19,7 +19,7 @@ using Xunit.Abstractions;
 
 namespace NuGet.XPlat.FuncTest
 {
-    [Collection("NuGet XPlat Test Collection")]
+    [Collection(XPlatCollection.Name)]
     public class XplatSignTests
     {
         private const string _invalidArgException = "Invalid value provided for '{0}'. The accepted values are {1}.";

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
@@ -57,7 +57,7 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var packagesToUpdate = await PackageUpdateCommandRunner.SelectPackagesToUpdateAsync(
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectSpecificPackagesToUpdateAsync(
             [package],
             packageSpec,
             logger.Object,
@@ -66,6 +66,7 @@ public class GetPackageToUpdateTests
 
         // Assert
         packagesToUpdate.Should().HaveCount(1);
+        scannedPackages.Should().ContainSingle().Which.Should().Be("Contoso.Utils");
         var packageToUpdate = packagesToUpdate.First().Package;
         packageToUpdate.Should().NotBeNull();
         packageToUpdate.Id.Should().Be("Contoso.Utils");
@@ -101,7 +102,7 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var packagesToUpdate = await PackageUpdateCommandRunner.SelectPackagesToUpdateAsync(
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectSpecificPackagesToUpdateAsync(
             [package],
             packageSpec,
             logger.Object,
@@ -110,6 +111,7 @@ public class GetPackageToUpdateTests
 
         // Assert
         packagesToUpdate.Should().HaveCount(1);
+        scannedPackages.Should().ContainSingle().Which.Should().Be("Contoso.Utils");
         var packageToUpdate = packagesToUpdate.First().Package;
         packageToUpdate.Should().NotBeNull();
         packageToUpdate.Id.Should().Be("Contoso.Utils");
@@ -141,7 +143,7 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var packagesToUpdate = await PackageUpdateCommandRunner.SelectPackagesToUpdateAsync(
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectSpecificPackagesToUpdateAsync(
             [package],
             packageSpec,
             logger.Object,
@@ -150,6 +152,7 @@ public class GetPackageToUpdateTests
 
         // Assert
         packagesToUpdate.Should().HaveCount(1);
+        scannedPackages.Should().ContainSingle().Which.Should().Be("Contoso.Utils");
         var packageToUpdate = packagesToUpdate.First().Package;
         packageToUpdate.Should().NotBeNull();
         packageToUpdate.Id.Should().Be("Contoso.Utils");
@@ -184,7 +187,7 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var packagesToUpdate = await PackageUpdateCommandRunner.SelectPackagesToUpdateAsync(
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectSpecificPackagesToUpdateAsync(
             [package],
             packageSpec,
             logger.Object,
@@ -193,6 +196,7 @@ public class GetPackageToUpdateTests
 
         // Assert
         packagesToUpdate.Should().BeEmpty();
+        scannedPackages.Should().ContainSingle().Which.Should().Be("Contoso.Utils");
         logger.Invocations.Count.Should().BeGreaterThan(0);
     }
 
@@ -229,7 +233,7 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var packagesToUpdate = await PackageUpdateCommandRunner.SelectPackagesToUpdateAsync(
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectSpecificPackagesToUpdateAsync(
             [package1, package2],
             packageSpec,
             logger.Object,
@@ -238,6 +242,7 @@ public class GetPackageToUpdateTests
 
         // Assert
         packagesToUpdate.Should().HaveCount(2);
+        scannedPackages.Should().HaveCount(2);
 
         var contosoUpdate = packagesToUpdate.First(p => p.Package.Id == "Contoso.Utils");
         contosoUpdate.Package.CurrentVersion.ToString().Should().Be("[1.0.0, )");
@@ -273,7 +278,7 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var packagesToUpdate = await PackageUpdateCommandRunner.SelectPackagesToUpdateAsync(
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectSpecificPackagesToUpdateAsync(
             [package],
             packageSpec,
             logger.Object,
@@ -282,6 +287,7 @@ public class GetPackageToUpdateTests
 
         // Assert
         packagesToUpdate.Should().BeEmpty();
+        scannedPackages.Should().BeEmpty();
     }
 
     [Fact]
@@ -308,21 +314,21 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var result = await PackageUpdateCommandRunner.SelectAllPackagesWithUpdatesAsync(
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectAllPackagesWithUpdatesAsync(
             packageSpec,
             logger.Object,
             packageUpdateIO.Object,
             CancellationToken.None);
 
         // Assert
-        result.packagesInProject.Should().Be(2);
-        result.packagesToUpdate.Should().HaveCount(2);
+        scannedPackages.Should().HaveCount(2);
+        packagesToUpdate.Should().HaveCount(2);
 
-        var package1Update = result.packagesToUpdate.First(p => p.Package.Id == "Test.Package1");
+        var package1Update = packagesToUpdate.First(p => p.Package.Id == "Test.Package1");
         package1Update.Package.CurrentVersion.ToString().Should().Be("[1.0.0, )");
         package1Update.Package.NewVersion.ToString().Should().Be("[1.2.3, )");
 
-        var package2Update = result.packagesToUpdate.First(p => p.Package.Id == "Test.Package2");
+        var package2Update = packagesToUpdate.First(p => p.Package.Id == "Test.Package2");
         package2Update.Package.CurrentVersion.ToString().Should().Be("[2.0.0, )");
         package2Update.Package.NewVersion.ToString().Should().Be("[2.1.0, )");
 
@@ -353,17 +359,17 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var result = await PackageUpdateCommandRunner.SelectAllPackagesWithUpdatesAsync(
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectAllPackagesWithUpdatesAsync(
             packageSpec,
             logger.Object,
             packageUpdateIO.Object,
             CancellationToken.None);
 
         // Assert
-        result.packagesInProject.Should().Be(2);
-        result.packagesToUpdate.Should().HaveCount(1);
+        scannedPackages.Should().HaveCount(2);
+        packagesToUpdate.Should().HaveCount(1);
 
-        var packageUpdate = result.packagesToUpdate.First();
+        var packageUpdate = packagesToUpdate.First();
         packageUpdate.Package.Id.Should().Be("Test.Package1");
         packageUpdate.Package.CurrentVersion.ToString().Should().Be("[1.0.0, )");
         packageUpdate.Package.NewVersion.ToString().Should().Be("[1.2.3, )");
@@ -395,15 +401,15 @@ public class GetPackageToUpdateTests
         var logger = new Mock<ILoggerWithColor>();
 
         // Act
-        var result = await PackageUpdateCommandRunner.SelectAllPackagesWithUpdatesAsync(
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectAllPackagesWithUpdatesAsync(
             packageSpec,
             logger.Object,
             packageUpdateIO.Object,
             CancellationToken.None);
 
         // Assert
-        result.packagesInProject.Should().Be(2);
-        result.packagesToUpdate.Should().BeEmpty();
+        scannedPackages.Should().HaveCount(2);
+        packagesToUpdate.Should().BeEmpty();
         logger.Invocations.Count.Should().Be(0);
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
@@ -195,7 +195,7 @@ public class GetPackageToUpdateTests
             CancellationToken.None);
 
         // Assert
-        packagesToUpdate.Should().BeEmpty();
+        packagesToUpdate.Should().BeNull();
         scannedPackages.Should().ContainSingle().Which.Should().Be("Contoso.Utils");
         logger.Invocations.Count.Should().BeGreaterThan(0);
     }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/MultiProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/MultiProjectTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -12,7 +13,10 @@ using NuGet.Configuration;
 using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Package.Update;
 using NuGet.Common;
+using NuGet.Frameworks;
 using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Model;
 using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
@@ -20,6 +24,7 @@ using Xunit;
 namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update.PackageUpdateCommandRunnerTests;
 
 using Pkg = XPlat.Commands.Package.PackageWithVersionRange;
+using Strings = NuGet.CommandLine.XPlat.Strings;
 
 public class MultiProjectTests
 {
@@ -91,12 +96,371 @@ public class MultiProjectTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task UpgradeAllPackages_TwoProjectsWithSamePackage_UpdatesBothProjects()
+    {
+        // Arrange
+        var solutionDirectory = RuntimeEnvironmentHelper.IsWindows
+            ? @"S:\path\to\repo\src"
+            : @"/path/to/repo/src";
+        var project1Path = Path.Combine(solutionDirectory, "ConsoleApp1", "ConsoleApp1.csproj");
+        var project1 = new TestPackageSpecFactory(project1Path, builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Test.Package", [new("Version", "1.0.0")]);
+        }).Build();
+
+        var project2Path = Path.Combine(solutionDirectory, "ClassLib1", "ClassLib1.csproj");
+        var project2 = new TestPackageSpecFactory(project2Path, builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Test.Package", [new("Version", "1.0.0")]);
+        }).Build();
+
+        DependencyGraphSpec dgSpec = new DependencyGraphSpec();
+        dgSpec.AddProject(project1);
+        dgSpec.AddProject(project2);
+        dgSpec.AddRestore(project1Path);
+        dgSpec.AddRestore(project2Path);
+
+        // no packages defined means update all packages
+        var packagesToUpdate = new List<Pkg>();
+
+        var latestPackageVersions = new Dictionary<string, string>
+        {
+            { "Test.Package", "2.0.0" }
+        };
+
+        TestData testData = InitTest(project1Path, packagesToUpdate, dgSpec, latestPackageVersions: latestPackageVersions);
+
+        // Act
+        int exitCode = await RunCommand(testData, CancellationToken.None);
+
+        // Assert
+        exitCode.Should().Be(0);
+
+        // Both projects should be updated
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.Is<PackageSpec>(p => p.FilePath == project1Path),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package" && p.NewVersion.ToString() == "[2.0.0, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.Is<PackageSpec>(p => p.FilePath == project2Path),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package" && p.NewVersion.ToString() == "[2.0.0, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+
+        // preview restore must have both projects
+        testData.IoMock.Verify(x => x.PreviewUpdatePackageReferenceAsync(
+            It.Is<DependencyGraphSpec>(d => d.Projects.Count == 2 && d.Restore.Count == 2),
+            It.IsAny<ILogger>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        int packagesScanned = dgSpec.Projects
+            .SelectMany(p => p.TargetFrameworks)
+            .SelectMany(tf => tf.Dependencies)
+            .Select(d => d.Name)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+        int packagesUpdated = latestPackageVersions.Count;
+        testData.LoggerMock.Verify(x => x.LogMinimal(
+            It.Is<string>(s => s.Contains(string.Format(Strings.PackageUpdate_FinalSummary, packagesUpdated, packagesScanned))),
+            It.IsAny<ConsoleColor>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpgradePackageA_TwoProjectsWithPackageAOneWithout_UpdatesOnlyPackageA()
+    {
+        // Arrange
+        var solutionDirectory = RuntimeEnvironmentHelper.IsWindows
+            ? @"S:\path\to\repo\src"
+            : @"/path/to/repo/src";
+        var project1Path = Path.Combine(solutionDirectory, "ConsoleApp1", "ConsoleApp1.csproj");
+        var project1 = new TestPackageSpecFactory(project1Path, builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "PackageA", [new("Version", "1.0.0")]);
+        }).Build();
+
+        var project2Path = Path.Combine(solutionDirectory, "ClassLib1", "ClassLib1.csproj");
+        var project2 = new TestPackageSpecFactory(project2Path, builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "PackageA", [new("Version", "1.0.0")]);
+        }).Build();
+
+        var project3Path = Path.Combine(solutionDirectory, "ClassLib2", "ClassLib2.csproj");
+        var project3 = new TestPackageSpecFactory(project3Path, builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "PackageB", [new("Version", "2.0.0")]);
+        }).Build();
+
+        DependencyGraphSpec dgSpec = new DependencyGraphSpec();
+        dgSpec.AddProject(project1);
+        dgSpec.AddProject(project2);
+        dgSpec.AddProject(project3);
+        dgSpec.AddRestore(project1Path);
+        dgSpec.AddRestore(project2Path);
+        dgSpec.AddRestore(project3Path);
+
+        var packagesToUpdate = new List<Pkg>
+        {
+            new Pkg { Id = "PackageA", VersionRange = new VersionRange(new NuGetVersion("3.0.0")) }
+        };
+
+        TestData testData = InitTest(project1Path, packagesToUpdate, dgSpec);
+
+        // Act
+        int exitCode = await RunCommand(testData, CancellationToken.None);
+
+        // Assert
+        exitCode.Should().Be(0);
+
+        // Projects 1 and 2 should be updated with PackageA
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.Is<PackageSpec>(p => p.FilePath == project1Path),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "PackageA" && p.NewVersion.ToString() == "[3.0.0, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.Is<PackageSpec>(p => p.FilePath == project2Path),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "PackageA" && p.NewVersion.ToString() == "[3.0.0, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+
+        // Project 3 should not be updated (it doesn't have PackageA)
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.Is<PackageSpec>(p => p.FilePath == project3Path),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
+            It.IsAny<ILogger>()),
+            Times.Never);
+
+        // preview restore must have all three projects
+        testData.IoMock.Verify(x => x.PreviewUpdatePackageReferenceAsync(
+            It.Is<DependencyGraphSpec>(d => d.Projects.Count == 3 && d.Restore.Count == 3),
+            It.IsAny<ILogger>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        int packagesScanned = testData.CommandArgs.Packages.Count;
+        testData.LoggerMock.Verify(x => x.LogMinimal(
+            It.Is<string>(s => s.Contains(string.Format(Strings.PackageUpdate_FinalSummary, 1, packagesScanned))),
+            It.IsAny<ConsoleColor>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpgradeVulnerable_TwoProjects_OneVulnerableOneNot_UpdatesOnlyVulnerablePackageToLowestSafeVersion()
+    {
+        // Arrange
+        var solutionDirectory = RuntimeEnvironmentHelper.IsWindows
+            ? @"S:\path\to\repo\src"
+            : @"/path/to/repo/src";
+        var project1Path = Path.Combine(solutionDirectory, "ConsoleApp1", "ConsoleApp1.csproj");
+        var project1 = new TestPackageSpecFactory(project1Path, builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "VulnerablePackage", [new("Version", "1.0.0")]);
+        }).Build();
+
+        var project2Path = Path.Combine(solutionDirectory, "ClassLib1", "ClassLib1.csproj");
+        var project2 = new TestPackageSpecFactory(project2Path, builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "SafePackage", [new("Version", "1.0.0")]);
+        }).Build();
+
+        DependencyGraphSpec dgSpec = new DependencyGraphSpec();
+        dgSpec.AddProject(project1);
+        dgSpec.AddProject(project2);
+        dgSpec.AddRestore(project1Path);
+        dgSpec.AddRestore(project2Path);
+
+        var packagesToUpdate = new List<Pkg>();
+
+        TestData testData = InitTest(project1Path, packagesToUpdate, dgSpec);
+        testData = testData with
+        {
+            CommandArgs = testData.CommandArgs with { Vulnerable = true }
+        };
+
+        var knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>
+        {
+            new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>(StringComparer.OrdinalIgnoreCase)
+            {
+                {
+                    "VulnerablePackage",
+                    new List<PackageVulnerabilityInfo>
+                    {
+                        new PackageVulnerabilityInfo(
+                            new Uri("https://cve.test/vulnerability1"),
+                            PackageVulnerabilitySeverity.High,
+                            VersionRange.Parse("[1.0.0, 2.0.0)"))
+                    }
+                }
+            }
+        };
+
+        testData.IoMock.Setup(x => x.GetKnownVulnerabilitiesAsync(
+            It.IsAny<ILogger>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(knownVulnerabilities);
+
+        testData.IoMock.Setup(x => x.GetNonVulnerableAsync(
+            "VulnerablePackage",
+            It.IsAny<IReadOnlyList<string>>(),
+            new NuGetVersion("1.0.0"),
+            It.IsAny<ILogger>(),
+            knownVulnerabilities,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("2.0.0"));
+
+        var lockFile = new LockFile
+        {
+            Version = 3,
+            PackageSpec = project1,
+            LogMessages = new List<IAssetsLogMessage>
+            {
+                new AssetsLogMessage(LogLevel.Warning, NuGetLogCode.NU1902, "Package 'VulnerablePackage' 1.0.0 has a known moderate severity vulnerability")
+                {
+                    LibraryId = "VulnerablePackage"
+                }
+            },
+            Libraries = new List<LockFileLibrary>
+            {
+                new LockFileLibrary
+                {
+                    Name = "VulnerablePackage",
+                    Version = new NuGetVersion("1.0.0"),
+                    Type = "package"
+                }
+            },
+            Targets = new List<LockFileTarget>
+            {
+                new LockFileTarget
+                {
+                    TargetFramework = NuGetFramework.Parse("net9.0"),
+                    Libraries = new List<LockFileTargetLibrary>
+                    {
+                        new LockFileTargetLibrary
+                        {
+                            Name = "VulnerablePackage",
+                            Version = new NuGetVersion("1.0.0"),
+                            Type = "package"
+                        }
+                    }
+                }
+            }
+        };
+
+        var project2LockFile = new LockFile
+        {
+            Version = 3,
+            PackageSpec = project2,
+            LogMessages = new List<IAssetsLogMessage>(),
+            Libraries = new List<LockFileLibrary>
+            {
+                new LockFileLibrary
+                {
+                    Name = "SafePackage",
+                    Version = new NuGetVersion("1.0.0"),
+                    Type = "package"
+                }
+            },
+            Targets = new List<LockFileTarget>
+            {
+                new LockFileTarget
+                {
+                    TargetFramework = NuGetFramework.Parse("net9.0"),
+                    Libraries = new List<LockFileTargetLibrary>
+                    {
+                        new LockFileTargetLibrary
+                        {
+                            Name = "SafePackage",
+                            Version = new NuGetVersion("1.0.0"),
+                            Type = "package"
+                        }
+                    }
+                }
+            }
+        };
+
+        testData.IoMock.Setup(x => x.GetProjectAssetsFileAsync(
+            It.IsAny<DependencyGraphSpec>(),
+            project1Path,
+            It.IsAny<ILogger>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(lockFile);
+
+        testData.IoMock.Setup(x => x.GetProjectAssetsFileAsync(
+            It.IsAny<DependencyGraphSpec>(),
+            project2Path,
+            It.IsAny<ILogger>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(project2LockFile);
+
+        // Act
+        int exitCode = await RunCommand(testData, CancellationToken.None);
+
+        // Assert
+        exitCode.Should().Be(0);
+
+        // Only project1 should be updated with VulnerablePackage to the safe version 2.0.0
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.Is<PackageSpec>(p => p.FilePath == project1Path),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "VulnerablePackage" && p.NewVersion.ToString() == "[2.0.0, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+
+        // Project2 should not be updated (SafePackage is not vulnerable)
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.Is<PackageSpec>(p => p.FilePath == project2Path),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
+            It.IsAny<ILogger>()),
+            Times.Never);
+
+        // Verify GetNonVulnerableAsync was called to find the lowest safe version
+        testData.IoMock.Verify(x => x.GetNonVulnerableAsync(
+            "VulnerablePackage",
+            It.IsAny<IReadOnlyList<string>>(),
+            new NuGetVersion("1.0.0"),
+            It.IsAny<ILogger>(),
+            knownVulnerabilities,
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var summaryMessage = string.Format(Strings.PackageUpdate_FinalSummary, 1, 2);
+        testData.LoggerMock.Verify(x => x.LogMinimal(
+            It.Is<string>(s => s.Contains(summaryMessage)),
+            It.IsAny<ConsoleColor>()),
+            Times.Once);
+    }
+
     private TestData InitTest(
         string updateTarget,
         IReadOnlyList<Pkg> packagesToUpdate,
         DependencyGraphSpec dgSpec,
         bool restoreSuccessful = true,
-        bool disablePackageSourceMapping = true)
+        bool disablePackageSourceMapping = true,
+        Dictionary<string, string>? latestPackageVersions = null)
     {
         var commandArgs = new PackageUpdateArgs
         {
@@ -141,6 +505,25 @@ public class MultiProjectTests
             var noMappings = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
             var packageSourceMapping = new PackageSourceMapping(noMappings);
             ioMock.Setup(x => x.GetPackageSourceMapping()).Returns(packageSourceMapping);
+        }
+
+        if (latestPackageVersions is not null)
+        {
+            ioMock.Setup(x => x.GetLatestVersionAsync(
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<ILogger>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string id, bool prerelease, IReadOnlyList<string> sources, ILogger logger, CancellationToken ct) =>
+                {
+                    if (latestPackageVersions.TryGetValue(id, out var versionString))
+                    {
+                        var version = NuGetVersion.Parse(versionString);
+                        return version;
+                    }
+                    return null;
+                });
         }
 
         var testData = new TestData

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -383,11 +383,22 @@ public class SingleProjectTests
         // Arrange
         var packageSpec = new TestPackageSpecFactory(builder =>
         {
-            builder.WithProperty("TargetFramework", "net9.0")
+            builder.WithProperty("TargetFrameworks", "net9.0;net8.0")
                    .WithProperty("NuGetAudit", "true")
-                   .WithProperty("NuGetAuditMode", auditMode)
-                   .WithItem("PackageReference", "Test.Package", [new("Version", "1.0.0")]);
-        }).Build();
+                   .WithProperty("NuGetAuditMode", auditMode);
+        })
+            .WithInnerBuild(builder =>
+            {
+                builder.WithProperty("TargetFramework", "net9.0")
+                       .WithProperty("RuntimeIdentifiers", "winx64;linux-x64")
+                       .WithItem("PackageReference", "Test.Package", [new("Version", "1.0.0")]);
+            })
+            .WithInnerBuild(builder =>
+            {
+                builder.WithProperty("TargetFramework", "net8.0")
+                       .WithProperty("RuntimeIdentifiers", "winx64;linux-x64")
+                       .WithItem("PackageReference", "Second.Package", [new("Version", "1.0.0")]);
+            }).Build();
 
         var packagesToUpdate = new List<Pkg>();
 
@@ -404,10 +415,17 @@ public class SingleProjectTests
             PackageSpec = packageSpec
         };
 
-        // Add a library to the lock file
+        // Add libraries to the lock file
         lockFile.Libraries.Add(new LockFileLibrary
         {
             Name = "Test.Package",
+            Version = new NuGetVersion("1.0.0"),
+            Type = "package"
+        });
+
+        lockFile.Libraries.Add(new LockFileLibrary
+        {
+            Name = "Second.Package",
             Version = new NuGetVersion("1.0.0"),
             Type = "package"
         });
@@ -420,32 +438,59 @@ public class SingleProjectTests
             Type = "package"
         });
 
-        // Add target with the vulnerable package
-        var target = new LockFileTarget
+        // Add target for net9.0 with Test.Package
+        var targetNet9 = new LockFileTarget
         {
             TargetFramework = packageSpec.TargetFrameworks[0].FrameworkName
         };
-        target.Libraries.Add(new LockFileTargetLibrary
+        targetNet9.Libraries.Add(new LockFileTargetLibrary
         {
             Name = "Test.Package",
             Version = new NuGetVersion("1.0.0"),
             Type = "package"
         });
-        target.Libraries.Add(new LockFileTargetLibrary
+        targetNet9.Libraries.Add(new LockFileTargetLibrary
         {
             Name = "Transitive.Package",
             Version = new NuGetVersion("1.0.0"),
             Type = "package"
         });
-        lockFile.Targets.Add(target);
+        lockFile.Targets.Add(targetNet9);
 
-        // Add vulnerability log message
+        // Add target for net8.0 with Second.Package
+        var targetNet8 = new LockFileTarget
+        {
+            TargetFramework = packageSpec.TargetFrameworks[1].FrameworkName
+        };
+        targetNet8.Libraries.Add(new LockFileTargetLibrary
+        {
+            Name = "Second.Package",
+            Version = new NuGetVersion("1.0.0"),
+            Type = "package"
+        });
+        targetNet8.Libraries.Add(new LockFileTargetLibrary
+        {
+            Name = "Transitive.Package",
+            Version = new NuGetVersion("1.0.0"),
+            Type = "package"
+        });
+        lockFile.Targets.Add(targetNet8);
+
+        // Add vulnerability log messages
         lockFile.LogMessages.Add(new AssetsLogMessage(
             LogLevel.Warning,
             NuGetLogCode.NU1903,
             "Test.Package has a known high severity vulnerability")
         {
             LibraryId = "Test.Package"
+        });
+
+        lockFile.LogMessages.Add(new AssetsLogMessage(
+            LogLevel.Warning,
+            NuGetLogCode.NU1903,
+            "Second.Package has a known high severity vulnerability")
+        {
+            LibraryId = "Second.Package"
         });
 
         if (auditMode.Equals("all", StringComparison.OrdinalIgnoreCase))
@@ -477,6 +522,7 @@ public class SingleProjectTests
             new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>(StringComparer.OrdinalIgnoreCase)
             {
                 { "Test.Package", new List<PackageVulnerabilityInfo> { vulnerabilityInfo } },
+                { "Second.Package", new List<PackageVulnerabilityInfo> { vulnerabilityInfo } },
                 { "Transitive.Package", new List<PackageVulnerabilityInfo> { vulnerabilityInfo } }
             }
         };
@@ -494,6 +540,14 @@ public class SingleProjectTests
             It.IsAny<IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>>(),
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(new NuGetVersion("1.2.3"));
+        testData.IoMock.Setup(x => x.GetNonVulnerableAsync(
+            "Second.Package",
+            It.IsAny<IReadOnlyList<string>>(),
+            new NuGetVersion("1.0.0"),
+            It.IsAny<ILogger>(),
+            It.IsAny<IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("2.1.0"));
         testData.IoMock.Setup(x => x.GetNonVulnerableAsync(
             "Transitive.Package",
             It.IsAny<IReadOnlyList<string>>(),
@@ -523,6 +577,15 @@ public class SingleProjectTests
             It.IsAny<CancellationToken>()),
             Times.Once);
 
+        testData.IoMock.Verify(x => x.GetNonVulnerableAsync(
+            "Second.Package",
+            It.IsAny<IReadOnlyList<string>>(),
+            new NuGetVersion("1.0.0"),
+            It.IsAny<ILogger>(),
+            It.IsAny<IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+
         if (auditMode.Equals("all", StringComparison.OrdinalIgnoreCase))
         {
             testData.IoMock.Verify(x => x.GetNonVulnerableAsync(
@@ -543,6 +606,14 @@ public class SingleProjectTests
             It.IsAny<ILogger>()),
             Times.Once);
 
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.IsAny<PackageSpec>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Second.Package" && p.NewVersion.ToString() == "[2.1.0, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+
         if (auditMode.Equals("all", StringComparison.OrdinalIgnoreCase))
         {
             testData.IoMock.Verify(x => x.UpdatePackageReference(
@@ -556,8 +627,8 @@ public class SingleProjectTests
 
         int packageCount =
             auditMode.Equals("all", StringComparison.OrdinalIgnoreCase)
-            ? 2
-            : 1;
+            ? 3
+            : 2;
         testData.LoggerMock.Verify(x => x.LogMinimal(
             It.Is<string>(s => s.Contains(string.Format(Strings.PackageUpdate_FinalSummary, packageCount, packageCount))),
             It.IsAny<ConsoleColor>()),

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -197,7 +197,7 @@ public class SingleProjectTests
     }
 
     [Fact]
-    public async Task PackageNotReferenced_ReturnsErrorExitCode()
+    public async Task PackageNotReferenced_ReturnsNothingToUpdateExitCode()
     {
         // Arrange
         var packageSpec = new TestPackageSpecFactory(builder =>
@@ -215,7 +215,7 @@ public class SingleProjectTests
         int exitCode = await RunCommand(testData, CancellationToken.None);
 
         // Assert
-        exitCode.Should().Be(3);
+        exitCode.Should().Be(PackageUpdateCommandRunner.ExitCodes.NoPackagesNeedUpdating);
 
         testData.IoMock.Verify(x => x.PreviewUpdatePackageReferenceAsync(
             It.IsAny<DependencyGraphSpec>(),

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -12,6 +12,8 @@ using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Package.Update;
 using NuGet.Common;
 using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Model;
 using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
@@ -19,6 +21,7 @@ using Xunit;
 namespace NuGet.CommandLine.Xplat.Tests.Commands.Package.Update.PackageUpdateCommandRunnerTests;
 
 using Pkg = XPlat.Commands.Package.PackageWithVersionRange;
+using Strings = NuGet.CommandLine.XPlat.Strings;
 
 public class SingleProjectTests
 {
@@ -370,6 +373,195 @@ public class SingleProjectTests
             It.IsAny<PackageUpdateCommandRunner.PackageToUpdate>(),
             It.IsAny<ILogger>()),
             Times.Never);
+    }
+
+    [Theory]
+    [InlineData("all")]
+    [InlineData("direct")]
+    public async Task VulnerablePackage_UpdatesToNonVulnerableVersion(string auditMode)
+    {
+        // Arrange
+        var packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithProperty("NuGetAudit", "true")
+                   .WithProperty("NuGetAuditMode", auditMode)
+                   .WithItem("PackageReference", "Test.Package", [new("Version", "1.0.0")]);
+        }).Build();
+
+        var packagesToUpdate = new List<Pkg>();
+
+        TestData testData = InitTest(packagesToUpdate, packageSpec);
+        testData = testData with
+        {
+            CommandArgs = testData.CommandArgs with { Vulnerable = true }
+        };
+
+        // Mock the GetProjectAssetsFileAsync to return a LockFile with vulnerability log messages
+        var lockFile = new LockFile
+        {
+            Version = 3,
+            PackageSpec = packageSpec
+        };
+
+        // Add a library to the lock file
+        lockFile.Libraries.Add(new LockFileLibrary
+        {
+            Name = "Test.Package",
+            Version = new NuGetVersion("1.0.0"),
+            Type = "package"
+        });
+
+        // Add a transitive package
+        lockFile.Libraries.Add(new LockFileLibrary
+        {
+            Name = "Transitive.Package",
+            Version = new NuGetVersion("1.0.0"),
+            Type = "package"
+        });
+
+        // Add target with the vulnerable package
+        var target = new LockFileTarget
+        {
+            TargetFramework = packageSpec.TargetFrameworks[0].FrameworkName
+        };
+        target.Libraries.Add(new LockFileTargetLibrary
+        {
+            Name = "Test.Package",
+            Version = new NuGetVersion("1.0.0"),
+            Type = "package"
+        });
+        target.Libraries.Add(new LockFileTargetLibrary
+        {
+            Name = "Transitive.Package",
+            Version = new NuGetVersion("1.0.0"),
+            Type = "package"
+        });
+        lockFile.Targets.Add(target);
+
+        // Add vulnerability log message
+        lockFile.LogMessages.Add(new AssetsLogMessage(
+            LogLevel.Warning,
+            NuGetLogCode.NU1903,
+            "Test.Package has a known high severity vulnerability")
+        {
+            LibraryId = "Test.Package"
+        });
+
+        if (auditMode.Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            lockFile.LogMessages.Add(new AssetsLogMessage(
+                LogLevel.Warning,
+                NuGetLogCode.NU1903,
+                "Transitive.Package has a known high severity vulnerability")
+            {
+                LibraryId = "Transitive.Package"
+            });
+        }
+
+        testData.IoMock.Setup(x => x.GetProjectAssetsFileAsync(
+            It.IsAny<DependencyGraphSpec>(),
+            It.IsAny<string>(),
+            It.IsAny<ILogger>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(lockFile);
+
+        // Mock GetKnownVulnerabilitiesAsync to return vulnerability data
+        var vulnerabilityInfo = new PackageVulnerabilityInfo(
+            new Uri("https://example.com/advisory"),
+            PackageVulnerabilitySeverity.High,
+            VersionRange.Parse("[1.0.0]"));
+
+        var knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>
+        {
+            new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "Test.Package", new List<PackageVulnerabilityInfo> { vulnerabilityInfo } },
+                { "Transitive.Package", new List<PackageVulnerabilityInfo> { vulnerabilityInfo } }
+            }
+        };
+
+        testData.IoMock.Setup(x => x.GetKnownVulnerabilitiesAsync(
+            It.IsAny<ILogger>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(knownVulnerabilities);
+
+        testData.IoMock.Setup(x => x.GetNonVulnerableAsync(
+            "Test.Package",
+            It.IsAny<IReadOnlyList<string>>(),
+            new NuGetVersion("1.0.0"),
+            It.IsAny<ILogger>(),
+            It.IsAny<IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("1.2.3"));
+        testData.IoMock.Setup(x => x.GetNonVulnerableAsync(
+            "Transitive.Package",
+            It.IsAny<IReadOnlyList<string>>(),
+            new NuGetVersion("1.0.0"),
+            It.IsAny<ILogger>(),
+            It.IsAny<IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("2.0.0"));
+
+        // Act
+        int exitCode = await RunCommand(testData, CancellationToken.None);
+
+        // Assert
+        exitCode.Should().Be(0);
+
+        testData.IoMock.Verify(x => x.GetKnownVulnerabilitiesAsync(
+            It.IsAny<ILogger>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        testData.IoMock.Verify(x => x.GetNonVulnerableAsync(
+            "Test.Package",
+            It.IsAny<IReadOnlyList<string>>(),
+            new NuGetVersion("1.0.0"),
+            It.IsAny<ILogger>(),
+            It.IsAny<IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        if (auditMode.Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            testData.IoMock.Verify(x => x.GetNonVulnerableAsync(
+                "Transitive.Package",
+                It.IsAny<IReadOnlyList<string>>(),
+                new NuGetVersion("1.0.0"),
+                It.IsAny<ILogger>(),
+                It.IsAny<IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>>(),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.IsAny<PackageSpec>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package" && p.NewVersion.ToString() == "[1.2.3, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+
+        if (auditMode.Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            testData.IoMock.Verify(x => x.UpdatePackageReference(
+                It.IsAny<PackageSpec>(),
+                It.IsAny<IPackageUpdateIO.RestoreResult>(),
+                It.IsAny<List<string>>(),
+                It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Transitive.Package" && p.NewVersion.ToString() == "[2.0.0, )"),
+                It.IsAny<ILogger>()),
+                Times.Once);
+        }
+
+        int packageCount =
+            auditMode.Equals("all", StringComparison.OrdinalIgnoreCase)
+            ? 2
+            : 1;
+        testData.LoggerMock.Verify(x => x.LogMinimal(
+            It.Is<string>(s => s.Contains(string.Format(Strings.PackageUpdate_FinalSummary, packageCount, packageCount))),
+            It.IsAny<ConsoleColor>()),
+            Times.Once);
     }
 
     [Theory]

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/ChildProcess/CommandRunner.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/ChildProcess/CommandRunner.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess
         /// <param name="testOutputHelper">An optional <see cref="ITestOutputHelper" /> to write output to.</param>
         /// <param name="timeoutRetryCount">An optional number of times to retry running the command if it times out. Defaults to 1.</param>
         /// <returns>A <see cref="CommandRunnerResult" /> containing details about the result of the running the executable including the exit code and console output.</returns>
-        public static CommandRunnerResult Run(string filename, string workingDirectory = null, string arguments = null, int timeOutInMilliseconds = 60000000, Action<StreamWriter> inputAction = null, IReadOnlyDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null, int timeoutRetryCount = 1)
+        public static CommandRunnerResult Run(string filename, string workingDirectory = null, string arguments = null, int timeOutInMilliseconds = 60000, Action<StreamWriter> inputAction = null, IReadOnlyDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null, int timeoutRetryCount = 1)
         {
             if (workingDirectory is null)
             {

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/ChildProcess/CommandRunner.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/ChildProcess/CommandRunner.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess
         /// <param name="testOutputHelper">An optional <see cref="ITestOutputHelper" /> to write output to.</param>
         /// <param name="timeoutRetryCount">An optional number of times to retry running the command if it times out. Defaults to 1.</param>
         /// <returns>A <see cref="CommandRunnerResult" /> containing details about the result of the running the executable including the exit code and console output.</returns>
-        public static CommandRunnerResult Run(string filename, string workingDirectory = null, string arguments = null, int timeOutInMilliseconds = 60000, Action<StreamWriter> inputAction = null, IReadOnlyDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null, int timeoutRetryCount = 1)
+        public static CommandRunnerResult Run(string filename, string workingDirectory = null, string arguments = null, int timeOutInMilliseconds = 60000000, Action<StreamWriter> inputAction = null, IReadOnlyDictionary<string, string> environmentVariables = null, ITestOutputHelper testOutputHelper = null, int timeoutRetryCount = 1)
         {
             if (workingDirectory is null)
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14309

## Description

Makes `dotnet package update` support solutions with multiple projects.

Key points:

* Projects are processed in parallel, so the perf isn't terrible on huge solutions.  Each project still handles packages serially, so that's a room for improvement, as it could theoretically be slow if a project has a huge number of packages.
* Copilot was suggesting that when upgrading specific packages (for example, `dotnet package update Microsoft.Extensions.DependencyInjection`), if no packages were updated, then don't return an error exit code. I remember being unsure about this when implementing the first versions of package update. But now I agree to make the command idempotent. On Linux and other UNIX's, it's typically not an error to delete a file or directory that doesn't exist, because the user was asking for an outcome, even if the outcome was true in the precondition. Similarly, asking to upgrade a package to the latest version when it's already the latest, the outcome is achieved. Asking to upgrade a package that isn't referenced by a project doesn't require the project to be modified. I think this makes it easier to script package update since you no longer need to worry about whether the package is referenced or if it's already up to date. Anyway, this could be considered a breaking change, but I feel like it's better ergonomics.
* Changed the final summary message "Updated x packages from y scanned" to report the unique package id counts, so that the same package being updated in multiple projects, or the same package being checked across multiple projects, doesn't double-count.  From some technical point of view, it might make sense to double count, but I think from a human point of view, if I ask for Contoso.Utils to be upgraded, it should be 1 package scanned, 1 package updated, no matter how many projects it appears in.
* Added a bunch of tests. The PackageUpdateIO class was previously untested, and it was much easier to add tests for multiple projects and debug the failing tests, than to do manual testing and debug when it crashed or had the wrong outcomes.
   * The PackageUpdateIO tests I decided to try creating a directory for the class, and then one test file per method being tested. I think I've used this pattern before in NuGet.Client, but I like it because when there are a lot of tests for a class in a single file, the test file can get very long, and then it's hard to check if a specific scenario is already tested. I hope it's easier when each method being tested has a test class.
* Made the XPlat func test collection use a const string, rather than a duplicated string literal. This caused a one line change in a bunch of files.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
