### PR TITLE
Correct typo in German localization for CommandPackageSaveMode

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.de.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.de.xlf
@@ -171,7 +171,7 @@ nuget client-certs List</target>
       </trans-unit>
       <trans-unit id="CommandPackageSaveMode">
         <source>Specifies types of files to save after package installation: nuspec, nupkg, nuspec;nupkg.</source>
-        <target state="translated">Gibt Typen von Dateiten an, die nach der Paketinstallation gespeichert werden sollen: nuspec, nupkg, nuspec;nupkg.</target>
+        <target state="translated">Gibt Typen von Dateien an, die nach der Paketinstallation gespeichert werden sollen: nuspec, nupkg, nuspec;nupkg.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandSourceDescription">


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: typo on german "nuget restore" command output

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
