### PR TITLE
Handle empty paths when locating extensions

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/ExtensionLocator.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/ExtensionLocator.cs
@@ -112,7 +112,7 @@ namespace NuGet.CommandLine
             // and among other things breaks our build.
             // Consequently, we'll use a convention - only binaries ending in the name Extensions would be loaded.
             var nugetDirectory = Path.GetDirectoryName(typeof(Program).Assembly.Location);
-            if (nugetDirectory == null)
+            if (string.IsNullOrEmpty(nugetDirectory))
             {
                 return paths;
             }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
- fixes: mono/mono#17158
- fixes: NuGet/Home#14764
 

## Description

`Assembly.Location` can return inly the assembly name and then the result is an empty path string.
This especially happens when you try to bundle with mono (`mkbundle`). 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
