### PR TITLE
Reduce memory allocations when creating SourceRepository instances

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/SourceRepositoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/SourceRepositoryTests.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using NuGet.Protocol.Core.Types;
+using Xunit;
+
+namespace NuGet.Protocol.Tests;
+
+public class SourceRepositoryTests
+{
+    [Fact]
+    public void ProviderCacheTypes_EqualsV3ResourceCount()
+    {
+        Assert.Equal(SourceRepository.ProviderCacheTypes, Repository.Provider.GetCoreV3().GroupBy(p => p.Value.ResourceType).Count());
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

As the title says, reduce allocations when creating SourceRepository instances. It takes a list of resource providers, groups them by the resource type, and creates a dictionary of type to list of providers.

I created a simple benchmark, and here are the results:

| Method              | Mean      | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|-------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| Original        | 11.890 us | 0.1388 us | 0.1298 us | 2.7618 | 0.1984 |  45.19 KB |
| Changed |  6.441 us | 0.0906 us | 0.0847 us | 1.3657 | 0.0916 |   22.4 KB |

roughly:
* 20 KB improvement from removing the `.OrderBy(..).ThenBy(..)` LINQ expression, and using a list with the right initial capacity and then using `List<>.Sort`
* 1KB improvement by creating the provider cache dictionary with the correct initial size
* 1KB from removing the `ordered` queue/list, and sorting the `items` list a second time in-place
* I forgot to check how much the unnecessary `.ToArray()` in the `Init` method was causing, but I guess this was most of the remaining memory savings, as there isn't really much else left in the PR.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
