### PR TITLE
Remove Microsoft.Net.Component.4.6.TargetingPack from .vsconfig

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -22,7 +22,6 @@
     "Microsoft.VisualStudio.Component.IntelliCode",
     "Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
-    "Microsoft.Net.Component.4.6.TargetingPack",
     "Microsoft.VisualStudio.Component.VSSDK",
     "Microsoft.VisualStudio.ComponentGroup.VisualStudioExtension.Prerequisites",
     "Microsoft.VisualStudio.Workload.VisualStudioExtension",


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14772

## Description

Removes Microsoft.Net.Component.4.6.TargetingPack which is not found for VS 2026.
I was able to import our vsconfig after this change.
And I was able to build NuGet's VSIX and debug after that.

<img width="532" height="203" alt="Image" src="https://github.com/user-attachments/assets/3568c80a-c909-424f-92c6-2da3b22b07f8" />

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
