### PR TITLE
[6.11.x] Use 1ES OutputParentDirectory to reduce scanning tasks

### DIFF
--- a/build/loc.proj
+++ b/build/loc.proj
@@ -90,9 +90,12 @@
 
   <!-- Prepares localization artifact -->
   <Target Name="CopyBinariesToLocalizationArtifacts" AfterTargets="Localize">
+    <Error
+      Condition=" '$(LocalizationArtifactsOutputPath)' == '' "
+      Text="LocalizationArtifactsOutputPath is not set." />
     <ItemGroup>
       <_EnglishBinaries Include="@(FilesToLocalize)">
-        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))\%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
+        <DestinationPath>$(LocalizationArtifactsOutputPath)\artifacts\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(FilesToLocalize.RootDir)%(FilesToLocalize.Directory)))\%(FilesToLocalize.Filename)%(FilesToLocalize.Extension)</DestinationPath>
       </_EnglishBinaries>
       <_LocalizeFolder Include="$(ArtifactsDirectory)localize\**\*" Exclude="$(ArtifactsDirectory)localize\ResponseFiles\**\*" />
       <_LocalizeFiles Include="@(_LocalizeFolder)">
@@ -100,7 +103,7 @@
       </_LocalizeFiles>
       <!-- Second Localize run creates appropiate LocProject.json -->
       <_LocalizeFiles Include="$(ArtifactsDirectory)localize\ResponseFiles\*.loc.002\ENU\LocProject.json">
-        <DestinationPath>$(ArtifactsDirectory)\localizationArtifacts\ENU\LocProject.json</DestinationPath>
+        <DestinationPath>$(LocalizationArtifactsOutputPath)\ENU\LocProject.json</DestinationPath>
       </_LocalizeFiles>
     </ItemGroup>
     <Copy SourceFiles="@(_EnglishBinaries)" DestinationFiles="@(_EnglishBinaries->'%(DestinationPath)')" />

--- a/build/symbols.proj
+++ b/build/symbols.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="GetSymbolsAndAssembliesToIndex" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
-  
+
   <!-- Configuration/global properties -->
   <PropertyGroup>
     <CommonMSBuildProperties>
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <Target Name="GetSymbolsAndAssembliesToIndex">
+    <Error Condition="'$(SymbolsOutputDirectory)' == ''" Text="SymbolsOutputDirectory property must be set."/>
     <MSBuild
       Projects="@(SolutionProjectsWithoutVSIX)"
       Targets="GetSymbolsToIndex"
@@ -25,7 +26,7 @@
     <ItemGroup>
       <FilteredSymbolsToIndex Include="@(SymbolsToIndex)" Condition="'%(SymbolsToIndex.Extension)' == '.dll' OR '%(SymbolsToIndex.Extension)' == '.exe'
                                                           OR   '%(SymbolsToIndex.Extension)' == '.pdb'">
-          <DestinationDir>$(ArtifactsDirectory)symbolstoindex\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(SymbolsToIndex.Identity)))</DestinationDir>
+          <DestinationDir>$(SymbolsOutputDirectory)\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(SymbolsToIndex.Identity)))</DestinationDir>
       </FilteredSymbolsToIndex>
     </ItemGroup>
     <Copy SourceFiles="@(FilteredSymbolsToIndex->'%(Identity)')" DestinationFiles="@(FilteredSymbolsToIndex->'%(DestinationDir)')"/>

--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -14,7 +14,13 @@ steps:
 - task: PowerShell@1
   inputs:
     scriptName: "$(Build.Repository.LocalPath)\\scripts\\cibuild\\ConfigureVstsBuild.ps1"
-    arguments: "-BuildRTM $(BuildRTM) -RepositoryPath $(Build.Repository.LocalPath) -BranchName $(SourceBranch) -CommitHash $(Build.SourceVersion) -BuildNumber $(Build.BuildNumber)"
+    arguments: >-
+      -BuildRTM $(BuildRTM)
+      -RepositoryPath $(Build.Repository.LocalPath)
+      -BranchName $(SourceBranch)
+      -CommitHash $(Build.SourceVersion)
+      -BuildNumber $(Build.BuildNumber)
+      -BuildInfoDirectory $(Build.StagingDirectory)\BuildInfo
   displayName: "Configure VSTS CI Environment"
 
 - task: PowerShell@1
@@ -113,7 +119,7 @@ steps:
   inputs:
     solution: "build\\loc.proj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore /property:LocType=${{parameters.NuGetLocalizationType}} /binarylogger:$(Build.StagingDirectory)\\binlog\\03.Localize.binlog"
+    msbuildArguments: "/restore /property:LocType=${{parameters.NuGetLocalizationType}} /property:LocalizationArtifactsOutputPath=$(Build.StagingDirectory)\\localizationArtifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\03.Localize.binlog"
 
 - task: MSBuild@1
   displayName: "Build NuGet.exe Localized"
@@ -332,16 +338,21 @@ steps:
   inputs:
     solution: "build\\symbols.proj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/restore:false /property:BuildProjectReferences=false /property:IsSymbolBuild=true /property:BuildRTM=$(BuildRTM) /binarylogger:$(Build.StagingDirectory)\\binlog\\18.CollectBuildSymbols.binlog"
+    msbuildArguments: >-
+      /restore:false
+      /property:BuildProjectReferences=false
+      /property:IsSymbolBuild=true
+      /property:BuildRTM=$(BuildRTM)
+      /property:SymbolsOutputDirectory=$(Build.StagingDirectory)\\symbolstoindex
+      /binarylogger:$(Build.StagingDirectory)\\binlog\\17.CollectBuildSymbols.binlog
     maximumCpuCount: true
-  condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
 
 - task: MSBuild@1
   displayName: "LocValidation: Verify VSIX"
   inputs:
     solution: "build\\BuildValidator.proj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/target:ValidateVsix /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\19.ValidateVsixLocalization.binlog"
+    msbuildArguments: "/target:ValidateVsix /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.StagingDirectory)\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\19.ValidateVsixLocalization.binlog"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
@@ -349,8 +360,22 @@ steps:
   inputs:
     solution: "build\\BuildValidator.proj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/target:ValidateArtifacts /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\20.ValidateArtifactsLocalization.binlog"
+    msbuildArguments: "/target:ValidateArtifacts /property:BuildRTM=$(BuildRTM) /property:LogsBasePath=$(Build.StagingDirectory)\\BuildValidatorLogs /property:TempDirectory=$(Agent.TempDirectory) /binarylogger:$(Build.StagingDirectory)\\binlog\\20.ValidateArtifactsLocalization.binlog"
   condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
+- task: CopyFiles@2
+  displayName: Copy product to staging directory
+  inputs:
+    SourceFolder: '$(Build.Repository.LocalPath)\\artifacts\\VS15'
+    Contents: '**'
+    TargetFolder: '$(Build.StagingDirectory)\\VS15'
+
+- task: CopyFiles@2
+  displayName: Copy nupkgs to staging directory
+  inputs:
+    SourceFolder: '$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)'
+    Contents: '**'
+    TargetFolder: '$(Build.StagingDirectory)\\nupkgs'
 
   # Use dotnet msbuild instead of MSBuild CLI.
   # Using MSBuild CLI results in an assembly binding failure for NuGet.Common.dll 4.4.0.3 because Microsoft.DotNet.Build.Tasks.Feed.dll references SleetLib.dll which references NuGet.Common 4.4.0.3.

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -108,18 +108,18 @@ stages:
           # DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
           # ShouldSkipOptimize: $(ShouldSkipOptimize)
           # AccessToken: $(System.AccessToken)
+      outputParentDirectory: '$(Build.StagingDirectory)'
       outputs:
       - output: pipelineArtifact
         displayName: 'Publish buildinfo.json as an artifact'
         condition: "succeeded()"
-        targetPath: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
+        targetPath: '$(Build.StagingDirectory)\BuildInfo'
         artifactName: 'BuildInfo'
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
-        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
+        targetPath: "$(Build.StagingDirectory)\\nupkgs"
         artifactName: "nupkgs - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
@@ -154,21 +154,19 @@ stages:
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe VSIX and EndToEnd.zip as artifact'
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+        targetPath: "$(Build.StagingDirectory)\\VS15"
         artifactName: "$(VsixPublishDir)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish localizationArtifacts artifact'
-        condition: "or(eq(variables['OverridePublishLocalizationArtifact'], 'true'), and(succeeded(), eq(variables['IsOfficialBuild'], 'true')))"
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localizationArtifacts\\"
+        targetPath: "$(Build.StagingDirectory)\\localizationArtifacts\\"
         artifactName: "localizationArtifacts"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'
-        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+        targetPath: "$(Build.StagingDirectory)\\symbolstoindex"
         artifactName: "symbols - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
@@ -177,16 +175,16 @@ stages:
         condition: "succeeded()"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
         buildNumber: '$(MicroBuild.ManifestDropName)'
-        sourcePath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+        sourcePath: "$(Build.StagingDirectory)\\VS15"
         toLowerCase: false
         usePat: true
         dropMetadataContainerName: "DropMetadata-Product"
 
       - output: pipelineArtifact
         displayName: 'LocValidation: Publish Logs as an artifact'
-        condition: "succeeded()"
-        artifactName: LocValidationLogs
-        targetPath: "$(Build.Repository.LocalPath)\\logs\\BuildValidatorLogs"
+        condition: "succeededOrFailed()"
+        artifactName: LocValidationLogs - Attempt $(System.JobAttempt)
+        targetPath: "$(Build.StagingDirectory)\\BuildValidatorLogs"
         sbomEnabled: true
 
       - output: pipelineArtifact
@@ -199,7 +197,7 @@ stages:
       - output: pipelineArtifact
         displayName: Publish SBOM manifest
         artifactName: $(ARTIFACT_NAME)
-        targetPath: '$(Build.SourcesDirectory)/artifacts'
+        targetPath: "$(Build.StagingDirectory)/sbom"
         sbomEnabled: false
 
     steps:
@@ -237,24 +235,24 @@ stages:
           enabled: true
         optprof:
           enabled: false
+      outputParentDirectory: '$(Build.StagingDirectory)'
       outputs:
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
         condition: "succeeded()"
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
+        targetPath: "$(Build.StagingDirectory)\\$(NupkgOutputDir)"
         artifactName: "nupkgs - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe VSIX and EndToEnd.zip as artifact'
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
+        targetPath: "$(Build.StagingDirectory)\\VS15"
         artifactName: "$(VsixPublishDir)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'
-        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
-        targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
+        targetPath: "$(Build.StagingDirectory)\\symbolstoindex"
         artifactName: "symbols - $(RtmLabel)"
         sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
 

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -21,6 +21,9 @@ The commit hash being built
 
 .PARAMETER BuildNumber
 The build number of the current build
+
+.PARAMETER BuildInfoDirectory
+Optional directory path to write buildinfo.json to. When not provided, defaults to the repository's artifacts directory.
 #>
 
 param
@@ -34,7 +37,9 @@ param
     [Parameter(Mandatory=$true)]
     [string]$CommitHash,
     [Parameter(Mandatory=$true)]
-    [string]$BuildNumber
+    [string]$BuildNumber,
+    [Parameter(Mandatory=$false)]
+    [string]$BuildInfoDirectory
 )
 
 Function Get-Version {
@@ -191,11 +196,21 @@ else
         NuGetVsVersion = $GetNuGetVsVersion
     }
 
-    # First create the file locally so that we can laster publish it as a build artifact from a local source file instead of a remote source file.
-    $localBuildInfoJsonFilePath = [System.IO.Path]::Combine("$RepositoryPath\artifacts", 'buildinfo.json')
+    if (-not [string]::IsNullOrWhiteSpace($BuildInfoDirectory))
+    {
+        $buildInfoDirectoryPath = $BuildInfoDirectory
+    }
+    else
+    {
+        $buildInfoDirectoryPath = Join-Path $RepositoryPath 'artifacts'
+    }
+
+    New-Item -Path $buildInfoDirectoryPath -ItemType Directory -Force | Out-Null
+    $localBuildInfoJsonFilePath = Join-Path $buildInfoDirectoryPath 'buildinfo.json'
 
     New-Item $localBuildInfoJsonFilePath -Force | Out-Null
     $jsonRepresentation | ConvertTo-Json | Set-Content $localBuildInfoJsonFilePath
+    Write-Host "Created $localBuildInfoJsonFilePath"
 
     Update-VsixVersion -manifestName source.extension.vsixmanifest -buildNumber $BuildNumber -RepositoryPath $RepositoryPath
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Engineering

## Description

Cherry picks https://github.com/NuGet/NuGet.Client/pull/7031
Wasn't a clean cherry pick, so needed to resolve some differences

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
