### PR TITLE
Improve readability as a follow up to e302692

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
@@ -52,29 +52,23 @@ namespace NuGet.ProjectModel
                 return true;
             }
 
-            bool equal = false;
-
             if (string.Equals(Path, other.Path, StringComparison.OrdinalIgnoreCase))
             {
                 // Handle null/empty dictionaries (treat them as equal)
                 bool thisEmpty = _properties == null || _properties.Count == 0;
                 bool otherEmpty = other._properties == null || other._properties.Count == 0;
 
-                if (thisEmpty && otherEmpty)
+                if (thisEmpty || otherEmpty)
                 {
-                    equal = true;
-                }
-                else if (thisEmpty || otherEmpty)
-                {
-                    equal = false;
+                    return thisEmpty && otherEmpty;
                 }
                 else
                 {
-                    equal = _properties.OrderedEquals(other._properties, pair => pair.Key, StringComparer.Ordinal);
+                    return _properties.OrderedEquals(other._properties, pair => pair.Key, StringComparer.Ordinal);
                 }
             }
 
-            return equal;
+            return false;
         }
 
         public override bool Equals(object obj)

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
@@ -52,6 +52,8 @@ namespace NuGet.ProjectModel
                 return true;
             }
 
+            bool equal = false;
+
             if (string.Equals(Path, other.Path, StringComparison.OrdinalIgnoreCase))
             {
                 // Handle null/empty dictionaries (treat them as equal)
@@ -60,18 +62,19 @@ namespace NuGet.ProjectModel
 
                 if (thisEmpty && otherEmpty)
                 {
-                    return true;
+                    equal = true;
                 }
-
-                if (thisEmpty || otherEmpty)
+                else if (thisEmpty || otherEmpty)
                 {
-                    return false;
+                    equal = false;
                 }
-
-                return _properties.OrderedEquals(other._properties, pair => pair.Key, StringComparer.Ordinal);
+                else
+                {
+                    equal = _properties.OrderedEquals(other._properties, pair => pair.Key, StringComparer.Ordinal);
+                }
             }
 
-            return false;
+            return equal;
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

## Description

Fixes: Improves readability of as a follow-up to e302692

When choosing between using two if's vs an if-else, one consideration should be whether the order of the if statements can be swapped. If they can be swapped, use two if's. If the order matters, use if-else. In this case, the order does matter, so using if-else makes more sense. In order words, the if-else structure codifies the fact that order of the check matters.

Also refactored the code to return from a single point except for obvious error conditions at the top, in accordance with coding conventions.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
