### PR TITLE
Update schema version determination logic

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -513,15 +513,9 @@ namespace NuGet.Packaging
             ICollection<IPackageFile> Files,
             ICollection<PackageDependencyGroup> package)
         {
-            if (HasContentFilesV2(Files) || HasIncludeExclude(package))
+            if (HasContentFilesV2(Files) || HasIncludeExclude(package) || HasXdtTransformFile(Files))
             {
-                // version 5
-                return ManifestVersionUtility.XdtTransformationVersion;
-            }
-
-            if (HasXdtTransformFile(Files))
-            {
-                // version 5
+                // version 6
                 return ManifestVersionUtility.XdtTransformationVersion;
             }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

Came across this code and I though I would clean it up by fixing the comment (`ManifestVersionUtility.XdtTransformationVersion` is version 6 not 5) and merging the two ifs.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
