### PR TITLE
disable .net analyzers temporarily

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -115,7 +115,7 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VsixOutputDirName>VS15</VsixOutputDirName>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <EnableNETAnalyzers Condition="'$(DotNetBuildSourceOnly)' == 'true'">false</EnableNETAnalyzers>
     <AnalysisLevel>8.0-None</AnalysisLevel>
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">true</EnforceCodeStyleInBuild>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Private/Official build failures due to Guardian SDL analysis

## Description

Guardian SDL analysis is breaking our builds. [Pipelines - Run 7.4.0.5 logs](https://devdiv.visualstudio.com/DevDiv/DevDiv%20Team/_build/results?buildId=13091021&view=logs&j=040ac555-3f5b-5d3c-ee11-2936924df871&t=a3958a78-e26f-5b45-1fd8-76d0c3f675fd&l=40)

> CSC : error CS8032: An instance of analyzer Microsoft.CodeAnalysis.UseExplicitTupleName.UseExplicitTupleNameDiagnosticAnalyzer cannot be created from D:\a\_work\1\s\cli\sdk\9.0.309\Sdks\Microsoft.NET.Sdk\codestyle\cs\Microsoft.CodeAnalysis.CodeStyle.dll : Exception has been thrown by the target of an invocation..[D:\a\_work\1\s\src\NuGet.Core\NuGet.Versioning\NuGet.Versioning.csproj::TargetFramework=net472]
 

As per the guidance, I tried [opting out of this feature](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-mohanb/security-integration/guardian-wiki/static-code-analysis-remediation-flow/runbook#i-have-encountered-a-bug-how-do-i-break-glass-and-opt-out) but the error still persists. 

I have disabled .NET analyzers temporarily. We can reenable the analysis once the issue has been fixed. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[ ] Added tests~
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~