### PR TITLE
Reduce allocations in SourceRepository.Sort by pre-sizing List

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
@@ -188,8 +188,8 @@ namespace NuGet.Protocol.Core.Types
             Sort(IEnumerable<Lazy<INuGetResourceProvider>> group)
         {
             // initial ordering to help make this deterministic
-            var items = new List<INuGetResourceProvider>(
-                group.Select(e => e.Value).OrderBy(e => e.Name).ThenBy(e => e.After.Count()).ThenBy(e => e.Before.Count()));
+            var items = new List<INuGetResourceProvider>(group.Count());
+            items.AddRange(group.Select(e => e.Value).OrderBy(e => e.Name).ThenBy(e => e.After.Count()).ThenBy(e => e.Before.Count()));
 
             var comparer = ProviderComparer.Instance;
 


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: `SourceRepository.Sort` creates a `List<INuGetResourceProvider>` by passing an `OrderBy/ThenBy` LINQ chain to the `List<T>(IEnumerable<T>)` constructor. Since `OrderedEnumerable<T>` doesn't implement `ICollection<T>`, the List doesn't know the size upfront and repeatedly resizes its internal array (4→8→16...), allocating new `INuGetResourceProvider[]` arrays on each resize.

  This matches the allocation stack flow showing `CreateRepository` → `SourceRepository..ctor` → `Init` → `Sort` → `List<>.Add` → `List<>.EnsureCapacity` → `List<>.set_Capacity` → `TypeAllocated!INuGetResourceProvider[]`

```
nuget.packagemanagement.visualstudio.dll!NuGet.PackageManagement.VisualStudio.ExtensibleSourceRepositoryProvider.CreateRepository
nuget.protocol.dll!NuGet.Protocol.Core.Types.SourceRepository..ctor
nuget.protocol.dll!NuGet.Protocol.Core.Types.SourceRepository.Init
nuget.protocol.dll!NuGet.Protocol.Core.Types.SourceRepository.Sort
mscorlib.dll!System.Collections.Generic.List`[System.__Canon]..ctor
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].Add
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].EnsureCapacity
mscorlib.dll!System.Collections.Generic.List`[System.__Canon].set_Capacity
clr.dll!JIT_NewArr1
TypeAllocated!INuGetResourceProvider[]
```

- Issue type: Eliminate unnecessary list resize allocations in hot path

- Proposed fix: Pre-allocate the `List<INuGetResourceProvider>` with the exact capacity using `group.Count()` before populating it with `AddRange`.
  `group.Count()` is O(1) because LINQ's `GroupBy` returns `Lookup<TKey, TElement>.Grouping` instances that implement `ICollection<T>`, and `Enumerable.Count()` detects this and returns the `Count` property directly instead of iterating.
  This eliminates the repeated array allocations (4→8→16...) by allocating once with the correct size.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&failureHash=291035b7-7cb7-a460-61f4-68763fba69ed)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2699594)