### PR TITLE
Reduce List resize allocations in PopulateItemGroups hot path

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemCollection.cs
@@ -115,6 +115,13 @@ namespace NuGet.ContentModel
 
                 if (groupAssets != null)
                 {
+                    // Pre-size the list to avoid repeated array allocations during Add operations.
+                    // Callers typically pass a List but check just to be safe.
+                    if (contentItemGroupList is List<ContentItemGroup> list)
+                    {
+                        list.Capacity = Math.Max(list.Capacity, contentItemGroupList.Count + groupAssets.Count);
+                    }
+
                     foreach (var (item, assets) in groupAssets)
                     {
                         contentItemGroupList.Add(new ContentItemGroup(


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: `ContentItemCollection.PopulateItemGroups()` adds items to a `List<ContentItemGroup>` that starts with default capacity (0). As items are added, the list repeatedly resizes its internal array (0→4→8→16...), allocating new `ContentItemGroup[]` arrays on each resize.

This matches the allocation stack flow showing `PopulateItemGroups` → `List<>.Add` → `List<>.EnsureCapacity` → `List<>.set_Capacity` → `TypeAllocated!ContentItemGroup[]`

```
nuget.commands.dll!NuGet.Commands.LockFileUtils.GetLockFileItems
nuget.packaging.dll!NuGet.ContentModel.ContentItemCollection.FindBestItemGroup
nuget.packaging.dll!NuGet.ContentModel.ContentItemCollection.PopulateItemGroups
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].Add
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].EnsureCapacity
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].set_Capacity
TypeAllocated!NuGet.ContentModel.ContentItemGroup[]
```

- Issue type: Avoid repeated array resize allocations in hot path

- Proposed fix: Pre-size the list capacity before adding items.
Before the `foreach` loop that adds `ContentItemGroup` items, set `list.Capacity` to accommodate all incoming items. This eliminates resize allocations since the exact count is known from `groupAssets.Count`.
The fix uses a pattern match (`is List<T>`) to safely access `Capacity`, falling back gracefully for other `IList` implementations without affecting functional behavior.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&failureHash=a17c70a7-b79c-b02e-ab5b-f9191cddfdcb)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2692240)