### PR TITLE
Reduce allocation in DownloadTimeoutStream.ReadAsync caused by avoida…

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Utility/DownloadTimeoutStream.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/DownloadTimeoutStream.cs
@@ -71,12 +71,6 @@ namespace NuGet.Protocol
             int count,
             CancellationToken cancellationToken)
         {
-            var timeoutMessage = string.Format(
-                CultureInfo.CurrentCulture,
-                Strings.Error_DownloadTimeout,
-                _downloadName,
-                _timeout.TotalMilliseconds);
-
             try
             {
                 var result = await TimeoutUtility.StartWithTimeout(
@@ -89,6 +83,12 @@ namespace NuGet.Protocol
             }
             catch (TimeoutException e)
             {
+                var timeoutMessage = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.Error_DownloadTimeout,
+                    _downloadName,
+                    _timeout.TotalMilliseconds);
+
                 // Failed stream operations should throw an IOException.
                 throw new IOException(timeoutMessage, e);
             }


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: The `ReadAsync` method in `DownloadTimeoutStream.cs` allocates a timeout error message string via `string.Format()` on every single call (line with `var timeoutMessage = string.Format(...)`), even though this message is only used when a `TimeoutException` is caught. This can lead to unnecessary allocations. Evidence: The stack trace shows `String.FormatHelper` being called from `DownloadTimeoutStream+<ReadAsync>d__.MoveNext`, and the source code confirms `string.Format` is called unconditionally at the start of every `ReadAsync` invocation.
Allocation path: `DownloadTimeoutStream.ReadAsync` → `String.FormatHelper` → `StringBuilder.ToString` → `TypeAllocated!System.String`

- Issue type: Reduce string allocations

- Proposed fix: Move the `string.Format` call from the beginning of the `ReadAsync` method into the `catch (TimeoutException)` block. This defers the string allocation to only occur when a timeout exception is actually caught, eliminating allocations on the hot path (normal successful reads).

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&failureHash=40b9fac7-4c43-27f1-dbfe-4e7a342be87d)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2677283)