### PR TITLE
VS Target Branch/Channel props & OptProf Schedule now reflect Dev18 VS release cadence

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -27,7 +27,6 @@
     <!-- Visual Studio Insertion Logic -->
     <VsTargetBranch Condition="'$(VsTargetBranch)' == '' And '$(IsEscrowMode)' != 'true'">main</VsTargetBranch>
     <VsTargetChannel Condition="'$(VsTargetChannel)' == '' And '$(IsEscrowMode)' != 'true'">int.main</VsTargetChannel>
-    <VsTargetChannelForTests Condition="'$(VsTargetChannelForTests)' == '' And '$(IsEscrowMode)' != 'true'">$(VsTargetChannel)</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
     <VsTargetMajorVersion Condition="'$(VsTargetMajorVersion)' == ''">$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
@@ -36,8 +35,9 @@
     <!-- These branches are used for creating insertion PRs -->
     <VsTargetBranch Condition="'$(VsTargetBranch)' == '' And '$(IsEscrowMode)' == 'true'">rel/insiders</VsTargetBranch>
     <VsTargetChannel Condition="'$(VsTargetChannel)' == '' And '$(IsEscrowMode)' == 'true'">insiders</VsTargetChannel>
-    <!-- Run Apex/E2E tests on the target release branch -->
-    <VsTargetChannelForTests Condition="'$(VsTargetChannelForTests)' == '' And '$(IsEscrowMode)' == 'true'">$(VsTargetChannel)</VsTargetChannelForTests>
+
+    <!-- Run Apex/E2E tests on the target branch -->
+    <VsTargetChannelForTests Condition="'$(VsTargetChannelForTests)' == ''">$(VsTargetChannel)</VsTargetChannelForTests>
   </PropertyGroup>
 
  <PropertyGroup Condition=" '$(PreReleaseVersion)' == '' ">

--- a/build/config.props
+++ b/build/config.props
@@ -25,17 +25,17 @@
     <IsEscrowMode Condition="'$(IsEscrowMode)' == ''">false</IsEscrowMode>
 
     <!-- Visual Studio Insertion Logic -->
-    <VsTargetMajorVersion Condition="'$(VsTargetMajorVersion)' == ''">$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch Condition="'$(VsTargetBranch)' == '' And '$(IsEscrowMode)' != 'true'">main</VsTargetBranch>
-    <VsTargetChannel Condition="'$(VsTargetChannel)' == '' And '$(IsEscrowMode)' != 'true'">int.$(VsTargetBranch)</VsTargetChannel>
-    <VsTargetChannelForTests Condition="'$(VsTargetChannelForTests)' == '' And '$(IsEscrowMode)' != 'true'">int.$(VsTargetBranch)</VsTargetChannelForTests>
+    <VsTargetChannel Condition="'$(VsTargetChannel)' == '' And '$(IsEscrowMode)' != 'true'">int.main</VsTargetChannel>
+    <VsTargetChannelForTests Condition="'$(VsTargetChannelForTests)' == '' And '$(IsEscrowMode)' != 'true'">$(VsTargetChannel)</VsTargetChannelForTests>
 
     <!-- NuGet SDK VS package Semantic Version -->
+    <VsTargetMajorVersion Condition="'$(VsTargetMajorVersion)' == ''">$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>
 
-    <!-- This branches are used for creating insertion PRs -->
-    <VsTargetBranch Condition="'$(VsTargetBranch)' == '' And '$(IsEscrowMode)' == 'true'">rel/d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetBranch>
-    <VsTargetChannel Condition="'$(VsTargetChannel)' == '' And '$(IsEscrowMode)' == 'true'">int.d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetChannel>
+    <!-- These branches are used for creating insertion PRs -->
+    <VsTargetBranch Condition="'$(VsTargetBranch)' == '' And '$(IsEscrowMode)' == 'true'">rel/insiders</VsTargetBranch>
+    <VsTargetChannel Condition="'$(VsTargetChannel)' == '' And '$(IsEscrowMode)' == 'true'">insiders</VsTargetChannel>
     <!-- Run Apex/E2E tests on the target release branch -->
     <VsTargetChannelForTests Condition="'$(VsTargetChannelForTests)' == '' And '$(IsEscrowMode)' == 'true'">$(VsTargetChannel)</VsTargetChannelForTests>
   </PropertyGroup>

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -111,11 +111,11 @@ stages:
 
           Write-Host "Target Visual Studio branch (full name): $VSBranch"
 
-          # The value will be something like 'main' or 'rel/d16.4';
+          # The value will be something like 'main' or 'rel/insiders';
           # however, the subsequent task which gets bootstrapper details has a parameter (VSBranch)
           # which (as of writing this) requires the branch "short" name.
           # For the 'main' branch, the short name is still 'main'.
-          # For the 'rel/d16.4' branch, the short name is 'd16.4'.
+          # For the 'rel/insiders' branch, the short name is 'insiders'.
           # Ideally, we would not need to figure out the branch short name ourselves,
           # but short-term we will to unblock ourselves.
           $branchParts = $VSBranch.Split('/')

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -10,12 +10,9 @@ resources:
       branches:
         include:
         - dev
-        - release-*
-        - release/*
-        exclude:
-        - release-6.0.x
-        - release-6.3.x
-        - release-6.2.x
+        - release-6.14.x
+        - release-6.12.x
+        - release-5.11.x
   - pipeline: DartLab
     source: DartLab
     branch: main


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3650

## Description

- Fixes OptProf on 18.4 or higher by changing the VS Target Branch/Channel to the new naming pattern for Dev18.

  Dev will use the latest main VS build, while the release branch will use the public Insiders VS build.

  |VsTargetChannel|Branch|
  |---|--|
  |insiders|Current release branch|
  |int.main |dev|

- Changes the triggers so that only LTS branches and dev branch run OptProf.
Going forward, only the branches that support VS's LTS release cycle need OptProf.

I also expect we'll stop seeing OptProf failures we've seen with `7.x.x` release branches since this change stops queuing all `7.x.x` release branches for OptProf.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
