### PR TITLE
[6.14.x] fix sbom artifact

### DIFF
--- a/eng/common/templates/steps/generate-sbom.yml
+++ b/eng/common/templates/steps/generate-sbom.yml
@@ -5,9 +5,9 @@
 
 parameters:
   PackageVersion: 7.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)\artifacts'
+  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
   PackageName: '.NET'
-  ManifestDirPath: '$(Build.SourcesDirectory)\artifacts'
+  ManifestDirPath: '$(Build.StagingDirectory)/sbom'
   sbomContinueOnError: true
 
 steps:

--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -220,7 +220,7 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.Core\\Microsoft.VisualStudio.NuGet.Core.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\16.GenerateVSManifestForVSIX.binlog"
+    msbuildArguments: "/property:ManifestDirPath=$(Build.StagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\16.GenerateVSManifestForVSIX.binlog"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: MSBuild@1
@@ -228,7 +228,7 @@ steps:
   inputs:
     solution: "setup\\Microsoft.VisualStudio.NuGet.BuildTools\\Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj"
     configuration: "$(BuildConfiguration)"
-    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.SourcesDirectory)/artifacts /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateVSManifestForToolsVSIX.binlog"
+    msbuildArguments: "/property:IsVsixBuild=false /property:ManifestDirPath=$(Build.StagingDirectory)/sbom /binarylogger:$(Build.StagingDirectory)\\binlog\\17.GenerateVSManifestForToolsVSIX.binlog"
   condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
 - task: NuGetCommand@2

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -89,14 +89,14 @@ stages:
         condition: "succeeded()"
         targetPath: '$(Build.Repository.LocalPath)\artifacts\buildinfo.json'
         artifactName: 'BuildInfo'
-        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
+        sbomBuildDropPath: $(Build.StagingDirectory)/sbom
 
       - output: pipelineArtifact
         displayName: 'Publish nupkgs'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\$(NupkgOutputDir)"
         artifactName: "nupkgs - $(RtmLabel)"
-        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
+        sbomBuildDropPath: $(Build.StagingDirectory)/sbom
 
       - output: artifactsDrop
         displayName: 'Publish the .runsettings files to artifact services'
@@ -124,21 +124,21 @@ stages:
         displayName: 'Publish NuGet.exe and VSIX as artifact'
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\VS15"
         artifactName: "$(VsixPublishDir)"
-        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
+        sbomBuildDropPath: $(Build.StagingDirectory)/sbom
 
       - output: pipelineArtifact
         displayName: 'Publish localizationArtifacts artifact'
         condition: "or(eq(variables['OverridePublishLocalizationArtifact'], 'true'), and(succeeded(), eq(variables['IsOfficialBuild'], 'true')))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\localizationArtifacts\\"
         artifactName: "localizationArtifacts"
-        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
+        sbomBuildDropPath: $(Build.StagingDirectory)/sbom
 
       - output: pipelineArtifact
         displayName: 'Publish symbols as pipeline artifacts'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         targetPath: "$(Build.Repository.LocalPath)\\artifacts\\symbolstoindex"
         artifactName: "symbols - $(RtmLabel)"
-        sbomBuildDropPath: $(Build.SourcesDirectory)/artifacts
+        sbomBuildDropPath: $(Build.StagingDirectory)/sbom
 
       - output: artifactsDrop
         displayName: 'Upload VSTS Drop'

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -167,7 +167,7 @@ stages:
       - output: pipelineArtifact
         displayName: Publish SBOM manifest
         artifactName: $(ARTIFACT_NAME)
-        targetPath: '$(Build.SourcesDirectory)/artifacts'
+        targetPath: '$(Build.StagingDirectory)/sbom'
         sbomEnabled: false
 
     steps:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 6.14 build

## Description

pipeline is publishing the entire build artifacts directory, instead of just the sbom files, causing compliance checks to fail the pipeline. Move the sbom to another location so it can be published independently.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
