### PR TITLE
AOT Compatible: Add overrideVersion to enforce -Version precedence

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -1147,7 +1147,7 @@ namespace NuGet.CommandLine
             {
                 // Don't validate the manifest since this might be a partial manifest
                 // The bulk of the metadata might be coming from the project.
-                Packaging.Manifest manifest = Packaging.Manifest.ReadFrom(stream, GetPropertyValue, validateSchema: true, builder.Version);
+                Packaging.Manifest manifest = Packaging.Manifest.ReadFrom(stream, GetPropertyValue, validateSchema: true);
                 builder.Populate(manifest.Metadata);
 
                 if (manifest.HasFilesNode)

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -1147,7 +1147,7 @@ namespace NuGet.CommandLine
             {
                 // Don't validate the manifest since this might be a partial manifest
                 // The bulk of the metadata might be coming from the project.
-                Packaging.Manifest manifest = Packaging.Manifest.ReadFrom(stream, GetPropertyValue, validateSchema: true);
+                Packaging.Manifest manifest = Packaging.Manifest.ReadFrom(stream, GetPropertyValue, validateSchema: true, builder.Version);
                 builder.Populate(manifest.Metadata);
 
                 if (manifest.HasFilesNode)

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -453,7 +453,8 @@ namespace NuGet.Commands
                     _packArgs.GetPropertyValue,
                     !_packArgs.ExcludeEmptyDirectories,
                     _packArgs.Deterministic,
-                    _packArgs.Logger);
+                    _packArgs.Logger,
+                    _packArgs.Version);
             }
 
             return new PackageBuilder(
@@ -462,7 +463,8 @@ namespace NuGet.Commands
                 _packArgs.GetPropertyValue,
                 !_packArgs.ExcludeEmptyDirectories,
                 _packArgs.Deterministic,
-                _packArgs.Logger);
+                _packArgs.Logger,
+                _packArgs.Version);
         }
 
         private bool BuildFromProjectFile(string path)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -14,8 +14,6 @@ using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageCreation.Resources;
 using NuGet.Packaging.Xml;
 using static NuGet.Shared.XmlUtility;
-using NuGet.Versioning;
-
 
 #if !IS_CORECLR
 using System.Xml.Schema;
@@ -117,11 +115,6 @@ namespace NuGet.Packaging
 
         public static Manifest ReadFrom(Stream stream, Func<string, string> propertyProvider, bool validateSchema)
         {
-            return ReadFrom(stream, propertyProvider, validateSchema, versionOverride: null);
-        }
-
-        public static Manifest ReadFrom(Stream stream, Func<string, string> propertyProvider, bool validateSchema, NuGetVersion versionOverride)
-        {
             XDocument document;
             if (propertyProvider == null)
             {
@@ -151,11 +144,6 @@ namespace NuGet.Packaging
 
             // Deserialize it
             var manifest = ManifestReader.ReadManifest(document);
-
-            if (versionOverride != null)
-            {
-                manifest.Metadata.Version = versionOverride;
-            }
 
             // Validate before returning
             Validate(manifest);

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -14,6 +14,8 @@ using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageCreation.Resources;
 using NuGet.Packaging.Xml;
 using static NuGet.Shared.XmlUtility;
+using NuGet.Versioning;
+
 
 #if !IS_CORECLR
 using System.Xml.Schema;
@@ -115,6 +117,11 @@ namespace NuGet.Packaging
 
         public static Manifest ReadFrom(Stream stream, Func<string, string> propertyProvider, bool validateSchema)
         {
+            return ReadFrom(stream, propertyProvider, validateSchema, overrideVersion: null);
+        }
+
+        public static Manifest ReadFrom(Stream stream, Func<string, string> propertyProvider, bool validateSchema, NuGetVersion overrideVersion)
+        {
             XDocument document;
             if (propertyProvider == null)
             {
@@ -144,6 +151,11 @@ namespace NuGet.Packaging
 
             // Deserialize it
             var manifest = ManifestReader.ReadManifest(document);
+
+            if (overrideVersion != null)
+            {
+                manifest.Metadata.Version = overrideVersion;
+            }
 
             // Validate before returning
             Validate(manifest);

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -117,6 +117,11 @@ namespace NuGet.Packaging
 
         public static Manifest ReadFrom(Stream stream, Func<string, string> propertyProvider, bool validateSchema)
         {
+            return ReadFrom(stream, propertyProvider, validateSchema, versionOverride: null);
+        }
+
+        public static Manifest ReadFrom(Stream stream, Func<string, string> propertyProvider, bool validateSchema, NuGetVersion versionOverride)
+        {
             XDocument document;
             if (propertyProvider == null)
             {
@@ -147,14 +152,9 @@ namespace NuGet.Packaging
             // Deserialize it
             var manifest = ManifestReader.ReadManifest(document);
 
-            // Update manifest metadata version if version was provided by the CLI command
-            if (propertyProvider is not null && propertyProvider.Target.GetType().Name.Equals("PackArgs"))
+            if (versionOverride != null)
             {
-                var versionProperty = propertyProvider.Target.GetType().GetProperty("Version");
-                if (versionProperty?.GetValue(propertyProvider.Target) is string version)
-                {
-                    manifest.Metadata.Version = NuGetVersion.Parse(version);
-                }
+                manifest.Metadata.Version = versionOverride;
             }
 
             // Validate before returning

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -950,12 +950,7 @@ namespace NuGet.Packaging
         private void ReadManifest(Stream stream, string basePath, Func<string, string> propertyProvider)
         {
             // Deserialize the document and extract the metadata
-            Manifest manifest = Manifest.ReadFrom(stream, propertyProvider, validateSchema: true);
-
-            if (!string.IsNullOrEmpty(_versionOverride))
-            {
-                manifest.Metadata.Version = NuGetVersion.Parse(_versionOverride);
-            }
+            Manifest manifest = Manifest.ReadFrom(stream, propertyProvider, validateSchema: true, overrideVersion: NuGetVersion.Parse(_versionOverride));
 
             Populate(manifest.Metadata);
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -950,7 +950,11 @@ namespace NuGet.Packaging
         private void ReadManifest(Stream stream, string basePath, Func<string, string> propertyProvider)
         {
             // Deserialize the document and extract the metadata
-            Manifest manifest = Manifest.ReadFrom(stream, propertyProvider, validateSchema: true, overrideVersion: NuGetVersion.Parse(_versionOverride));
+            Manifest manifest = Manifest.ReadFrom(
+                stream,
+                propertyProvider,
+                validateSchema: true,
+                overrideVersion: !(string.IsNullOrEmpty(_versionOverride)) ? NuGetVersion.Parse(_versionOverride) : null);
 
             Populate(manifest.Metadata);
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -927,7 +927,7 @@ namespace NuGet.Packaging
         private void ReadManifest(Stream stream, string basePath, Func<string, string> propertyProvider)
         {
             // Deserialize the document and extract the metadata
-            Manifest manifest = Manifest.ReadFrom(stream, propertyProvider, validateSchema: true);
+            Manifest manifest = Manifest.ReadFrom(stream, propertyProvider, validateSchema: true, TryGetVersionOverride(propertyProvider));
 
             Populate(manifest.Metadata);
 
@@ -997,6 +997,23 @@ namespace NuGet.Packaging
             {
                 AddFiles(basePath, file.Source, file.Target, file.Exclude);
             }
+        }
+
+        private static NuGetVersion TryGetVersionOverride(Func<string, string> propertyProvider)
+        {
+            if (propertyProvider == null)
+            {
+                return null;
+            }
+
+            var value = propertyProvider("Version");
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            return NuGetVersion.TryParse(value, out var parsed) ? parsed : null;
         }
 
         private ZipArchiveEntry CreateEntry(ZipArchive package, string entryName, CompressionLevel compressionLevel)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -35,6 +35,7 @@ namespace NuGet.Packaging
         private readonly bool _includeEmptyDirectories;
         private readonly bool _deterministic;
         private readonly ILogger _logger;
+        private readonly string _versionOverride;
 
         /// <summary>
         /// Maximum Icon file size: 1 megabyte
@@ -52,7 +53,12 @@ namespace NuGet.Packaging
         }
 
         public PackageBuilder(string path, Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, ILogger logger)
-            : this(path, Path.GetDirectoryName(path), propertyProvider, includeEmptyDirectories, deterministic, logger)
+            : this(path, Path.GetDirectoryName(path), propertyProvider, includeEmptyDirectories, deterministic, logger, versionOverride: "")
+        {
+        }
+
+        public PackageBuilder(string path, Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, ILogger logger, string versionOverride)
+            : this(path, Path.GetDirectoryName(path), propertyProvider, includeEmptyDirectories, deterministic, logger, versionOverride)
         {
         }
 
@@ -62,12 +68,21 @@ namespace NuGet.Packaging
         }
 
         public PackageBuilder(string path, string basePath, Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, ILogger logger)
-            : this(path, basePath, propertyProvider, includeEmptyDirectories, deterministic)
+            : this(path, basePath, propertyProvider, includeEmptyDirectories, deterministic, logger, versionOverride: "")
+        {
+        }
+        public PackageBuilder(string path, string basePath, Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, ILogger logger, string versionOverride)
+            : this(path, basePath, propertyProvider, includeEmptyDirectories, deterministic, versionOverride)
         {
             _logger = logger;
         }
 
         public PackageBuilder(string path, string basePath, Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic)
+            : this(path, basePath, propertyProvider, includeEmptyDirectories, deterministic, versionOverride: "")
+        {
+
+        }
+        public PackageBuilder(string path, string basePath, Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, string versionOverride)
             : this(includeEmptyDirectories, deterministic)
         {
             if (!File.Exists(path))
@@ -76,6 +91,8 @@ namespace NuGet.Packaging
                     NuGetLogCode.NU5008,
                     string.Format(CultureInfo.CurrentCulture, Strings.ErrorManifestFileNotFound, path ?? "null"));
             }
+
+            _versionOverride = versionOverride;
 
             using (Stream stream = File.OpenRead(path))
             {
@@ -89,8 +106,14 @@ namespace NuGet.Packaging
         }
 
         public PackageBuilder(Stream stream, string basePath, Func<string, string> propertyProvider)
+            : this(stream, basePath, propertyProvider, "")
+        {
+        }
+
+        public PackageBuilder(Stream stream, string basePath, Func<string, string> propertyProvider, string versionOverride)
             : this()
         {
+            _versionOverride = versionOverride;
             ReadManifest(stream, basePath, propertyProvider);
         }
 
@@ -927,7 +950,12 @@ namespace NuGet.Packaging
         private void ReadManifest(Stream stream, string basePath, Func<string, string> propertyProvider)
         {
             // Deserialize the document and extract the metadata
-            Manifest manifest = Manifest.ReadFrom(stream, propertyProvider, validateSchema: true, TryGetVersionOverride(propertyProvider));
+            Manifest manifest = Manifest.ReadFrom(stream, propertyProvider, validateSchema: true);
+
+            if (!string.IsNullOrEmpty(_versionOverride))
+            {
+                manifest.Metadata.Version = NuGetVersion.Parse(_versionOverride);
+            }
 
             Populate(manifest.Metadata);
 
@@ -997,23 +1025,6 @@ namespace NuGet.Packaging
             {
                 AddFiles(basePath, file.Source, file.Target, file.Exclude);
             }
-        }
-
-        private static NuGetVersion TryGetVersionOverride(Func<string, string> propertyProvider)
-        {
-            if (propertyProvider == null)
-            {
-                return null;
-            }
-
-            var value = propertyProvider("Version");
-
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                return null;
-            }
-
-            return NuGetVersion.TryParse(value, out var parsed) ? parsed : null;
         }
 
         private ZipArchiveEntry CreateEntry(ZipArchive package, string entryName, CompressionLevel compressionLevel)

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~static NuGet.Packaging.Manifest.ReadFrom(System.IO.Stream stream, System.Func<string, string> propertyProvider, bool validateSchema, NuGet.Versioning.NuGetVersion versionOverride) -> NuGet.Packaging.Manifest

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@
 ~NuGet.Packaging.PackageBuilder.PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, string versionOverride) -> void
 ~NuGet.Packaging.PackageBuilder.PackageBuilder(string path, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, NuGet.Common.ILogger logger, string versionOverride) -> void
 ~NuGet.Packaging.PackageBuilder.PackageBuilder(System.IO.Stream stream, string basePath, System.Func<string, string> propertyProvider, string versionOverride) -> void
+~static NuGet.Packaging.Manifest.ReadFrom(System.IO.Stream stream, System.Func<string, string> propertyProvider, bool validateSchema, NuGet.Versioning.NuGetVersion overrideVersion) -> NuGet.Packaging.Manifest

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
 #nullable enable
-~static NuGet.Packaging.Manifest.ReadFrom(System.IO.Stream stream, System.Func<string, string> propertyProvider, bool validateSchema, NuGet.Versioning.NuGetVersion versionOverride) -> NuGet.Packaging.Manifest
+~NuGet.Packaging.PackageBuilder.PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, NuGet.Common.ILogger logger, string versionOverride) -> void
+~NuGet.Packaging.PackageBuilder.PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, string versionOverride) -> void
+~NuGet.Packaging.PackageBuilder.PackageBuilder(string path, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, NuGet.Common.ILogger logger, string versionOverride) -> void
+~NuGet.Packaging.PackageBuilder.PackageBuilder(System.IO.Stream stream, string basePath, System.Func<string, string> propertyProvider, string versionOverride) -> void

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~static NuGet.Packaging.Manifest.ReadFrom(System.IO.Stream stream, System.Func<string, string> propertyProvider, bool validateSchema, NuGet.Versioning.NuGetVersion versionOverride) -> NuGet.Packaging.Manifest

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@
 ~NuGet.Packaging.PackageBuilder.PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, string versionOverride) -> void
 ~NuGet.Packaging.PackageBuilder.PackageBuilder(string path, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, NuGet.Common.ILogger logger, string versionOverride) -> void
 ~NuGet.Packaging.PackageBuilder.PackageBuilder(System.IO.Stream stream, string basePath, System.Func<string, string> propertyProvider, string versionOverride) -> void
+~static NuGet.Packaging.Manifest.ReadFrom(System.IO.Stream stream, System.Func<string, string> propertyProvider, bool validateSchema, NuGet.Versioning.NuGetVersion overrideVersion) -> NuGet.Packaging.Manifest

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
 #nullable enable
-~static NuGet.Packaging.Manifest.ReadFrom(System.IO.Stream stream, System.Func<string, string> propertyProvider, bool validateSchema, NuGet.Versioning.NuGetVersion versionOverride) -> NuGet.Packaging.Manifest
+~NuGet.Packaging.PackageBuilder.PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, NuGet.Common.ILogger logger, string versionOverride) -> void
+~NuGet.Packaging.PackageBuilder.PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, string versionOverride) -> void
+~NuGet.Packaging.PackageBuilder.PackageBuilder(string path, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, NuGet.Common.ILogger logger, string versionOverride) -> void
+~NuGet.Packaging.PackageBuilder.PackageBuilder(System.IO.Stream stream, string basePath, System.Func<string, string> propertyProvider, string versionOverride) -> void


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug
<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 
related: https://github.com/NuGet/Home/issues/14408
## Description

`pack` allows setting the package version via:

* `-Properties version=<v>`
* `-Version <v>`

`-Version` should have the highest priority. Previously, this precedence was enforced using reflection to inspect `PackArgs.Version` inside `Manifest.ReadFrom`.

This PR ensures the override is done by directly passing the -Version value down to Manifest, 

Previous implementation PR: https://github.com/NuGet/NuGet.Client/pull/6092 , https://github.com/NuGet/NuGet.Client/pull/6361

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
