### PR TITLE
Reduce allocation in GetNuGetProjects by providing capacity for List

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
@@ -182,9 +182,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
             try
             {
-                return _primaryCache
-                    .Select(kv => kv.Value.NuGetProject)
-                    .ToList();
+                List<NuGetProject> result = new List<NuGetProject>(_primaryCache.Count);
+                foreach (var kv in _primaryCache)
+                {
+                    result.Add(kv.Value.NuGetProject);
+                }
+
+                return result;
             }
             finally
             {


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: `ProjectSystemCache.GetNuGetProjects()` builds the return value via LINQ + `ToList()`:

```csharp
_primaryCache.Select(kv => kv.Value.NuGetProject).ToList();
```

Because the source is an iterator (`Select` over the dictionary), `ToList()` can’t pre-size the list and grows it incrementally, triggering `List<T>.EnsureCapacity` and allocating/resizing the backing `NuGetProject[]`.
This matches the allocation stack:
```
TypeAllocated!NuGet.ProjectManagement.NuGetProject[]
clr.dll!SVR::gc_heap::try_allocate_more_space
clr.dll!SVR::GCHeap::Alloc
clr.dll!AllocateArrayEx
clr.dll!JIT_NewArr1
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].set_Capacity
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].EnsureCapacity
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].Add
mscorlib.dll!System.Collections.Generic.List`[System.__Canon]..ctor
system.core.dll!System.Linq.Enumerable.ToList[System.__Canon]
nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.ProjectSystemCache.GetNuGetProjects
```


- Issue type: Specify an up-front capacity for collections if one is known

- Proposed fix: Pre-size the list using _primaryCache.Count and fill it without LINQ:
This removes the EnsureCapacity -> set_Capacity -> AllocateArray growth path that’s producing the NuGetProject[] allocation spikes.


[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&failureHash=88f4062f-ff51-ea32-af62-ef6f62e91c96)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2681165)