### PR TITLE
Lazy initialize Spectre.Console in XPlat command registration

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -115,10 +115,12 @@ namespace NuGet.CommandLine.XPlat
                     var nugetCommand = new Command("nuget");
                     rootCommand.Subcommands.Add(nugetCommand);
 
+                    var lazyConsole = new Lazy<Spectre.Console.IAnsiConsole>(() => Spectre.Console.AnsiConsole.Console);
+
                     ConfigCommand.Register(nugetCommand, getHidePrefixLogger);
                     ConfigCommand.Register(rootCommand, getHidePrefixLogger);
-                    Commands.Why.WhyCommand.Register(nugetCommand, Spectre.Console.AnsiConsole.Console);
-                    Commands.Why.WhyCommand.Register(rootCommand, Spectre.Console.AnsiConsole.Console);
+                    Commands.Why.WhyCommand.Register(nugetCommand, lazyConsole);
+                    Commands.Why.WhyCommand.Register(rootCommand, lazyConsole);
                 }
 
                 CancellationTokenSource tokenSource = new CancellationTokenSource();

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using NuGet.CommandLine.XPlat.Commands;
 using NuGet.CommandLine.XPlat.Commands.Why;
+using Spectre.Console;
 using Spectre.Console.Testing;
 using Xunit;
 
@@ -19,9 +20,10 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
         {
             // Arrange
             Command rootCommand = new("nuget");
+            var console = new Lazy<IAnsiConsole>(() => new TestConsole());
 
             // Act
-            WhyCommand.Register(rootCommand, new TestConsole());
+            WhyCommand.Register(rootCommand, console);
 
             // Assert
             rootCommand.Subcommands[0].Should().BeAssignableTo<DocumentedCommand>();
@@ -33,8 +35,10 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
         {
             // Arrange
             Command rootCommand = new("nuget");
+            var console = new Lazy<IAnsiConsole>(() => new TestConsole());
 
-            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
+
+            WhyCommand.Register(rootCommand, console, whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().Be(@"path\to\my.proj");
@@ -54,8 +58,9 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
         {
             // Arrange
             Command rootCommand = new("nuget");
+            var console = new Lazy<IAnsiConsole>(() => new TestConsole());
 
-            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
+            WhyCommand.Register(rootCommand, console, whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().NotBeNull();
@@ -75,8 +80,9 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
         {
             // Arrange
             Command rootCommand = new("nuget");
+            var console = new Lazy<IAnsiConsole>(() => new TestConsole());
 
-            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
+            WhyCommand.Register(rootCommand, console, whyCommandArgs =>
             {
                 // Assert
                 throw new Exception("Should not get here");
@@ -92,8 +98,9 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
         {
             // Arrange
             Command rootCommand = new("nuget");
+            var console = new Lazy<IAnsiConsole>(() => new TestConsole());
 
-            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
+            WhyCommand.Register(rootCommand, console, whyCommandArgs =>
             {
                 // Assert
                 throw new Exception("Should not get here");
@@ -112,8 +119,9 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
         {
             // Arrange
             Command rootCommand = new("nuget");
+            var console = new Lazy<IAnsiConsole>(() => new TestConsole());
 
-            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
+            WhyCommand.Register(rootCommand, console, whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().Be("my.proj");
@@ -135,8 +143,9 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
         {
             // Arrange
             Command rootCommand = new("nuget");
+            var console = new Lazy<IAnsiConsole>(() => new TestConsole());
 
-            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
+            WhyCommand.Register(rootCommand, console, whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().Be("my.proj");
@@ -156,8 +165,9 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
         {
             // Arrange
             Command rootCommand = new("nuget");
+            var console = new Lazy<IAnsiConsole>(() => new TestConsole());
 
-            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
+            WhyCommand.Register(rootCommand, console, whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().Be("my.proj");
@@ -177,8 +187,9 @@ namespace NuGet.CommandLine.Xplat.Tests.Commands.Why
         {
             // Arrange
             Command rootCommand = new("nuget");
+            var console = new Lazy<IAnsiConsole>(() => new TestConsole());
 
-            WhyCommand.Register(rootCommand, new TestConsole(), whyCommandArgs =>
+            WhyCommand.Register(rootCommand, console, whyCommandArgs =>
             {
                 // Assert
                 whyCommandArgs.Path.Should().Be("my.proj");


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/dotnet/sdk/issues/52278

## Description

This code has already been merged into the dotnet VMR, but NuGet.Client doesn't have a backflow configured for the 10.0.2xx branch: https://github.com/dotnet/dotnet/pull/4139

Spectre.Console's `AnsiConsole` will send VT commands on initialzation, which breaks formatting of other parts of the dotnet CLI when it expects that the terminal has default settings.  So, only initialize AnsiConsole when it's about to be used.

Tests were not added because testing this is very difficult. You can't test using a child process or redirecting to a file, because Spectre detects that the output is being redirected about avoids sending the VT commands. In order to test, we'd need to P/Invoke operating system specific APIs to open a new PTY. We'd then need all new child process test infrastructure to capture the output. If we just wanted to make sure that the VT command that Spectre sends on init isn't sent, we'd need to first figure out what VT command that is, but then searching for it in the output should be simple enough.  However, if we wanted to validate that `dotnet --info`'s output isn't being malformed, then we'd need to implement a lot of a terminal emulator to figure out what the console output would look like, and then validate there's no leading whitespace on the SDK version number list.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ see description
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc: https://github.com/dotnet/core/pull/10201
