### PR TITLE
Fix list capacity calculation in GetGraphItemAsync that is leading to allocations

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.DependencyGraphItem.cs
@@ -97,7 +97,7 @@ namespace NuGet.Commands
                 }
 
                 // Create a new list that is big enough for the existing items plus any runtime dependencies
-                List<LibraryDependency> dependencies = new(capacity: RuntimeDependencies?.Count ?? 0 + item.Data.Dependencies.Count);
+                List<LibraryDependency> dependencies = new(capacity: (RuntimeDependencies?.Count ?? 0) + item.Data.Dependencies.Count);
 
                 // Loop through the defined dependencies, leaving out any pruned packages or runtime packages that replace them
                 for (int i = 0; i < item.Data.Dependencies.Count; i++)


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: The allocation hot path is `TypeAllocated!NuGet.LibraryModel.LibraryDependency[]` with frames showing `List<T>.EnsureCapacity/set_Capacity`, which indicates repeated List backing-array growth.
In `DependencyGraphResolver.DependencyGraphItem.cs`, method `DependencyGraphResolver.DependencyGraphItem.GetGraphItemAsync`, the new list is created with an incorrect capacity due to operator precedence:

`new(capacity: RuntimeDependencies?.Count ?? 0 + item.Data.Dependencies.Count)`

Because `+` binds tighter than `??`, when `RuntimeDependencies` is non-null the capacity becomes just `RuntimeDependencies.Count` (ignoring `item.Data.Dependencies.Count`), causing predictable resizing and `LibraryDependency[]` allocations as items are added.
- Issue type: Specify an up-front capacity for collections if one is known
- Proposed fix: Fixing the expression to `new(capacity: (RuntimeDependencies?.Count ?? 0) + item.Data.Dependencies.Count)` is a trivial, localized change with minimal risk and directly addresses the hot-path allocations.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&failureHash=68c35ad7-6379-308c-b43d-0620a39e8271&query=r%3D17.14%20(c%3DGetGraphItemAsync%20c%3DEnsureCapacity))
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2381097)