### PR TITLE
[cherry-pick] copy test binaries for runsettings to new location into release/7.3.x branch (#7040)

### DIFF
--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -235,11 +235,11 @@ steps:
       inlineScript: |
         try {
           Write-Output "Copying NuGet.OptProf binaries"
-          Copy-Item test\NuGet.Tests.Apex\NuGet.OptProf\bin\$(BuildConfiguration) artifacts\RunSettings\NuGet.OptProf\ -Recurse -ErrorAction Stop
+          Copy-Item test\NuGet.Tests.Apex\NuGet.OptProf\bin\$(BuildConfiguration) $(Build.StagingDirectory)\RunSettings\NuGet.OptProf\ -Recurse -ErrorAction Stop
           Write-Output "Copying NuGet.Tests.Apex binaries"
-          Copy-Item test\NuGet.Tests.Apex\NuGet.Tests.Apex\bin\$(BuildConfiguration) artifacts\RunSettings\NuGet.Tests.Apex\ -Recurse -ErrorAction Stop
+          Copy-Item test\NuGet.Tests.Apex\NuGet.Tests.Apex\bin\$(BuildConfiguration) $(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex\ -Recurse -ErrorAction Stop
           Write-Output "Copying NuGet.Tests.Apex.Daily binaries"
-          Copy-Item test\NuGet.Tests.Apex\NuGet.Tests.Apex.Daily\bin\$(BuildConfiguration) artifacts\RunSettings\NuGet.Tests.Apex.Daily\ -Recurse -ErrorAction Stop
+          Copy-Item test\NuGet.Tests.Apex\NuGet.Tests.Apex.Daily\bin\$(BuildConfiguration) $(Build.StagingDirectory)\RunSettings\NuGet.Tests.Apex.Daily\ -Recurse -ErrorAction Stop
         } catch {
           Write-Host "##vso[task.LogIssue type=error;]$_"
           exit 1


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Optprof improvements

## Description

Cherry-pick Optprof fix https://github.com/NuGet/NuGet.Client/commit/4c1e976a709020c0f06c15cb77a2cf11c7cc0253 from dev to release/7.3.x branch.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[ ] Added tests~
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
