### PR TITLE
Cherry-picking localized strings related to "Create region headings & Audit Sources is collapsed until needed in VS Options" change into release/7.3.x branch

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">Použít samostatné zdroje pro audit ohrožení zabezpečení</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">Zdroje balíčků pro celý počítač jsou zřizovány pracovními úlohami Visual Studia a lze je pouze povolit, nebo zakázat.</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">Für die Sicherheitsrisikoüberwachung separate Quellen verwenden</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">Computerweite Paketquellen werden von Visual Studio-Workloads bereitgestellt und können nur aktiviert bzw. deaktiviert werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">Uso de orígenes independientes para la auditoría de vulnerabilidades</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">Los orígenes de paquetes para todo el equipo se aprovisionan mediante cargas de trabajo Visual Studio y solo se pueden habilitar o deshabilitar.</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">Utilisez des sources distinctes pour l’audit des vulnérabilités</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">Les sources de packages à l’échelle de la machine sont fournies par les charges de travail Visual Studio et ne peuvent être qu’activées ou désactivées.</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">Usa origini separate per il controllo delle vulnerabilità</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">Il provisioning delle origini pacchetto a livello di computer, che possono essere abilitate o disabilitate, viene effettuato dai carichi di lavoro di Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">脆弱性監査に個別のソースを使用する</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">マシン全体のパッケージ ソースは Visual Studio ワークロードによってプロビジョニングされ、有効化または無効化のみが可能です。</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">취약성 감사에 별도의 원본 사용</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">컴퓨터 전체 패키지 원본은 Visual Studio 워크로드를 통해 프로비전되며, 활성화하거나 비활성화할 수만 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">Skorzystaj z oddzielnych źródeł do inspekcji luk w zabezpieczeniach</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">Źródła pakietów dla całej maszyny są aprowizowane przez obciążenia programu Visual Studio i można je tylko włączać lub wyłączać.</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">Usar fontes separadas para auditoria de vulnerabilidades</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">As fontes de pacotes em todo o computador são provisionadas por cargas de trabalho do Visual Studio e só podem ser habilitadas ou desabilitadas.</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">Использовать отдельные источники для аудита уязвимостей</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">Источники пакетов на уровне компьютера подготавливаются рабочими нагрузками Visual Studio и могут быть только включены или отключены.</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">Güvenlik açığı denetimi için ayrı kaynaklar kullan</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">Makine genelinde paket kaynakları Visual Studio iş yükleri tarafından sağlanır ve yalnızca etkinleştirilebilir veya devre dışı bırakılabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">使用独立源进行漏洞审计</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">计算机范围的包源由 Visual Studio 工作负载预配，只能启用或禁用。</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -134,7 +134,7 @@
       </trans-unit>
       <trans-unit id="Text_AuditSources_Checkbox">
         <source>Use separate sources for vulnerability audit</source>
-        <target state="new">Use separate sources for vulnerability audit</target>
+        <target state="translated">使用個別來源進行弱點稽核</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_AuditSources_Description">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="Text_MachineWidePackageSource_Description">
         <source>Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</source>
-        <target state="new">Machine‑wide package sources are provisioned by Visual Studio workloads and can only be enabled or disabled.</target>
+        <target state="translated">全機套件來源由 Visual Studio 工作負載提供，僅能啟用或停用。</target>
         <note />
       </trans-unit>
       <trans-unit id="Text_PackageSourceEnabled_Header">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.cs.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">Zdroje balíčků</target>
+        <target state="translated">Zdroje</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.de.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">Paketquellen</target>
+        <target state="translated">Quellen</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.es.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">Orígenes del paquete</target>
+        <target state="translated">Orígenes</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.fr.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">Sources de package</target>
+        <target state="translated">Sources</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.it.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">Origini pacchetti</target>
+        <target state="translated">Origini</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.ja.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">パッケージ ソース</target>
+        <target state="translated">ソース</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.ko.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">패키지 소스</target>
+        <target state="translated">원본</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.pl.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">Źródła pakietów</target>
+        <target state="translated">Źródła</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.pt-BR.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">Origens do Pacote</target>
+        <target state="translated">Fontes</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.ru.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">Источники пакетов</target>
+        <target state="translated">Источники</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.tr.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">Paket Kaynakları</target>
+        <target state="translated">Kaynaklar</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.zh-Hans.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">程序包源</target>
+        <target state="translated">源</target>
         <note />
       </trans-unit>
       <trans-unit id="115">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/VSPackage.zh-Hant.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="114">
         <source>Sources</source>
-        <target state="needs-review-translation">套件來源</target>
+        <target state="translated">來源</target>
         <note />
       </trans-unit>
       <trans-unit id="115">


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14715 and https://github.com/NuGet/Home/issues/14716

## Description

We updated the product code that contains localized strings in [`release/7.3.x/` branch](https://github.com/NuGet/NuGet.Client/commits/release/7.3.x/). However, only the product changes were included in the release branch, while the localized strings were merged into the dev branch a week later.

Localization commit: [NuGet/NuGet.Client@31c6e73](https://github.com/NuGet/NuGet.Client/commit/31c6e73d877956abaaac1a96181a12f83a2e6c89)
Product changes commit: [NuGet/NuGet.Client@36a5b01](https://github.com/NuGet/NuGet.Client/commit/36a5b01d4567a5cc6435a414de30b360d2ffeba5)

Cherry-picking localization strings commit into release branch 31c6e73d877956abaaac1a96181a12f83a2e6c89 for insertion into VS.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
~- [ ] Added tests~
~- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~