### PR TITLE
Reduce allocation in GetContentFileGroup by providing accurate capacity for List

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/ContentFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ContentFiles/ContentFileUtils.cs
@@ -75,7 +75,6 @@ namespace NuGet.Commands
             NuspecReader nuspec,
             List<ContentItemGroup> contentFileGroups)
         {
-            var results = new List<LockFileContentFile>(contentFileGroups.Count);
             var rootFolderPathLength = ContentFilesFolderName.Length;
 
             // Read the contentFiles section of the nuspec
@@ -147,6 +146,8 @@ namespace NuGet.Commands
                     }
                 }
             }
+
+            var results = new List<LockFileContentFile>(entryMappings.Count);
 
             // Create lock file entries for each item in the contentFiles folder
             foreach ((var file, var entries) in entryMappings)


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: In `ContentFileUtils.GetContentFileGroup` the `results` list is initialized with `contentFileGroups.Count` as capacity, but the actual number of items added equals `entryMappings.Count` (which is the count of unique file paths across all groups). Since each content group typically contains multiple items, `entryMappings.Count` is significantly larger than `contentFileGroups.Count`, causing repeated list resizing and unnecessary `LockFileContentFile[]` allocations.
Evidence:
  ```
  TypeAllocated!NuGet.ProjectModel.LockFileContentFile[]
  clr.dll!JIT_NewArr1
  mscorlib.dll!System.Collections.Generic.List`[System.__Canon].set_Capacity
  mscorlib.dll!System.Collections.Generic.List`[System.__Canon].EnsureCapacity
  mscorlib.dll!System.Collections.Generic.List`[System.__Canon].Add
  nuget.commands.dll!NuGet.Commands.ContentFileUtils.GetContentFileGroup
  ```

- Issue type: Specify an up-front capacity for collections if one is known

- Proposed fix: Move the `results` list initialization to after the `entryMappings` dictionary is fully populated, and change the capacity from `contentFileGroups.Count` to `entryMappings.Count`. This ensures the list is allocated with the exact required capacity, eliminating all resize-triggered array allocations.


[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?query=c%3AEnsureCapacity%20l%3A60&eventType=allocation&failureType=dualdirection&failureHash=8b4f019f-bb4b-3955-b581-bb62b0aaf12d)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2678214)