### PR TITLE
Avoid LineInfoAnnotation allocations in MetadataFieldConverter JSON parsing

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/MetadataFieldConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/MetadataFieldConverter.cs
@@ -12,12 +12,6 @@ namespace NuGet.Protocol
 {
     public class MetadataFieldConverter : JsonConverter
     {
-        private static readonly JsonLoadSettings DefaultLoadSettings = new JsonLoadSettings()
-        {
-            LineInfoHandling = LineInfoHandling.Ignore,
-            CommentHandling = CommentHandling.Ignore
-        };
-
         public override bool CanConvert(Type objectType) => (objectType == typeof(string));
 
         public override bool CanWrite => false;
@@ -31,7 +25,7 @@ namespace NuGet.Protocol
 
             if (reader.TokenType == JsonToken.StartArray)
             {
-                var array = JArray.Load(reader, DefaultLoadSettings);
+                var array = JArray.Load(reader, JsonUtility.DefaultLoadSettings);
                 return string.Join(", ", array.Values<string>().Where(s => !string.IsNullOrWhiteSpace(s)));
             }
 

--- a/src/NuGet.Core/NuGet.Protocol/Converters/MetadataFieldConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/MetadataFieldConverter.cs
@@ -12,6 +12,12 @@ namespace NuGet.Protocol
 {
     public class MetadataFieldConverter : JsonConverter
     {
+        private static readonly JsonLoadSettings DefaultLoadSettings = new JsonLoadSettings()
+        {
+            LineInfoHandling = LineInfoHandling.Ignore,
+            CommentHandling = CommentHandling.Ignore
+        };
+
         public override bool CanConvert(Type objectType) => (objectType == typeof(string));
 
         public override bool CanWrite => false;
@@ -25,7 +31,7 @@ namespace NuGet.Protocol
 
             if (reader.TokenType == JsonToken.StartArray)
             {
-                var array = JArray.Load(reader);
+                var array = JArray.Load(reader, DefaultLoadSettings);
                 return string.Join(", ", array.Values<string>().Where(s => !string.IsNullOrWhiteSpace(s)));
             }
 


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: `MetadataFieldConverter.ReadJson()` loads the JSON array into a full LINQ-to-JSON DOM (`JArray.Load(reader)`), which allocates a `JValue` per element and by default attaches line-info metadata (`LineInfoAnnotation`) to each token.
This matches the allocation stack flow showing `MetadataFieldConverter.ReadJson` → `Newtonsoft.Json.Linq.JArray.Load` → `JContainer.ReadTokenFrom/ReadContentFrom` → `JToken.SetLineInfo` → `TypeAllocated!LineInfoAnnotation`


```
nuget.protocol.dll!NuGet.Protocol.MetadataFieldConverter.ReadJson
newtonsoft.json.dll!Newtonsoft.Json.Linq.JArray.Load
newtonsoft.json.dll!Newtonsoft.Json.Linq.JContainer.ReadTokenFrom
newtonsoft.json.dll!Newtonsoft.Json.Linq.JContainer.ReadContentFrom
newtonsoft.json.dll!Newtonsoft.Json.Linq.JToken.SetLineInfo
TypeAllocated!LineInfoAnnotation
```

- Issue type: Avoid unneeded line-info allocations while loading JSON

- Proposed fix: Load the array with line info disabled.
`ReadJson` immediately converts the array to a string and doesn’t use token line/column metadata.
So skipping LineInfoAnnotation reduces unnecessary allocations without affecting functional behavior.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&query=c%3ASetLineInfo&failureHash=d60e9f52-8591-abbe-b127-ded68b44890e)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2683046)