### PR TITLE
Fix "Collect Build Symbols" binary logger path formatting in Build.yml

### DIFF
--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -263,7 +263,7 @@ steps:
         /property:IsSymbolBuild=true
         /property:BuildRTM=$(BuildRTM)
         /property:SymbolsOutputDirectory=$(Build.StagingDirectory)\\symbolstoindex
-        /binarylogger:$(Build.StagingDirectory)\\binlog\\18.CollectBuildSymbols.binlog"
+        /binarylogger:$(Build.StagingDirectory)\\binlog\\18.CollectBuildSymbols.binlog
       maximumCpuCount: true
     condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 


### PR DESCRIPTION
Fixes: engineering

Appears to be a bug introduced in https://github.com/NuGet/NuGet.Client/pull/7023