### PR TITLE
Update CODEOWNERS for new directory ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,5 @@
 # For more on how to customize the CODEOWNERS file - https://help.github.com/en/articles/about-code-owners
 *       @NuGet/nuget-client
 *       @NuGet/nuget-client-pull-request-auto-assignment
+
+/eng/dotnet-build/ @dotnet/source-build @dotnet/product-construction


### PR DESCRIPTION
Add dotnet/source-build and dotnet/product-construction teams for /eng/dotnet-build/ which is the VMR entry-point. Any changes made to that folder should get reviewed by these teams.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
