### PR TITLE
Fix `dotnet add package --no-restore` ignoring Central Package Management

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -52,16 +52,12 @@ namespace NuGet.CommandLine.XPlat
                     versionRange = VersionRange.Parse(packageReferenceArgs.PackageVersion);
                 }
 
-                var isCPMEnabled = MSBuildAPIUtility.IsCentralPackageManagementEnabled(
-                    packageReferenceArgs.ProjectPath);
-
                 var libraryDependency = new LibraryDependency()
                 {
                     LibraryRange = new LibraryRange(
                         name: packageReferenceArgs.PackageId,
                         versionRange: versionRange,
-                        typeConstraint: LibraryDependencyTarget.Package),
-                    VersionCentrallyManaged = isCPMEnabled
+                        typeConstraint: LibraryDependencyTarget.Package)
                 };
 
                 msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency, packageReferenceArgs.NoVersion);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -52,12 +52,16 @@ namespace NuGet.CommandLine.XPlat
                     versionRange = VersionRange.Parse(packageReferenceArgs.PackageVersion);
                 }
 
+                var isCPMEnabled = MSBuildAPIUtility.IsCentralPackageManagementEnabled(
+                    packageReferenceArgs.ProjectPath);
+
                 var libraryDependency = new LibraryDependency()
                 {
                     LibraryRange = new LibraryRange(
                         name: packageReferenceArgs.PackageId,
                         versionRange: versionRange,
-                        typeConstraint: LibraryDependencyTarget.Package)
+                        typeConstraint: LibraryDependencyTarget.Package),
+                    VersionCentrallyManaged = isCPMEnabled
                 };
 
                 msBuild.AddPackageReference(packageReferenceArgs.ProjectPath, libraryDependency, packageReferenceArgs.NoVersion);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -282,9 +282,6 @@ namespace NuGet.CommandLine.XPlat
         {
             var project = GetProject(projectPath);
 
-            // Determine CPM status from the loaded project so callers don't need to check separately.
-            libraryDependency.VersionCentrallyManaged = IsCentralPackageManagementEnabled(project);
-
             // Here we get package references for any framework.
             // If the project has a conditional reference, then an unconditional reference is not added.
 
@@ -308,10 +305,6 @@ namespace NuGet.CommandLine.XPlat
                 var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 { { "TargetFramework", framework } };
                 var project = GetProject(projectPath, globalProperties);
-
-                // Determine CPM status from the loaded project so callers don't need to check separately.
-                libraryDependency.VersionCentrallyManaged = IsCentralPackageManagementEnabled(project);
-
                 var existingPackageReferences = GetPackageReferences(project, libraryDependency);
                 AddPackageReference(project, libraryDependency, existingPackageReferences, noVersion, framework);
                 ProjectCollection.GlobalProjectCollection.UnloadProject(project);
@@ -332,8 +325,11 @@ namespace NuGet.CommandLine.XPlat
             bool noVersion,
             string framework = null)
         {
+            // Determine CPM status from the loaded project so callers don't need to check separately.
+            bool isCentralPackageManagementEnabled = IsCentralPackageManagementEnabled(project);
+
             // Add packageReference to the project file only if it does not exist.
-            if (!libraryDependency.VersionCentrallyManaged)
+            if (!isCentralPackageManagementEnabled)
             {
                 if (!existingPackageReferences.Any())
                 {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -83,6 +83,27 @@ namespace NuGet.CommandLine.XPlat
             return new Project(projectRootElement, globalProperties, toolsVersion: null);
         }
 
+        /// <summary>
+        /// Checks whether Central Package Management is enabled for the given project
+        /// by evaluating the ManagePackageVersionsCentrally MSBuild property.
+        /// </summary>
+        /// <param name="projectCSProjPath">CSProj file to check</param>
+        /// <returns>True if CPM is enabled, false otherwise.</returns>
+        internal static bool IsCentralPackageManagementEnabled(string projectCSProjPath)
+        {
+            var project = GetProject(projectCSProjPath);
+            try
+            {
+                return StringComparer.OrdinalIgnoreCase.Equals(
+                    project.GetPropertyValue("ManagePackageVersionsCentrally"),
+                    "true");
+            }
+            finally
+            {
+                ProjectCollection.GlobalProjectCollection.UnloadProject(project);
+            }
+        }
+
         internal static IEnumerable<string> GetProjectsFromSolution(string solutionPath)
         {
             var sln = SolutionFile.Parse(solutionPath);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -83,25 +83,11 @@ namespace NuGet.CommandLine.XPlat
             return new Project(projectRootElement, globalProperties, toolsVersion: null);
         }
 
-        /// <summary>
-        /// Checks whether Central Package Management is enabled for the given project
-        /// by evaluating the ManagePackageVersionsCentrally MSBuild property.
-        /// </summary>
-        /// <param name="projectCSProjPath">CSProj file to check</param>
-        /// <returns>True if CPM is enabled, false otherwise.</returns>
-        internal static bool IsCentralPackageManagementEnabled(string projectCSProjPath)
+        private static bool IsCentralPackageManagementEnabled(Project project)
         {
-            var project = GetProject(projectCSProjPath);
-            try
-            {
-                return StringComparer.OrdinalIgnoreCase.Equals(
-                    project.GetPropertyValue("ManagePackageVersionsCentrally"),
-                    "true");
-            }
-            finally
-            {
-                ProjectCollection.GlobalProjectCollection.UnloadProject(project);
-            }
+            return StringComparer.OrdinalIgnoreCase.Equals(
+                project.GetPropertyValue("ManagePackageVersionsCentrally"),
+                "true");
         }
 
         internal static IEnumerable<string> GetProjectsFromSolution(string solutionPath)
@@ -296,6 +282,9 @@ namespace NuGet.CommandLine.XPlat
         {
             var project = GetProject(projectPath);
 
+            // Determine CPM status from the loaded project so callers don't need to check separately.
+            libraryDependency.VersionCentrallyManaged = IsCentralPackageManagementEnabled(project);
+
             // Here we get package references for any framework.
             // If the project has a conditional reference, then an unconditional reference is not added.
 
@@ -319,6 +308,10 @@ namespace NuGet.CommandLine.XPlat
                 var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 { { "TargetFramework", framework } };
                 var project = GetProject(projectPath, globalProperties);
+
+                // Determine CPM status from the loaded project so callers don't need to check separately.
+                libraryDependency.VersionCentrallyManaged = IsCentralPackageManagementEnabled(project);
+
                 var existingPackageReferences = GetPackageReferences(project, libraryDependency);
                 AddPackageReference(project, libraryDependency, existingPackageReferences, noVersion, framework);
                 ProjectCollection.GlobalProjectCollection.UnloadProject(project);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -573,6 +573,55 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        [Theory]
+        [InlineData("net46", "net46", "1.0.0")]
+        [InlineData("net46; netcoreapp1.0", "net46; netcoreapp1.0", "1.0.0")]
+        public async Task AddPkg_NoRestoreWithCPM_AddsVersionlessPackageReferenceAndPackageVersion(string packageFrameworks,
+            string projectFrameworks,
+            string userInputVersion)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, projectFrameworks);
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: packageFrameworks);
+
+                // Generate Package
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Create Directory.Packages.props to enable CPM
+                var directoryPackagesPropsPath = Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props");
+                File.WriteAllText(directoryPackagesPropsPath,
+@"<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>");
+
+                var logger = new TestCommandOutputLogger(_testOutputHelper);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, userInputVersion, projectA, noRestore: true);
+                var commandRunner = new AddPackageReferenceCommandRunner();
+
+                // Act
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var projectXml = File.ReadAllText(projectA.ProjectPath);
+                var propsXml = File.ReadAllText(directoryPackagesPropsPath);
+
+                // Assert
+                Assert.Equal(0, result);
+
+                // .csproj should contain versionless PackageReference
+                Assert.Contains($"<PackageReference Include=\"{packageX.Id}\"", projectXml);
+                Assert.DoesNotContain("Version=", projectXml);
+
+                // Directory.Packages.props should contain PackageVersion with version
+                Assert.Contains($"<PackageVersion Include=\"{packageX.Id}\" Version=\"{userInputVersion}\"", propsXml);
+            }
+        }
+
         [Fact]
         public async Task AddPkg_UnconditionalAddWithoutVersion_Success()
         {

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -461,6 +461,58 @@ namespace NuGet.CommandLine.Xplat.Tests
             Assert.DoesNotContain(@$"<PackageVersion Include=""X"" VersionOverride=""3.0.0"" />", updatedPropsFile);
         }
 
+        [PlatformFact(Platform.Windows)]
+        public void IsCentralPackageManagementEnabled_WhenEnabled_ReturnsTrue()
+        {
+            // Arrange
+            using var testDirectory = TestDirectory.Create();
+
+            var propsFile =
+@$"<Project>
+    <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+</Project>";
+            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
+
+            string projectContent =
+@$"<Project Sdk=""Microsoft.NET.Sdk"">
+	<PropertyGroup>
+	<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
+</Project>";
+            var projectPath = Path.Combine(testDirectory, "projectA.csproj");
+            File.WriteAllText(projectPath, projectContent);
+
+            // Act
+            var result = MSBuildAPIUtility.IsCentralPackageManagementEnabled(projectPath);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void IsCentralPackageManagementEnabled_WhenNotEnabled_ReturnsFalse()
+        {
+            // Arrange
+            using var testDirectory = TestDirectory.Create();
+
+            string projectContent =
+@$"<Project Sdk=""Microsoft.NET.Sdk"">
+	<PropertyGroup>
+	<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
+</Project>";
+            var projectPath = Path.Combine(testDirectory, "projectA.csproj");
+            File.WriteAllText(projectPath, projectContent);
+
+            // Act
+            var result = MSBuildAPIUtility.IsCentralPackageManagementEnabled(projectPath);
+
+            // Assert
+            Assert.False(result);
+        }
+
         [Fact]
         public void GetListOfProjectsFromPathArgument_WithProjectFile_ReturnsCorrectPaths()
         {

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -462,55 +462,86 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [PlatformFact(Platform.Windows)]
-        public void IsCentralPackageManagementEnabled_WhenEnabled_ReturnsTrue()
+        public void AddPackageReference_WithCPMEnabled_AddsPackageVersionToProps()
         {
             // Arrange
             using var testDirectory = TestDirectory.Create();
 
             var propsFile =
-@$"<Project>
+@"<Project>
     <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
 </Project>";
             File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
 
             string projectContent =
-@$"<Project Sdk=""Microsoft.NET.Sdk"">
+@"<Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
-	<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 </Project>";
             var projectPath = Path.Combine(testDirectory, "projectA.csproj");
             File.WriteAllText(projectPath, projectContent);
 
+            var libraryDependency = new LibraryDependency
+            {
+                LibraryRange = new LibraryRange(
+                    name: "X",
+                    versionRange: VersionRange.Parse("1.0.0"),
+                    typeConstraint: LibraryDependencyTarget.Package)
+            };
+
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+
             // Act
-            var result = MSBuildAPIUtility.IsCentralPackageManagementEnabled(projectPath);
+            msObject.AddPackageReference(projectPath, libraryDependency, noVersion: false);
 
             // Assert
-            Assert.True(result);
+            string updatedProjectFile = File.ReadAllText(projectPath);
+            string updatedPropsFile = File.ReadAllText(Path.Combine(testDirectory, "Directory.Packages.props"));
+
+            // .csproj should contain versionless PackageReference
+            Assert.Contains(@"<PackageReference Include=""X""", updatedProjectFile);
+            Assert.DoesNotContain("Version=", updatedProjectFile);
+
+            // Directory.Packages.props should contain PackageVersion with version
+            Assert.Contains(@"<PackageVersion Include=""X"" Version=""1.0.0""", updatedPropsFile);
         }
 
         [PlatformFact(Platform.Windows)]
-        public void IsCentralPackageManagementEnabled_WhenNotEnabled_ReturnsFalse()
+        public void AddPackageReference_WithoutCPM_AddsVersionedPackageReference()
         {
             // Arrange
             using var testDirectory = TestDirectory.Create();
 
             string projectContent =
-@$"<Project Sdk=""Microsoft.NET.Sdk"">
+@"<Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
-	<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 </Project>";
             var projectPath = Path.Combine(testDirectory, "projectA.csproj");
             File.WriteAllText(projectPath, projectContent);
 
+            var libraryDependency = new LibraryDependency
+            {
+                LibraryRange = new LibraryRange(
+                    name: "X",
+                    versionRange: VersionRange.Parse("1.0.0"),
+                    typeConstraint: LibraryDependencyTarget.Package)
+            };
+
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+
             // Act
-            var result = MSBuildAPIUtility.IsCentralPackageManagementEnabled(projectPath);
+            msObject.AddPackageReference(projectPath, libraryDependency, noVersion: false);
 
             // Assert
-            Assert.False(result);
+            string updatedProjectFile = File.ReadAllText(projectPath);
+
+            // .csproj should contain PackageReference with version
+            Assert.Contains(@"<PackageReference Include=""X"" Version=""1.0.0""", updatedProjectFile);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/12552

## Description

When `--no-restore` is passed to `dotnet add package` in a CPM-enabled project, the command writes a versioned `<PackageReference Version="...">` directly to the .csproj, ignoring Central Package Management. This happens because CPM detection relies on the `DependencyGraphSpec` built during restore, which `--no-restore` skips. The result is NU1008 on the next restore.

This fix adds a new `IsCentralPackageManagementEnabled()` method to `MSBuildAPIUtility` that checks the MSBuild-evaluated `ManagePackageVersionsCentrally` property (available via `GetProject()` without restore), and sets `VersionCentrallyManaged` on the `LibraryDependency` in the `--no-restore` path. The existing downstream CPM handling then correctly produces a versionless `<PackageReference>` in the .csproj and a `<PackageVersion>` in `Directory.Packages.props`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
