### PR TITLE
Fix build symbols CI step

### DIFF
--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -263,7 +263,7 @@ steps:
         /property:IsSymbolBuild=true
         /property:BuildRTM=$(BuildRTM)
         /property:SymbolsOutputDirectory=$(Build.StagingDirectory)\\symbolstoindex
-        /binarylogger:$(Build.StagingDirectory)\\binlog\\18.CollectBuildSymbols.binlog"
+        /binarylogger:$(Build.StagingDirectory)\\binlog\\18.CollectBuildSymbols.binlog
       maximumCpuCount: true
     condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 

--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -265,7 +265,6 @@ steps:
         /property:SymbolsOutputDirectory=$(Build.StagingDirectory)\\symbolstoindex
         /binarylogger:$(Build.StagingDirectory)\\binlog\\18.CollectBuildSymbols.binlog
       maximumCpuCount: true
-    condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
   - task: MSBuild@1
     displayName: "LocValidation: Verify VSIX"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -105,7 +105,6 @@ stages:
 
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
-        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.StagingDirectory)\\nupkgs"
         artifactName: "nupkgs - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
@@ -140,7 +139,6 @@ stages:
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'
-        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.StagingDirectory)\\symbolstoindex"
         artifactName: "symbols - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
@@ -227,7 +225,6 @@ stages:
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'
-        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.StagingDirectory)\\symbolstoindex"
         artifactName: "symbols - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: engineering

## Description

The PR https://github.com/NuGet/NuGet.Client/pull/7023 has an error, which wasn't caught because the step only runs on official builds, not PR builds.

I also removed the conditions on IsOfficial, so that the pull request build validates more of what the official build does. These types of errors should be caught before getting merged.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
