### PR TITLE
Use V3 version of the assets file when a SDK project restore is missing a TargetFramework

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -1986,6 +1986,17 @@ namespace NuGet.Commands
             }
             else
             {
+                if (project.RestoreMetadata.UsingMicrosoftNETSdk)
+                {
+                    foreach (TargetFrameworkInformation tfi in project.TargetFrameworks)
+                    {
+                        if (string.IsNullOrEmpty(tfi.TargetAlias))
+                        {
+                            return false;
+                        }
+                    }
+                }
+
                 // If the SDK version is a prerelease, we need to ensure it's a prerelease version that can handle the aliased assets file.
                 if (project.RestoreSettings.SdkVersion?.IsPrerelease == true)
                 {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14755

## Description

In arcade, when the traversal SDK is used, sometimes they unset the TargetFramework.

Unfortunately that leads to a failure down the line because....rightfully so, NuGet requires a TargetFramework for SDK projects. 
Unfortunately we never quite codified that until now, and it breaking VMR builds in https://dev.azure.com/dnceng/internal/_build/results?buildId=2900375&view=results.  cc @MichaelSimons 

We want to unblock the VMR first, but we'll continue the conversation around the unsetting of the TargetFramework. 

https://github.com/dotnet/dotnet/pull/4768 has the tests I did.

Context from the issue: 

<hr/>
https://dev.azure.com/dnceng/internal/_build/results?buildId=2900375&view=results

The root cause is that there is an Microsoft.Build.Travelsal project that the arcade SDK unsets the TargetFramework for. 

https://github.com/dotnet/dotnet/blob/bfb70557c99bd674a30bd3ab81197ff44ea3c0bf/build.proj#L1

https://github.com/dotnet/dotnet/blob/bfb70557c99bd674a30bd3ab81197ff44ea3c0bf/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets#L18-L19

Basically it unsets framework aliases on linux, and for Traversal that has a default tfm of net45, that leaves it with nothing.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
