### PR TITLE
Add azureSubscription input to Visual Studio bootstrapper

### DIFF
--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -184,6 +184,7 @@ stages:
     - task: MicroBuildBuildVSBootstrapper@3
       displayName: 'Build a Visual Studio bootstrapper'
       inputs:
+        azureSubscription: 'VSEng-VSDrop-MI'
         channelName: "$(VsTargetChannel)"
         vsMajorVersion: "$(VsTargetMajorVersion)"
         manifests: '$(Pipeline.Workspace)\ComponentBuildUnderTest\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

This PR updates the optprof pipeline to use the VSEng-VSDrop-MI service connection for the bootstrapper task in order to address https://devdiv.visualstudio.com/DevDiv/DevDiv%20Team/_build/results?buildId=13118314&view=logs&j=87ee994e-8d25-5c3a-5836-c28a1c54ff14&t=93ea8a76-8b7b-5aa6-3fb8-688f276f6f0c&l=12

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
