### PR TITLE
Stop using the consumption feed, use VSSDK and vs-impl directly

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -7,7 +7,9 @@
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="myget-legacy@Local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy%40Local/nuget/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
-    <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption%40Local/nuget/v3/index.json" />
+    <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
+    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
   <auditSources>
     <clear />
@@ -57,6 +59,7 @@
       <package pattern="nuget.client.endtoend.testdata" />
       <package pattern="nugetvalidator" />
     </packageSource>
+
     <packageSource key="vside">
       <package pattern="envdte" />
       <package pattern="envdte100" />
@@ -69,10 +72,43 @@
       <package pattern="Microsoft.Internal.VisualStudio.Shell.Framework" />
       <package pattern="Microsoft.NET.StringTools" />
       <package pattern="microsoft.servicehub.*" />
-      <package pattern="Microsoft.ServiceHub.Framework" />
       <package pattern="Microsoft.TeamFoundationServer.ExtendedClient" />
       <package pattern="microsoft.test.apex.visualstudio" />
       <package pattern="Microsoft.VisualStudio.*" />
+      <package pattern="Microsoft.VSSDK.*" />
+      <package pattern="Microsoft.VisualStudioEng.MicroBuild.Core" />
+      <package pattern="Microsoft.VSSDK.BuildTools" />
+      <package pattern="stdole" />
+      <package pattern="streamjsonrpc" />
+      <package pattern="vslangproj" />
+      <package pattern="vslangproj100" />
+      <package pattern="vslangproj110" />
+      <package pattern="vslangproj140" />
+      <package pattern="vslangproj150" />
+      <package pattern="vslangproj157" />
+      <package pattern="vslangproj158" />
+      <package pattern="vslangproj165" />
+      <package pattern="vslangproj2" />
+      <package pattern="vslangproj80" />
+      <package pattern="vslangproj90" />
+      <package pattern="vswebsite.interop" />
+    </packageSource>
+    <packageSource key="vssdk">
+      <package pattern="envdte" />
+      <package pattern="envdte100" />
+      <package pattern="envdte80" />
+      <package pattern="envdte90" />
+      <package pattern="envdte90a" />
+      <package pattern="Microsoft.Build.Framework" />
+      <package pattern="Microsoft.DataAI.NuGetRecommender.Contracts" />
+      <package pattern="microsoft.internal.visualstudio.*" />
+      <package pattern="Microsoft.Internal.VisualStudio.Shell.Framework" />
+      <package pattern="Microsoft.NET.StringTools" />
+      <package pattern="microsoft.servicehub.*" />
+      <package pattern="Microsoft.TeamFoundationServer.ExtendedClient" />
+      <package pattern="microsoft.test.apex.visualstudio" />
+      <package pattern="Microsoft.VisualStudio.*" />
+      <package pattern="Microsoft.VSSDK.*" />
       <package pattern="Microsoft.VisualStudioEng.MicroBuild.Core" />
       <package pattern="Microsoft.VSSDK.*" />
       <package pattern="stdole" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -61,7 +61,7 @@
     </packageSource>
     <!-- It is not always easiest to figure out which packages come from vs-impl and which packages come from vssdk, so for simplicity we can duplicate the mappings.
     There are redundant mappings this way, but probably easier to maintain this way. -->
-    <packageSource key="vside">
+    <packageSource key="vs-impl">
       <package pattern="envdte" />
       <package pattern="envdte100" />
       <package pattern="envdte80" />
@@ -78,7 +78,6 @@
       <package pattern="Microsoft.VisualStudio.*" />
       <package pattern="Microsoft.VSSDK.*" />
       <package pattern="Microsoft.VisualStudioEng.MicroBuild.Core" />
-      <package pattern="Microsoft.VSSDK.BuildTools" />
       <package pattern="stdole" />
       <package pattern="streamjsonrpc" />
       <package pattern="vslangproj" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -59,7 +59,8 @@
       <package pattern="nuget.client.endtoend.testdata" />
       <package pattern="nugetvalidator" />
     </packageSource>
-
+    <!-- It is not always easiest to figure out which packages come from vs-impl and which packages come from vssdk, so for simplicity we can duplicate the mappings.
+    There are redundant mappings this way, but probably easier to maintain this way. -->
     <packageSource key="vside">
       <package pattern="envdte" />
       <package pattern="envdte100" />
@@ -68,7 +69,7 @@
       <package pattern="envdte90a" />
       <package pattern="Microsoft.Build.Framework" />
       <package pattern="Microsoft.DataAI.NuGetRecommender.Contracts" />
-      <package pattern="microsoft.internal.visualstudio.*" />
+      <package pattern="Microsoft.Internal.VisualStudio.*" />
       <package pattern="Microsoft.Internal.VisualStudio.Shell.Framework" />
       <package pattern="Microsoft.NET.StringTools" />
       <package pattern="microsoft.servicehub.*" />
@@ -101,7 +102,7 @@
       <package pattern="envdte90a" />
       <package pattern="Microsoft.Build.Framework" />
       <package pattern="Microsoft.DataAI.NuGetRecommender.Contracts" />
-      <package pattern="microsoft.internal.visualstudio.*" />
+      <package pattern="Microsoft.Internal.VisualStudio.*" />
       <package pattern="Microsoft.Internal.VisualStudio.Shell.Framework" />
       <package pattern="Microsoft.NET.StringTools" />
       <package pattern="microsoft.servicehub.*" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/nuget/client.engineering/issues/2877

## Description

Follow up to the challenges in https://github.com/NuGet/NuGet.Client/pull/7036. 
The consumption feed needs to be managed to bring in new packages and for that reason we have been using the local view of it. 

The better solution and what other public products like roslyn are doing is referencing the vs-impl and vssdk feeds: https://github.com/dotnet/roslyn/blob/main/NuGet.config. 

I also added a note that we probably want to duplicate these mappings across the 2 feeds. There are redundancies, but my thinking right now is it would be simpler to do. 

If people think the redundancies are not fine, I'd be happy to try and clean them up.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
