### PR TITLE
Avoid redundant SourceRepository allocation on cache hit in CachingSourceProvider

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/CachingSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/CachingSourceProvider.cs
@@ -64,6 +64,11 @@ namespace NuGet.Protocol
 
         public SourceRepository CreateRepository(PackageSource source, FeedType type)
         {
+            if (_cachedSources.TryGetValue(source.Source, out SourceRepository cached))
+            {
+                return cached;
+            }
+
             return _cachedSources.GetOrAdd(source.Source, new SourceRepository(source, _resourceProviders, type));
         }
 


### PR DESCRIPTION
**&#129302; AI-Generated Pull Request &#129302;**

This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

---

- Issue: `CachingSourceProvider.CreateRepository` calls `ConcurrentDictionary.GetOrAdd(key, value)` where the `value` is `new SourceRepository(source, _resourceProviders, type)`.

  This eagerly constructs a `SourceRepository` on **every call** — even when the key already exists in the cache and the newly-constructed instance is immediately discarded.

  The `SourceRepository` constructor calls `Init()` → `GroupBy()` → `Sort()`, allocating multiple `List<T>`, `Dictionary<Type, ...>`, and `Int32[]` instances per construction even if they are already cached.

  This matches the allocation stack flow showing `DependencyGraphSpecRequestProvider.GetRequestsFromItems` → `RestoreArgs.GetEffectiveSourcesCore` → `CachingSourceProvider.CreateRepository` → `SourceRepository..ctor` → `SourceRepository.Init` → `SourceRepository.Sort` → `List<T>..ctor` → `EnumerableSorter.Sort` → `JIT_NewArr1` → `SVR::GCHeap::Alloc` → `TypeAllocated!System.Int32[]`

```
nuget.commands.dll!NuGet.Commands.DependencyGraphSpecRequestProvider+<>c__DisplayClass_0.<GetRequestsFromItems>b__
nuget.commands.dll!NuGet.Commands.RestoreArgs.GetEffectiveSourcesCore
nuget.protocol.dll!NuGet.Protocol.CachingSourceProvider.CreateRepository
nuget.protocol.dll!NuGet.Protocol.Core.Types.SourceRepository..ctor
nuget.protocol.dll!NuGet.Protocol.Core.Types.SourceRepository.Init
nuget.protocol.dll!NuGet.Protocol.Core.Types.SourceRepository.Sort
mscorlib.dll!System.Collections.Generic.List`[System.__Canon]..ctor
system.core.dll!System.Linq.EnumerableSorter`[System.__Canon].Sort
clr.dll!JIT_NewArr1
clr.dll!SVR::GCHeap::Alloc
TypeAllocated!System.Int32[]
```

- Issue type: Eliminate redundant `SourceRepository` construction and associated LINQ/sort/collection allocations on cache-hit hot path

- Proposed fix: Add a `TryGetValue` fast-path check before `GetOrAdd` in `CachingSourceProvider.CreateRepository`.
  On a cache hit (the common case under parallel restore), `TryGetValue` returns the existing `SourceRepository` with **zero allocations** — no constructor call, no closure, no LINQ overhead. The `GetOrAdd` fallback is only reached on a cache miss, where the `SourceRepository` construction cost is unavoidable and identical to the original behavior.

  The `_cachedSources` dictionary is append-only (no removals anywhere in the codebase), so a `TryGetValue` hit guarantees the key remains present, making the non-atomic `TryGetValue` → `GetOrAdd` sequence safe.

  **Alternatively**, if a single dictionary access is preferred, `GetOrAdd(key, _ => new SourceRepository(...))` can be used — it trades a small closure allocation (~32 bytes) per call for simpler code, which is still a major improvement over the current eager construction.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&failureHash=669321c0-44bb-1e56-c53b-29c6feade0f6)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2723342)