### PR TITLE
[6.11.x] Don't run static analysis on official builds

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -54,22 +54,23 @@ stages:
     steps:
     - template: /eng/pipelines/templates/Initialize_Build.yml@self
 
-- stage: StaticSourceAnalysis
-  displayName: Static Source Analysis
-  dependsOn: []
-  jobs:
-  - job: RunStaticSourceAnalysis
-    displayName: Run Static Source Analysis
-    condition: "and(succeeded(), ne(variables['RunStaticAnalysis'], 'false'))"
-    timeoutInMinutes: 15
-    pool:
-      name: AzurePipelines-EO
-      image: 1ESPT-Windows2022
-      os: windows
-    steps:
-    - template: /eng/pipelines/templates/Static_Source_Analysis.yml@self
-      parameters:
-        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+- ${{ if not(parameters.isOfficialBuild) }}:
+  - stage: StaticSourceAnalysis
+    displayName: Static Source Analysis
+    dependsOn: []
+    jobs:
+    - job: RunStaticSourceAnalysis
+      displayName: Run Static Source Analysis
+      condition: "and(succeeded(), ne(variables['RunStaticAnalysis'], 'false'))"
+      timeoutInMinutes: 15
+      pool:
+        name: AzurePipelines-EO
+        image: 1ESPT-Windows2022
+        os: windows
+      steps:
+      - template: /eng/pipelines/templates/Static_Source_Analysis.yml@self
+        parameters:
+          isOfficialBuild: ${{ parameters.isOfficialBuild }}
 
 - stage: Build_Insertable
   displayName: Build NuGet inserted into VS and .NET SDK


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: build infrastructure

## Description

We don't care about whitespace violations on the official build, and we already run the other static analysis jobs in the compliance pipeline.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
