### PR TITLE
Reduce allocations in `ResolverMetadataClient.ProcessPackageVersion` by avoiding JArray enumerator allocations

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
@@ -80,8 +80,9 @@ namespace NuGet.Protocol
 
             if (dependencyGroupsArray != null)
             {
-                foreach (JObject dependencyGroupObj in dependencyGroupsArray)
+                for (int i = 0; i < dependencyGroupsArray.Count; i++)
                 {
+                    var dependencyGroupObj = (JObject)dependencyGroupsArray[i];
                     var currentFramework = GetFramework(dependencyGroupObj);
 
                     var groupDependencies = new List<PackageDependency>();
@@ -91,8 +92,10 @@ namespace NuGet.Protocol
                     // Packages with no dependencies have 'dependencyGroups' but no 'dependencies'
                     if (dependencyGroupObj.TryGetValue("dependencies", out dependenciesObj))
                     {
-                        foreach (JObject dependencyObj in dependenciesObj)
+                        var dependencies = (JArray)dependenciesObj;
+                        for (int j = 0; j < dependencies.Count; j++)
                         {
+                            var dependencyObj = (JObject)dependencies[j];
                             var dependencyId = dependencyObj.Value<string>("id");
                             var dependencyRange = RegistrationUtility.CreateVersionRange(dependencyObj.Value<string>("range"));
 


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: `ResolverMetadataClient.ProcessPackageVersion()` uses `foreach` to iterate over `JArray` objects. 
ForEach over JArray calls JArray.GetEnumerator(), which returns the internal List<JToken>.Enumerator struct as IEnumerator<JToken>, causing it to be boxed and allocated on the heap.

```
nuget.protocol.dll!NuGet.Protocol.ResolverMetadataClient+<GetDependencies>d__.MoveNext
nuget.protocol.dll!NuGet.Protocol.ResolverMetadataClient.ProcessPackageVersion
newtonsoft.json.dll!Newtonsoft.Json.Linq.JArray.GetEnumerator
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].System.Collections.Generic.IEnumerable<T>.GetEnumerator
TypeAllocated!Enumerator[Newtonsoft.Json.Linq.JToken]
```

- Issue type: Avoid enumerator allocations in hot path

- Proposed fix: Replace `foreach` with index-based `for` loops using `JArray.Count` and `JArray[index]`.
This eliminates Enumerator<JToken> heap allocations since JArray supports O(1) index access via its internal List<JToken>.
The fix is applied to both the outer loop (dependency groups) and inner loop (dependencies), with the inner loop having higher impact due to nesting.


[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?query=c%3AResolverMetadataClient.ProcessPackageVersion&eventType=allocation&failureType=dualdirection&failureHash=01a0a96b-0728-9ab8-d953-546e18c085e7)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2695440)