### PR TITLE
dotnet list package works with unlisted and prerelease packages

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -422,7 +422,7 @@ namespace NuGet.CommandLine.XPlat
                     : (Environment.ProcessorCount / listPackageArgs.PackageSources.Count) + 1;
 
             await ThrottledForEachAsync(allPackages,
-                async (packageId, cancellationToken) => await GetPackageVersionsAsync(packageId, listPackageArgs, cancellationToken),
+                async (packageId, cancellationToken) => await GetPackageMetadataAsync(packageId, listPackageArgs, cancellationToken),
                 packageMetadata => packageMetadataById[packageMetadata.Key] = packageMetadata.Value,
                 maxParallel,
                 listPackageArgs.CancellationToken);
@@ -559,7 +559,10 @@ namespace NuGet.CommandLine.XPlat
                         // Get latest metadata *only* if this is a report requiring "outdated" metadata
                         if (listPackageArgs.ReportType == ReportType.Outdated && matchingPackage.Count > 0)
                         {
-                            var latestVersion = matchingPackage.Where(newVersion => MeetsConstraints(newVersion.Identity.Version, topLevelPackage, listPackageArgs)).Max(i => i.Identity.Version);
+                            var latestVersion = matchingPackage
+                                .Where(package => package.IsListed)
+                                .Where(newVersion => MeetsConstraints(newVersion.Identity.Version, topLevelPackage, listPackageArgs))
+                                .Max(i => i.Identity.Version);
 
                             if (latestVersion is not null)
                             {
@@ -595,7 +598,10 @@ namespace NuGet.CommandLine.XPlat
                         // Get latest metadata *only* if this is a report requiring "outdated" metadata
                         if (listPackageArgs.ReportType == ReportType.Outdated && matchingPackage.Count > 0)
                         {
-                            var latestVersion = matchingPackage.Where(newVersion => MeetsConstraints(newVersion.Identity.Version, transitivePackage, listPackageArgs)).Max(i => i.Identity.Version);
+                            var latestVersion = matchingPackage
+                                .Where(newVersion => newVersion.IsListed)
+                                .Where(newVersion => MeetsConstraints(newVersion.Identity.Version, transitivePackage, listPackageArgs))
+                                .Max(i => i.Identity.Version);
 
                             transitivePackage.LatestPackageMetadata = matchingPackage.First(p => p.Identity.Version == latestVersion);
                             transitivePackage.UpdateLevel = GetUpdateLevel(transitivePackage.ResolvedPackageMetadata.Identity.Version, transitivePackage.LatestPackageMetadata.Identity.Version);
@@ -645,14 +651,13 @@ namespace NuGet.CommandLine.XPlat
         }
 
         /// <summary>
-        /// Prepares the calls to sources for latest versions and updates
-        /// the list of tasks with the requests
+        /// Gets the package metadata for a specific package from all sources
         /// </summary>
         /// <param name="package">The package to get the latest version for</param>
         /// <param name="listPackageArgs">List args for the token and source provider></param>
         /// <param name="cancellationToken"></param>
         /// <returns>A list of tasks for all latest versions for packages from all sources</returns>
-        private async Task<KeyValuePair<string, List<IPackageSearchMetadata>>> GetPackageVersionsAsync(
+        private async Task<KeyValuePair<string, List<IPackageSearchMetadata>>> GetPackageMetadataAsync(
             string package,
             ListPackageArgs listPackageArgs,
             CancellationToken cancellationToken)
@@ -661,7 +666,7 @@ namespace NuGet.CommandLine.XPlat
             var sources = listPackageArgs.PackageSources;
 
             await ThrottledForEachAsync(sources,
-                async (source, innerCancellationToken) => await GetLatestVersionPerSourceAsync(source, listPackageArgs, package, innerCancellationToken),
+                async (source, innerCancellationToken) => await GetPackageMetadataAsync(source, listPackageArgs, package, innerCancellationToken),
                 continuation: results.AddRange,
                 maxParallel: listPackageArgs.PackageSources.Count,
                 cancellationToken);
@@ -670,14 +675,14 @@ namespace NuGet.CommandLine.XPlat
         }
 
         /// <summary>
-        /// Gets the highest version of a package from a specific source
+        /// Gets package metadata for a specific package from a specific source
         /// </summary>
         /// <param name="packageSource">The source to look for packages at</param>
         /// <param name="listPackageArgs">The list args for the cancellation token</param>
         /// <param name="package">Package to look for updates for</param>
         /// <param name="cancellationToken"></param>
         /// <returns>An updated package with the highest version at a single source</returns>
-        private async Task<IEnumerable<IPackageSearchMetadata>> GetLatestVersionPerSourceAsync(
+        private async Task<IEnumerable<IPackageSearchMetadata>> GetPackageMetadataAsync(
             PackageSource packageSource,
             ListPackageArgs listPackageArgs,
             string package,
@@ -687,11 +692,16 @@ namespace NuGet.CommandLine.XPlat
             var packageMetadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(cancellationToken);
 
             using var sourceCacheContext = new SourceCacheContext();
+            // This is used for --outdated, --deprecated, and --vulnerable.
+            // So, we need the package metadata for the currently installed version,
+            // even if it's pre-release or unlisted.
+            // This means that the logic for --outdated has to do filtering based on IsListed and
+            // prerelease.
             IEnumerable<IPackageSearchMetadata> packages =
                 await packageMetadataResource.GetMetadataAsync(
                     package,
-                    includePrerelease: listPackageArgs.Prerelease,
-                    includeUnlisted: false,
+                    includePrerelease: true,
+                    includeUnlisted: true,
                     sourceCacheContext: sourceCacheContext,
                     log: listPackageArgs.Logger,
                     token: listPackageArgs.CancellationToken);
@@ -710,7 +720,7 @@ namespace NuGet.CommandLine.XPlat
         /// <returns>Whether the new version meets the constraints or not</returns>
         private bool MeetsConstraints(NuGetVersion newVersion, InstalledPackageReference package, ListPackageArgs listPackageArgs)
         {
-            var result = !newVersion.IsPrerelease || listPackageArgs.Prerelease || package.ResolvedPackageMetadata.Identity.Version.IsPrerelease;
+            var result = !newVersion.IsPrerelease || listPackageArgs.Prerelease;
 
             if (listPackageArgs.HighestPatch)
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -559,7 +559,12 @@ namespace NuGet.CommandLine.Test
         /// </summary>
         public static JObject CreateSinglePackageRegistrationBlob(MockServer server, string id, string version)
         {
-            return FeedUtilities.CreatePackageRegistrationBlob(server.Uri, id, new KeyValuePair<string, bool>[] { new KeyValuePair<string, bool>(version, true) }, new HashSet<PackageIdentity>());
+            return FeedUtilities.CreatePackageRegistrationBlob(
+                server.Uri,
+                id,
+                new KeyValuePair<string, bool>[] { new KeyValuePair<string, bool>(version, true) },
+                new HashSet<PackageIdentity>(),
+                null);
         }
 
         public static string CreateProjFileContent(

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -182,7 +182,8 @@ namespace Dotnet.Integration.Test
                 // the one set by the _inner_ (test environment-specific) dotnet cli call we're about to make.
                 // We need to ensure that this points to the correct SDK directory because this value
                 // is used to locate many Tasks - especially those located by relative path or name.
-                ["MSBuildExtensionsPath"] = SdkDirectory.FullName
+                ["MSBuildExtensionsPath"] = SdkDirectory.FullName,
+                ["PATH"] = $"{_cliDirectory}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}"
             };
 
             if (enableDiagnostics)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -699,7 +699,7 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             using var pathContext = _fixture.CreateSimpleTestPathContext();
-            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net472");
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, Constants.ProjectTargetFramework);
 
             var packageA100 = new SimpleTestPackageContext("PackageA", "1.0.0");
             var packageA200 = new SimpleTestPackageContext("PackageA", "2.0.0");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -18,7 +18,9 @@ using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging;
+using NuGet.Protocol;
 using NuGet.Test.Utility;
+using NuGet.Versioning;
 using NuGet.XPlat.FuncTest;
 using Test.Utility;
 using Xunit;
@@ -692,6 +694,38 @@ namespace Dotnet.Integration.Test
             }
         }
 
+        [Fact]
+        public async Task DotnetListPackage_Outdated_WithHighestVersionUnlisted_ReportsHighestListedVersion()
+        {
+            // Arrange
+            using var pathContext = _fixture.CreateSimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net472");
+
+            var packageA100 = new SimpleTestPackageContext("PackageA", "1.0.0");
+            var packageA200 = new SimpleTestPackageContext("PackageA", "2.0.0");
+            var packageA300 = new SimpleTestPackageContext("PackageA", "3.0.0");
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageA100, packageA200, packageA300);
+
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
+            var packageSource = new PackageSource(mockServer.ServiceIndexUri, "source");
+            pathContext.Settings.RemoveSource(packageSource.Name);
+            pathContext.Settings.AddSource(packageSource.Name, packageSource.Source, allowInsecureConnectionsValue: "true");
+            mockServer.Start();
+
+            // Mark the highest version as unlisted
+            mockServer.UnlistedPackages.Add(packageA300.Identity);
+
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package PackageA --version 1.0.0", testOutputHelper: _testOutputHelper);
+
+            // Act
+            var result = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, "list package --outdated", testOutputHelper: _testOutputHelper);
+
+            // Assert
+            // Should show 2.0.0 as the latest version, not 3.0.0 (which is unlisted)
+            Assert.True(ContainsIgnoringSpaces(result.AllOutput, "PackageA1.0.01.0.02.0.0"));
+            Assert.False(ContainsIgnoringSpaces(result.AllOutput, "3.0.0"));
+        }
+
         [PlatformTheory(Platform.Windows)]
         [InlineData("1.1.0-beta", "")]
         [InlineData("2.0.0-beta", "--highest-patch")]
@@ -1132,6 +1166,208 @@ namespace Dotnet.Integration.Test
 
             // Assert - Verify the package is listed correctly
             Assert.True(ContainsIgnoringSpaces(listResult.AllOutput, "PackageX1.0.01.0.0"));
+        }
+
+        [Fact]
+        public async Task DeprecatedOption_WithUnlistedPackage_Succeeds()
+        {
+            // Arrange
+            using var pathContext = _fixture.CreateSimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, Constants.ProjectTargetFramework);
+
+            var packageA100 = new SimpleTestPackageContext("PackageA", "1.0.0");
+            var packageB100 = new SimpleTestPackageContext("PackageB", "1.0.0");
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageA100, packageB100);
+
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
+            var packageSource = new PackageSource(mockServer.ServiceIndexUri, "source");
+            pathContext.Settings.RemoveSource(packageSource.Name);
+            pathContext.Settings.AddSource(packageSource.Name, packageSource.Source, allowInsecureConnectionsValue: "true");
+            mockServer.Start();
+
+            mockServer.UnlistedPackages.Add(packageA100.Identity);
+            mockServer.UnlistedPackages.Add(packageB100.Identity);
+
+            // Only PackageA is deprecated
+            mockServer.DeprecatedPackages.Add(packageA100.Identity);
+
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package PackageA --version 1.0.0", testOutputHelper: _testOutputHelper);
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package PackageB --version 1.0.0", testOutputHelper: _testOutputHelper);
+
+            // Act
+            var result = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, "list package --deprecated --format json", testOutputHelper: _testOutputHelper);
+
+            // Assert
+            var json = JObject.Parse(result.AllOutput);
+            var projects = (JArray)json.SelectToken("$.projects");
+            projects.Should().NotBeNull();
+            projects.Count.Should().Be(1);
+
+            var frameworks = (JArray)projects[0].SelectToken("$.frameworks");
+            frameworks.Should().NotBeNull();
+            frameworks.Count.Should().Be(1);
+
+            var topLevelPackages = (JArray)frameworks[0].SelectToken("$.topLevelPackages");
+            topLevelPackages.Should().NotBeNull();
+            topLevelPackages.Count.Should().Be(1, "only PackageA should be listed as it's deprecated");
+
+            var package = topLevelPackages[0];
+            package["id"].ToString().Should().Be("PackageA");
+            package["resolvedVersion"].ToString().Should().Be("1.0.0");
+            package["deprecationReasons"].Should().NotBeNull();
+            ((JArray)package["deprecationReasons"]).Select(t => t.ToString()).Should().Contain("CriticalBugs");
+        }
+
+        [Fact]
+        public async Task DeprecatedOption_WithPrereleasePackage_Succeeds()
+        {
+            // Arrange
+            using var pathContext = _fixture.CreateSimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, Constants.ProjectTargetFramework);
+
+            var packageA100 = new SimpleTestPackageContext("PackageA", "1.0.0-alpha");
+            var packageB100 = new SimpleTestPackageContext("PackageB", "1.0.0-alpha");
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageA100, packageB100);
+
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
+            var packageSource = new PackageSource(mockServer.ServiceIndexUri, "source");
+            pathContext.Settings.RemoveSource(packageSource.Name);
+            pathContext.Settings.AddSource(packageSource.Name, packageSource.Source, allowInsecureConnectionsValue: "true");
+            mockServer.Start();
+
+            // Only PackageA is deprecated
+            mockServer.DeprecatedPackages.Add(packageA100.Identity);
+
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package PackageA --version 1.0.0-alpha", testOutputHelper: _testOutputHelper);
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package PackageB --version 1.0.0-alpha", testOutputHelper: _testOutputHelper);
+
+            // Act
+            // Do not pass --prerelease argument. Since the project is already referencing the prerelease version, the command should still work.
+            var result = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, "list package --deprecated --format json", testOutputHelper: _testOutputHelper);
+
+            // Assert
+            var json = JObject.Parse(result.AllOutput);
+            var projects = (JArray)json.SelectToken("$.projects");
+            projects.Should().NotBeNull();
+            projects.Count.Should().Be(1);
+
+            var frameworks = (JArray)projects[0].SelectToken("$.frameworks");
+            frameworks.Should().NotBeNull();
+            frameworks.Count.Should().Be(1);
+
+            var topLevelPackages = (JArray)frameworks[0].SelectToken("$.topLevelPackages");
+            topLevelPackages.Should().NotBeNull();
+            topLevelPackages.Count.Should().Be(1, "only PackageA should be listed as it's deprecated");
+
+            var package = topLevelPackages[0];
+            package["id"].ToString().Should().Be("PackageA");
+            package["resolvedVersion"].ToString().Should().Be("1.0.0-alpha");
+            package["deprecationReasons"].Should().NotBeNull();
+            ((JArray)package["deprecationReasons"]).Select(t => t.ToString()).Should().Contain("CriticalBugs");
+        }
+
+        [Fact]
+        public async Task VulnerableOption_WithUnlistedPackage_Succeeds()
+        {
+            // Arrange
+            using var pathContext = _fixture.CreateSimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, Constants.ProjectTargetFramework);
+
+            var packageA100 = new SimpleTestPackageContext("PackageA", "1.0.0");
+            var packageB100 = new SimpleTestPackageContext("PackageB", "1.0.0");
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageA100, packageB100);
+
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource, sourceReportsVulnerabilities: true);
+            var packageSource = new PackageSource(mockServer.ServiceIndexUri, "source");
+            pathContext.Settings.RemoveSource(packageSource.Name);
+            pathContext.Settings.AddSource(packageSource.Name, packageSource.Source, allowInsecureConnectionsValue: "true");
+            mockServer.Start();
+
+            mockServer.UnlistedPackages.Add(packageA100.Identity);
+            mockServer.UnlistedPackages.Add(packageB100.Identity);
+
+            // Only PackageA is vulnerable
+            mockServer.Vulnerabilities.Add("PackageA", new List<(Uri, PackageVulnerabilitySeverity, VersionRange)>
+            {
+                (new Uri("https://contoso.com/advisory"), PackageVulnerabilitySeverity.Moderate, VersionRange.Parse("[1.0.0]"))
+            });
+
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package PackageA --version 1.0.0", testOutputHelper: _testOutputHelper);
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package PackageB --version 1.0.0", testOutputHelper: _testOutputHelper);
+
+            // Act
+            var result = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, "list package --vulnerable --format json", testOutputHelper: _testOutputHelper);
+
+            // Assert
+            var json = JObject.Parse(result.AllOutput);
+            var projects = (JArray)json.SelectToken("$.projects");
+            projects.Should().NotBeNull();
+            projects.Count.Should().Be(1);
+
+            var frameworks = (JArray)projects[0].SelectToken("$.frameworks");
+            frameworks.Should().NotBeNull();
+            frameworks.Count.Should().Be(1);
+
+            var topLevelPackages = (JArray)frameworks[0].SelectToken("$.topLevelPackages");
+            topLevelPackages.Should().NotBeNull();
+            topLevelPackages.Count.Should().Be(1, "only PackageA should be listed as it's vulnerable");
+
+            var package = topLevelPackages[0];
+            package["id"].ToString().Should().Be("PackageA");
+            package["resolvedVersion"].ToString().Should().Be("1.0.0");
+            package["vulnerabilities"].Should().NotBeNull();
+            ((JArray)package["vulnerabilities"]).Count.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public async Task VulnerableOption_WithPrereleasePackage_Succeeds()
+        {
+            // Arrange
+            using var pathContext = _fixture.CreateSimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, Constants.ProjectTargetFramework);
+
+            var packageA100 = new SimpleTestPackageContext("PackageA", "1.0.0-alpha");
+            var packageB100 = new SimpleTestPackageContext("PackageB", "1.0.0-alpha");
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageA100, packageB100);
+
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource, sourceReportsVulnerabilities: true);
+            var packageSource = new PackageSource(mockServer.ServiceIndexUri, "source");
+            pathContext.Settings.RemoveSource(packageSource.Name);
+            pathContext.Settings.AddSource(packageSource.Name, packageSource.Source, allowInsecureConnectionsValue: "true");
+            mockServer.Start();
+
+            // Only PackageA is vulnerable
+            mockServer.Vulnerabilities.Add("PackageA", new List<(Uri, PackageVulnerabilitySeverity, VersionRange)>
+            {
+                (new Uri("https://contoso.com/advisory"), PackageVulnerabilitySeverity.Moderate, VersionRange.Parse("[1.0.0-alpha]"))
+            });
+
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package PackageA --version 1.0.0-alpha", testOutputHelper: _testOutputHelper);
+            _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, $"add package PackageB --version 1.0.0-alpha", testOutputHelper: _testOutputHelper);
+
+            // Act
+            // Do not pass --prerelease argument. Since the project is already referencing the prerelease version, the command should still work.
+            var result = _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName, "list package --vulnerable --format json", testOutputHelper: _testOutputHelper);
+
+            // Assert
+            var json = JObject.Parse(result.AllOutput);
+            var projects = (JArray)json.SelectToken("$.projects");
+            projects.Should().NotBeNull();
+            projects.Count.Should().Be(1);
+
+            var frameworks = (JArray)projects[0].SelectToken("$.frameworks");
+            frameworks.Should().NotBeNull();
+            frameworks.Count.Should().Be(1);
+
+            var topLevelPackages = (JArray)frameworks[0].SelectToken("$.topLevelPackages");
+            topLevelPackages.Should().NotBeNull();
+            topLevelPackages.Count.Should().Be(1, "only PackageA should be listed as it's vulnerable");
+
+            var package = topLevelPackages[0];
+            package["id"].ToString().Should().Be("PackageA");
+            package["resolvedVersion"].ToString().Should().Be("1.0.0-alpha");
+            package["vulnerabilities"].Should().NotBeNull();
+            ((JArray)package["vulnerabilities"]).Count.Should().BeGreaterThan(0);
         }
 
         private static string CollapseSpaces(string input)

--- a/test/TestUtilities/Test.Utility/FileSystemBackedV3MockServer.cs
+++ b/test/TestUtilities/Test.Utility/FileSystemBackedV3MockServer.cs
@@ -21,7 +21,11 @@ namespace Test.Utility
         private string _packageDirectory;
         private readonly MockResponseBuilder _builder;
         private readonly bool _isPrivateFeed;
+
+        /// <summary>Does the source support the VulnerabilityInfo resource</summary>
+        /// <remarks>Sources can provide vulnerability info on registration pages without supporting the vulnerability info resource.</remarks>
         private readonly bool _sourceReportsVulnerabilities;
+
         public FileSystemBackedV3MockServer(string packageDirectory, bool isPrivateFeed = false, bool sourceReportsVulnerabilities = false)
         {
             _packageDirectory = packageDirectory;
@@ -33,7 +37,7 @@ namespace Test.Utility
 
         public ISet<PackageIdentity> UnlistedPackages { get; } = new HashSet<PackageIdentity>();
 
-        public Dictionary<string, List<(Uri, PackageVulnerabilitySeverity, VersionRange)>> Vulnerabilities = new();
+        public Dictionary<string, List<(Uri, PackageVulnerabilitySeverity, VersionRange)>> Vulnerabilities = new(StringComparer.OrdinalIgnoreCase);
 
         public ISet<PackageIdentity> DeprecatedPackages { get; } = new HashSet<PackageIdentity>();
 
@@ -147,7 +151,7 @@ namespace Test.Utility
                     {
                         response.ContentType = "text/javascript";
                         var packageToListedMapping = packages.Select(e => new KeyValuePair<PackageIdentity, bool>(e.Identity, !UnlistedPackages.Contains(e.Identity))).ToArray();
-                        MockResponse mockResponse = _builder.BuildRegistrationIndexResponse(Uri, packageToListedMapping, DeprecatedPackages);
+                        MockResponse mockResponse = _builder.BuildRegistrationIndexResponse(Uri, packageToListedMapping, DeprecatedPackages, Vulnerabilities);
                         SetResponseContent(response, mockResponse.Content);
                     });
                 }

--- a/test/TestUtilities/Test.Utility/MockResponses/MockResponseBuilder.cs
+++ b/test/TestUtilities/Test.Utility/MockResponses/MockResponseBuilder.cs
@@ -199,7 +199,8 @@ namespace Test.Utility
                 e => new KeyValuePair<string, bool>(
                     e.Key.Version.ToNormalizedString().ToLowerInvariant(),
                     e.Value));
-            if (!allVulnerabilities.TryGetValue(id, out var packageVulnerabilities))
+            List<(Uri, PackageVulnerabilitySeverity, VersionRange)> packageVulnerabilities = null;
+            if (allVulnerabilities != null && !allVulnerabilities.TryGetValue(id, out packageVulnerabilities))
             {
                 packageVulnerabilities = null;
             }

--- a/test/TestUtilities/Test.Utility/MockResponses/MockResponseBuilder.cs
+++ b/test/TestUtilities/Test.Utility/MockResponses/MockResponseBuilder.cs
@@ -14,6 +14,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Protocol;
 using NuGet.Versioning;
 
 namespace Test.Utility
@@ -183,17 +184,27 @@ namespace Test.Utility
                     new KeyValuePair<PackageIdentity, bool>(
                         e,
                         true)).ToArray(),
-                new HashSet<PackageIdentity>());
+                new HashSet<PackageIdentity>(),
+                null);
         }
 
-        public MockResponse BuildRegistrationIndexResponse(string serverUri, KeyValuePair<PackageIdentity, bool>[] packageIdentityToListed, ISet<PackageIdentity> deprecatedPackages)
+        public MockResponse BuildRegistrationIndexResponse(
+            string serverUri,
+            KeyValuePair<PackageIdentity, bool>[] packageIdentityToListed,
+            ISet<PackageIdentity> deprecatedPackages,
+            IReadOnlyDictionary<string, List<(Uri, PackageVulnerabilitySeverity, VersionRange)>> allVulnerabilities)
         {
             var id = packageIdentityToListed[0].Key.Id.ToLowerInvariant();
             var versions = packageIdentityToListed.Select(
                 e => new KeyValuePair<string, bool>(
                     e.Key.Version.ToNormalizedString().ToLowerInvariant(),
                     e.Value));
-            var registrationIndex = FeedUtilities.CreatePackageRegistrationBlob(serverUri, id, versions, deprecatedPackages);
+            if (!allVulnerabilities.TryGetValue(id, out var packageVulnerabilities))
+            {
+                packageVulnerabilities = null;
+            }
+
+            var registrationIndex = FeedUtilities.CreatePackageRegistrationBlob(serverUri, id, versions, deprecatedPackages, packageVulnerabilities);
 
             return new MockResponse
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14477

## Description

I assume that `dotnet list package` supported checking for deprecated and vulnerable packages sometime after it supported checking for outdated packages, because some of the method names were different to what they were actually doing, plus the code to get package metadata from package sources wouldn't get metadata about unlisted or prerelease packages, even if the project was using those packages. So, it was changed to always get metadata about prerelease and unlisted packages, and the outdated report was updated to filter out the unlisted packages.

There was some test infrastructure fixes as well. Since commands like `dotnet add package` run msbuild as a child process before running NuGet's main logic for the command, these child processes were failing because the child process was using the system installed dotnet, rather than the test dotnet, and global.json was forcing it to use a specific version of the sdk. Adding the test dotnet to the path fixed it, allowing `--format json` to capture and parse json, making validation less fragile from variable space issues.

Also needed to add support for vulnerability info on registration pages to the mock server.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
