### PR TITLE
Pin .NET SDK version to 9.0.308 in release/7.0.x branch

### DIFF
--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,2 +1,2 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 9.0.3xx
+-Version 9.0.308


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: release/7.0.x branch builds are failing due to https://github.com/dotnet/roslyn/issues/82010.

## Description

Pin the .NET SDK to 9.0.308 temporarily until https://github.com/dotnet/roslyn/issues/82010 has been resolved. I have created another issue https://github.com/NuGet/Client.Engineering/issues/3585 to revert this change once the Roslyn issue has been addressed.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[ ] Added tests~
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~