### PR TITLE
attempt at a fix for msbuild-12580

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
@@ -200,7 +200,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Main entry point for packing packages
     ============================================================
   -->
-  <Target Name="Pack" DependsOnTargets="$(PackDependsOn)">
+  <Target Name="Pack" DependsOnTargets="$(PackDependsOn)" Condition="'$(IsInnerBuild)' != 'true'">
      <IsPackableFalseWarningTask Condition="'$(IsPackable)' == 'false' AND '$(WarnOnPackingNonPackableProject)' == 'true'"/>
   </Target>
   <Target Name="_IntermediatePack">

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
@@ -200,7 +200,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Main entry point for packing packages
     ============================================================
   -->
-  <Target Name="Pack" DependsOnTargets="$(PackDependsOn)" Condition="'$(IsInnerBuild)' != 'true'">
+  <Target Name="Pack" DependsOnTargets="$(PackDependsOn)">
      <IsPackableFalseWarningTask Condition="'$(IsPackable)' == 'false' AND '$(WarnOnPackingNonPackableProject)' == 'true'"/>
   </Target>
   <Target Name="_IntermediatePack">

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -6395,5 +6395,160 @@ namespace ClassLibrary
             dependencyGroups[1].Packages.First().Id.Should().Be("X");
             dependencyGroups[1].Packages.Last().Id.Should().Be("Z");
         }
+
+        /// <summary>
+        /// Tests that pack works correctly with -graph mode for multi-targeted projects.
+        /// This tests the fix for https://github.com/dotnet/msbuild/issues/12580 where
+        /// concurrent inner builds in graph mode would cause file access conflicts
+        /// when trying to write to the same .nupkg file.
+        /// </summary>
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_MultiTargetedProject_WithGraphMode_Succeeds()
+        {
+            // Arrange
+            using (SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext())
+            {
+                SimpleTestSettingsContext settings = pathContext.Settings;
+                settings.AddNetStandardFeeds();
+
+                string testDirectory = pathContext.WorkingDirectory;
+                var projectName = "MultiTargetLib";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName, args: "classlib", testOutputHelper: _testOutputHelper);
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    // Set up multi-targeting with two target frameworks
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"net8.0;{Constants.ProjectTargetFramework}");
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                _dotnetFixture.RestoreProjectExpectSuccess(workingDirectory, projectName, testOutputHelper: _testOutputHelper);
+
+                // Act - Use -graph mode which enables parallel builds and was causing issues before the fix
+                var result = _dotnetFixture.PackProjectExpectSuccess(
+                    workingDirectory,
+                    projectName,
+                    $"-graph /p:PackageOutputPath={workingDirectory}",
+                    testOutputHelper: _testOutputHelper);
+
+                // Assert
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                // Verify the package contains both target frameworks
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var libItems = nupkgReader.GetLibItems().ToList();
+                    Assert.Equal(2, libItems.Count);
+
+                    var frameworks = libItems.Select(l => l.TargetFramework.GetShortFolderName()).OrderBy(f => f).ToList();
+                    Assert.Contains("net8.0", frameworks);
+                    Assert.Contains(NuGetFramework.Parse(Constants.ProjectTargetFramework).GetShortFolderName(), frameworks);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tests that pack with -graph mode produces the same output as pack without -graph mode
+        /// for multi-targeted projects.
+        /// </summary>
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_MultiTargetedProject_GraphModeMatchesNonGraphMode()
+        {
+            // Arrange
+            using (SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext())
+            {
+                SimpleTestSettingsContext settings = pathContext.Settings;
+                settings.AddNetStandardFeeds();
+
+                string testDirectory = pathContext.WorkingDirectory;
+                var projectName = "MultiTargetLib";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                // Create project with specific package metadata
+                _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName, args: "classlib", testOutputHelper: _testOutputHelper);
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"net8.0;{Constants.ProjectTargetFramework}");
+                    ProjectFileUtils.AddProperty(xml, "PackageId", "TestPackage");
+                    ProjectFileUtils.AddProperty(xml, "Version", "2.0.0");
+                    ProjectFileUtils.AddProperty(xml, "Authors", "TestAuthor");
+                    ProjectFileUtils.AddProperty(xml, "Description", "A test package for graph mode testing");
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                _dotnetFixture.RestoreProjectExpectSuccess(workingDirectory, projectName, testOutputHelper: _testOutputHelper);
+
+                // Create output directories for each mode
+                var regularOutput = Path.Combine(workingDirectory, "regular");
+                var graphOutput = Path.Combine(workingDirectory, "graph");
+                Directory.CreateDirectory(regularOutput);
+                Directory.CreateDirectory(graphOutput);
+
+                // Act - Pack without graph mode
+                _dotnetFixture.PackProjectExpectSuccess(
+                    workingDirectory,
+                    projectName,
+                    $"/p:PackageOutputPath={regularOutput}",
+                    testOutputHelper: _testOutputHelper);
+
+                // Clean intermediate files to ensure fresh build
+                var objDir = Path.Combine(workingDirectory, "obj");
+                if (Directory.Exists(objDir))
+                {
+                    foreach (var file in Directory.GetFiles(objDir, "*.nuspec", SearchOption.AllDirectories))
+                    {
+                        File.Delete(file);
+                    }
+                }
+
+                // Act - Pack with graph mode
+                _dotnetFixture.PackProjectExpectSuccess(
+                    workingDirectory,
+                    projectName,
+                    $"-graph /p:PackageOutputPath={graphOutput}",
+                    testOutputHelper: _testOutputHelper);
+
+                // Assert - Both packages should exist and have the same content
+                var regularNupkg = Path.Combine(regularOutput, "TestPackage.2.0.0.nupkg");
+                var graphNupkg = Path.Combine(graphOutput, "TestPackage.2.0.0.nupkg");
+
+                Assert.True(File.Exists(regularNupkg), "Regular mode .nupkg should exist");
+                Assert.True(File.Exists(graphNupkg), "Graph mode .nupkg should exist");
+
+                using (var regularReader = new PackageArchiveReader(regularNupkg))
+                using (var graphReader = new PackageArchiveReader(graphNupkg))
+                {
+                    // Compare nuspec metadata
+                    var regularNuspec = regularReader.NuspecReader;
+                    var graphNuspec = graphReader.NuspecReader;
+
+                    Assert.Equal(regularNuspec.GetId(), graphNuspec.GetId());
+                    Assert.Equal(regularNuspec.GetVersion(), graphNuspec.GetVersion());
+                    Assert.Equal(regularNuspec.GetAuthors(), graphNuspec.GetAuthors());
+                    Assert.Equal(regularNuspec.GetDescription(), graphNuspec.GetDescription());
+
+                    // Compare lib items
+                    var regularLibItems = regularReader.GetLibItems().ToList();
+                    var graphLibItems = graphReader.GetLibItems().ToList();
+
+                    Assert.Equal(regularLibItems.Count, graphLibItems.Count);
+                    Assert.Equal(2, graphLibItems.Count);
+
+                    var regularFrameworks = regularLibItems.Select(l => l.TargetFramework.GetShortFolderName()).OrderBy(f => f).ToList();
+                    var graphFrameworks = graphLibItems.Select(l => l.TargetFramework.GetShortFolderName()).OrderBy(f => f).ToList();
+
+                    Assert.Equal(regularFrameworks, graphFrameworks);
+                }
+            }
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -6401,6 +6401,13 @@ namespace ClassLibrary
         /// This tests the fix for https://github.com/dotnet/msbuild/issues/12580 where
         /// concurrent inner builds in graph mode would cause file access conflicts
         /// when trying to write to the same .nupkg file.
+        /// 
+        /// The race condition occurs reliably when:
+        /// 1. Using Microsoft.Build.Traversal SDK with a dirs.proj that references the project
+        /// 2. The project is multi-targeted
+        /// 3. MSBuild server mode is enabled (MSBUILDUSESERVER=1)
+        /// 4. Graph mode is used (-graph)
+        /// 5. Clean build (no cached obj/bin artifacts)
         /// </summary>
         [PlatformFact(Platform.Windows)]
         public void PackCommand_MultiTargetedProject_WithGraphMode_Succeeds()
@@ -6412,33 +6419,79 @@ namespace ClassLibrary
                 settings.AddNetStandardFeeds();
 
                 string testDirectory = pathContext.WorkingDirectory;
-                var projectName = "MultiTargetLib";
-                var workingDirectory = Path.Combine(testDirectory, projectName);
-                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                var projectName = "SomePackage";
+                var projectDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(projectDirectory, $"{projectName}.csproj");
+
+                // Create the project in a subdirectory
                 _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName, args: "classlib", testOutputHelper: _testOutputHelper);
 
+                // Set up multi-targeting - same as the repro case
                 using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
                     var xml = XDocument.Load(stream);
-                    // Set up multi-targeting with two target frameworks
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"net8.0;{Constants.ProjectTargetFramework}");
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
-                _dotnetFixture.RestoreProjectExpectSuccess(workingDirectory, projectName, testOutputHelper: _testOutputHelper);
+                // Create a dirs.proj with Microsoft.Build.Traversal SDK - this is critical for reproducing the issue
+                // The traversal project pattern causes MSBuild to create separate build nodes in graph mode
+                var dirsProjContent = $@"<Project Sdk=""Microsoft.Build.Traversal"">
+  <ItemGroup>
+    <ProjectReference Include=""{projectName}\{projectName}.csproj"" />
+  </ItemGroup>
+</Project>";
+                File.WriteAllText(Path.Combine(testDirectory, "dirs.proj"), dirsProjContent);
 
-                // Act - Use -graph mode which enables parallel builds and was causing issues before the fix
-                var result = _dotnetFixture.PackProjectExpectSuccess(
-                    workingDirectory,
-                    projectName,
-                    $"-graph /p:PackageOutputPath={workingDirectory}",
+                // Create global.json to specify the Traversal SDK version
+                var globalJsonContent = @"{
+  ""msbuild-sdks"": {
+    ""Microsoft.Build.Traversal"": ""4.1.82""
+  }
+}";
+                File.WriteAllText(Path.Combine(testDirectory, "global.json"), globalJsonContent);
+
+                // Restore both the traversal project and the actual project
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, "restore dirs.proj", testOutputHelper: _testOutputHelper);
+
+                // Delete ALL build outputs to simulate a completely clean build scenario
+                // This is critical - the race condition only occurs on clean builds
+                var binDir = Path.Combine(projectDirectory, "bin");
+                if (Directory.Exists(binDir))
+                {
+                    Directory.Delete(binDir, recursive: true);
+                }
+
+                // Delete the entire obj folder and restore fresh
+                var objDir = Path.Combine(projectDirectory, "obj");
+                if (Directory.Exists(objDir))
+                {
+                    Directory.Delete(objDir, recursive: true);
+                }
+
+                // Restore again after cleaning obj
+                _dotnetFixture.RunDotnetExpectSuccess(testDirectory, "restore dirs.proj", testOutputHelper: _testOutputHelper);
+
+                // Enable MSBuild server mode - required to reproduce the race condition
+                var environmentVariables = new Dictionary<string, string>
+                {
+                    ["MSBUILDUSESERVER"] = "1"
+                };
+
+                // Act - Run pack with -graph mode directly on the multi-targeted project
+                // This is the scenario from the issue: multi-targeted project + graph + server mode
+                // Without the IsInnerBuild condition on the Pack target, both inner builds (net8.0, net9.0)
+                // run Pack simultaneously and race to write to the same .nupkg/.nuspec files.
+                var result = _dotnetFixture.RunDotnetExpectSuccess(
+                    projectDirectory,
+                    $"pack {projectName}.csproj -graph -c Release",
+                    environmentVariables: environmentVariables,
                     testOutputHelper: _testOutputHelper);
 
-                // Assert
-                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
-                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
-                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
-                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+                // Assert - The pack should succeed and produce a valid package
+                var nupkgPath = Path.Combine(projectDirectory, "bin", "Release", $"{projectName}.1.0.0.nupkg");
+
+                Assert.True(File.Exists(nupkgPath), $"The output .nupkg is not in the expected place: {nupkgPath}");
 
                 // Verify the package contains both target frameworks
                 using (var nupkgReader = new PackageArchiveReader(nupkgPath))

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -362,17 +362,68 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
         {
             const string packProjectName = "NuGet.Build.Tasks.Pack";
 
-            // Copy the pack SDK.
+            // Copy the pack SDK DLLs from NuGet.Build.Tasks.Pack project.
             var packProjectBinDirectory = Path.Combine(artifactsDirectory, packProjectName, "bin", configuration);
             var tfmToCopy = GetTfmToCopy(packProjectBinDirectory);
             var packProjectCoreArtifactsDirectory = new DirectoryInfo(Path.Combine(packProjectBinDirectory, tfmToCopy));
 
-            foreach (var assembly in packProjectCoreArtifactsDirectory.EnumerateFiles("*.dll"))
+            // Copy DLLs to the main SDK folder
+            foreach (var file in packProjectCoreArtifactsDirectory.EnumerateFiles("*.dll"))
             {
                 File.Copy(
-                    sourceFileName: assembly.FullName,
-                    destFileName: Path.Combine(pathToSdkInCli, assembly.Name),
+                    sourceFileName: file.FullName,
+                    destFileName: Path.Combine(pathToSdkInCli, file.Name),
                     overwrite: true);
+            }
+
+            // Copy .targets files from NuGet.Build.Tasks project (where they are actually built)
+            // to the NuGet.Build.Tasks.Pack SDK subfolders.
+            // The SDK has separate build and buildCrossTargeting folders for the targets files.
+            // These contain important build logic that may have fixes we need to test
+            // (e.g., IsInnerBuild conditions for graph mode).
+            const string buildTasksProjectName = "NuGet.Build.Tasks";
+            var buildTasksBinDirectory = Path.Combine(artifactsDirectory, buildTasksProjectName, "bin", configuration);
+            var buildTasksTfm = GetTfmToCopy(buildTasksBinDirectory);
+            var buildTasksArtifactsDirectory = new DirectoryInfo(Path.Combine(buildTasksBinDirectory, buildTasksTfm));
+
+            var packSdkBuildFolder = Path.Combine(pathToSdkInCli, "Sdks", packProjectName, "build");
+            var packSdkCrossTargetingFolder = Path.Combine(pathToSdkInCli, "Sdks", packProjectName, "buildCrossTargeting");
+
+            foreach (var file in buildTasksArtifactsDirectory.EnumerateFiles("NuGet.Build.Tasks.Pack.targets"))
+            {
+                // Copy to the SDK root folder (for SDK 10.0+, targets are at root level)
+                File.Copy(
+                    sourceFileName: file.FullName,
+                    destFileName: Path.Combine(pathToSdkInCli, file.Name),
+                    overwrite: true);
+
+                // Also copy to runtimes\any\native if it exists (SDK 10.0+ structure)
+                var runtimesNativeFolder = Path.Combine(pathToSdkInCli, "runtimes", "any", "native");
+                if (Directory.Exists(runtimesNativeFolder))
+                {
+                    File.Copy(
+                        sourceFileName: file.FullName,
+                        destFileName: Path.Combine(runtimesNativeFolder, file.Name),
+                        overwrite: true);
+                }
+
+                // Copy to the build folder (for single-targeted projects) - older SDK structure
+                if (Directory.Exists(packSdkBuildFolder))
+                {
+                    File.Copy(
+                        sourceFileName: file.FullName,
+                        destFileName: Path.Combine(packSdkBuildFolder, file.Name),
+                        overwrite: true);
+                }
+
+                // Copy to the buildCrossTargeting folder (for multi-targeted projects) - older SDK structure
+                if (Directory.Exists(packSdkCrossTargetingFolder))
+                {
+                    File.Copy(
+                        sourceFileName: file.FullName,
+                        destFileName: Path.Combine(packSdkCrossTargetingFolder, file.Name),
+                        overwrite: true);
+                }
             }
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/dotnet/msbuild/issues/12580

## Description
When running the reproduction as described in the [linked issue](https://github.com/dotnet/msbuild/issues/12580), the first time around the build fails due to a file being locked.
This is an attempt to remedy the issue by only running the target in the inner build. This is consistent with how _PackAsBuildAfterTarget already handles the GeneratePackageOnBuild scenario (lines 164-165):

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
