### PR TITLE
Use 1ES OutputParentDirectory to reduce scanning tasks

### DIFF
--- a/build/symbols.proj
+++ b/build/symbols.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="GetSymbolsAndAssembliesToIndex" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
-  
+
   <!-- Configuration/global properties -->
   <PropertyGroup>
     <CommonMSBuildProperties>
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <Target Name="GetSymbolsAndAssembliesToIndex">
+    <Error Condition="'$(SymbolsOutputDirectory)' == ''" Text="SymbolsOutputDirectory property must be set."/>
     <MSBuild
       Projects="@(SolutionProjectsWithoutVSIX)"
       Targets="GetSymbolsToIndex"
@@ -25,7 +26,7 @@
     <ItemGroup>
       <FilteredSymbolsToIndex Include="@(SymbolsToIndex)" Condition="'%(SymbolsToIndex.Extension)' == '.dll' OR '%(SymbolsToIndex.Extension)' == '.exe'
                                                           OR   '%(SymbolsToIndex.Extension)' == '.pdb'">
-          <DestinationDir>$(ArtifactsDirectory)symbolstoindex\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(SymbolsToIndex.Identity)))</DestinationDir>
+          <DestinationDir>$(SymbolsOutputDirectory)\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(SymbolsToIndex.Identity)))</DestinationDir>
       </FilteredSymbolsToIndex>
     </ItemGroup>
     <Copy SourceFiles="@(FilteredSymbolsToIndex->'%(Identity)')" DestinationFiles="@(FilteredSymbolsToIndex->'%(DestinationDir)')"/>

--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -151,12 +151,12 @@ steps:
     inputs:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
-    msbuildArguments: >-
-      /restore:false
-      /target:StagingDirectory
-      /property:NupkgOutputDirectory=$(Build.StagingDirectory)\\nupkgs
-      /property:ExcludeTestProjects=$(BuildRTM)
-      /binarylogger:$(Build.StagingDirectory)\\binlog\\12.EnsurePackagesExist.binlog"
+      msbuildArguments: >-
+        /restore:false
+        /target:StagingDirectory
+        /property:NupkgOutputDirectory=$(Build.StagingDirectory)\\nupkgs
+        /property:ExcludeTestProjects=$(BuildRTM)
+        /binarylogger:$(Build.StagingDirectory)\\binlog\\12.EnsurePackagesExist.binlog"
 
   - task: MSBuild@1
     displayName: "Pack VSIX"

--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -129,34 +129,21 @@ steps:
     inputs:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: >-
-        /restore:false
-        /target:Pack
-        /property:BuildRTM=$(BuildRTM)
-        /property:ExcludeTestProjects=$(BuildRTM)
-        /property:BuildNumber=$(BuildNumber)
-        /binarylogger:$(Build.StagingDirectory)\\binlog\\11.Pack.binlog
-        /property:NupkgOutputDirectory=$(Build.StagingDirectory)\\nupkgs
-        /property:MicroBuild_SigningEnabled=false"
+      msbuildArguments: "/restore:false /target:Pack /property:BuildRTM=$(BuildRTM) /property:ExcludeTestProjects=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /binarylogger:$(Build.StagingDirectory)\\binlog\\11.Pack.binlog /property:MicroBuild_SigningEnabled=false"
 
   - task: PowerShell@1
     displayName: "Check expected packages exist for publishing"
     name: "EnsureAllPackagesExist"
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\utils\\EnsureAllPackagesExist.ps1"
-      arguments: "-BuildRTM:$$(BuildRTM) -NupkgOutputPath '$(Build.StagingDirectory)\\nupkgs'"
+      arguments: "-BuildRTM:$$(BuildRTM) -NupkgOutputPath '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'"
 
   - task: MSBuild@1
     displayName: "Ensure all Nupkgs and Symbols are created"
     inputs:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: >-
-        /restore:false
-        /target:StagingDirectory
-        /property:NupkgOutputDirectory=$(Build.StagingDirectory)\\nupkgs
-        /property:ExcludeTestProjects=$(BuildRTM)
-        /binarylogger:$(Build.StagingDirectory)\\binlog\\12.EnsurePackagesExist.binlog"
+      msbuildArguments: "/restore:false /target:EnsurePackagesExist /property:ExcludeTestProjects=$(BuildRTM) /binarylogger:$(Build.StagingDirectory)\\binlog\\12.EnsurePackagesExist.binlog"
 
   - task: MSBuild@1
     displayName: "Pack VSIX"
@@ -196,12 +183,12 @@ steps:
     displayName: "Verify Nupkg Signatures"
     inputs:
       command: "custom"
-      arguments: "verify -Signatures $(Build.StagingDirectory)\\nupkgs\\*.nupkg"
+      arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
 
   - task: MicroBuildCodesignVerify@3
     displayName: Verify Assembly Signatures and StrongName for the nupkgs
     inputs:
-      TargetFolders: '$(Build.StagingDirectory)\\nupkgs'
+      TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
 
   - task: MicroBuildCodesignVerify@3
     displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
@@ -299,9 +286,16 @@ steps:
   - task: CopyFiles@2
     displayName: Copy product to staging directory
     inputs:
-      SourceFolder: 'artifacts/VS15'
+      SourceFolder: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
       Contents: '**'
-      TargetFolder: '$(Build.StagingDirectory)/VS15'
+      TargetFolder: '$(Build.StagingDirectory)\\VS15'
+
+  - task: CopyFiles@2
+    displayName: Copy nupkgs to staging directory
+    inputs:
+      SourceFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+      Contents: '**'
+      TargetFolder: '$(Build.StagingDirectory)\\nupkgs'
 
     # Use dotnet msbuild instead of MSBuild CLI.
     # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.
@@ -324,18 +318,7 @@ steps:
       scriptType: ps
       scriptLocation: inlineScript
       inlineScript: |
-        $(Agent.TempDirectory)/dotnet/dotnet msbuild `
-          $(Build.Repository.LocalPath)\build\publish.proj `
-          /t:PublishToBuildAssetRegistry `
-          /property:NuGetClientNupkgsDirectoryPath=$(Build.StagingDirectory)\nupkgs `
-          /property:BUILD_BUILDNUMBER=$(Build.BuildNumber) `
-          /property:BUILD_SOURCEBRANCH=$(SourceBranch) `
-          /property:BUILD_SOURCEVERSION=$(Build.SourceVersion) `
-          /property:BUILD_REPOSITORY_URI=$(Build.Repository.Uri) `
-          /property:BUILD_REPOSITORY_NAME=$(Build.Repository.Name) `
-          /property:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ `
-          /binarylogger:$(Build.StagingDirectory)\binlog\21.PublishToBuildAssetRegistry.binlog `
-          /property:MaestroApiEndpoint=$(MaestroApiEndpoint)
+        $(Agent.TempDirectory)/dotnet/dotnet msbuild $(Build.Repository.LocalPath)\build\publish.proj /t:PublishToBuildAssetRegistry /property:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /property:BUILD_BUILDNUMBER=$(Build.BuildNumber) /property:BUILD_SOURCEBRANCH=$(SourceBranch) /property:BUILD_SOURCEVERSION=$(Build.SourceVersion) /property:BUILD_REPOSITORY_URI=$(Build.Repository.Uri) /property:BUILD_REPOSITORY_NAME=$(Build.Repository.Name) /property:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ /binarylogger:$(Build.StagingDirectory)\binlog\21.PublishToBuildAssetRegistry.binlog /property:MaestroApiEndpoint=$(MaestroApiEndpoint)
       workingDirectory: cli
       failOnStderr: true
     env:

--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -15,7 +15,13 @@ steps:
   - task: PowerShell@1
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-      arguments: "-BuildRTM $(BuildRTM) -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(SourceBranch) -CommitHash $(Build.SourceVersion) -BuildNumber $(Build.BuildNumber)"
+      arguments: >-
+        -BuildRTM $(BuildRTM)
+        -RepositoryPath $(Build.Repository.LocalPath)
+        -BranchName $(SourceBranch)
+        -CommitHash $(Build.SourceVersion)
+        -BuildNumber $(Build.BuildNumber)
+        -BuildInfoDirectoryPath $(Build.StagingDirectory)\BuildInfo
     displayName: "Configure VSTS CI Environment"
 
   - task: PowerShell@1
@@ -123,21 +129,34 @@ steps:
     inputs:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/restore:false /target:Pack /property:BuildRTM=$(BuildRTM) /property:ExcludeTestProjects=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /binarylogger:$(Build.StagingDirectory)\\binlog\\11.Pack.binlog /property:MicroBuild_SigningEnabled=false"
+      msbuildArguments: >-
+        /restore:false
+        /target:Pack
+        /property:BuildRTM=$(BuildRTM)
+        /property:ExcludeTestProjects=$(BuildRTM)
+        /property:BuildNumber=$(BuildNumber)
+        /binarylogger:$(Build.StagingDirectory)\\binlog\\11.Pack.binlog
+        /property:PackageOutputPath=$(Build.StagingDirectory)\\nupkgs
+        /property:MicroBuild_SigningEnabled=false"
 
   - task: PowerShell@1
     displayName: "Check expected packages exist for publishing"
     name: "EnsureAllPackagesExist"
     inputs:
       scriptName: "$(Build.Repository.LocalPath)\\scripts\\utils\\EnsureAllPackagesExist.ps1"
-      arguments: "-BuildRTM:$$(BuildRTM) -NupkgOutputPath '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'"
+      arguments: "-BuildRTM:$$(BuildRTM) -NupkgOutputPath '$(Build.StagingDirectory)\\nupkgs'"
 
   - task: MSBuild@1
     displayName: "Ensure all Nupkgs and Symbols are created"
     inputs:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/restore:false /target:EnsurePackagesExist /property:ExcludeTestProjects=$(BuildRTM) /binarylogger:$(Build.StagingDirectory)\\binlog\\12.EnsurePackagesExist.binlog"
+    msbuildArguments: >-
+      /restore:false
+      /target:StagingDirectory
+      /property:NupkgOutputDirectory=$(Build.StagingDirectory)\\nupkgs
+      /property:ExcludeTestProjects=$(BuildRTM)
+      /binarylogger:$(Build.StagingDirectory)\\binlog\\12.EnsurePackagesExist.binlog"
 
   - task: MSBuild@1
     displayName: "Pack VSIX"
@@ -177,12 +196,12 @@ steps:
     displayName: "Verify Nupkg Signatures"
     inputs:
       command: "custom"
-      arguments: "verify -Signatures $(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)\\*.nupkg"
+      arguments: "verify -Signatures $(Build.StagingDirectory)\\nupkgs\\*.nupkg"
 
   - task: MicroBuildCodesignVerify@3
     displayName: Verify Assembly Signatures and StrongName for the nupkgs
     inputs:
-      TargetFolders: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+      TargetFolders: '$(Build.StagingDirectory)\\nupkgs'
 
   - task: MicroBuildCodesignVerify@3
     displayName: Verify Assembly Signatures and StrongName for the VSIX & exes
@@ -225,7 +244,7 @@ steps:
     displayName: "Generate .runsettings files"
     inputs:
       solution: 'build\runsettings.proj'
-      msbuildArguments: '/restore:false /property:OutputPath="$(Build.Repository.LocalPath)\artifacts\RunSettings" /property:TestDrop="$(RunSettingsDropName)" /property:ProfilingInputsDrop="$(ProfilingInputsDropName)" /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateRunSettings.binlog'
+      msbuildArguments: '/restore:false /property:OutputPath="$(Build.StagingDirectory)\RunSettings" /property:TestDrop="$(RunSettingsDropName)" /property:ProfilingInputsDrop="$(ProfilingInputsDropName)" /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateRunSettings.binlog'
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: PowerShell@1
@@ -251,7 +270,13 @@ steps:
     inputs:
       solution: "build\\symbols.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:IsSymbolBuild=true /property:BuildRTM=$(BuildRTM) /binarylogger:$(Build.StagingDirectory)\\binlog\\18.CollectBuildSymbols.binlog"
+      msbuildArguments: >-
+        /restore:false
+        /property:BuildProjectReferences=false
+        /property:IsSymbolBuild=true
+        /property:BuildRTM=$(BuildRTM)
+        /property:SymbolsOutputDirectory=$(Build.StagingDirectory)\\symbolstoindex
+        /binarylogger:$(Build.StagingDirectory)\\binlog\\18.CollectBuildSymbols.binlog"
       maximumCpuCount: true
     condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
@@ -260,7 +285,7 @@ steps:
     inputs:
       solution: "build\\BuildValidator.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/target:ValidateVsix /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\19.ValidateVsixLocalization.binlog"
+      msbuildArguments: "/target:ValidateVsix /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.StagingDirectory)\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\19.ValidateVsixLocalization.binlog"
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
   - task: MSBuild@1
@@ -268,8 +293,15 @@ steps:
     inputs:
       solution: "build\\BuildValidator.proj"
       configuration: "$(BuildConfiguration)"
-      msbuildArguments: "/target:ValidateArtifacts /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\20.ValidateArtifactsLocalization.binlog"
+      msbuildArguments: "/target:ValidateArtifacts /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.StagingDirectory)\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\20.ValidateArtifactsLocalization.binlog"
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+  - task: CopyFiles@2
+    displayName: Copy product to staging directory
+    inputs:
+      SourceFolder: 'artifacts/VS15'
+      Contents: '**'
+      TargetFolder: '$(Build.StagingDirectory)/VS15'
 
     # Use dotnet msbuild instead of MSBuild CLI.
     # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.
@@ -292,7 +324,18 @@ steps:
       scriptType: ps
       scriptLocation: inlineScript
       inlineScript: |
-        $(Agent.TempDirectory)/dotnet/dotnet msbuild $(Build.Repository.LocalPath)\build\publish.proj /t:PublishToBuildAssetRegistry /property:NuGetClientNupkgsDirectoryPath=$(Build.Repository.LocalPath)\artifacts\$(NupkgOutputDir) /property:BUILD_BUILDNUMBER=$(Build.BuildNumber) /property:BUILD_SOURCEBRANCH=$(SourceBranch) /property:BUILD_SOURCEVERSION=$(Build.SourceVersion) /property:BUILD_REPOSITORY_URI=$(Build.Repository.Uri) /property:BUILD_REPOSITORY_NAME=$(Build.Repository.Name) /property:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ /binarylogger:$(Build.StagingDirectory)\binlog\21.PublishToBuildAssetRegistry.binlog /property:MaestroApiEndpoint=$(MaestroApiEndpoint)
+        $(Agent.TempDirectory)/dotnet/dotnet msbuild `
+          $(Build.Repository.LocalPath)\build\publish.proj `
+          /t:PublishToBuildAssetRegistry `
+          /property:NuGetClientNupkgsDirectoryPath=$(Build.StagingDirectory)\nupkgs `
+          /property:BUILD_BUILDNUMBER=$(Build.BuildNumber) `
+          /property:BUILD_SOURCEBRANCH=$(SourceBranch) `
+          /property:BUILD_SOURCEVERSION=$(Build.SourceVersion) `
+          /property:BUILD_REPOSITORY_URI=$(Build.Repository.Uri) `
+          /property:BUILD_REPOSITORY_NAME=$(Build.Repository.Name) `
+          /property:ArtifactsLogDir=$(Build.Repository.LocalPath)\artifacts\manifests\ `
+          /binarylogger:$(Build.StagingDirectory)\binlog\21.PublishToBuildAssetRegistry.binlog `
+          /property:MaestroApiEndpoint=$(MaestroApiEndpoint)
       workingDirectory: cli
       failOnStderr: true
     env:

--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -136,7 +136,7 @@ steps:
         /property:ExcludeTestProjects=$(BuildRTM)
         /property:BuildNumber=$(BuildNumber)
         /binarylogger:$(Build.StagingDirectory)\\binlog\\11.Pack.binlog
-        /property:PackageOutputPath=$(Build.StagingDirectory)\\nupkgs
+        /property:NupkgOutputDirectory=$(Build.StagingDirectory)\\nupkgs
         /property:MicroBuild_SigningEnabled=false"
 
   - task: PowerShell@1

--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -21,7 +21,7 @@ steps:
         -BranchName $(SourceBranch)
         -CommitHash $(Build.SourceVersion)
         -BuildNumber $(Build.BuildNumber)
-        -BuildInfoDirectoryPath $(Build.StagingDirectory)\BuildInfo
+        -BuildInfoDirectory $(Build.StagingDirectory)\BuildInfo
     displayName: "Configure VSTS CI Environment"
 
   - task: PowerShell@1

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -94,18 +94,19 @@ stages:
           DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
           ShouldSkipOptimize: $(ShouldSkipOptimize)
           AccessToken: $(System.AccessToken)
+      outputParentDirectory: '$(Build.StagingDirectory)'
       outputs:
       - output: pipelineArtifact
         displayName: 'Publish buildinfo.json as an artifact'
         condition: "succeeded()"
-        targetPath: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
+        targetPath: '$(Build.StagingDirectory)\BuildInfo'
         artifactName: 'BuildInfo'
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
+        targetPath: "$(Build.StagingDirectory)\\nupkgs"
         artifactName: "nupkgs - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
@@ -114,7 +115,7 @@ stages:
         condition: "succeeded()"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
         buildNumber: '$(RunSettingsDropName)'
-        sourcePath: 'artifacts\RunSettings'
+        sourcePath: '$(Build.StagingDirectory)\RunSettings'
         toLowerCase: false
         usePat: true
         dropMetadataContainerName: 'DropMetadata-RunSettings'
@@ -126,21 +127,21 @@ stages:
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
         buildNumber: '$(ProfilingInputsDropName)'
-        sourcePath: '$(Build.ArtifactStagingDirectory)\OptProf\ProfilingInputs'
+        sourcePath: '$(Build.StagingDirectory)\OptProf\ProfilingInputs'
         toLowerCase: false
         usePat: true
         dropMetadataContainerName: 'DropMetadata-ProfilingInputs'
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe and VSIX as artifact'
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+        targetPath: "$(Build.StagingDirectory)\\VS15"
         artifactName: "$(VsixPublishDir)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+        targetPath: "$(Build.StagingDirectory)\\symbolstoindex"
         artifactName: "symbols - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
@@ -149,7 +150,7 @@ stages:
         condition: "succeeded()"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
         buildNumber: '$(MicroBuild.ManifestDropName)'
-        sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+        sourcePath: "$(Build.StagingDirectory)\\VS15"
         toLowerCase: false
         usePat: true
         dropMetadataContainerName: "DropMetadata-Product"
@@ -158,7 +159,7 @@ stages:
         displayName: 'LocValidation: Publish Logs as an artifact'
         condition: "succeededOrFailed()"
         artifactName: LocValidationLogs - Attempt $(System.JobAttempt)
-        targetPath: "$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs"
+        targetPath: "$(Build.StagingDirectory)\\BuildValidatorLogs"
         sbomEnabled: true
 
       - output: pipelineArtifact
@@ -171,7 +172,7 @@ stages:
       - output: pipelineArtifact
         displayName: Publish SBOM manifest
         artifactName: $(ARTIFACT_NAME)
-        targetPath: "$(Build.SourcesDirectory)/artifacts/_manifest"
+        targetPath: "$(Build.StagingDirectory)/sbom"
         sbomEnabled: false
 
     steps:
@@ -209,24 +210,25 @@ stages:
           enabled: true
         optprof:
           enabled: false
+      outputParentDirectory: '$(Build.StagingDirectory)'
       outputs:
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
         condition: "succeeded()"
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
+        targetPath: "$(Build.StagingDirectory)\\$(NupkgOutputDir)"
         artifactName: "nupkgs - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe and VSIX as artifact'
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+        targetPath: "$(Build.StagingDirectory)\\VS15"
         artifactName: "$(VsixPublishDir)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+        targetPath: "$(Build.StagingDirectory)\\symbolstoindex"
         artifactName: "symbols - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -21,6 +21,9 @@ The commit hash being built
 
 .PARAMETER BuildNumber
 The build number of the current build
+
+.PARAMETER BuildInfoDirectory
+Optional directory path to write buildinfo.json to. When not provided, defaults to the repository's artifacts directory.
 #>
 
 param
@@ -34,7 +37,9 @@ param
     [Parameter(Mandatory=$true)]
     [string]$CommitHash,
     [Parameter(Mandatory=$true)]
-    [string]$BuildNumber
+    [string]$BuildNumber,
+    [Parameter(Mandatory=$false)]
+    [string]$BuildInfoDirectory
 )
 
 Function Get-Version {
@@ -141,8 +146,17 @@ else
         NuGetVsVersion = $GetNuGetVsVersion
     }
 
-    # First create the file locally so that we can laster publish it as a build artifact from a local source file instead of a remote source file.
-    $localBuildInfoJsonFilePath = [System.IO.Path]::Combine("$RepositoryPath\artifacts", 'buildinfo.json')
+    if (-not [string]::IsNullOrWhiteSpace($BuildInfoDirectory))
+    {
+        $buildInfoDirectoryPath = $BuildInfoDirectory
+    }
+    else
+    {
+        $buildInfoDirectoryPath = Join-Path $RepositoryPath 'artifacts'
+    }
+
+    New-Item -Path $buildInfoDirectoryPath -ItemType Directory -Force | Out-Null
+    $localBuildInfoJsonFilePath = Join-Path $buildInfoDirectoryPath 'buildinfo.json'
 
     New-Item $localBuildInfoJsonFilePath -Force | Out-Null
     $jsonRepresentation | ConvertTo-Json | Set-Content $localBuildInfoJsonFilePath

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -160,6 +160,7 @@ else
 
     New-Item $localBuildInfoJsonFilePath -Force | Out-Null
     $jsonRepresentation | ConvertTo-Json | Set-Content $localBuildInfoJsonFilePath
+    Write-Host "Created $localBuildInfoJsonFilePath"
 
     Update-VsixVersion -manifestName source.extension.vsixmanifest -buildNumber $BuildNumber -RepositoryPath $RepositoryPath
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: engineering

## Description

The docs on 1ES PT say that jobs with multiple outputs can get better pipeline performance by making sure all output artifacts are in the same parent directory, then using `outputParentDirectory`. This makes the scanning tasks happen once on the parent directory, and get skipped on each individual output.

Looking at the last 7 days of PrivateDev builds (admidetly not many, given it's around New Year), the "nonRTM" job is taking 27-30 minutes. My branch has two successful builds, taking 20 to 22 minutes. So, it looks like doing this might save around 7 minutes per build.

It also signifiantly reduces the number of tasks in the job log, making it much easier to find the logs for the publish artifact tasks.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
