### PR TITLE
Add net11.0 to common frameworks

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -15,6 +15,7 @@ namespace NuGet.Frameworks
         public static readonly Version Version8 = new Version(8, 0, 0, 0);
         public static readonly Version Version9 = new Version(9, 0, 0, 0);
         public static readonly Version Version10 = new Version(10, 0, 0, 0);
+        public static readonly Version Version11 = new Version(11, 0, 0, 0);
         public static readonly FrameworkRange DotNetAll = new FrameworkRange(
                         new NuGetFramework(FrameworkIdentifiers.NetPlatform, FrameworkConstants.EmptyVersion),
                         new NuGetFramework(FrameworkIdentifiers.NetPlatform, FrameworkConstants.MaxVersion));
@@ -240,6 +241,8 @@ namespace NuGet.Frameworks
             public static readonly NuGetFramework Net90 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9);
             /// <summary>net10.0 (.NETCoreApp,Version=v10.0)</summary>
             public static readonly NuGetFramework Net10_0 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10);
+            /// <summary>net11.0 (.NETCoreApp,Version=v11.0)</summary>
+            public static readonly NuGetFramework Net11_0 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version11);
 
             public static readonly NuGetFramework Native = new NuGetFramework(FrameworkIdentifiers.Native, new Version(0, 0, 0, 0));
         }

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -689,6 +689,9 @@ namespace NuGet.Frameworks
                 case "net10.0":
                     framework = FrameworkConstants.CommonFrameworks.Net10_0;
                     break;
+                case "net11.0":
+                    framework = FrameworkConstants.CommonFrameworks.Net11_0;
+                    break;
             }
 
             return framework != null;

--- a/src/NuGet.Core/NuGet.Frameworks/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Frameworks/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static readonly NuGet.Frameworks.FrameworkConstants.CommonFrameworks.Net11_0 -> NuGet.Frameworks.NuGetFramework!
+static readonly NuGet.Frameworks.FrameworkConstants.Version11 -> System.Version!


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14759

## Description

Add net11.0 to common frameworks.

There's a test for NuGetFramework.Parse that uses reflection on all fields in CommonFrameworks, so there's no need to add an additional test.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ existing test, see description
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
