### PR TITLE
Add availability check for NuGet Solver MCP Server tool

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/FixVulnerabilitiesWithCopilotErrorType.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/FixVulnerabilitiesWithCopilotErrorType.cs
@@ -10,6 +10,7 @@ namespace NuGet.PackageManagement.Telemetry
         ServiceBrokerNotAvailable,
         CopilotServiceNotAvailable,
         McpToolServiceNotAvailable,
-        CopilotAccessDenied
+        CopilotAccessDenied,
+        NuGetSolverNotAvailable,
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerablitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerablitiesService.cs
@@ -102,7 +102,7 @@ namespace NuGetVSExtension
                     string solutionPathContext = $"The current solution file path is: {GetSolutionPath()}.";
                     CopilotContext context = new CopilotContext(ProviderDescriptor.Moniker, ContextDescriptor, request.CorrelationId, solutionPathContext);
                     IReadOnlyList<CopilotFunctionDescriptor> functions = await cfp.GetFunctionsAsync(request.CorrelationId, cancellationToken);
-                    if (functions == null || !functions.Select(f => f.Name).Contains($"{NuGetMCPServerName}_{NuGetSolverToolName}"))
+                    if (functions is null || !functions.Any(f => string.Equals(f.Name, $"{NuGetMCPServerName}_{NuGetSolverToolName}", StringComparison.OrdinalIgnoreCase)))
                     {
                         SendTelemetryEvent(FixVulnerabilitiesWithCopilotErrorType.NuGetSolverNotAvailable);
                         ShowWarningMessage(Resources.Error_NuGetSolverNotAvailable);

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerablitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerablitiesService.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceHub.Framework;
@@ -26,6 +27,8 @@ namespace NuGetVSExtension
         private const string AgentModeResponderServiceMoniker = "Microsoft.VisualStudio.Copilot.AgentModeResponder";
         private const string AuthStatusDetermined = "c936efcc-6baa-4ad3-9c2b-7ba750acf18f";
         private const string ServiceName = "Microsoft.VisualStudio.Copilot.SolutionContextProvider";
+        private const string NuGetMCPServerName = "nuget";
+        private const string NuGetSolverToolName = "get-nuget-solver";
 
         private static readonly Guid CopilotReadyUIContext = new(AuthStatusDetermined);
         private static readonly ServiceRpcDescriptor ProviderDescriptor = CopilotDescriptors.CreateContextProviderDescriptor(ServiceName);
@@ -99,6 +102,13 @@ namespace NuGetVSExtension
                     string solutionPathContext = $"The current solution file path is: {GetSolutionPath()}.";
                     CopilotContext context = new CopilotContext(ProviderDescriptor.Moniker, ContextDescriptor, request.CorrelationId, solutionPathContext);
                     IReadOnlyList<CopilotFunctionDescriptor> functions = await cfp.GetFunctionsAsync(request.CorrelationId, cancellationToken);
+                    if (functions == null || !functions.Select(f => f.Name).Contains($"{NuGetMCPServerName}_{NuGetSolverToolName}"))
+                    {
+                        SendTelemetryEvent(FixVulnerabilitiesWithCopilotErrorType.NuGetSolverNotAvailable);
+                        ShowWarningMessage(Resources.Error_NuGetSolverNotAvailable);
+                        return;
+                    }
+
                     CopilotRequest requestWithFunctionsAndContext = request.WithFunctions(functions).WithContext(context);
 
                     try

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -142,6 +142,15 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again..
+        /// </summary>
+        internal static string Error_NuGetSolverNotAvailable {
+            get {
+                return ResourceManager.GetString("Error_NuGetSolverNotAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A package pattern must be provided..
         /// </summary>
         internal static string Error_PackageSourceMappingPattern_Missing {

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -292,4 +292,8 @@
     <value>Access denied. Please ensure you are signed in to GitHub Copilot.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
+  <data name="Error_NuGetSolverNotAvailable" xml:space="preserve">
+    <value>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
+    <comment>Do not translate GitHub or Copilot</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Služba MCP Tool není k dispozici. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">Je nutné zadat vzor balíčku.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Der MCP-Tooldienst ist nicht verfügbar. Bitte stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">Ein Paketmuster muss angegeben werden.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -42,6 +42,11 @@
         <target state="translated">El servicio de herramientas MCP no está disponible. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">Se debe proporcionar un patrón de paquete.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Désolé, le service MCP Tool n’est pas disponible. Veuillez vérifier que GitHub Copilot est installé et que vous êtes connecté(e).</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">Le modèle de package doit être fourni.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Il servizio dello strumento MCP non è disponibile. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">Specificare un modello di pacchetto.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -42,6 +42,11 @@
         <target state="translated">MCP ツール サービスは使用できません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">パッケージ パターンを指定する必要があります。</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -42,6 +42,11 @@
         <target state="translated">MCP 도구 서비스를 사용할 수 없습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">패키지 패턴을 제공해야 합니다.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Usługa narzędzia MCP jest niedostępna. Upewnij się, że usługa GitHub Copilot jest zainstalowana i zalogowano się.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">Należy podać wzorzec pakietu.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="translated">O Serviço de Ferramenta MCP não está disponível. Verifique se o GitHub Copilot está instalado e conectado.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">Um padrão de pacote deve ser fornecido.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Служба MCP Tool Service недоступна. Убедитесь, что GitHub Copilot установлен и вы вошли в свою учетную запись.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">Необходимо указать шаблон пакета.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">MCP Araç Hizmeti kullanılamıyor. Lütfen GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">Bir paket deseni sağlanmalıdır.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="translated">MCP 工具服务不可用。请确保 GitHub Copilot 已安装并登录。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">必须提供包模式。</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="translated">MCP 工具服務無法使用。請確保已安裝並登入 GitHub Copilot。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_NuGetSolverNotAvailable">
+        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
         <source>A package pattern must be provided.</source>
         <target state="translated">必須提供套件模式。</target>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3631

## Description
Check availability of NuGet Solver MCP Server tool. If unavailable, show a warning with instructions to enable the NuGet MCP Server, and block the operation. Note: the NuGet Solver MCP Server tool will be available as long as the NuGet MCP Server itself is enabled.

Warning dialog:
<img width="728" height="302" alt="image" src="https://github.com/user-attachments/assets/e89321e6-3cdf-4a3e-b4da-a2dfbbbd7489" />

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
