### PR TITLE
Do not consider a pinned dependency to be in conflict

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -776,6 +776,7 @@ namespace NuGet.Commands
                 // 4. The dependency has a version specified
                 // 5. The version range is not satisfied by the resolved version
                 // 6. A corresponding downgrade was not detected
+                // 7. The package is not pinned
                 if (resolvedDependencyGraphItem.Item.Key.Type != LibraryType.Project
                     && resolvedDependencyGraphItem.Item.Key.Type != LibraryType.ExternalProject
                     && resolvedDependencyGraphItem.Item.Key.Type != LibraryType.Unresolved
@@ -783,7 +784,8 @@ namespace NuGet.Commands
                     && childLibraryDependency.SuppressParent != LibraryIncludeFlags.All
                     && childLibraryDependency.LibraryRange.VersionRange != null
                     && !childLibraryDependency.LibraryRange.VersionRange!.Satisfies(resolvedDependencyGraphItem.Item.Key.Version)
-                    && !downgrades.ContainsKey(childResolvedLibraryRangeIndex))
+                    && !downgrades.ContainsKey(childResolvedLibraryRangeIndex)
+                    && !resolvedDependencyGraphItem.IsCentrallyPinnedTransitivePackage)
                 {
                     conflictingNode = new(childLibraryDependency.LibraryRange)
                     {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_AlgorithmEquivalencyTests.cs
@@ -2937,6 +2937,93 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Targets[0].Libraries.Should().HaveCount(2);
         }
 
+        // P -> A [1.0.0, )
+        //      -> B [1.0.0]
+        // P -> C [1.0.0, )
+        //      -> B [2.0.0,)
+        //
+        // B is pinned to [2.0.0,) to get around the version conflict
+        [Fact]
+        public async Task RestoreCommand_WithTransitivePinningEnabledToFixVersionConflict_VerifiesEquivalency()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+
+            // Setup packages
+            var packageA = new SimpleTestPackageContext("A", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("B", "1.0.0")
+                    {
+                        DependencyVersionRange = "[1.0.0]"
+                    },
+                ]
+            };
+
+            var packageC = new SimpleTestPackageContext("C", "1.0.0")
+            {
+                Dependencies =
+                [
+                    new SimpleTestPackageContext("B", "2.0.0")
+                ]
+            };
+
+            var packageB100 = new SimpleTestPackageContext("B", "1.0.0");
+            var packageB200 = new SimpleTestPackageContext("B", "2.0.0");
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageA,
+                packageB100,
+                packageB200,
+                packageC);
+
+            var project1 = @"
+                {
+                    ""restore"": {
+                      ""centralPackageVersionsManagementEnabled"": true,
+                      ""CentralPackageTransitivePinningEnabled"": true,
+                    },
+                    ""frameworks"": {
+                      ""net472"": {
+                          ""dependencies"": {
+                            ""A"" : {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package"",
+                                ""versionCentrallyManaged"": true
+                            },
+                            ""C"" : {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package"",
+                                ""versionCentrallyManaged"": true
+                            },
+                          },
+                          ""centralPackageVersions"": {
+                            ""A"": ""[1.0.0,)"",
+                            ""B"": ""[2.0.0,)"",
+                            ""C"": ""[1.0.0,)"",
+                          }
+                    }
+                  }
+                }";
+
+            // Setup project
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, project1);
+
+            // Act & Assert
+            (var result, _) = await ValidateRestoreAlgorithmEquivalency(pathContext, projectSpec);
+            result.LockFile.Targets.Should().HaveCount(1);
+            result.LockFile.Targets[0].Libraries.Should().HaveCount(3);
+            result.LockFile.Targets[0].Libraries[0].Name.Should().Be("A");
+            result.LockFile.Targets[0].Libraries[0].Version.Should().Be(new NuGetVersion("1.0.0"));
+            result.LockFile.Targets[0].Libraries[1].Name.Should().Be("B");
+            result.LockFile.Targets[0].Libraries[1].Version.Should().Be(new NuGetVersion("2.0.0"));
+            result.LockFile.Targets[0].Libraries[2].Name.Should().Be("C");
+            result.LockFile.Targets[0].Libraries[2].Version.Should().Be(new NuGetVersion("1.0.0"));
+        }
+
         // Here's why package driven dependencies should flow.
         // Say we have P1 -> P2 -> P3 -> A 1.0.0 -> B 2.0.0
         //                            -> B 1.5.0

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageContext.cs
@@ -70,6 +70,8 @@ namespace NuGet.Test.Utility
         public Uri V3ServiceIndexUrl { get; set; }
         public IReadOnlyList<string> PackageOwners { get; set; }
 
+        public string DependencyVersionRange { get; set; }
+
         /// <summary>
         /// runtime.json
         /// </summary>

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -342,13 +342,28 @@ namespace NuGet.Test.Utility
             return packages.Select(e =>
                 new PackageDependency(
                     e.Id,
-                    e.Version != null ? VersionRange.Parse(e.Version) : null,
+                    GetVersionRange(e),
                     string.IsNullOrEmpty(e.Include)
                         ? new List<string>()
                         : e.Include.Split(',').ToList(),
                     string.IsNullOrEmpty(e.Exclude)
                         ? new List<string>()
                         : e.Exclude.Split(',').ToList())).ToList();
+
+            VersionRange GetVersionRange(SimpleTestPackageContext packageContext)
+            {
+                if (packageContext.DependencyVersionRange != null)
+                {
+                    return VersionRange.Parse(packageContext.DependencyVersionRange);
+                }
+
+                if (packageContext.Version != null)
+                {
+                    return VersionRange.Parse(packageContext.Version);
+                }
+
+                return null;
+            }
         }
 
         private static SignPackageRequest GetPrimarySignRequest(SimpleTestPackageContext packageContext)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
This is a follow-up to https://github.com/NuGet/NuGet.Client/pull/6999

The logic needs to not consider it a conflicting version if its pinned.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
