### PR TITLE
Use target graph name with framework

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreTargetGraph.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreTargetGraph.cs
@@ -81,7 +81,7 @@ namespace NuGet.Commands
             RuntimeGraph = runtimeGraph;
             Framework = framework;
             Graphs = graphs;
-            TargetGraphName = string.IsNullOrEmpty(TargetAlias) ? FrameworkRuntimePair.GetTargetGraphName(Framework, RuntimeIdentifier) : GetTargetGraphName(TargetAlias, RuntimeIdentifier);
+            TargetGraphName = FrameworkRuntimePair.GetTargetGraphName(Framework, RuntimeIdentifier);
             Conventions = new ManagedCodeConventions(runtimeGraph);
 
             Install = install;

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileExtensions.cs
@@ -33,7 +33,7 @@ namespace NuGet.ProjectModel
             {
                 return assetsFile.Targets;
             }
-            return assetsFile.Targets.Where(target => message.TargetGraphs.Contains(target.TargetAlias + (string.IsNullOrEmpty(target.RuntimeIdentifier) ? "" : "/" + target.RuntimeIdentifier), StringComparer.OrdinalIgnoreCase));
+            return assetsFile.Targets.Where(target => message.TargetGraphs.Contains(target.Name, StringComparer.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -145,7 +145,7 @@ namespace NuGet.CommandLine.Test
                 log.FilePath.Should().Be(projectA.ProjectPath);
                 log.LibraryId.Should().Be("z");
                 log.Level.Should().Be(LogLevel.Warning);
-                log.TargetGraphs.Select(e => string.Join(",", e)).Should().Contain(targetAlias);
+                log.TargetGraphs.Select(e => string.Join(",", e)).Should().Contain(netcoreapp1.DotNetFrameworkName);
                 log.Message.Should().Contain("Detected package version outside of dependency constraint: x 1.0.0 requires z (= 1.0.0) but version z 2.0.0 was resolved.");
             }
         }
@@ -326,7 +326,7 @@ namespace NuGet.CommandLine.Test
                 log.FilePath.Should().Be(projectA.ProjectPath);
                 log.LibraryId.Should().Be("b");
                 log.Level.Should().Be(LogLevel.Error);
-                log.TargetGraphs.Should().BeEquivalentTo(new[] { targetAlias });
+                log.TargetGraphs.Should().BeEquivalentTo(new[] { netcoreapp1.DotNetFrameworkName });
                 log.Message.Should().Be("Project b is not compatible with netcoreapp1.0 (.NETCoreApp,Version=v1.0). Project b supports: netcoreapp2.0 (.NETCoreApp,Version=v2.0)");
             }
         }
@@ -369,7 +369,7 @@ namespace NuGet.CommandLine.Test
                 log.FilePath.Should().Be(projectA.ProjectPath);
                 log.LibraryId.Should().Be("x");
                 log.Level.Should().Be(LogLevel.Error);
-                log.TargetGraphs.Should().BeEquivalentTo(new[] { targetAlias });
+                log.TargetGraphs.Should().BeEquivalentTo(new[] { netcoreapp1.DotNetFrameworkName });
                 log.Message.Should().Be("Package x 1.0.0 is not compatible with netcoreapp1.0 (.NETCoreApp,Version=v1.0). Package x 1.0.0 supports: netcoreapp2.0 (.NETCoreApp,Version=v2.0)");
             }
         }
@@ -413,7 +413,7 @@ namespace NuGet.CommandLine.Test
                 log.FilePath.Should().Be(projectA.ProjectPath);
                 log.LibraryId.Should().Be("x");
                 log.Level.Should().Be(LogLevel.Error);
-                log.TargetGraphs.Single().Should().Contain(targetAlias);
+                log.TargetGraphs.Single().Should().Contain(netcoreapp1.DotNetFrameworkName);
                 log.Message.Should().Contain("x 1.0.0 provides a compile-time reference assembly for a on .NETCoreApp,Version=v1.0, but there is no run-time assembly compatible with");
             }
         }
@@ -456,7 +456,7 @@ namespace NuGet.CommandLine.Test
                 log.FilePath.Should().Be(projectA.ProjectPath);
                 log.LibraryId.Should().Be("x");
                 log.Level.Should().Be(LogLevel.Error);
-                log.TargetGraphs.Single().Should().Contain(targetAlias);
+                log.TargetGraphs.Single().Should().Contain(netcoreapp1.DotNetFrameworkName);
                 log.Message.Should().Contain("a -> x 1.0.0 -> y 1.0.0 -> x (>= 1.0.0)");
             }
         }
@@ -532,7 +532,7 @@ namespace NuGet.CommandLine.Test
                 log.FilePath.Should().Be(projectA.ProjectPath);
                 log.LibraryId.Should().Be("z");
                 log.Level.Should().Be(LogLevel.Error);
-                log.TargetGraphs.Single().Should().Contain(targetAlias);
+                log.TargetGraphs.Single().Should().Contain(netcoreapp1.DotNetFrameworkName);
                 log.Message.Should().Contain("Version conflict detected for z");
                 log.Message.Should().Contain("a -> y 1.0.0 -> z (= 2.0.0)");
                 log.Message.Should().Contain("a -> x 1.0.0 -> z (= 1.0.0).");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3450,8 +3450,8 @@ EndGlobal";
                 var appleProps = new Dictionary<string, string>
                     {
                         { "TargetFrameworkIdentifier", ".NETCoreApp" },
-                        { "TargetFrameworkVersion", $"v{Constants.DefaultTargetFramework.Version.ToString(2)}" },
-                        { "TargetFrameworkMoniker", $".NETCoreApp, Version={Constants.DefaultTargetFramework.Version.ToString(2)}" }
+                        { "TargetFrameworkVersion", $"v{TestConstants.DefaultTargetFramework.Version.ToString(2)}" },
+                        { "TargetFrameworkMoniker", $".NETCoreApp, Version={TestConstants.DefaultTargetFramework.Version.ToString(2)}" }
                     };
                 ProjectFileUtils.AddProperties(xml, appleProps, $" '$(TargetFramework)' == '{apple}' ");
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileExtensionsTests.cs
@@ -21,7 +21,6 @@ namespace NuGet.ProjectModel.Test
             assetsFile.Targets.Add(new LockFileTarget()
             {
                 TargetFramework = NuGetFramework.Parse("net45"),
-                TargetAlias = "net45"
             });
 
             assetsFile.Targets.Single().Libraries.Add(new LockFileTargetLibrary()
@@ -31,12 +30,11 @@ namespace NuGet.ProjectModel.Test
             });
 
             var expected = NuGetFramework.Parse("net45").DotNetFrameworkName;
-            var message = new AssetsLogMessage(LogLevel.Warning, NuGetLogCode.NU1103, "test", "net45");
+            var message = new AssetsLogMessage(LogLevel.Warning, NuGetLogCode.NU1103, "test", expected);
 
             var graphs = message.GetTargetGraphs(assetsFile);
 
             graphs.Select(e => e.Name).Should().BeEquivalentTo(new[] { expected });
-            graphs.Select(e => e.TargetAlias).Should().BeEquivalentTo(new[] { "net45" });
         }
 
         [Fact]
@@ -46,28 +44,24 @@ namespace NuGet.ProjectModel.Test
             assetsFile.Targets.Add(new LockFileTarget()
             {
                 TargetFramework = NuGetFramework.Parse("net45"),
-                TargetAlias = "net45"
             });
 
             assetsFile.Targets.Add(new LockFileTarget()
             {
                 TargetFramework = NuGetFramework.Parse("net46"),
-                RuntimeIdentifier = "win8",
-                TargetAlias = "net46"
+                RuntimeIdentifier = "win8"
             });
 
             var expected1 = NuGetFramework.Parse("net45").DotNetFrameworkName;
             var expected2 = NuGetFramework.Parse("net46").DotNetFrameworkName + "/win8";
             var message = new AssetsLogMessage(LogLevel.Warning, NuGetLogCode.NU1103, "test")
             {
-                TargetGraphs = new[] { "net45", "net46/win8" }
+                TargetGraphs = new[] { expected1, expected2 }
             };
 
             var graphs = message.GetTargetGraphs(assetsFile);
 
             graphs.Select(e => e.Name).Should().BeEquivalentTo(new[] { expected1, expected2 });
-            graphs.Select(e => e.TargetAlias).Should().BeEquivalentTo(new[] { "net45", "net46" });
-            graphs.Select(e => e.RuntimeIdentifier).Should().BeEquivalentTo(new[] { null, "win8" });
         }
 
         [Fact]
@@ -123,12 +117,9 @@ namespace NuGet.ProjectModel.Test
         public void GivenALogMessageVerifyTargetGraphLibraryIsReturned()
         {
             var assetsFile = new LockFile();
-            var targetAlias = "net45";
             assetsFile.Targets.Add(new LockFileTarget()
             {
-                TargetFramework = NuGetFramework.Parse(targetAlias),
-                TargetAlias = targetAlias
-
+                TargetFramework = NuGetFramework.Parse("net45"),
             });
 
             assetsFile.Targets.Single().Libraries.Add(new LockFileTargetLibrary()
@@ -137,7 +128,8 @@ namespace NuGet.ProjectModel.Test
                 Version = NuGetVersion.Parse("1.0.0")
             });
 
-            var message = new AssetsLogMessage(LogLevel.Warning, NuGetLogCode.NU1103, "test", targetAlias);
+            var expected = NuGetFramework.Parse("net45").DotNetFrameworkName;
+            var message = new AssetsLogMessage(LogLevel.Warning, NuGetLogCode.NU1103, "test", expected);
 
             var graphs = message.GetTargetGraphs(assetsFile);
 

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -129,7 +129,10 @@ namespace NuGet.Commands.Test
             updated.RestoreMetadata.ProjectPath = projectPath;
             updated.RestoreMetadata.CentralPackageVersionsEnabled = spec.RestoreMetadata?.CentralPackageVersionsEnabled ?? false;
             updated.RestoreMetadata.CentralPackageTransitivePinningEnabled = spec.RestoreMetadata?.CentralPackageTransitivePinningEnabled ?? false;
-
+            if (spec.RestoreMetadata != null)
+            {
+                updated.RestoreMetadata.ProjectWideWarningProperties = spec.RestoreMetadata.ProjectWideWarningProperties;
+            }
             updated.RestoreMetadata.RestoreAuditProperties = new RestoreAuditProperties()
             {
                 EnableAudit = bool.FalseString


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14756

## Description

This is the patch friendly version of https://github.com/NuGet/NuGet.Client/pull/7153. 

In https://github.com/NuGet/NuGet.Client/pull/6805 and more notably in https://github.com/NuGet/NuGet.Client/pull/6923 a sizable part of the restore core logic was reworked to consider aliases as pivot instead of NuGetFramework. 

Turns out that was handled pretty well in most cases, except in scenarios where the TargetFramework element does not actually match the GetShortFolderName of a framework. 
In these cases, package specific suppressions *do not work*.
An example is net10.0-windows frameworks. Maui projects would probably suffer from the same issue as well as the linked issues suggest.

Originally in https://github.com/NuGet/NuGet.Client/pull/6805 and https://github.com/NuGet/NuGet.Client/pull/6923 a large majority of the internal restore infrastructure was changed to use string alias, instead of the NuGetFramework. 
Note that this work was done in a way that didn't make intentional functional changes, but simply made changes that are purely internal.
Turns out that it ended up breaking package specific warning suppressions for aliased frameworks such as net10.0-windows. Projects like maui have this issue as well. 
The root cause for that is that now *all* RestoreLogMessage have a target graph that has the alias. Note that this TargetGraphName is shared in many places, so it'll be really hard to understand the impact it'd have if we chnaged it for log messages only.

Workaround: Set the full name of the TargetFramework, so for net10.0-windows set net10.0-windows7.0. 

The simplest solution here is to change the TargetGraphName to the previous behavior, which is framework/rid instead of alias/rid.

This is insufficient with aliasing, but plenty good for a patch. 

The only place beyond NuGet where these strings are being read is the SDK and the SDK already knows how to handle both https://github.com/dotnet/sdk/pull/50694, so this shouldn't be an issue.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
