### PR TITLE
Reduce allocations in JsonRuntimeFormat.ReadRuntimeDescription by pre-sizing List

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/JsonRuntimeFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/JsonRuntimeFormat.cs
@@ -208,7 +208,7 @@ namespace NuGet.RuntimeModel
                     var imports = property.Value as JArray;
                     foreach (var import in imports)
                     {
-                        inheritedRuntimes ??= new();
+                        inheritedRuntimes ??= new List<string>(imports.Count);
                         inheritedRuntimes.Add(import.Value<string>());
                     }
                 }


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: `JsonRuntimeFormat.ReadRuntimeDescription()` adds items to a `List<string>` that starts with default capacity (0). As items are added, the list repeatedly resizes its internal array (0→4→8→16...), allocating new `String[]` arrays on each resize.

This matches the allocation stack flow showing `ReadRuntimeDescription` → `List<>.Add` → `List<>.EnsureCapacity` → `List<>.set_Capacity` → `TypeAllocated!System.String[]`

```
nuget.packaging.dll!NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph
nuget.packaging.dll!NuGet.RuntimeModel.RuntimeGraph..ctor
system.core.dll!System.Linq.Enumerable.ToDictionary
nuget.packaging.dll!NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeDescription
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].Add
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].EnsureCapacity
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].set_Capacity
TypeAllocated!System.String[]
```

- Issue type: Avoid repeated array resize allocations in hot path

- Proposed fix: Pre-size the list capacity using the known `JArray.Count`.
Change `inheritedRuntimes ??= new()` to `inheritedRuntimes ??= new List<string>(imports.Count)`.
This eliminates resize allocations since the exact count is known upfront from the `JArray`. The `??=` pattern ensures the list is only created on first iteration and reuses it for subsequent items.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?query=(c%3DJsonRuntimeFormat.ReadRuntimeDescription%20c%3DSystem.String%5B%5D)&eventType=allocation&failureType=dualdirection&failureHash=a8a863ab-7106-e982-1984-962a2c2813e8)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2694099)