### PR TITLE
Update NuGet MCP server in Visual Studio to 1.1.29

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/mcp.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/mcp.json
@@ -4,7 +4,7 @@
       "type": "stdio",
       "command": "dnx",
       "args": [
-        "NuGet.Mcp.Server@1.0.0",
+        "NuGet.Mcp.Server@1.1.29",
         "--source",
         "https://api.nuget.org/v3/index.json",
         "--yes"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
This updates the version of the NuGet MCP server that's in Visual Studio 2026.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
