### PR TITLE
Check OneLocReleaseBranch at runtime instead of compile-time

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -10,9 +10,6 @@ parameters:
   values:
   - Real
   - Test
-- name: OneLocReleaseBranch
-  displayName: Release branch to run OneLocBuild
-  type: string
 
 resources:
   repositories:
@@ -54,7 +51,5 @@ extends:
     - template: /eng/pipelines/templates/pipeline.yml@self
       parameters:
         isOfficialBuild: true
-        ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), eq(variables['Build.SourceBranch'], format('refs/heads/{0}', parameters.OneLocReleaseBranch))) }}:
-          RunOneLocBuild: true
         RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
         SigningType: ${{ parameters.SigningType }}

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -53,3 +53,4 @@ extends:
         isOfficialBuild: true
         RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
         SigningType: ${{ parameters.SigningType }}
+        TryRunOneLocBuild: true

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -10,6 +10,9 @@ parameters:
   values:
   - Real
   - Test
+- name: OneLocReleaseBranch
+  displayName: Release branch to run OneLocBuild
+  type: string
 
 resources:
   repositories:
@@ -51,7 +54,7 @@ extends:
     - template: /eng/pipelines/templates/pipeline.yml@self
       parameters:
         isOfficialBuild: true
-        ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), eq(variables['Build.SourceBranch'], format('refs/heads/{0}', variables['OneLocReleaseBranch']))) }}:
+        ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), eq(variables['Build.SourceBranch'], format('refs/heads/{0}', parameters.OneLocReleaseBranch))) }}:
           RunOneLocBuild: true
         RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
         SigningType: ${{ parameters.SigningType }}

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -48,7 +48,7 @@ stages:
   condition: |
     and(
       succeeded(),
-      eq(variables['IsOfficialBuild'], 'true')),
+      eq(variables['IsOfficialBuild'], 'true'),
       or(
         eq('${{ parameters.RunOneLocBuild }}', 'true'),
         eq(variables['Build.SourceBranch'], 'refs/heads/dev'),

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -2,8 +2,8 @@ parameters:
 - name: isOfficialBuild
   type: boolean
   default: false
-- name: RunOneLocBuild
-  displayName: Run OneLocBuild
+- name: TryRunOneLocBuild
+  displayName: Run OneLocBuild if on dev or a OneLoc release branch
   type: boolean
   default: false
 - name: RunBuildForPublishing
@@ -43,6 +43,7 @@ stages:
     steps:
     - template: /eng/pipelines/templates/Initialize_Build.yml@self
 
+${{ if eq(parameters.TryRunOneLocBuild, true) }}:
 - stage: RunOneLocBuild
   displayName: Run OneLocBuild
   condition: |
@@ -50,7 +51,6 @@ stages:
       succeeded(),
       eq(variables['IsOfficialBuild'], 'true'),
       or(
-        eq('${{ parameters.RunOneLocBuild }}', 'true'),
         eq(variables['Build.SourceBranch'], 'refs/heads/dev'),
         and(
           ne(variables['OneLocReleaseBranch'], ''),

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -52,14 +52,8 @@ stages:
         eq(variables['IsOfficialBuild'], 'true'),
         or(
           eq(variables['Build.SourceBranch'], 'refs/heads/dev'),
-          and(
-            ne(variables['OneLocReleaseBranch'], ''),
-            or(
-              eq(variables['SourceBranch'], variables['OneLocReleaseBranch']),
-              eq(variables['Build.SourceBranch'], variables['OneLocReleaseBranch']),
-              eq(variables['Build.SourceBranch'], format('refs/heads/{0}', variables['OneLocReleaseBranch']))
-            )
-          )
+          eq(variables['Build.SourceBranch'], variables['OneLocReleaseBranch']),
+          eq(variables['Build.SourceBranch'], format('refs/heads/{0}', variables['OneLocReleaseBranch']))
         )
       )
     jobs:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -43,36 +43,36 @@ stages:
     steps:
     - template: /eng/pipelines/templates/Initialize_Build.yml@self
 
-${{ if eq(parameters.TryRunOneLocBuild, true) }}:
-- stage: RunOneLocBuild
-  displayName: Run OneLocBuild
-  condition: |
-    and(
-      succeeded(),
-      eq(variables['IsOfficialBuild'], 'true'),
-      or(
-        eq(variables['Build.SourceBranch'], 'refs/heads/dev'),
-        and(
-          ne(variables['OneLocReleaseBranch'], ''),
-          or(
-            eq(variables['SourceBranch'], variables['OneLocReleaseBranch']),
-            eq(variables['Build.SourceBranch'], variables['OneLocReleaseBranch']),
-            eq(variables['Build.SourceBranch'], format('refs/heads/{0}', variables['OneLocReleaseBranch']))
+- ${{ if eq(parameters.TryRunOneLocBuild, true) }}:
+  - stage: RunOneLocBuild
+    displayName: Run OneLocBuild
+    condition: |
+      and(
+        succeeded(),
+        eq(variables['IsOfficialBuild'], 'true'),
+        or(
+          eq(variables['Build.SourceBranch'], 'refs/heads/dev'),
+          and(
+            ne(variables['OneLocReleaseBranch'], ''),
+            or(
+              eq(variables['SourceBranch'], variables['OneLocReleaseBranch']),
+              eq(variables['Build.SourceBranch'], variables['OneLocReleaseBranch']),
+              eq(variables['Build.SourceBranch'], format('refs/heads/{0}', variables['OneLocReleaseBranch']))
+            )
           )
         )
       )
-    )
-  jobs:
-  - template: /eng/common/templates-official/job/onelocbuild.yml
-    parameters:
-      LclSource: lclFilesfromPackage
-      ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/dev') }}:
-        LclPackageId: 'LCL-JUNO-PROD-NuGetClient'
-      ${{ else }}:
-        LclPackageId: 'LCL-JUNO-PROD-NuGetClientRel'
-      MirrorRepo: 'NuGet.Client'
-      MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
-      GitHubOrg: 'NuGet'
+    jobs:
+    - template: /eng/common/templates-official/job/onelocbuild.yml
+      parameters:
+        LclSource: lclFilesfromPackage
+        ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/dev') }}:
+          LclPackageId: 'LCL-JUNO-PROD-NuGetClient'
+        ${{ else }}:
+          LclPackageId: 'LCL-JUNO-PROD-NuGetClientRel'
+        MirrorRepo: 'NuGet.Client'
+        MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
+        GitHubOrg: 'NuGet'
 
 - stage: Build_Insertable
   displayName: Build NuGet inserted into VS and .NET SDK

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -43,20 +43,36 @@ stages:
     steps:
     - template: /eng/pipelines/templates/Initialize_Build.yml@self
 
-- ${{ if eq(parameters.RunOneLocBuild, true) }}:
-  - stage: RunOneLocBuild
-    displayName: Run OneLocBuild
-    jobs:
-    - template: /eng/common/templates-official/job/onelocbuild.yml
-      parameters:
-        LclSource: lclFilesfromPackage
-        ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/dev') }}:
-          LclPackageId: 'LCL-JUNO-PROD-NuGetClient'
-        ${{ else }}:
-          LclPackageId: 'LCL-JUNO-PROD-NuGetClientRel'
-        MirrorRepo: 'NuGet.Client'
-        MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
-        GitHubOrg: 'NuGet'
+- stage: RunOneLocBuild
+  displayName: Run OneLocBuild
+  condition: |
+    and(
+      succeeded(),
+      eq(variables['IsOfficialBuild'], 'true')),
+      or(
+        eq('${{ parameters.RunOneLocBuild }}', 'true'),
+        eq(variables['Build.SourceBranch'], 'refs/heads/dev'),
+        and(
+          ne(variables['OneLocReleaseBranch'], ''),
+          or(
+            eq(variables['SourceBranch'], variables['OneLocReleaseBranch']),
+            eq(variables['Build.SourceBranch'], variables['OneLocReleaseBranch']),
+            eq(variables['Build.SourceBranch'], format('refs/heads/{0}', variables['OneLocReleaseBranch']))
+          )
+        )
+      )
+    )
+  jobs:
+  - template: /eng/common/templates-official/job/onelocbuild.yml
+    parameters:
+      LclSource: lclFilesfromPackage
+      ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/dev') }}:
+        LclPackageId: 'LCL-JUNO-PROD-NuGetClient'
+      ${{ else }}:
+        LclPackageId: 'LCL-JUNO-PROD-NuGetClientRel'
+      MirrorRepo: 'NuGet.Client'
+      MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
+      GitHubOrg: 'NuGet'
 
 - stage: Build_Insertable
   displayName: Build NuGet inserted into VS and .NET SDK


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3647

## Description

A recent change made to our loc process was to only run for `dev` and a release branch designated in the `OneLocReleaseBranch` pipeline variable.

However, the YAML condition was written as a template expression, meaning runtime variables are not yet loaded by the ADO job. Therefore, the condition evaluated to false and did not pass `RunOneLocBuild`.

I've moved the check to the pipeline.yml with a runtime condition.
- The official.yml will pass `TryRunOneLocBuild: true` to inject the stage at compile-time, and then the stage itself will condition on the branches at runtime.
This way, PR builds don't see the stage at all (just to waste time evaluating the branch name and ultimately skipping running OneLoc on PR builds).
- Compares directly against `Build.SourceBranch` to the `OneLocReleaseBranch` and tries trimming `refs/heads/` in case someone puts that in the build variable at some point which would result in a localization issue otherwise.


Tested by switching the variable to one of my branches and running to ensure it can read the ADO variable: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=13359377&view=results

Will need cherry-pick to release-7.3.x.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
