### PR TITLE
dotnet package update: use per-project packages directory

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -134,14 +134,12 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
                 new DependencyGraphSpecRequestProvider(providerCache, dgSpec)
             };
 
-        var globalPackagesFolder = dgSpec.GetProjectSpec(dgSpec.Restore.First()).RestoreMetadata.PackagesPath;
 
         var restoreContext = new RestoreArgs()
         {
             CacheContext = _sourceCacheContext,
             Log = restoreLogger,
             MachineWideSettings = new XPlatMachineWideSetting(),
-            GlobalPackagesFolder = globalPackagesFolder,
             PreLoadedRequestProviders = providers
             // Sources : No need to pass it, because SourceRepositories contains the already built SourceRepository objects
         };


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14735

## Description

I had originally copy/pasted some code from `dotnet package add` for `dotnet package update`, but it turns out that `dotnet packge add` is the only command NuGet has to override the packages directory via `--package-directory`. Since `dotnet package update` doesn't have such a CLI option, we shouldn't be setting the `GlobalPackageFolder` property on the `RestoreArgs` object, to allow each project to potentially override their packages directory via MSBuild property.

So, this PR stops setting the property.  Also see https://github.com/NuGet/NuGet.Client/pull/7014#discussion_r2688590559 for more context.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ This code programmatically runs restore, and there are already tests for restore on projects that set the RestorePackagesPath property
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc~ no changes to documented features
