### PR TITLE
Update test project target framework constant in tests to fix build failures.

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -699,7 +699,7 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             using var pathContext = _fixture.CreateSimpleTestPathContext();
-            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, Constants.ProjectTargetFramework);
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, TestConstants.ProjectTargetFramework);
 
             var packageA100 = new SimpleTestPackageContext("PackageA", "1.0.0");
             var packageA200 = new SimpleTestPackageContext("PackageA", "2.0.0");
@@ -1173,7 +1173,7 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             using var pathContext = _fixture.CreateSimpleTestPathContext();
-            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, Constants.ProjectTargetFramework);
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, TestConstants.ProjectTargetFramework);
 
             var packageA100 = new SimpleTestPackageContext("PackageA", "1.0.0");
             var packageB100 = new SimpleTestPackageContext("PackageB", "1.0.0");
@@ -1223,7 +1223,7 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             using var pathContext = _fixture.CreateSimpleTestPathContext();
-            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, Constants.ProjectTargetFramework);
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, TestConstants.ProjectTargetFramework);
 
             var packageA100 = new SimpleTestPackageContext("PackageA", "1.0.0-alpha");
             var packageB100 = new SimpleTestPackageContext("PackageB", "1.0.0-alpha");
@@ -1271,7 +1271,7 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             using var pathContext = _fixture.CreateSimpleTestPathContext();
-            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, Constants.ProjectTargetFramework);
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, TestConstants.ProjectTargetFramework);
 
             var packageA100 = new SimpleTestPackageContext("PackageA", "1.0.0");
             var packageB100 = new SimpleTestPackageContext("PackageB", "1.0.0");
@@ -1324,7 +1324,7 @@ namespace Dotnet.Integration.Test
         {
             // Arrange
             using var pathContext = _fixture.CreateSimpleTestPathContext();
-            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, Constants.ProjectTargetFramework);
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, TestConstants.ProjectTargetFramework);
 
             var packageA100 = new SimpleTestPackageContext("PackageA", "1.0.0-alpha");
             var packageB100 = new SimpleTestPackageContext("PackageB", "1.0.0-alpha");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
[Fix build failures in dev branch](https://dev.azure.com/devdiv/DevDiv/DevDiv%20Team/_build/results?buildId=13100784&view=logs&j=040ac555-3f5b-5d3c-ee11-2936924df871&t=a3958a78-e26f-5b45-1fd8-76d0c3f675fd&l=124). Replaced `Constants.ProjectTargetFramework` with `TestConstants.ProjectTargetFramework` in several test methods in `DotnetListPackageTests.cs` to ensure the correct target framework is used when creating test projects.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
~- [ ] Added tests~
~- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
