### PR TITLE
Always refresh after Package Source changes in VS Options

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Options/PackageSourcesPageTests.cs
@@ -71,7 +71,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task SetValueAsync_AuditSources_WhenNameChanging_RaisesSettingValuesChangedAsync(bool isNameChanging)
+        public async Task SetValueAsync_AuditSources_Never_RaisesSettingValuesChangedAsync(bool isNameChanging)
         {
             // Arrange
             string originalSourceName = "auditTestingSourceName";
@@ -224,6 +224,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             failure.ErrorMessage.Should().StartWith(Strings.Error_NuGetConfig_InvalidState);
         }
 
+        /// <summary>
+        /// Any edit will cause the event to be raised. Here we test changing the source's name followed by the source's URL.
+        /// </summary>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -273,7 +276,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Options
             // Assert
             result.Should().NotBeNull();
             result.Should().BeOfType<ExternalSettingOperationResult.Success>();
-            wasVsSettingsSettingsChangedCalled.Should().Be(isPackageNameChanging);
+            wasVsSettingsSettingsChangedCalled.Should().Be(true);
         }
 
         [Theory]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14693

## Description

The Issue highlights a scenario where refreshing the entire Sources options page is necessary.
In this example, a user-level package source named "Microsoft Visual Studio Offline Packages" hides a source with the same name from the Visual Studio installation directory's nuget.config.

When this user-level package source is deleted, it unhides the machine-wide package source.
To display this source, the machine-wide source table needs to be refreshed.

The cost to refresh the Sources settings in VS Options is low. The simplest solution to this and possibly other unknown edge cases is to just refresh all Sources setting data when a package source is modified.

Simplifies logic by removing the detection of Package Source name changes. Now a removal or any edit to a package source will refresh the data.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. **NA**
