### PR TITLE
[7.4.x] VS Target Branch/Channel props & OptProf Schedule now reflect Dev18 VS release cadence

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -25,19 +25,19 @@
     <IsEscrowMode Condition="'$(IsEscrowMode)' == ''">true</IsEscrowMode>
 
     <!-- Visual Studio Insertion Logic -->
-    <VsTargetMajorVersion Condition="'$(VsTargetMajorVersion)' == ''">$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <VsTargetBranch Condition="'$(VsTargetBranch)' == '' And '$(IsEscrowMode)' != 'true'">main</VsTargetBranch>
-    <VsTargetChannel Condition="'$(VsTargetChannel)' == '' And '$(IsEscrowMode)' != 'true'">int.$(VsTargetBranch)</VsTargetChannel>
-    <VsTargetChannelForTests Condition="'$(VsTargetChannelForTests)' == '' And '$(IsEscrowMode)' != 'true'">int.$(VsTargetBranch)</VsTargetChannelForTests>
+    <VsTargetChannel Condition="'$(VsTargetChannel)' == '' And '$(IsEscrowMode)' != 'true'">int.main</VsTargetChannel>
 
     <!-- NuGet SDK VS package Semantic Version -->
+    <VsTargetMajorVersion Condition="'$(VsTargetMajorVersion)' == ''">$([MSBuild]::Add(11, $(MajorNuGetVersion)))</VsTargetMajorVersion>
     <NuGetSdkVsSemanticVersion>$(VsTargetMajorVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</NuGetSdkVsSemanticVersion>
 
-    <!-- This branches are used for creating insertion PRs -->
+    <!-- These branches are used for creating insertion PRs -->
     <VsTargetBranch Condition="'$(VsTargetBranch)' == '' And '$(IsEscrowMode)' == 'true'">rel/insiders</VsTargetBranch>
-    <VsTargetChannel Condition="'$(VsTargetChannel)' == '' And '$(IsEscrowMode)' == 'true'">int.d$(VsTargetMajorVersion).$(MinorNuGetVersion)</VsTargetChannel>
-    <!-- Run Apex/E2E tests on the target release branch -->
-    <VsTargetChannelForTests Condition="'$(VsTargetChannelForTests)' == '' And '$(IsEscrowMode)' == 'true'">$(VsTargetChannel)</VsTargetChannelForTests>
+    <VsTargetChannel Condition="'$(VsTargetChannel)' == '' And '$(IsEscrowMode)' == 'true'">insiders</VsTargetChannel>
+
+    <!-- Run Apex/E2E tests on the target branch -->
+    <VsTargetChannelForTests Condition="'$(VsTargetChannelForTests)' == ''">$(VsTargetChannel)</VsTargetChannelForTests>
   </PropertyGroup>
 
  <PropertyGroup Condition=" '$(PreReleaseVersion)' == '' ">

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -10,12 +10,9 @@ resources:
       branches:
         include:
         - dev
-        - release-*
-        - release/*
-        exclude:
-        - release-6.0.x
-        - release-6.3.x
-        - release-6.2.x
+        - release-6.14.x
+        - release-6.12.x
+        - release-5.11.x
   - pipeline: DartLab
     source: DartLab
     branch: main
@@ -111,11 +108,11 @@ stages:
 
           Write-Host "Target Visual Studio branch (full name): $VSBranch"
 
-          # The value will be something like 'main' or 'rel/d16.4';
+          # The value will be something like 'main' or 'rel/insiders';
           # however, the subsequent task which gets bootstrapper details has a parameter (VSBranch)
           # which (as of writing this) requires the branch "short" name.
           # For the 'main' branch, the short name is still 'main'.
-          # For the 'rel/d16.4' branch, the short name is 'd16.4'.
+          # For the 'rel/insiders' branch, the short name is 'insiders'.
           # Ideally, we would not need to figure out the branch short name ourselves,
           # but short-term we will to unblock ourselves.
           $branchParts = $VSBranch.Split('/')


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: engineering

## Description

Cherry-pick of https://github.com/NuGet/NuGet.Client/pull/7163
7.4.x should be the only branch needing the config.props changes as 18.4 is the first VS release changing how the bootstrapper process works.
Dev is already updated so I expect upcoming branches to work correctly.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
