### PR TITLE
NuGet.CommandLine.XPlat should target net10.0

### DIFF
--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,2 +1,2 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 9.0.3xx
+-Channel 10.0.1xx

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -13,7 +13,7 @@
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
     <NETCoreTargetFramework>net8.0</NETCoreTargetFramework>
     <NETCoreTargetFramework Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildFromVMR)' == 'true'">net10.0</NETCoreTargetFramework>
-    <LatestNETCoreTargetFramework>net9.0</LatestNETCoreTargetFramework>
+    <LatestNETCoreTargetFramework>net10.0</LatestNETCoreTargetFramework>
     <LatestNETCoreTargetFramework Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildFromVMR)' == 'true'">net10.0</LatestNETCoreTargetFramework>
 
     <!-- Target frameworks for class libraries-->
@@ -88,7 +88,7 @@
     <Features>strict</Features>
     <!-- Same as SDK default, but without CandidateAssemblyFiles in front, which would search in Content items -->
     <AssemblySearchPaths>{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
-    <LangVersion>12</LangVersion>
+    <LangVersion>14</LangVersion>
     <LangVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'">latest</LangVersion>
   </PropertyGroup>
 

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -68,12 +68,12 @@ stages:
 
 - ${{ if eq(parameters.RunUnitTestsOnWindows, true) }}:
   - stage:
-    displayName: Unit Tests on Windows (.NET 9.0)
+    displayName: Unit Tests on Windows (.NET 10.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Unit Tests on Windows (.NET 9.0)
+        displayName: Unit Tests on Windows (.NET 10.0)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -81,7 +81,7 @@ stages:
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Unit
-        testTargetFramework: net9.0
+        testTargetFramework: net10.0
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
@@ -160,12 +160,12 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: Dotnet.Integration.Test on Windows (.NET 9.0)
+    displayName: Dotnet.Integration.Test on Windows (.NET 10.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Dotnet.Integration.Test on Windows (.NET 9.0)
+        displayName: Dotnet.Integration.Test on Windows (.NET 10.0)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -173,18 +173,18 @@ stages:
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
-        testTargetFramework: net9.0
+        testTargetFramework: net10.0
         testProjectName: Dotnet.Integration.Test
         timeoutInMinutes: 60
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
-    displayName: NuGet.Packaging.FuncTest on Windows (.NET 9.0)
+    displayName: NuGet.Packaging.FuncTest on Windows (.NET 10.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: NuGet.Packaging.FuncTest on Windows (.NET 9.0)
+        displayName: NuGet.Packaging.FuncTest on Windows (.NET 10.0)
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
@@ -192,61 +192,61 @@ stages:
         ${{ else }}:
           agentPool: VSEngSS-MicroBuild2022-1ES
         testType: Functional
-        testTargetFramework: net9.0
+        testTargetFramework: net10.0
         testProjectName: NuGet.Packaging.FuncTest
 
 - ${{ if eq(parameters.RunUnitTestsOnLinux, true) }}:
   - stage:
-    displayName: Unit Tests on Linux (.NET 9.0)
+    displayName: Unit Tests on Linux (.NET 10.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Unit Tests on Linux (.NET 9.0)
+        displayName: Unit Tests on Linux (.NET 10.0)
         osName: Linux
         vmImage: ubuntu-latest
         testType: Unit
-        testTargetFramework: net9.0
+        testTargetFramework: net10.0
 
 - ${{ if eq(parameters.RunFunctionalTestsOnLinux, true) }}:
   - stage:
-    displayName: Functional Tests on Linux (.NET 9.0)
+    displayName: Functional Tests on Linux (.NET 10.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on Linux (.NET 9.0)
+        displayName: Functional Tests on Linux (.NET 10.0)
         osName: Linux
         vmImage: ubuntu-latest
         testType: Functional
-        testTargetFramework: net9.0
+        testTargetFramework: net10.0
         timeoutInMinutes: 30
 
 - ${{ if eq(parameters.RunUnitTestsOnMacOS, true) }}:
   - stage:
-    displayName: Unit Tests on MacOS (.NET 9.0)
+    displayName: Unit Tests on MacOS (.NET 10.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Unit Tests on MacOS (.NET 9.0)
+        displayName: Unit Tests on MacOS (.NET 10.0)
         osName: MacOS
         vmImage: macos-14
         testType: Unit
-        testTargetFramework: net9.0
+        testTargetFramework: net10.0
 
 - ${{ if eq(parameters.RunFunctionalTestsOnMacOS, true) }}:
   - stage:
-    displayName: Functional Tests on MacOS (.NET 9.0)
+    displayName: Functional Tests on MacOS (.NET 10.0)
     dependsOn: []
     jobs:
     - template: pr.job.yml
       parameters:
-        displayName: Functional Tests on MacOS (.NET 9.0)
+        displayName: Functional Tests on MacOS (.NET 10.0)
         osName: MacOS
         vmImage: macos-14
         testType: Functional
-        testTargetFramework: net9.0
+        testTargetFramework: net10.0
         timeoutInMinutes: 30
 
 - ${{ if or(eq(parameters.RunSourceBuild, true), eq(parameters.RunStaticAnalysis, true)) }}:

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "9.0.300",
+    "version": "10.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "9.0.300",
+    "dotnet": "10.0.100",
     "pinned": true
   },
   "msbuild-sdks": {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
@@ -1664,7 +1664,7 @@ namespace NuGet.CommandLine.Test
                 {
                     v2DownloadWait.Wait();
 
-                    var id = parts.Reverse().Skip(1).First();
+                    var id = parts.AsEnumerable().Reverse().Skip(1).First();
                     var version = parts.Last();
 
                     var file = new FileInfo(Path.Combine(repositoryPath, $"{id}.{version}.nupkg"));
@@ -1691,7 +1691,7 @@ namespace NuGet.CommandLine.Test
                 }
                 else if (path.StartsWith("/reg/") && path.EndsWith("/index.json"))
                 {
-                    var id = parts.Reverse().Skip(1).First();
+                    var id = parts.AsEnumerable().Reverse().Skip(1).First();
                     var version = "1.0.0";
 
                     return new Action<HttpListenerResponse>(response =>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9726,7 +9726,7 @@ namespace NuGet.CommandLine.Test
                 var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
                     "proj",
                     pathContext.SolutionRoot,
-                    "net9.0-windows");
+                    "net10.0-windows");
 
                 project.AddPackageToAllFrameworks(packageX);
                 solution.Projects.Add(project);
@@ -9745,7 +9745,7 @@ namespace NuGet.CommandLine.Test
 
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ItemGroup").ToList();
 
-                Assert.Contains("'$(TargetFramework)' == 'net9.0-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Contains("'$(TargetFramework)' == 'net10.0-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9746,7 +9746,7 @@ namespace NuGet.CommandLine.Test
 
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ItemGroup").ToList();
 
-                Assert.Contains("'$(TargetFramework)' == 'net10.0-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Contains($"'$(TargetFramework)' == '{TestConstants.ProjectTargetFramework}-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -24,6 +24,7 @@ using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -9726,7 +9727,7 @@ namespace NuGet.CommandLine.Test
                 var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
                     "proj",
                     pathContext.SolutionRoot,
-                    "net10.0-windows");
+                    $"{TestConstants.ProjectTargetFramework}-windows");
 
                 project.AddPackageToAllFrameworks(packageX);
                 solution.Projects.Add(project);

--- a/test/NuGet.Clients.Tests/NuGet.Indexing.Test/MergeTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Indexing.Test/MergeTests.cs
@@ -164,7 +164,7 @@ namespace NuGet.Indexing.Test
             //  pair-wise merging - but now in a different order - should be the same result
 
             var result2 = Enumerable.Empty<string>();
-            foreach (var l in data.Reverse())
+            foreach (var l in data.AsEnumerable().Reverse())
             {
                 result2 = result2.Merge(l.Select(ch => ch.ToString()), comparer);
             }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Constants.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Constants.cs
@@ -2,19 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using NuGet.Frameworks;
 
 namespace Dotnet.Integration.Test
 {
     internal static class Constants
     {
-#if NET10_0
-        // Specifies a target framework for projects used during testing.  This should match the framework that the SDK being tested has.
-        internal const string ProjectTargetFramework = "net10.0";
-        internal static readonly NuGetFramework DefaultTargetFramework = NuGetFramework.Parse(ProjectTargetFramework);
-#else
-#error Update the logic for which target framework to use for tests projects!!!
-#endif
         internal static readonly Uri DotNetPackageSource = new("https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet7/nuget/v3/index.json");
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Constants.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Constants.cs
@@ -8,7 +8,7 @@ namespace Dotnet.Integration.Test
 {
     internal static class Constants
     {
-#if NET9_0
+#if NET10_0
         // Specifies a target framework for projects used during testing.  This should match the framework that the SDK being tested has.
         internal const string ProjectTargetFramework = "net10.0";
         internal static readonly NuGetFramework DefaultTargetFramework = NuGetFramework.Parse(ProjectTargetFramework);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -15,6 +15,7 @@ using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using NuGet.XPlat.FuncTest;
+using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -610,7 +611,7 @@ namespace Dotnet.Integration.Test
             using (SimpleTestPathContext pathContext = new())
             {
                 var projectName = "project";
-                string targetFrameworks = Constants.DefaultTargetFramework.GetShortFolderName();
+                string targetFrameworks = TestConstants.DefaultTargetFramework.GetShortFolderName();
                 SimpleTestProjectContext projectA = XPlatTestUtils.CreateProject(projectName, pathContext, targetFrameworks);
 
                 // This package is important because:

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -1045,7 +1045,7 @@ EndGlobal";
             using (SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext())
             {
                 // Arrange
-                string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+                string tfm = TestConstants.DefaultTargetFramework.GetShortFolderName();
                 string projectFileContents =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
@@ -1065,7 +1065,7 @@ EndGlobal";
                 // Assert
                 PackagesLockFile lockFile = PackagesLockFileFormat.Read(lockFilePath);
                 Assert.Equal(2, lockFile.Targets.Count);
-                Assert.Contains(lockFile.Targets, target => target.TargetFramework == Constants.DefaultTargetFramework);
+                Assert.Contains(lockFile.Targets, target => target.TargetFramework == TestConstants.DefaultTargetFramework);
                 NuGetFramework targetFramework = NuGetFramework.Parse($"{tfm}-windows7.0");
                 Assert.Contains(lockFile.Targets, target => target.TargetFramework == targetFramework);
             }
@@ -2654,7 +2654,7 @@ EndGlobal";
                 using (var stream = File.Open(projectFile1, FileMode.Open, FileAccess.ReadWrite))
                 {
                     var xml = XDocument.Load(stream);
-                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", Constants.DefaultTargetFramework.GetShortFolderName());
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", TestConstants.DefaultTargetFramework.GetShortFolderName());
                     ProjectFileUtils.AddProperty(xml, "ManagePackageVersionsCentrally", "true");
 
                     ProjectFileUtils.AddItem(
@@ -2692,7 +2692,7 @@ EndGlobal";
                 var assetsFilePath = Path.Combine(workingDirectory1, "obj", "project.assets.json");
                 File.Exists(assetsFilePath).Should().BeTrue(because: "The assets file needs to exist");
                 var assetsFile = new LockFileFormat().Read(assetsFilePath);
-                LockFileTarget target = assetsFile.Targets.Single(e => e.TargetFramework.Equals(Constants.DefaultTargetFramework) && string.IsNullOrEmpty(e.RuntimeIdentifier));
+                LockFileTarget target = assetsFile.Targets.Single(e => e.TargetFramework.Equals(TestConstants.DefaultTargetFramework) && string.IsNullOrEmpty(e.RuntimeIdentifier));
                 target.Libraries.Should().ContainSingle(e => e.Name.Equals("x"));
 
                 // Act another restore
@@ -2711,7 +2711,7 @@ EndGlobal";
             // Arrange
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, new SimpleTestPackageContext("x", "1.0.0"));
-            string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+            string tfm = TestConstants.DefaultTargetFramework.GetShortFolderName();
             string projectFileContents =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
@@ -2755,7 +2755,7 @@ EndGlobal";
             Directory.CreateDirectory(projectBWorkingDirectory);
             var projectAPath = Path.Combine(projectAWorkingDirectory, "a.csproj");
             var projectBPath = Path.Combine(projectBWorkingDirectory, "b.csproj");
-            string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+            string tfm = TestConstants.DefaultTargetFramework.GetShortFolderName();
             string projectAFileContents =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
@@ -2800,7 +2800,7 @@ EndGlobal";
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
             var additionalSource = Path.Combine(pathContext.SolutionRoot, "additionalSource");
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(additionalSource, new SimpleTestPackageContext("x", "1.0.0"));
-            string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+            string tfm = TestConstants.DefaultTargetFramework.GetShortFolderName();
             string projectFileContents =
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
     <PropertyGroup>
@@ -2863,7 +2863,7 @@ EndGlobal";
                 pathContext.PackageSource,
                 packageA1);
 
-            var targetFramework = Constants.DefaultTargetFramework.GetShortFolderName();
+            var targetFramework = TestConstants.DefaultTargetFramework.GetShortFolderName();
             string csprojContents = GetProjectFileForRestoreTaskOutputTests(targetFramework);
             var csprojPath = Path.Combine(pathContext.SolutionRoot, "test.csproj");
             File.WriteAllText(csprojPath, csprojContents);
@@ -2892,7 +2892,7 @@ EndGlobal";
             using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
             pathContext.Settings.RemoveSource("source");
             pathContext.Settings.AddSource("source", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "true");
-            var targetFramework = Constants.DefaultTargetFramework.GetShortFolderName();
+            var targetFramework = TestConstants.DefaultTargetFramework.GetShortFolderName();
             string csprojContents = GetProjectFileForRestoreTaskOutputTestsFromPackageId(targetFramework, id);
             var csprojPath = Path.Combine(pathContext.SolutionRoot, "test.csproj");
             File.WriteAllText(csprojPath, csprojContents);
@@ -2925,7 +2925,7 @@ EndGlobal";
                 pathContext.PackageSource,
                 packageA1);
 
-            var targetFramework = Constants.DefaultTargetFramework.GetShortFolderName();
+            var targetFramework = TestConstants.DefaultTargetFramework.GetShortFolderName();
             string csprojContents = GetProjectFileForRestoreTaskOutputTestsFromPackageId(targetFramework, packageid);
             var csprojPath = Path.Combine(pathContext.SolutionRoot, "test.csproj");
             File.WriteAllText(csprojPath, csprojContents);
@@ -2954,7 +2954,7 @@ EndGlobal";
                 pathContext.PackageSource,
                 packageA1);
 
-            var targetFramework = Constants.DefaultTargetFramework.GetShortFolderName();
+            var targetFramework = TestConstants.DefaultTargetFramework.GetShortFolderName();
             string csprojContents = GetProjectFileForRestoreTaskOutputTests(targetFramework);
             var csprojPath = Path.Combine(pathContext.SolutionRoot, "test.csproj");
             File.WriteAllText(csprojPath, csprojContents);
@@ -3012,7 +3012,7 @@ EndGlobal";
             var projectName = "ClassLibrary1";
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
             var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
-            string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+            string tfm = TestConstants.DefaultTargetFramework.GetShortFolderName();
             await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, new SimpleTestPackageContext("X", "1.0.0") { Dependencies = [new SimpleTestPackageContext("Y", "1.0.0")] });
 
             _dotnetFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib -f netstandard2.1", testOutputHelper: _testOutputHelper);
@@ -3076,7 +3076,7 @@ EndGlobal";
         [InlineData("9.0.100", "true", false)]
         public async Task DotnetRestore_SDKAnalysisLevelAndRestoreEnablePackagePruning_EnablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning, bool useStaticGraphRestore)
         {
-            string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+            string tfm = TestConstants.DefaultTargetFramework.GetShortFolderName();
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
             var projectName = "ClassLibrary1";
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -3130,7 +3130,7 @@ EndGlobal";
         [InlineData("10.0.100", "false")]
         public async Task DotnetRestore_SDKAnalysisLevelAndRestoreEnablePackagePruning_DisablesPruning(string sdkAnalysisLevel, string restoreEnablePackagePruning)
         {
-            string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+            string tfm = TestConstants.DefaultTargetFramework.GetShortFolderName();
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
             var projectName = "ClassLibrary1";
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
@@ -3216,7 +3216,7 @@ EndGlobal";
 
         private async Task<LockFile> DotnetRestore_MultiTargetedProjectWithSDKAnalysisLevel(SimpleTestPathContext pathContext, string sdkAnalysisLevel, bool useStaticGraphRestore)
         {
-            string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+            string tfm = TestConstants.DefaultTargetFramework.GetShortFolderName();
             var projectName = "ClassLibrary1";
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
             var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
@@ -3298,7 +3298,7 @@ EndGlobal";
 
         private async Task<LockFile> DotnetRestore_MultiTargetedProjectWithRestoreEnablePackagePruning(SimpleTestPathContext pathContext, string restoreEnablePackagePruning, string condition, bool useStaticGraphRestore)
         {
-            string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+            string tfm = TestConstants.DefaultTargetFramework.GetShortFolderName();
             var projectName = "ClassLibrary1";
             var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
             var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 using NuGet.CommandLine.XPlat;
 using NuGet.Test.Utility;
 using NuGet.XPlat.FuncTest;
+using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -34,14 +35,14 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
-            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, Constants.ProjectTargetFramework);
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
-            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", Constants.ProjectTargetFramework);
-            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1", Constants.ProjectTargetFramework);
+            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", TestConstants.ProjectTargetFramework);
+            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1", TestConstants.ProjectTargetFramework);
 
             packageX.Dependencies.Add(packageY);
 
-            project.AddPackageToFramework(Constants.ProjectTargetFramework, packageX);
+            project.AddPackageToFramework(TestConstants.ProjectTargetFramework, packageX);
 
             await SimpleTestPackageUtility.CreatePackagesAsync(
                 pathContext.PackageSource,
@@ -66,12 +67,12 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
-            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, Constants.ProjectTargetFramework);
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
-            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", Constants.ProjectTargetFramework);
-            project.AddPackageToFramework(Constants.ProjectTargetFramework, packageX);
+            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", TestConstants.ProjectTargetFramework);
+            project.AddPackageToFramework(TestConstants.ProjectTargetFramework, packageX);
 
-            var packageZ = XPlatTestUtils.CreatePackage("PackageZ", "1.0.0", Constants.ProjectTargetFramework);
+            var packageZ = XPlatTestUtils.CreatePackage("PackageZ", "1.0.0", TestConstants.ProjectTargetFramework);
 
             await SimpleTestPackageUtility.CreatePackagesAsync(
                 pathContext.PackageSource,
@@ -96,14 +97,14 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
-            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, Constants.ProjectTargetFramework);
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
-            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", Constants.ProjectTargetFramework);
-            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1", Constants.ProjectTargetFramework);
+            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", TestConstants.ProjectTargetFramework);
+            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1", TestConstants.ProjectTargetFramework);
 
             packageX.Dependencies.Add(packageY);
 
-            project.AddPackageToFramework(Constants.ProjectTargetFramework, packageX);
+            project.AddPackageToFramework(TestConstants.ProjectTargetFramework, packageX);
 
             await SimpleTestPackageUtility.CreatePackagesAsync(
                 pathContext.PackageSource,
@@ -113,7 +114,7 @@ namespace Dotnet.Integration.Test
             string addPackageCommandArgs = $"add {project.ProjectPath} package {packageX.Id}";
             CommandRunnerResult addPackageResult = _testFixture.RunDotnetExpectSuccess(pathContext.SolutionRoot, addPackageCommandArgs, testOutputHelper: _testOutputHelper);
 
-            string whyCommandArgs = $"nuget why {project.ProjectPath} {packageY.Id} --framework {Constants.ProjectTargetFramework}";
+            string whyCommandArgs = $"nuget why {project.ProjectPath} {packageY.Id} --framework {TestConstants.ProjectTargetFramework}";
 
             // Act
             CommandRunnerResult result = _testFixture.RunDotnetExpectSuccess(pathContext.SolutionRoot, whyCommandArgs, testOutputHelper: _testOutputHelper);
@@ -128,14 +129,14 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
-            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, Constants.ProjectTargetFramework);
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
-            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", Constants.ProjectTargetFramework);
-            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1", Constants.ProjectTargetFramework);
+            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", TestConstants.ProjectTargetFramework);
+            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1", TestConstants.ProjectTargetFramework);
 
             packageX.Dependencies.Add(packageY);
 
-            project.AddPackageToFramework(Constants.ProjectTargetFramework, packageX);
+            project.AddPackageToFramework(TestConstants.ProjectTargetFramework, packageX);
 
             await SimpleTestPackageUtility.CreatePackagesAsync(
                 pathContext.PackageSource,
@@ -145,7 +146,7 @@ namespace Dotnet.Integration.Test
             string addPackageCommandArgs = $"add {project.ProjectPath} package {packageX.Id}";
             CommandRunnerResult addPackageResult = _testFixture.RunDotnetExpectSuccess(pathContext.SolutionRoot, addPackageCommandArgs, testOutputHelper: _testOutputHelper);
 
-            string whyCommandArgs = $"nuget why {project.ProjectPath} {packageY.Id} -f {Constants.ProjectTargetFramework}";
+            string whyCommandArgs = $"nuget why {project.ProjectPath} {packageY.Id} -f {TestConstants.ProjectTargetFramework}";
 
             // Act
             CommandRunnerResult result = _testFixture.RunDotnetExpectSuccess(pathContext.SolutionRoot, whyCommandArgs, testOutputHelper: _testOutputHelper);
@@ -176,7 +177,7 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
-            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, Constants.ProjectTargetFramework);
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
             string whyCommandArgs = $"nuget why {project.ProjectPath}";
 
@@ -193,14 +194,14 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
-            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, Constants.ProjectTargetFramework);
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
-            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", Constants.ProjectTargetFramework);
-            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1", Constants.ProjectTargetFramework);
+            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", TestConstants.ProjectTargetFramework);
+            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1", TestConstants.ProjectTargetFramework);
 
             packageX.Dependencies.Add(packageY);
 
-            project.AddPackageToFramework(Constants.ProjectTargetFramework, packageX);
+            project.AddPackageToFramework(TestConstants.ProjectTargetFramework, packageX);
 
             await SimpleTestPackageUtility.CreatePackagesAsync(
                 pathContext.PackageSource,
@@ -226,14 +227,14 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             var pathContext = new SimpleTestPathContext();
-            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, Constants.ProjectTargetFramework);
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
-            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", Constants.ProjectTargetFramework);
-            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1", Constants.ProjectTargetFramework);
+            var packageX = XPlatTestUtils.CreatePackage("PackageX", "1.0.0", TestConstants.ProjectTargetFramework);
+            var packageY = XPlatTestUtils.CreatePackage("PackageY", "1.0.1", TestConstants.ProjectTargetFramework);
 
             packageX.Dependencies.Add(packageY);
 
-            project.AddPackageToFramework(Constants.ProjectTargetFramework, packageX);
+            project.AddPackageToFramework(TestConstants.ProjectTargetFramework, packageX);
 
             await SimpleTestPackageUtility.CreatePackagesAsync(
                 pathContext.PackageSource,

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -20,6 +20,7 @@ using NuGet.ProjectModel;
 using NuGet.Shared;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -61,7 +62,7 @@ namespace Dotnet.Integration.Test
                     <None Include=""abc.dll"" Pack=""True""  PackagePath=""lib"" />
                     <Content Include=""abc.txt"" Pack=""True"" />
 </ItemGroup>";
-                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", Constants.ProjectTargetFramework);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", TestConstants.ProjectTargetFramework);
                     ProjectFileUtils.AddCustomXmlToProjectRoot(xml, itemGroup);
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
@@ -742,7 +743,7 @@ namespace Dotnet.Integration.Test
                 Directory.CreateDirectory(pkgsPath);
                 Directory.CreateDirectory(basePackagePath);
 
-                string tfm = Constants.DefaultTargetFramework.GetShortFolderName();
+                string tfm = TestConstants.DefaultTargetFramework.GetShortFolderName();
 
                 // Base Package
                 var basePackageProjectContent = @$"<Project Sdk='Microsoft.NET.Sdk'>
@@ -982,8 +983,8 @@ namespace Dotnet.Integration.Test
         [PlatformTheory(Platform.Windows)]
         [InlineData("TargetFramework", "netstandard1.4")]
         [InlineData("TargetFrameworks", "netstandard1.4;net46")]
-        [InlineData("TargetFramework", Constants.ProjectTargetFramework)]
-        [InlineData("TargetFrameworks", $"netstandard1.4;{Constants.ProjectTargetFramework}")]
+        [InlineData("TargetFramework", TestConstants.ProjectTargetFramework)]
+        [InlineData("TargetFrameworks", $"netstandard1.4;{TestConstants.ProjectTargetFramework}")]
         public void PackCommand_PackProject_ExactVersionOverrideProjectRefVersionInMsbuild(string tfmProperty, string tfmValue)
         {
             // Arrange
@@ -1072,8 +1073,8 @@ namespace Dotnet.Integration.Test
         [PlatformTheory(Platform.Windows)]
         [InlineData("TargetFramework", "netstandard1.4")]
         [InlineData("TargetFrameworks", "netstandard1.4;net46")]
-        [InlineData("TargetFramework", Constants.ProjectTargetFramework)]
-        [InlineData("TargetFrameworks", $"netstandard1.4;{Constants.ProjectTargetFramework}")]
+        [InlineData("TargetFramework", TestConstants.ProjectTargetFramework)]
+        [InlineData("TargetFrameworks", $"netstandard1.4;{TestConstants.ProjectTargetFramework}")]
         public void PackCommand_PackProject_GetsProjectRefVersionFromMsbuild(string tfmProperty, string tfmValue)
         {
             // Arrange
@@ -1149,8 +1150,8 @@ namespace Dotnet.Integration.Test
         [PlatformTheory(Platform.Windows)]
         [InlineData("TargetFramework", "netstandard1.4")]
         [InlineData("TargetFrameworks", "netstandard1.4;net46")]
-        [InlineData("TargetFramework", Constants.ProjectTargetFramework)]
-        [InlineData("TargetFrameworks", $"netstandard1.4;{Constants.ProjectTargetFramework}")]
+        [InlineData("TargetFramework", TestConstants.ProjectTargetFramework)]
+        [InlineData("TargetFrameworks", $"netstandard1.4;{TestConstants.ProjectTargetFramework}")]
         public void PackCommand_PackProject_GetPackageVersionDependsOnWorks(string tfmProperty, string tfmValue)
         {
             // Arrange
@@ -2027,7 +2028,7 @@ namespace Dotnet.Integration.Test
                 using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
                     var xml = XDocument.Load(stream);
-                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", Constants.ProjectTargetFramework);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", TestConstants.ProjectTargetFramework);
                     ProjectFileUtils.AddProperty(xml, "GeneratePackageOnBuild", "true");
                     ProjectFileUtils.AddProperty(xml, "NuspecOutputPath", "obj\\Debug");
 
@@ -2067,7 +2068,7 @@ namespace Dotnet.Integration.Test
 
                     var dependencyGroups = nuspecReader.GetDependencyGroups().ToList();
                     Assert.Equal(1, dependencyGroups.Count);
-                    Assert.Equal(Constants.ProjectTargetFramework, dependencyGroups[0].TargetFramework.GetShortFolderName());
+                    Assert.Equal(TestConstants.ProjectTargetFramework, dependencyGroups[0].TargetFramework.GetShortFolderName());
                     var packages = dependencyGroups[0].Packages.ToList();
                     Assert.Equal(1, packages.Count);
                     Assert.Equal("Newtonsoft.json", packages[0].Id);
@@ -2078,8 +2079,8 @@ namespace Dotnet.Integration.Test
                     // Validate the assets.
                     var libItems = nupkgReader.GetLibItems().ToList();
                     Assert.Equal(1, libItems.Count);
-                    Assert.Equal(Constants.ProjectTargetFramework, libItems[0].TargetFramework.GetShortFolderName());
-                    Assert.Equal(new[] { $"lib/{Constants.ProjectTargetFramework}/ClassLibrary1.dll" }, libItems[0].Items);
+                    Assert.Equal(TestConstants.ProjectTargetFramework, libItems[0].TargetFramework.GetShortFolderName());
+                    Assert.Equal(new[] { $"lib/{TestConstants.ProjectTargetFramework}/ClassLibrary1.dll" }, libItems[0].Items);
                 }
 
             }
@@ -3379,8 +3380,8 @@ namespace ClassLibrary
         [PlatformTheory(Platform.Windows)]
         [InlineData("TargetFramework", "netstandard1.4")]
         [InlineData("TargetFrameworks", "netstandard1.4;net46")]
-        [InlineData("TargetFramework", Constants.ProjectTargetFramework)]
-        [InlineData("TargetFrameworks", $"netstandard1.4;{Constants.ProjectTargetFramework}")]
+        [InlineData("TargetFramework", TestConstants.ProjectTargetFramework)]
+        [InlineData("TargetFrameworks", $"netstandard1.4;{TestConstants.ProjectTargetFramework}")]
         public void PackCommand_PackTargetHook_ExecutesBeforePack(string tfmProperty,
     string tfmValue)
         {
@@ -3422,8 +3423,8 @@ namespace ClassLibrary
         [PlatformTheory(Platform.Windows)]
         [InlineData("TargetFramework", "netstandard1.4")]
         [InlineData("TargetFrameworks", "netstandard1.4;net46")]
-        [InlineData("TargetFramework", Constants.ProjectTargetFramework)]
-        [InlineData("TargetFrameworks", $"netstandard1.4;{Constants.ProjectTargetFramework}")]
+        [InlineData("TargetFramework", TestConstants.ProjectTargetFramework)]
+        [InlineData("TargetFrameworks", $"netstandard1.4;{TestConstants.ProjectTargetFramework}")]
         public void PackCommand_PackTarget_IsIncremental(string tfmProperty, string tfmValue)
         {
             using (var testDirectory = _dotnetFixture.CreateTestDirectory())
@@ -4075,7 +4076,7 @@ namespace ClassLibrary
                 using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
                 {
                     var xml = XDocument.Load(stream);
-                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", Constants.ProjectTargetFramework);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", TestConstants.ProjectTargetFramework);
                     ProjectFileUtils.AddProperty(xml, "DefaultAllowedOutputExtensionsInPackageBuildOutputFolder", ".dll");
                     ProjectFileUtils.AddProperty(xml, "GenerateDocumentationFile", "true");
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
@@ -4095,8 +4096,8 @@ namespace ClassLibrary
                 using (var nupkgReader = new PackageArchiveReader(nupkgPath))
                 {
                     var allFiles = nupkgReader.GetFiles().ToList();
-                    Assert.Contains($"lib/{Constants.ProjectTargetFramework}/{projectName}.dll", allFiles);
-                    Assert.DoesNotContain($"lib/{Constants.ProjectTargetFramework}/{projectName}.xml", allFiles);
+                    Assert.Contains($"lib/{TestConstants.ProjectTargetFramework}/{projectName}.dll", allFiles);
+                    Assert.DoesNotContain($"lib/{TestConstants.ProjectTargetFramework}/{projectName}.xml", allFiles);
                     Assert.DoesNotContain(allFiles, f => f.EndsWith(".exe"));
                     Assert.DoesNotContain(allFiles, f => f.EndsWith(".winmd"));
                     Assert.DoesNotContain(allFiles, f => f.EndsWith(".json"));
@@ -5737,7 +5738,7 @@ namespace ClassLibrary
                 _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName, args: "classlib", testOutputHelper: _testOutputHelper);
                 string projectXml = $@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFramework>{Constants.DefaultTargetFramework.GetShortFolderName()}</TargetFramework>
+    <TargetFramework>{TestConstants.DefaultTargetFramework.GetShortFolderName()}</TargetFramework>
     <Version>1.2.3</Version>
   </PropertyGroup>
 
@@ -5779,7 +5780,7 @@ namespace ClassLibrary
                 _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName, args: "classlib", testOutputHelper: _testOutputHelper);
                 string projectXml = $@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFramework>{Constants.DefaultTargetFramework.GetShortFolderName()}</TargetFramework>
+    <TargetFramework>{TestConstants.DefaultTargetFramework.GetShortFolderName()}</TargetFramework>
     <Version>1.2.3</Version>
   </PropertyGroup>
   <ItemGroup>
@@ -5848,7 +5849,7 @@ namespace ClassLibrary
                 _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName, args: "classlib", testOutputHelper: _testOutputHelper);
                 string projectXml = $@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFramework>{Constants.DefaultTargetFramework.GetShortFolderName()}</TargetFramework>
+    <TargetFramework>{TestConstants.DefaultTargetFramework.GetShortFolderName()}</TargetFramework>
     <Version>1.2.3</Version>
   </PropertyGroup>
 
@@ -5893,7 +5894,7 @@ namespace ClassLibrary
                 _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName, args: "classlib", testOutputHelper: _testOutputHelper);
                 string projectXml = $@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFrameworks>{Constants.DefaultTargetFramework.GetShortFolderName()}</TargetFrameworks>
+    <TargetFrameworks>{TestConstants.DefaultTargetFramework.GetShortFolderName()}</TargetFrameworks>
     <Version>1.2.3</Version>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5104</NoWarn>
@@ -5970,7 +5971,7 @@ namespace ClassLibrary
                 _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName, args: "classlib", testOutputHelper: _testOutputHelper);
                 string projectXml = $@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFrameworks>{Constants.ProjectTargetFramework};net45</TargetFrameworks>
+    <TargetFrameworks>{TestConstants.ProjectTargetFramework};net45</TargetFrameworks>
     <Version>1.2.3</Version>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -6029,7 +6030,7 @@ namespace ClassLibrary
                 _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName, args: "classlib", testOutputHelper: _testOutputHelper);
                 string projectXml = $@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFrameworks>{Constants.ProjectTargetFramework};net45</TargetFrameworks>
+    <TargetFrameworks>{TestConstants.ProjectTargetFramework};net45</TargetFrameworks>
     <Version>1.2.3</Version>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -6111,7 +6112,7 @@ namespace ClassLibrary
                 _dotnetFixture.CreateDotnetNewProject(testDirectory, projectName, args: "classlib", testOutputHelper: _testOutputHelper);
                 string projectXml = $@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFrameworks>{Constants.DefaultTargetFramework.GetShortFolderName()};net48</TargetFrameworks>
+    <TargetFrameworks>{TestConstants.DefaultTargetFramework.GetShortFolderName()};net48</TargetFrameworks>
     <Version>1.2.3</Version>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5104</NoWarn>

--- a/test/NuGet.Core.Tests/NuGet.Shared.Tests/HashCodeCombinerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Shared.Tests/HashCodeCombinerTests.cs
@@ -27,9 +27,9 @@ public class HashCodeCombinerTests
             new KeyValuePair<int, string>(200, "BBB")
        };
 
-        Assert.Equal(Compute(pairs1), Compute(pairs1.Reverse()));
+        Assert.Equal(Compute(pairs1), Compute(pairs1.AsEnumerable().Reverse()));
 
-        Assert.Equal(Compute(pairs2), Compute(pairs2.Reverse()));
+        Assert.Equal(Compute(pairs2), Compute(pairs2.AsEnumerable().Reverse()));
 
         Assert.NotEqual(Compute(pairs1), Compute(pairs2));
 
@@ -47,9 +47,9 @@ public class HashCodeCombinerTests
         var values1 = new[] { 1, 2, 3, 4 };
         var values2 = new[] { 100, 200, 300, 400 };
 
-        Assert.Equal(Compute(values1), Compute(values1.Reverse()));
+        Assert.Equal(Compute(values1), Compute(values1.AsEnumerable().Reverse()));
 
-        Assert.Equal(Compute(values2), Compute(values2.Reverse()));
+        Assert.Equal(Compute(values2), Compute(values2.AsEnumerable().Reverse()));
 
         Assert.NotEqual(Compute(values1), Compute(values2));
 
@@ -98,15 +98,15 @@ public class HashCodeCombinerTests
 
         Assert.Equal(
             Compute(valuesUpper, StringComparer.Ordinal),
-            Compute(valuesUpper.Reverse(), StringComparer.Ordinal));
+            Compute(valuesUpper.AsEnumerable().Reverse(), StringComparer.Ordinal));
 
         Assert.Equal(
             Compute(valuesUpper, StringComparer.OrdinalIgnoreCase),
-            Compute(valuesUpper.Reverse(), StringComparer.OrdinalIgnoreCase));
+            Compute(valuesUpper.AsEnumerable().Reverse(), StringComparer.OrdinalIgnoreCase));
 
         Assert.Equal(
             Compute(valuesLower, StringComparer.OrdinalIgnoreCase),
-            Compute(valuesUpper.Reverse(), StringComparer.OrdinalIgnoreCase));
+            Compute(valuesUpper.AsEnumerable().Reverse(), StringComparer.OrdinalIgnoreCase));
 
         Assert.NotEqual(
             Compute(valuesUpper, StringComparer.Ordinal),

--- a/test/TestUtilities/Test.Utility/TestConstants.cs
+++ b/test/TestUtilities/Test.Utility/TestConstants.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Frameworks;
+
+namespace Test.Utility;
+
+public static class TestConstants
+{
+#if NET10_0 || NETFRAMEWORK
+    // Specifies a target framework for projects used during testing.  This should match the framework that the SDK being tested has.
+    public const string ProjectTargetFramework = "net10.0";
+    public static readonly NuGetFramework DefaultTargetFramework = NuGetFramework.Parse(ProjectTargetFramework);
+#else
+#error Update the logic for which target framework to use for tests projects!!!
+#endif
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

Working on NuGet.CommandLine.XPlat has been a bit painful the last few months, because all my test projects I create using `dotnet new` will target .NET 10, but when XPlat is targeting net9.0, then MSBuild locator will load the  .NET 9 SDK, and then MSBuild's APIs to load project files fail because the .NET 9 SDK can't target net10.0.

So, this PR:
* Changes the version of the .NET SDK we use to build NuGet
* Change the LangVersion to C# 14, so we can use the latest net10.0 language features. I'm particularly looking forward to using [the `field` keyword](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#the-field-keyword)
* Retarget XPlat, and a few test projects that use the same property, to net10.0
* Fix some build errors that popped up. I'm not sure I've seen errors pop up when upgrading the LangVersion before, but I guess this is exactly why that setting exists.


## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
