### PR TITLE
Use the .NET SDK version to control the new assets file format

### DIFF
--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -2,4 +2,4 @@
 # To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
 -Channel 8.0 -Runtime dotnet
 -Channel 9.0 -Runtime dotnet
--Channel 10.0.2xx -Quality daily
+-Channel 10.0.3xx -Quality daily

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -25,6 +25,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Graph;
 using Microsoft.Build.Logging;
 using NuGet.Commands;
+using NuGet.Commands.Restore;
 using NuGet.Commands.Restore.Utility;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -567,6 +568,23 @@ namespace NuGet.Build.Tasks.Console
         }
 
         /// <summary>
+        /// Gets the .NET SDK version. If not specified, it will return null.
+        /// </summary>
+        /// <param name="project">The <see cref="ITargetFramework" /> representing the project.</param>
+        /// <returns>The <see cref="NuGetVersion" /> of the .NET SDK if one was found, otherwise <see langword="null">null</see>.</returns>
+        internal static NuGetVersion GetSdkVersion(IMSBuildItem project)
+        {
+            string version = project.GetProperty("NETCoreSdkVersion");
+
+            if (version == null)
+            {
+                return null;
+            }
+
+            return NuGetVersion.Parse(version);
+        }
+
+        /// <summary>
         /// Gets the repository path for the specified project.
         /// </summary>
         /// <param name="project">The <see cref="IMSBuildItem" /> representing the project.</param>
@@ -975,7 +993,11 @@ namespace NuGet.Build.Tasks.Console
                         .Select(s => new CompatibilityProfile(s))
                         .ToList()
                     ),
-                Version = GetProjectVersion(project)
+                Version = GetProjectVersion(project),
+                RestoreSettings = new ProjectRestoreSettings()
+                {
+                    SdkVersion = GetSdkVersion(project)
+                }
             };
 
             return packageSpec;

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -959,6 +959,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <NuGetAuditMode>$(NuGetAuditMode)</NuGetAuditMode>
         <SdkAnalysisLevel>$(SdkAnalysisLevel)</SdkAnalysisLevel>
         <UsingMicrosoftNETSdk>$(UsingMicrosoftNETSdk)</UsingMicrosoftNETSdk>
+        <NETCoreSdkVersion>$(NETCoreSdkVersion)</NETCoreSdkVersion>
         <RestoreUseLegacyDependencyResolver>$(RestoreUseLegacyDependencyResolver)</RestoreUseLegacyDependencyResolver>
       </_RestoreGraphEntry>
     </ItemGroup>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -1496,19 +1496,19 @@ namespace NuGet.Commands
                     if (_request.Project.RestoreSettings.SdkVersion?.IsPrerelease == true)
                     {
                         if (_request.Project.RestoreSettings.SdkVersion.Major == 10
-                            && _request.Project.RestoreSettings.SdkVersion.Major == 0
+                            && _request.Project.RestoreSettings.SdkVersion.Minor == 0
                             && _request.Project.RestoreSettings.SdkVersion.Patch == 300)
                         {
-                            if (_request.Project.RestoreSettings.SdkVersion <= NuGetVersion.Parse("10.0.300-preview.2"))
+                            if (_request.Project.RestoreSettings.SdkVersion <= NuGetVersion.Parse("10.0.300-preview.1"))
                             {
                                 lockFileVersion = LockFileFormat.LegacyVersion;
                             }
                         }
                         if (_request.Project.RestoreSettings.SdkVersion.Major == 11
-                            && _request.Project.RestoreSettings.SdkVersion.Major == 0
+                            && _request.Project.RestoreSettings.SdkVersion.Minor == 0
                             && _request.Project.RestoreSettings.SdkVersion.Patch == 100)
                         {
-                            if (_request.Project.RestoreSettings.SdkVersion <= NuGetVersion.Parse("11.0.100-preview.1.26104.118"))
+                            if (_request.Project.RestoreSettings.SdkVersion <= NuGetVersion.Parse("11.0.100-preview.1.26104"))
                             {
                                 lockFileVersion = LockFileFormat.LegacyVersion;
                             }
@@ -1899,12 +1899,7 @@ namespace NuGet.Commands
 
                 return (success, []);
             }
-
-            bool shouldDoDuplicatesCheck = _request.Project.RestoreMetadata.UsingMicrosoftNETSdk &&
-                    !SdkAnalysisLevelMinimums.IsEnabled(
-                    _request.Project.RestoreMetadata.SdkAnalysisLevel,
-                    _request.Project.RestoreMetadata.UsingMicrosoftNETSdk,
-                    SdkAnalysisLevelMinimums.V10_0_300);
+            var shouldDoDuplicatesCheck = !DoesProjectToolsetSupportsDuplicateFrameworks();
 
             if (shouldDoDuplicatesCheck)
             {
@@ -2005,6 +2000,46 @@ namespace NuGet.Commands
             }
 
             return (success, graphs);
+        }
+
+        private bool DoesProjectToolsetSupportsDuplicateFrameworks()
+        {
+            if (_request.Project.RestoreMetadata.UsingMicrosoftNETSdk &&
+                    !SdkAnalysisLevelMinimums.IsEnabled(
+                    _request.Project.RestoreMetadata.SdkAnalysisLevel,
+                    _request.Project.RestoreMetadata.UsingMicrosoftNETSdk,
+                    SdkAnalysisLevelMinimums.V10_0_300))
+            {
+                return false;
+            }
+            else
+            {
+                // If the SDK version is a prerelease, we need to ensure it's a prerelease version that can handle the aliased assets file.
+                if (_request.Project.RestoreSettings.SdkVersion?.IsPrerelease == true)
+                {
+                    if (_request.Project.RestoreSettings.SdkVersion.Major == 10
+                        && _request.Project.RestoreSettings.SdkVersion.Minor == 0
+                        && _request.Project.RestoreSettings.SdkVersion.Patch == 300)
+                    {
+                        if (_request.Project.RestoreSettings.SdkVersion < NuGetVersion.Parse("10.0.300-preview.1"))
+                        {
+                            return false;
+                        }
+                    }
+                    if (_request.Project.RestoreSettings.SdkVersion.Major == 11
+                        && _request.Project.RestoreSettings.SdkVersion.Minor == 0
+                        && _request.Project.RestoreSettings.SdkVersion.Patch == 100)
+                    {
+                        if (_request.Project.RestoreSettings.SdkVersion < NuGetVersion.Parse("11.0.100-preview.1.26104"))
+                        {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+            }
+
+            return true;
         }
 
         // Check for duplicate frameworks and log an error if found.

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -1508,12 +1508,11 @@ namespace NuGet.Commands
                             && _request.Project.RestoreSettings.SdkVersion.Major == 0
                             && _request.Project.RestoreSettings.SdkVersion.Patch == 100)
                         {
-                            if (_request.Project.RestoreSettings.SdkVersion <= NuGetVersion.Parse("11.0.100-preview.2"))
+                            if (_request.Project.RestoreSettings.SdkVersion <= NuGetVersion.Parse("11.0.100-preview.1.26104.118"))
                             {
                                 lockFileVersion = LockFileFormat.LegacyVersion;
                             }
                         }
-
                     }
                 }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -1490,6 +1490,32 @@ namespace NuGet.Commands
                 {
                     lockFileVersion = LockFileFormat.LegacyVersion;
                 }
+                else
+                {
+                    // If the SDK version is a prerelease, we need to ensure it's a prerelease version that can handle the aliased assets file.
+                    if (_request.Project.RestoreSettings.SdkVersion?.IsPrerelease == true)
+                    {
+                        if (_request.Project.RestoreSettings.SdkVersion.Major == 10
+                            && _request.Project.RestoreSettings.SdkVersion.Major == 0
+                            && _request.Project.RestoreSettings.SdkVersion.Patch == 300)
+                        {
+                            if (_request.Project.RestoreSettings.SdkVersion <= NuGetVersion.Parse("10.0.300-preview.2"))
+                            {
+                                lockFileVersion = LockFileFormat.LegacyVersion;
+                            }
+                        }
+                        if (_request.Project.RestoreSettings.SdkVersion.Major == 11
+                            && _request.Project.RestoreSettings.SdkVersion.Major == 0
+                            && _request.Project.RestoreSettings.SdkVersion.Patch == 100)
+                        {
+                            if (_request.Project.RestoreSettings.SdkVersion <= NuGetVersion.Parse("11.0.100-preview.2"))
+                            {
+                                lockFileVersion = LockFileFormat.LegacyVersion;
+                            }
+                        }
+
+                    }
+                }
 
                 return lockFileVersion;
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -1479,44 +1479,13 @@ namespace NuGet.Commands
 
             int DetermineLockFileVersion()
             {
-                int lockFileVersion = _request.LockFileVersion;
-
-                // We use the request provided version, unless we are using the Microsoft.NET.Sdk that does not support reading of aliased assets files.
-                if (_request.Project.RestoreMetadata.UsingMicrosoftNETSdk &&
-                    !SdkAnalysisLevelMinimums.IsEnabled(
-                    _request.Project.RestoreMetadata.SdkAnalysisLevel,
-                    _request.Project.RestoreMetadata.UsingMicrosoftNETSdk,
-                    SdkAnalysisLevelMinimums.V10_0_300))
+                // We use the request provided version, unless we are using the Microsoft.NET.Sdk version that does not support reading of aliased assets files.
+                if (DoesProjectToolsetSupportsDuplicateFrameworks(_request.Project))
                 {
-                    lockFileVersion = LockFileFormat.LegacyVersion;
-                }
-                else
-                {
-                    // If the SDK version is a prerelease, we need to ensure it's a prerelease version that can handle the aliased assets file.
-                    if (_request.Project.RestoreSettings.SdkVersion?.IsPrerelease == true)
-                    {
-                        if (_request.Project.RestoreSettings.SdkVersion.Major == 10
-                            && _request.Project.RestoreSettings.SdkVersion.Minor == 0
-                            && _request.Project.RestoreSettings.SdkVersion.Patch == 300)
-                        {
-                            if (_request.Project.RestoreSettings.SdkVersion <= NuGetVersion.Parse("10.0.300-preview.1"))
-                            {
-                                lockFileVersion = LockFileFormat.LegacyVersion;
-                            }
-                        }
-                        if (_request.Project.RestoreSettings.SdkVersion.Major == 11
-                            && _request.Project.RestoreSettings.SdkVersion.Minor == 0
-                            && _request.Project.RestoreSettings.SdkVersion.Patch == 100)
-                        {
-                            if (_request.Project.RestoreSettings.SdkVersion <= NuGetVersion.Parse("11.0.100-preview.1.26104"))
-                            {
-                                lockFileVersion = LockFileFormat.LegacyVersion;
-                            }
-                        }
-                    }
+                    return _request.LockFileVersion;
                 }
 
-                return lockFileVersion;
+                return LockFileFormat.LegacyVersion;
             }
         }
 
@@ -1899,7 +1868,7 @@ namespace NuGet.Commands
 
                 return (success, []);
             }
-            var shouldDoDuplicatesCheck = !DoesProjectToolsetSupportsDuplicateFrameworks();
+            var shouldDoDuplicatesCheck = !DoesProjectToolsetSupportsDuplicateFrameworks(_request.Project);
 
             if (shouldDoDuplicatesCheck)
             {
@@ -2002,12 +1971,12 @@ namespace NuGet.Commands
             return (success, graphs);
         }
 
-        private bool DoesProjectToolsetSupportsDuplicateFrameworks()
+        private static bool DoesProjectToolsetSupportsDuplicateFrameworks(PackageSpec project)
         {
-            if (_request.Project.RestoreMetadata.UsingMicrosoftNETSdk &&
+            if (project.RestoreMetadata.UsingMicrosoftNETSdk &&
                     !SdkAnalysisLevelMinimums.IsEnabled(
-                    _request.Project.RestoreMetadata.SdkAnalysisLevel,
-                    _request.Project.RestoreMetadata.UsingMicrosoftNETSdk,
+                    project.RestoreMetadata.SdkAnalysisLevel,
+                    project.RestoreMetadata.UsingMicrosoftNETSdk,
                     SdkAnalysisLevelMinimums.V10_0_300))
             {
                 return false;
@@ -2015,22 +1984,22 @@ namespace NuGet.Commands
             else
             {
                 // If the SDK version is a prerelease, we need to ensure it's a prerelease version that can handle the aliased assets file.
-                if (_request.Project.RestoreSettings.SdkVersion?.IsPrerelease == true)
+                if (project.RestoreSettings.SdkVersion?.IsPrerelease == true)
                 {
-                    if (_request.Project.RestoreSettings.SdkVersion.Major == 10
-                        && _request.Project.RestoreSettings.SdkVersion.Minor == 0
-                        && _request.Project.RestoreSettings.SdkVersion.Patch == 300)
+                    if (project.RestoreSettings.SdkVersion.Major == 10
+                        && project.RestoreSettings.SdkVersion.Minor == 0
+                        && project.RestoreSettings.SdkVersion.Patch == 300)
                     {
-                        if (_request.Project.RestoreSettings.SdkVersion < NuGetVersion.Parse("10.0.300-preview.1"))
+                        if (project.RestoreSettings.SdkVersion < NuGetVersion.Parse("10.0.300-preview.1"))
                         {
                             return false;
                         }
                     }
-                    if (_request.Project.RestoreSettings.SdkVersion.Major == 11
-                        && _request.Project.RestoreSettings.SdkVersion.Minor == 0
-                        && _request.Project.RestoreSettings.SdkVersion.Patch == 100)
+                    if (project.RestoreSettings.SdkVersion.Major == 11
+                        && project.RestoreSettings.SdkVersion.Minor == 0
+                        && project.RestoreSettings.SdkVersion.Patch == 100)
                     {
-                        if (_request.Project.RestoreSettings.SdkVersion < NuGetVersion.Parse("11.0.100-preview.1.26104"))
+                        if (project.RestoreSettings.SdkVersion < NuGetVersion.Parse("11.0.100-preview.1.26104"))
                         {
                             return false;
                         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -293,6 +293,7 @@ namespace NuGet.Commands
                 result.RestoreMetadata.UsingMicrosoftNETSdk = GetUsingMicrosoftNETSdk(specItem.GetProperty("UsingMicrosoftNETSdk"));
                 result.RestoreMetadata.SdkAnalysisLevel = GetSdkAnalysisLevel(specItem.GetProperty("SdkAnalysisLevel"));
                 result.RestoreMetadata.UseLegacyDependencyResolver = IsPropertyTrue(specItem, "RestoreUseLegacyDependencyResolver");
+                result.RestoreSettings.SdkVersion = GetSdkAnalysisLevel(specItem.GetProperty("NETCoreSdkVersion"));
             }
 
             return result;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
@@ -60,7 +60,11 @@ namespace NuGet.Commands.Restore.Utility
                         .Select(s => new CompatibilityProfile(s))
                         .ToList()
                     ),
-                Version = GetProjectVersion(project.OuterBuild)
+                Version = GetProjectVersion(project.OuterBuild),
+                RestoreSettings = new ProjectRestoreSettings()
+                {
+                    SdkVersion = GetSdkVersion(project.OuterBuild)
+                }
             };
 
             return packageSpec;
@@ -78,6 +82,23 @@ namespace NuGet.Commands.Restore.Utility
             if (version == null)
             {
                 return PackageSpec.DefaultVersion;
+            }
+
+            return NuGetVersion.Parse(version);
+        }
+
+        /// <summary>
+        /// Gets the .NET SDK version. If not specified, it will return null.
+        /// </summary>
+        /// <param name="project">The <see cref="ITargetFramework" /> representing the project.</param>
+        /// <returns>The <see cref="NuGetVersion" /> of the .NET SDK if one was found, otherwise <see langword="null">null</see>.</returns>
+        internal static NuGetVersion? GetSdkVersion(ITargetFramework project)
+        {
+            string? version = project.GetProperty("NETCoreSdkVersion");
+
+            if (version == null)
+            {
+                return null;
             }
 
             return NuGetVersion.Parse(version);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3413,7 +3413,7 @@ EndGlobal";
 
         // P1 (banana) -> X
         // P1 (apple) -> Y
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Skip = "https://github.com/NuGet/Client.Engineering/issues/3632")]
         public async Task DotnetRestore_WithAliasesOfTheSameFramework_UsesCorrectPackages()
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
@@ -3433,7 +3433,6 @@ EndGlobal";
             {
                 var xml = XDocument.Load(stream);
                 ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"{apple};{banana}");
-                ProjectFileUtils.AddProperty(xml, "SDKAnalysisLevel", "10.0.300");
 
                 var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
 
@@ -3486,7 +3485,7 @@ EndGlobal";
 
         // P (apple)  -> Net472 package, with ATF, succeeds
         // P (banana) -> Net472 package, with ATF, fails
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Skip = "https://github.com/NuGet/Client.Engineering/issues/3632")]
         public async Task DotnetRestore_WithAliasesOfSameFramework_WithAssetTargetFallback_OneSucceedsOneFails()
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
@@ -3507,7 +3506,6 @@ EndGlobal";
             {
                 var xml = XDocument.Load(stream);
                 ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"{apple};{banana}");
-                ProjectFileUtils.AddProperty(xml, "SDKAnalysisLevel", "10.0.300");
 
                 var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
 
@@ -3570,7 +3568,7 @@ EndGlobal";
 
         // P (apple)  -> Net472 package -> Transitive Net472 package, with ATF, succeeds
         // P (banana) -> Net472 package, with ATF, fails
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Skip = "https://github.com/NuGet/Client.Engineering/issues/3632")]
         public async Task DotnetRestore_WithAliasesOfSameFramework_WithAssetTargetFallback_TransitiveDependenciesFlowCorrectly()
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
@@ -3597,7 +3595,6 @@ EndGlobal";
             {
                 var xml = XDocument.Load(stream);
                 ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"{apple};{banana}");
-                ProjectFileUtils.AddProperty(xml, "SDKAnalysisLevel", "10.0.300");
 
                 var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
 
@@ -3665,7 +3662,7 @@ EndGlobal";
 
         // P (apple) -> Project2 (apple) -> Package A
         // P (banana) -> Project2 (banana) -> Package B
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Skip = "https://github.com/NuGet/Client.Engineering/issues/3632")]
         public async Task DotnetRestore_WithAliasesOfSameFrameworkAndProjectReferences_TransitivePackageDependenciesFlowCorrectly()
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
@@ -3687,7 +3684,6 @@ EndGlobal";
             {
                 var xml = XDocument.Load(stream);
                 ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"{apple};{banana}");
-                ProjectFileUtils.AddProperty(xml, "SDKAnalysisLevel", "10.0.300");
 
                 var attributesA = new Dictionary<string, string>() { { "Version", "1.0.0" } };
                 var attributesB = new Dictionary<string, string>() { { "Version", "1.0.0" } };
@@ -3737,7 +3733,6 @@ EndGlobal";
             {
                 var xml = XDocument.Load(stream);
                 ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"{apple};{banana}");
-                ProjectFileUtils.AddProperty(xml, "SDKAnalysisLevel", "10.0.300");
 
                 // Add project reference to project2
                 ProjectFileUtils.AddItem(
@@ -3787,7 +3782,7 @@ EndGlobal";
 
         // P (apple) -> Project2 
         // P (banana) -> Project3
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Skip = "https://github.com/NuGet/Client.Engineering/issues/3632")]
         public async Task DotnetRestore_WithAliasesOfSameFramework_MultipleProjectReferencesFlowCorrectly()
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
@@ -3813,7 +3808,6 @@ EndGlobal";
             {
                 var xml = XDocument.Load(stream);
                 ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"{apple};{banana}");
-                ProjectFileUtils.AddProperty(xml, "SDKAnalysisLevel", "10.0.300");
 
                 // Add Project2 reference only for apple alias
                 ProjectFileUtils.AddItem(
@@ -3940,7 +3934,7 @@ EndGlobal";
 
         // P (apple) -> Project2 with APPLE constant -> Uses Project2Type
         // P (banana) -> Project3 with BANANA constant -> Uses Project3Type
-        [PlatformFact(Platform.Windows)]
+        [PlatformFact(Platform.Windows, Skip = "https://github.com/NuGet/Client.Engineering/issues/3632")]
         public async Task DotnetRestore_WithAliasesOfSameFramework_MultipleProjectReferencesWithConditionalCompilation_BuildSucceeds()
         {
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
@@ -3990,7 +3984,6 @@ EndGlobal";
             {
                 var xml = XDocument.Load(stream);
                 ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", $"{apple};{banana}");
-                ProjectFileUtils.AddProperty(xml, "SDKAnalysisLevel", "10.0.300");
 
                 // Add Project2 reference only for apple alias
                 ProjectFileUtils.AddItem(

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_Aliases.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_Aliases.cs
@@ -409,13 +409,40 @@ namespace NuGet.Commands.FuncTest
             bananaTarget.Libraries.Should().Contain(e => e.Name!.Equals("Project3"));
         }
 
-        // P1 (banana) -> X
-        // P1 (apple) -> Y
-        [Fact]
-        public async Task RestoreCommand_WithAliasesOfSameFramework_And10_0_200_FailsWithNU1018()
+        [Theory]
+        [InlineData("10.0.200", "10.0.300")]
+        [InlineData("10.0.300", "10.0.300-preview.0.12345")]
+        [InlineData("11.0.100", "11.0.100-preview.1.26103")]
+        public async Task RestoreCommand_WithAliasesOfSameFramework_AndIncompatibleSDKAnalysisLevelAndSDKVersionCombinations_FailsWithNU1018(string sdkAnalysisLevel, string sdkVersion)
         {
             using var pathContext = new SimpleTestPathContext();
 
+            RestoreResult result = await RunSimpleAliasedRestoreWithSDKAnalysisLevelAndSDKVersion(pathContext, sdkAnalysisLevel, sdkVersion);
+
+            result.Success.Should().BeFalse();
+            result.LockFile.LogMessages.Should().HaveCount(1);
+            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1018);
+        }
+
+        [Theory]
+        [InlineData("10.0.300", "10.0.300")]
+        [InlineData("10.0.300", "10.0.400")]
+        [InlineData("10.0.300", null)] // Null value means we let it be.
+        [InlineData("10.0.300", "10.0.300-preview.1.12345")] // This is a dummy value that'll need to be updated once we have a real one.
+        [InlineData("11.0.100", "11.0.100-preview.1.26104")]
+        [InlineData("11.0.100", "11.0.100")]
+        [InlineData("11.0.100", "11.0.101")]
+        public async Task RestoreCommand_WithAliasesOfSameFramework_AndValidSDKAnalysisLevelAndSDKVersionCombinations_Succeeds(string sdkAnalysisLevel, string sdkVersion)
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            RestoreResult result = await RunSimpleAliasedRestoreWithSDKAnalysisLevelAndSDKVersion(pathContext, sdkAnalysisLevel, sdkVersion);
+
+            result.Success.Should().BeTrue();
+        }
+
+        private static async Task<RestoreResult> RunSimpleAliasedRestoreWithSDKAnalysisLevelAndSDKVersion(SimpleTestPathContext pathContext, string sdkAnalysisLevel, string sdkVersion)
+        {
             // Setup packages
             var packageA = new SimpleTestPackageContext("packageA", "1.0.0")
             {
@@ -461,14 +488,12 @@ namespace NuGet.Commands.FuncTest
                 new SimpleTestPackageContext("x", "1.0.0"),
                 new SimpleTestPackageContext("y", "1.0.0"));
 
-            projectSpec.RestoreMetadata.SdkAnalysisLevel = NuGetVersion.Parse("10.0.200");
+            projectSpec.RestoreMetadata.SdkAnalysisLevel = NuGetVersion.Parse(sdkAnalysisLevel);
             projectSpec.RestoreMetadata.UsingMicrosoftNETSdk = true;
+            projectSpec.RestoreSettings.SdkVersion = sdkVersion != null ? NuGetVersion.Parse(sdkVersion) : null;
 
             // Act & Assert
-            var result = await RunRestoreAsync(pathContext, projectSpec);
-            result.Success.Should().BeFalse();
-            result.LockFile.LogMessages.Should().HaveCount(1);
-            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1018);
+            return await RunRestoreAsync(pathContext, projectSpec);
         }
 
         internal static Task<RestoreResult> RunRestoreAsync(SimpleTestPathContext pathContext, params PackageSpec[] projects)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/nuget/home/issues/14745

## Description

The tldr is that the SDKAnalysisLevel is set for all .NET 11.0.100 and 10.0.300 versions of the .NET SDKs including previews, but some of those versions don't support aliasing. 
So is a low precision thing.

To solve this, whenever we are using one of those 2 versions of the SDK, and it's a prerelease SDK we perform an additional check.
We know for .NET 11, 11.0.100-preview.1.26104.118 supports aliased files. 
We don't know the 10.0.3xx version yet because https://github.com/dotnet/dotnet/pull/4555 is not merged yet.

Note that I did end up having to remove some 10.0.3xx tests, since I need the .NET 10.0.3xx version to support aliasing and currently that's blocked.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests 
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
