### PR TITLE
Pre-size List in TryGetPortableFrameworks to avoid array resize allocations

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -500,7 +500,7 @@ namespace NuGet.Frameworks
 
             var shortNames = shortPortableProfiles.Split(new char[] { '+' }, StringSplitOptions.RemoveEmptyEntries);
 
-            var result = new List<NuGetFramework>();
+            var result = new List<NuGetFramework>(shortNames.Length);
             foreach (var name in shortNames)
             {
                 var framework = NuGetFramework.Parse(name, this);


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: `FrameworkNameProvider.TryGetPortableFrameworks(string)` adds items to a `List<NuGetFramework>` that starts with default capacity (0). As items are added, the list repeatedly resizes its internal array (0→4→8→16...), allocating new `NuGetFramework[]` arrays on each resize.

This matches the allocation stack flow showing `ParseFolder` → `TryGetPortableFrameworks` → `List<>.Add` → `List<>.EnsureCapacity` → `List<>.set_Capacity` → `TypeAllocated!NuGet.Frameworks.NuGetFramework[]`

```
nuget.frameworks.dll![COLD]NuGet.Frameworks.NuGetFramework.ParseFolder
nuget.frameworks.dll!NuGet.Frameworks.FrameworkNameProvider.TryGetPortableFrameworks
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].Add
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].EnsureCapacity
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].set_Capacity
clr.dll!JIT_NewArr1
TypeAllocated!NuGet.Frameworks.NuGetFramework[]
```

- Issue type: Avoid repeated array resize allocations in hot path

- Proposed fix: Pre-size the list capacity using the known `shortNames.Length`.
Change `new List<NuGetFramework>()` to `new List<NuGetFramework>(shortNames.Length)`.
This eliminates resize allocations since the exact count is known upfront from the split result. After splitting on `'+'`, we know precisely how many frameworks will be parsed and added to the list.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?query=c%3AEnsureCapacity%20l%3A45&eventType=allocation&failureType=dualdirection&failureHash=fe4fdda0-aceb-0098-350a-c5620ace1679)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2695593)