### PR TITLE
Add package and update package treat --framework as aliases correctly for aliased projects

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1467,5 +1467,140 @@ namespace NuGet.XPlat.FuncTest
             Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, packageX.Version));
             Assert.True(XPlatTestUtils.ValidateAssetsFile(projectA, packageX.Id));
         }
+
+        [Theory]
+        [InlineData("apple;banana", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0", "apple")]
+        [InlineData("apple;banana", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0", "banana")]
+        [InlineData("apple;banana;pear", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0", "apple;pear")]
+        [InlineData("net46;netcoreapp20;net50", ".NETFramework,Version=v4.6;NetCoreApp,Version=v2.0;NetCoreApp,Version=v5.0", "netcoreapp20")]
+        [InlineData("net46;netcoreapp20;net50", ".NETFramework,Version=v4.6;NetCoreApp,Version=v2.0;NetCoreApp,Version=v5.0", "netcoreapp20;net50")]
+        public async Task AddPkg_ConditionalWithAlias_UserInputFramework_Success(
+            string projectFrameworks,
+            string projectTargetFrameworkMonikers,
+            string userInputFrameworks)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var userInputVersion = "1.0.0";
+                var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks, projectTargetFrameworkMonikers);
+
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: "netcoreapp2.0");
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var logger = new TestCommandOutputLogger(_testOutputHelper);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, userInputVersion, project,
+                    frameworks: userInputFrameworks);
+                var commandRunner = new AddPackageReferenceCommandRunner();
+
+                // Act
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
+
+                // Assert
+                Assert.Equal(0, result);
+
+                foreach (var fw in MSBuildStringUtility.Split(userInputFrameworks))
+                {
+                    var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, fw);
+                    Assert.NotNull(itemGroup);
+                    Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("netcoreapp20;net50", ".NETCoreApp,Version=v2.0;.NETCoreApp,Version=v5.0")]
+        public async Task AddPkg_UnconditionalWithAlias_Success(
+            string projectFrameworks,
+            string projectTargetFrameworkMonikers)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var userInputVersion = "1.0.0";
+                var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks, projectTargetFrameworkMonikers);
+
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: "netcoreapp2.0");
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var logger = new TestCommandOutputLogger(_testOutputHelper);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, userInputVersion, project);
+                var commandRunner = new AddPackageReferenceCommandRunner();
+
+                // Act
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
+                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
+
+                // Assert
+                Assert.Equal(0, result);
+                Assert.NotNull(itemGroup);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
+            }
+        }
+
+        [Theory]
+        [InlineData("net46;netcoreapp20;net50", ".NETFramework,Version=v4.6;NetCoreApp,Version=v2.0;NetCoreApp,Version=v5.0", "0.0.5", "1.0.0")]
+        public async Task AddPkg_ConditionalAddAsUpdateWithAlias_Success(
+            string projectFrameworks,
+            string projectTargetFrameworkMonikers,
+            string userInputVersionOld,
+            string userInputVersionNew)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks, projectTargetFrameworkMonikers);
+
+                var latestVersion = "1.0.0";
+                var packages = new SimpleTestPackageContext[] { XPlatTestUtils.CreatePackage(packageVersion: latestVersion),
+                        XPlatTestUtils.CreatePackage(packageVersion: "0.0.5"), XPlatTestUtils.CreatePackage(packageVersion: "0.0.9") };
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packages);
+
+                var logger = new TestCommandOutputLogger(_testOutputHelper);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packages[0].Id, userInputVersionOld, project);
+                var commandRunner = new AddPackageReferenceCommandRunner();
+                var msBuild = new MSBuildAPIUtility(logger);
+
+                // Create a package ref with old version
+                var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
+
+                // Preconditions
+                Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packages[0].Id, userInputVersionOld));
+
+                // The model from which the args are generated needs updated as well
+                project.AddPackageToAllFrameworks(new SimpleTestPackageContext(packages[0].Id, userInputVersionOld));
+
+                packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packages[0].Id, userInputVersionNew, project);
+                commandRunner = new AddPackageReferenceCommandRunner();
+
+                // Act
+                // Create a package ref with new version
+                result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
+
+                // Assert
+                // Verify that the only package reference is with the new version
+                Assert.Equal(0, result);
+                Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packages[0].Id, userInputVersionNew));
+            }
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1597,5 +1597,110 @@ namespace NuGet.XPlat.FuncTest
             Assert.Equal(0, result);
             Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, "packageX", userInputVersionNew));
         }
+
+        [Theory]
+        [InlineData("apple;banana", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0", "apple", "0.0.5", "1.0.0")]
+        [InlineData("apple;banana", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0", "banana", "0.0.5", "1.0.0")]
+        [InlineData("apple;banana;pear", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0", "apple;pear", "0.0.5", "1.0.0")]
+        public async Task AddPkg_ConditionalAddAsUpdateWithAlias_UserInputFramework_Success(
+            string projectFrameworks,
+            string projectTargetFrameworkMonikers,
+            string userInputFrameworks,
+            string userInputVersionOld,
+            string userInputVersionNew)
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks, projectTargetFrameworkMonikers);
+            project.SDKAnalysisLevel = "10.0.400";
+
+            // Generate Package
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                XPlatTestUtils.CreatePackage(packageVersion: userInputVersionNew),
+                XPlatTestUtils.CreatePackage(packageVersion: userInputVersionOld));
+
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, "packageX", userInputVersionOld, project,
+                frameworks: userInputFrameworks);
+            var commandRunner = new AddPackageReferenceCommandRunner();
+            var msBuild = new MSBuildAPIUtility(logger);
+
+            // Create a package ref with old version
+            var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
+            var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
+
+            // Preconditions
+            result.Should().Be(0, because: logger.ShowErrors());
+            foreach (var fw in MSBuildStringUtility.Split(userInputFrameworks))
+            {
+                var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, fw);
+                Assert.NotNull(itemGroup);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, "packageX", userInputVersionOld));
+            }
+
+            // The model from which the args are generated needs updated as well
+            project.AddPackageToAllFrameworks(new SimpleTestPackageContext("packageX", userInputVersionOld));
+
+            packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, "packageX", userInputVersionNew, project,
+                frameworks: userInputFrameworks);
+            commandRunner = new AddPackageReferenceCommandRunner();
+
+            // Act
+            // Create a package ref with new version
+            result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
+            projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
+
+            // Assert
+            // Verify that the only package reference is with the new version
+            Assert.Equal(0, result);
+            foreach (var fw in MSBuildStringUtility.Split(userInputFrameworks))
+            {
+                var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, fw);
+                Assert.NotNull(itemGroup);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, "packageX", userInputVersionNew));
+            }
+        }
+
+        [Theory]
+        [InlineData("apple;banana", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v8.0", "apple")]
+        [InlineData("apple;banana", "NetCoreApp,Version=v8.0;NetCoreApp,Version=v10.0", "banana")]
+        [InlineData("apple;banana;pear", "NetCoreApp,Version=v8.0;NetCoreApp,Version=v8.0;NetCoreApp,Version=v10.0", "pear")]
+        public async Task AddPkg_AutomaticallyConditionalDueToCompatibilityWithAlias_Success(
+           string projectFrameworks,
+           string projectTargetFrameworkMonikers,
+           string expectedFramework)
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var userInputVersion = "1.0.0";
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks, projectTargetFrameworkMonikers);
+            project.SDKAnalysisLevel = "10.0.400";
+
+            // Generate Package
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                XPlatTestUtils.CreatePackage(frameworkString: "net9.0"));
+
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, "packageX", userInputVersion, project);
+            var commandRunner = new AddPackageReferenceCommandRunner();
+
+            // Act
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
+
+            // Assert
+            Assert.Equal(0, result);
+
+            foreach (var fw in MSBuildStringUtility.Split(expectedFramework))
+            {
+                var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, fw);
+                Assert.NotNull(itemGroup);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, "packageX", userInputVersion));
+            }
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1472,135 +1472,130 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("apple;banana", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0", "apple")]
         [InlineData("apple;banana", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0", "banana")]
         [InlineData("apple;banana;pear", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0", "apple;pear")]
-        [InlineData("net46;netcoreapp20;net50", ".NETFramework,Version=v4.6;NetCoreApp,Version=v2.0;NetCoreApp,Version=v5.0", "netcoreapp20")]
-        [InlineData("net46;netcoreapp20;net50", ".NETFramework,Version=v4.6;NetCoreApp,Version=v2.0;NetCoreApp,Version=v5.0", "netcoreapp20;net50")]
         public async Task AddPkg_ConditionalWithAlias_UserInputFramework_Success(
             string projectFrameworks,
             string projectTargetFrameworkMonikers,
             string userInputFrameworks)
         {
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
+            using var pathContext = new SimpleTestPathContext();
+            var userInputVersion = "1.0.0";
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks, projectTargetFrameworkMonikers);
+            project.SDKAnalysisLevel = "10.0.400";
+
+            // Generate Package
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                XPlatTestUtils.CreatePackage(frameworkString: "netcoreapp2.0"));
+
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, "packageX", userInputVersion, project,
+                frameworks: userInputFrameworks);
+            var commandRunner = new AddPackageReferenceCommandRunner();
+
+            // Act
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
+
+            // Assert
+            Assert.Equal(0, result);
+
+            foreach (var fw in MSBuildStringUtility.Split(userInputFrameworks))
             {
-                var userInputVersion = "1.0.0";
-                var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks, projectTargetFrameworkMonikers);
-
-                var packageX = XPlatTestUtils.CreatePackage(frameworkString: "netcoreapp2.0");
-
-                // Generate Package
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    PackageSaveMode.Defaultv3,
-                    packageX);
-
-                var logger = new TestCommandOutputLogger(_testOutputHelper);
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, userInputVersion, project,
-                    frameworks: userInputFrameworks);
-                var commandRunner = new AddPackageReferenceCommandRunner();
-
-                // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
-
-                // Assert
-                Assert.Equal(0, result);
-
-                foreach (var fw in MSBuildStringUtility.Split(userInputFrameworks))
-                {
-                    var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, fw);
-                    Assert.NotNull(itemGroup);
-                    Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
-                }
+                var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, fw);
+                Assert.NotNull(itemGroup);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, "packageX", userInputVersion));
             }
         }
 
         [Theory]
-        [InlineData("netcoreapp20;net50", ".NETCoreApp,Version=v2.0;.NETCoreApp,Version=v5.0")]
+        [InlineData("apple;banana", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0")]
+        [InlineData("apple;banana;pear", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0")]
+        [InlineData("apple;banana", "NetCoreApp,Version=v9.0;NetCoreApp,Version=v10.0")]
         public async Task AddPkg_UnconditionalWithAlias_Success(
             string projectFrameworks,
             string projectTargetFrameworkMonikers)
         {
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                var userInputVersion = "1.0.0";
-                var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks, projectTargetFrameworkMonikers);
+            using var pathContext = new SimpleTestPathContext();
+            var userInputVersion = "1.0.0";
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks, projectTargetFrameworkMonikers);
+            project.SDKAnalysisLevel = "10.0.400";
 
-                var packageX = XPlatTestUtils.CreatePackage(frameworkString: "netcoreapp2.0");
+            // Generate Package
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                XPlatTestUtils.CreatePackage(frameworkString: "net9.0"));
 
-                // Generate Package
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    PackageSaveMode.Defaultv3,
-                    packageX);
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, "packageX", userInputVersion, project);
+            var commandRunner = new AddPackageReferenceCommandRunner();
 
-                var logger = new TestCommandOutputLogger(_testOutputHelper);
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, userInputVersion, project);
-                var commandRunner = new AddPackageReferenceCommandRunner();
+            // Act
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
+            var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
-                // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
-                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
-
-                // Assert
-                Assert.Equal(0, result);
-                Assert.NotNull(itemGroup);
-                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
-            }
+            // Assert
+            Assert.Equal(0, result);
+            Assert.NotNull(itemGroup);
+            Assert.True(XPlatTestUtils.ValidateReference(itemGroup, "packageX", userInputVersion));
         }
 
         [Theory]
-        [InlineData("net46;netcoreapp20;net50", ".NETFramework,Version=v4.6;NetCoreApp,Version=v2.0;NetCoreApp,Version=v5.0", "0.0.5", "1.0.0")]
-        public async Task AddPkg_ConditionalAddAsUpdateWithAlias_Success(
+        [InlineData("apple;banana", "NetCoreApp,Version=v9.0;NetCoreApp,Version=v10.0", "0.0.5", "1.0.0")]
+        [InlineData("apple;banana", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0", "0.0.5", "1.0.0")]
+        [InlineData("apple;banana;pear", "NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0;NetCoreApp,Version=v10.0", "0.0.5", "1.0.0")]
+        public async Task AddPkg_UnconditionalAddAsUpdateWithAlias_Success(
             string projectFrameworks,
             string projectTargetFrameworkMonikers,
             string userInputVersionOld,
             string userInputVersionNew)
         {
             // Arrange
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks, projectTargetFrameworkMonikers);
+            using var pathContext = new SimpleTestPathContext();
+            var project = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks, projectTargetFrameworkMonikers);
+            project.SDKAnalysisLevel = "10.0.400";
 
-                var latestVersion = "1.0.0";
-                var packages = new SimpleTestPackageContext[] { XPlatTestUtils.CreatePackage(packageVersion: latestVersion),
-                        XPlatTestUtils.CreatePackage(packageVersion: "0.0.5"), XPlatTestUtils.CreatePackage(packageVersion: "0.0.9") };
+            var latestVersion = "1.0.0";
 
-                // Generate Package
-                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
-                    pathContext.PackageSource,
-                    PackageSaveMode.Defaultv3,
-                    packages);
+            // Generate Package
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                XPlatTestUtils.CreatePackage(packageVersion: latestVersion, frameworkString: "netcoreapp2.0"),
+                XPlatTestUtils.CreatePackage(packageVersion: "0.0.5", frameworkString: "netcoreapp2.0"));
 
-                var logger = new TestCommandOutputLogger(_testOutputHelper);
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packages[0].Id, userInputVersionOld, project);
-                var commandRunner = new AddPackageReferenceCommandRunner();
-                var msBuild = new MSBuildAPIUtility(logger);
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, "packageX", userInputVersionOld, project);
+            var commandRunner = new AddPackageReferenceCommandRunner();
+            var msBuild = new MSBuildAPIUtility(logger);
 
-                // Create a package ref with old version
-                var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
+            // Create a package ref with old version
+            var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
+            var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
 
-                // Preconditions
-                Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packages[0].Id, userInputVersionOld));
+            // Preconditions
+            result.Should().Be(0, because: logger.ShowErrors());
+            Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, "packageX", userInputVersionOld));
 
-                // The model from which the args are generated needs updated as well
-                project.AddPackageToAllFrameworks(new SimpleTestPackageContext(packages[0].Id, userInputVersionOld));
+            // The model from which the args are generated needs updated as well
+            project.AddPackageToAllFrameworks(new SimpleTestPackageContext("packageX", userInputVersionOld));
 
-                packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packages[0].Id, userInputVersionNew, project);
-                commandRunner = new AddPackageReferenceCommandRunner();
+            packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, "packageX", userInputVersionNew, project);
+            commandRunner = new AddPackageReferenceCommandRunner();
 
-                // Act
-                // Create a package ref with new version
-                result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
-                projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
+            // Act
+            // Create a package ref with new version
+            result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
+            projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
 
-                // Assert
-                // Verify that the only package reference is with the new version
-                Assert.Equal(0, result);
-                Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packages[0].Id, userInputVersionNew));
-            }
+            // Assert
+            // Verify that the only package reference is with the new version
+            Assert.Equal(0, result);
+            Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, "packageX", userInputVersionNew));
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -126,6 +126,34 @@ namespace NuGet.XPlat.FuncTest
             return project;
         }
 
+        public static SimpleTestProjectContext CreateProject(string projectName,
+            SimpleTestPathContext pathContext,
+            string projectFrameworks,
+            string projectTargetFrameworkMonikers)
+        {
+            var settings = Settings.LoadDefaultSettings(Path.GetDirectoryName(pathContext.NuGetConfig), Path.GetFileName(pathContext.NuGetConfig), null);
+            var actualProjectFrameworks = MSBuildStringUtility.Split(projectFrameworks);
+            var actualTfms = MSBuildStringUtility.Split(projectTargetFrameworkMonikers);
+            var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                    projectName: projectName,
+                    solutionRoot: pathContext.SolutionRoot,
+                    frameworks: actualProjectFrameworks);
+
+            for (int i = 0; i < actualProjectFrameworks.Length; i++)
+            {
+                var framework = project.Frameworks.Single(e => e.TargetAlias.Equals(actualProjectFrameworks[i]));
+                framework.Properties.Add("TargetFrameworkMoniker", actualTfms[i]);
+            }
+
+            project.FallbackFolders = (IList<string>)SettingsUtility.GetFallbackPackageFolders(settings);
+            project.GlobalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
+            var packageSourceProvider = new PackageSourceProvider(settings);
+            project.Sources = packageSourceProvider.LoadPackageSources();
+
+            project.Save();
+            return project;
+        }
+
         public static SimpleTestPackageContext CreatePackage(string packageId = "packageX",
             string packageVersion = "1.0.0",
             string? frameworkString = null,

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -11,6 +11,7 @@ using System.Xml.Linq;
 using NuGet.CommandLine.XPlat;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
@@ -134,15 +135,18 @@ namespace NuGet.XPlat.FuncTest
             var settings = Settings.LoadDefaultSettings(Path.GetDirectoryName(pathContext.NuGetConfig), Path.GetFileName(pathContext.NuGetConfig), null);
             var actualProjectFrameworks = MSBuildStringUtility.Split(projectFrameworks);
             var actualTfms = MSBuildStringUtility.Split(projectTargetFrameworkMonikers);
-            var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
-                    projectName: projectName,
-                    solutionRoot: pathContext.SolutionRoot,
-                    frameworks: actualProjectFrameworks);
+            var project = new SimpleTestProjectContext(projectName, ProjectStyle.PackageReference, pathContext.SolutionRoot);
+            project.ToolingVersion15 = true;
+            project.Properties.Add("BuildWithNetFrameworkHostedCompiler", bool.FalseString);
 
             for (int i = 0; i < actualProjectFrameworks.Length; i++)
             {
-                var framework = project.Frameworks.Single(e => e.TargetAlias.Equals(actualProjectFrameworks[i]));
-                framework.Properties.Add("TargetFrameworkMoniker", actualTfms[i]);
+                var fw = new SimpleTestProjectFrameworkContext(NuGetFramework.Parse(actualTfms[i]))
+                {
+                    TargetAlias = actualProjectFrameworks[i]
+                };
+                fw.Properties.Add("TargetFrameworkMoniker", actualTfms[i]);
+                project.Frameworks.Add(fw);
             }
 
             project.FallbackFolders = (IList<string>)SettingsUtility.GetFallbackPackageFolders(settings);

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -251,8 +251,8 @@ public class SingleProjectTests
                 builder
                 .WithProperty("TargetFramework", "apple")
                 .WithProperty("TargetFrameworkIdentifier", ".NETCoreApp")
-                .WithProperty("TargetFrameworkVersion", "v9.0")
-                .WithProperty("TargetFrameworkMoniker", ".NETCoreApp,Version=v9.0")
+                .WithProperty("TargetFrameworkVersion", "v10.0")
+                .WithProperty("TargetFrameworkMoniker", ".NETCoreApp,Version=v10.0")
                 .WithItem("PackageReference", "Contoso.Polyfill", [new("Version", "1.0.0")]);
             })
             .WithInnerBuild(builder =>

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -197,6 +197,112 @@ public class SingleProjectTests
     }
 
     [Fact]
+    public async Task SingleTargetWithAlias_SinglePackage_UpdatesCorrectPackageVersion()
+    {
+        // Arrange
+        var packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder
+            .WithProperty("TargetFramework", "myapp")
+            .WithProperty("TargetFrameworkIdentifier", ".NETCoreApp")
+            .WithProperty("TargetFrameworkVersion", "v9.0")
+            .WithProperty("TargetFrameworkMoniker", ".NETCoreApp,Version=v9.0")
+            .WithItem("PackageReference", "Test.Package", [new("Version", "1.0.0")]);
+        }).Build();
+
+        var packagesToUpdate = new List<Pkg>
+        {
+            new Pkg { Id = "Test.Package", VersionRange = new VersionRange(new NuGetVersion("1.2.3")) }
+        };
+
+        TestData testData = InitTest(packagesToUpdate, packageSpec);
+
+        // Act
+        int exitCode = await RunCommand(testData, CancellationToken.None);
+
+        // Assert
+        exitCode.Should().Be(0);
+
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.IsAny<PackageSpec>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.IsAny<List<string>>(),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Test.Package" && p.NewVersion.ToString() == "[1.2.3, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+
+        testData.LoggerMock.Verify(x => x.LogMinimal(
+            It.Is<string>(s => s.Contains(string.Format(Strings.PackageUpdate_FinalSummary, 1, 1))),
+            It.IsAny<ConsoleColor>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task MultiTargetingWithAliases_ConditionalAndUnconditionalPackages_UpdatesCorrectly()
+    {
+        // Arrange
+        var packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFrameworks", "apple;banana")
+                   .WithItem("PackageReference", "Contoso.Tools", [new("Version", "1.0.0")]);
+        })
+            .WithInnerBuild(builder =>
+            {
+                builder
+                .WithProperty("TargetFramework", "apple")
+                .WithProperty("TargetFrameworkIdentifier", ".NETCoreApp")
+                .WithProperty("TargetFrameworkVersion", "v9.0")
+                .WithProperty("TargetFrameworkMoniker", ".NETCoreApp,Version=v9.0")
+                .WithItem("PackageReference", "Contoso.Polyfill", [new("Version", "1.0.0")]);
+            })
+            .WithInnerBuild(builder =>
+            {
+                builder
+                .WithProperty("TargetFramework", "banana")
+                .WithProperty("TargetFrameworkIdentifier", ".NETCoreApp")
+                .WithProperty("TargetFrameworkVersion", "v10.0")
+                .WithProperty("TargetFrameworkMoniker", ".NETCoreApp,Version=v10.0");
+            }).Build();
+
+        var packagesToUpdate = new List<Pkg>
+        {
+            new Pkg { Id = "Contoso.Tools", VersionRange = new VersionRange(new NuGetVersion("2.0.0")) },
+            new Pkg { Id = "Contoso.Polyfill", VersionRange = new VersionRange(new NuGetVersion("1.2.3")) }
+        };
+
+        TestData testData = InitTest(packagesToUpdate, packageSpec);
+
+        // Act
+        int exitCode = await RunCommand(testData, CancellationToken.None);
+
+        // Assert
+        exitCode.Should().Be(0);
+
+        // Unconditional package (in all TFMs) - updated with both framework aliases
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.IsAny<PackageSpec>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.Is<List<string>>(p => p.Count == 2),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Contoso.Tools" && p.NewVersion.ToString() == "[2.0.0, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+
+        // Conditional package (only in "apple") - updated with specific framework alias
+        testData.IoMock.Verify(x => x.UpdatePackageReference(
+            It.IsAny<PackageSpec>(),
+            It.IsAny<IPackageUpdateIO.RestoreResult>(),
+            It.Is<List<string>>(p => p.Count == 1 && p[0] == "apple"),
+            It.Is<PackageUpdateCommandRunner.PackageToUpdate>(p => p.Id == "Contoso.Polyfill" && p.NewVersion.ToString() == "[1.2.3, )"),
+            It.IsAny<ILogger>()),
+            Times.Once);
+
+        testData.LoggerMock.Verify(x => x.LogMinimal(
+            It.Is<string>(s => s.Contains(string.Format(Strings.PackageUpdate_FinalSummary, 2, 2))),
+            It.IsAny<ConsoleColor>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task PackageNotReferenced_ReturnsNothingToUpdateExitCode()
     {
         // Arrange

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -128,6 +128,8 @@ namespace NuGet.Test.Utility
 
         public bool SetMSBuildProjectExtensionsPath { get; set; } = true;
 
+        public string SDKAnalysisLevel { get; set; }
+
         /// <summary>
         /// project.lock.json or project.assets.json
         /// </summary>
@@ -288,6 +290,16 @@ namespace NuGet.Test.Utility
                 if (Frameworks.Count > 1)
                 {
                     _packageSpec.RestoreMetadata.CrossTargeting = true;
+                    _packageSpec.RestoreMetadata.UsingMicrosoftNETSdk = true;
+                }
+
+                if (!IsLegacyPackageReference)
+                {
+                    _packageSpec.RestoreMetadata.UsingMicrosoftNETSdk = true;
+                    if (!string.IsNullOrEmpty(SDKAnalysisLevel))
+                    {
+                        _packageSpec.RestoreMetadata.SdkAnalysisLevel = NuGetVersion.Parse(SDKAnalysisLevel);
+                    }
                 }
 
                 return _packageSpec;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14540

## Description

The motivation here is straightforward, and a follow up to https://github.com/NuGet/NuGet.Client/pull/7102. 
There are some minimal changes that needed made in both add package and update package.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
