### PR TITLE
Only run OneLoc task if it's the latest release branch

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -24,7 +24,6 @@ variables:
   NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY: 3,1000
   Codeql.Enabled: true
   Codeql.TSAEnabled: true
-  # Update monthly to target the release branch for OneLoc.
   OneLocReleaseBranch: release/7.3.x
   RunBuildForPublishing: ${{ parameters.RunBuildForPublishing }}
   SourceBranch: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -24,7 +24,6 @@ variables:
   NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY: 3,1000
   Codeql.Enabled: true
   Codeql.TSAEnabled: true
-  OneLocReleaseBranch: release/7.3.x
   RunBuildForPublishing: ${{ parameters.RunBuildForPublishing }}
   SourceBranch: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
 

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -24,6 +24,8 @@ variables:
   NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY: 3,1000
   Codeql.Enabled: true
   Codeql.TSAEnabled: true
+  # Update monthly to target the release branch for OneLoc.
+  OneLocReleaseBranch: release/7.3.x
   RunBuildForPublishing: ${{ parameters.RunBuildForPublishing }}
   SourceBranch: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
 
@@ -53,7 +55,7 @@ extends:
     - template: /eng/pipelines/templates/pipeline.yml@self
       parameters:
         isOfficialBuild: true
-        ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+        ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), eq(variables['Build.SourceBranch'], format('refs/heads/{0}', variables['OneLocReleaseBranch']))) }}:
           RunOneLocBuild: true
         RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
         SigningType: ${{ parameters.SigningType }}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Confirmed with the localization team that localization is only done to latest release branch and dev. This PR changes our CI pipeline to only run with the specific release branch; this variable would need to be updated every time we do a branching process.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
