### PR TITLE
Show CRL and OCSP URLs in verify output

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateUtility.cs
@@ -56,6 +56,16 @@ namespace NuGet.Packaging.Signing
             issues.Add(SignatureLog.InformationLog($"{indentation}{string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateIssuer, cert.IssuerName.Name)}"));
             issues.Add(SignatureLog.MinimalLog($"{indentation}{string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateValidity, cert.NotBefore, cert.NotAfter)}"));
 
+            foreach (string url in GetCrlDistributionPointUrls(cert))
+            {
+                issues.Add(SignatureLog.InformationLog($"{indentation}{string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateCrlUrl, url)}"));
+            }
+
+            foreach (string url in GetOcspUrls(cert))
+            {
+                issues.Add(SignatureLog.InformationLog($"{indentation}{string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateOcspUrl, url)}"));
+            }
+
             return issues;
         }
 
@@ -68,6 +78,16 @@ namespace NuGet.Packaging.Signing
             certStringBuilder.AppendLine(indentation + string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateHash, fingerprintAlgorithm.ToString(), certificateFingerprint));
             certStringBuilder.AppendLine(indentation + string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateIssuer, cert.IssuerName.Name));
             certStringBuilder.AppendLine(indentation + string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateValidity, cert.NotBefore, cert.NotAfter));
+
+            foreach (string url in GetCrlDistributionPointUrls(cert))
+            {
+                certStringBuilder.AppendLine(indentation + string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateCrlUrl, url));
+            }
+
+            foreach (string url in GetOcspUrls(cert))
+            {
+                certStringBuilder.AppendLine(indentation + string.Format(CultureInfo.CurrentCulture, Strings.CertUtilityCertificateOcspUrl, url));
+            }
         }
 
         /// <summary>
@@ -446,6 +466,118 @@ namespace NuGet.Packaging.Signing
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Extracts CRL Distribution Point URLs from the certificate's CRL Distribution Points extension (OID 2.5.29.31).
+        /// </summary>
+        internal static IReadOnlyList<string> GetCrlDistributionPointUrls(X509Certificate2 cert)
+        {
+            const string CrlDistributionPointsOid = "2.5.29.31";
+            // context-specific primitive tag [6] for uniformResourceIdentifier in GeneralName
+            const byte GeneralNameUriTag = 0x86;
+
+            var urls = new List<string>();
+            var extension = cert.Extensions[CrlDistributionPointsOid];
+
+            if (extension == null)
+            {
+                return urls;
+            }
+
+            try
+            {
+                // CRLDistributionPoints ::= SEQUENCE OF DistributionPoint
+                var reader = new DerEncoding.DerSequenceReader(extension.RawData);
+
+                while (reader.HasData)
+                {
+                    // DistributionPoint ::= SEQUENCE { distributionPoint [0] ... }
+                    var dpReader = reader.ReadSequence();
+
+                    if (dpReader.HasData && dpReader.HasTag(DerEncoding.DerSequenceReader.ContextSpecificConstructedTag0))
+                    {
+                        // distributionPoint [0] CONSTRUCTED
+                        byte[] dpNameData = dpReader.ReadValue((DerEncoding.DerSequenceReader.DerTag)DerEncoding.DerSequenceReader.ContextSpecificConstructedTag0);
+                        var dpNameReader = DerEncoding.DerSequenceReader.CreateForPayload(dpNameData);
+
+                        if (dpNameReader.HasData && dpNameReader.HasTag(DerEncoding.DerSequenceReader.ContextSpecificConstructedTag0))
+                        {
+                            // fullName [0] CONSTRUCTED = GeneralNames
+                            byte[] fullNameData = dpNameReader.ReadValue((DerEncoding.DerSequenceReader.DerTag)DerEncoding.DerSequenceReader.ContextSpecificConstructedTag0);
+                            var gnReader = DerEncoding.DerSequenceReader.CreateForPayload(fullNameData);
+
+                            while (gnReader.HasData)
+                            {
+                                byte tag = gnReader.PeekTag();
+
+                                if (tag == GeneralNameUriTag)
+                                {
+                                    byte[] uriBytes = gnReader.ReadValue((DerEncoding.DerSequenceReader.DerTag)GeneralNameUriTag);
+                                    urls.Add(Encoding.ASCII.GetString(uriBytes));
+                                }
+                                else
+                                {
+                                    gnReader.SkipValue();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (System.Security.Cryptography.CryptographicException)
+            {
+            }
+
+            return urls;
+        }
+
+        /// <summary>
+        /// Extracts OCSP responder URLs from the certificate's Authority Information Access extension (OID 1.3.6.1.5.5.7.1.1).
+        /// </summary>
+        internal static IReadOnlyList<string> GetOcspUrls(X509Certificate2 cert)
+        {
+            const string AuthorityInfoAccessOid = "1.3.6.1.5.5.7.1.1";
+            const string OcspAccessMethodOid = "1.3.6.1.5.5.7.48.1";
+            // context-specific primitive tag [6] for uniformResourceIdentifier in GeneralName
+            const byte GeneralNameUriTag = 0x86;
+
+            var urls = new List<string>();
+            var extension = cert.Extensions[AuthorityInfoAccessOid];
+
+            if (extension == null)
+            {
+                return urls;
+            }
+
+            try
+            {
+                // AuthorityInfoAccessSyntax ::= SEQUENCE OF AccessDescription
+                var reader = new DerEncoding.DerSequenceReader(extension.RawData);
+
+                while (reader.HasData)
+                {
+                    // AccessDescription ::= SEQUENCE { accessMethod OID, accessLocation GeneralName }
+                    var adReader = reader.ReadSequence();
+                    string oid = adReader.ReadOidAsString();
+
+                    if (string.Equals(oid, OcspAccessMethodOid, StringComparison.Ordinal) && adReader.HasData)
+                    {
+                        byte tag = adReader.PeekTag();
+
+                        if (tag == GeneralNameUriTag)
+                        {
+                            byte[] uriBytes = adReader.ReadValue((DerEncoding.DerSequenceReader.DerTag)GeneralNameUriTag);
+                            urls.Add(Encoding.ASCII.GetString(uriBytes));
+                        }
+                    }
+                }
+            }
+            catch (System.Security.Cryptography.CryptographicException)
+            {
+            }
+
+            return urls;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -151,6 +151,24 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to CRL URL: {0}.
+        /// </summary>
+        internal static string CertUtilityCertificateCrlUrl {
+            get {
+                return ResourceManager.GetString("CertUtilityCertificateCrlUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OCSP URL: {0}.
+        /// </summary>
+        internal static string CertUtilityCertificateOcspUrl {
+            get {
+                return ResourceManager.GetString("CertUtilityCertificateOcspUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ... {0} more..
         /// </summary>
         internal static string CertUtilityMultipleCertificatesFooter {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -271,6 +271,14 @@
     <comment>0 -  start date
 1 - end date</comment>
   </data>
+  <data name="CertUtilityCertificateCrlUrl" xml:space="preserve">
+    <value>CRL URL: {0}</value>
+    <comment>0 - CRL distribution point URL</comment>
+  </data>
+  <data name="CertUtilityCertificateOcspUrl" xml:space="preserve">
+    <value>OCSP URL: {0}</value>
+    <comment>0 - OCSP responder URL</comment>
+  </data>
   <data name="CertUtilityMultipleCertificatesFooter" xml:space="preserve">
     <value>... {0} more.</value>
     <comment>0 - number of certificates left</comment>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.cs.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">... dalších {0}.</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.de.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">... {0} weitere.</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.es.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">... {0} más.</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.fr.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">... {0} de plus.</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.it.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">... altri {0}.</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.ja.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">... さらに {0}。</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.ko.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">...기타 {0}개.</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.pl.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">... {0} więcej.</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.pt-BR.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">... {0} mais.</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.ru.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">и другие ({0}).</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.tr.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">... {0} daha.</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.zh-Hans.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">...另外 {0} 个。</target>

--- a/src/NuGet.Core/NuGet.Packaging/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.Packaging/xlf/Strings.zh-Hant.xlf
@@ -44,6 +44,16 @@
         <note>0 -  start date
 1 - end date</note>
       </trans-unit>
+      <trans-unit id="CertUtilityCertificateCrlUrl">
+        <source>CRL URL: {0}</source>
+        <target state="new">CRL URL: {0}</target>
+        <note>0 - CRL distribution point URL</note>
+      </trans-unit>
+      <trans-unit id="CertUtilityCertificateOcspUrl">
+        <source>OCSP URL: {0}</source>
+        <target state="new">OCSP URL: {0}</target>
+        <note>0 - OCSP responder URL</note>
+      </trans-unit>
       <trans-unit id="CertUtilityMultipleCertificatesFooter">
         <source>... {0} more.</source>
         <target state="translated">... 其他 {0} 個。</target>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateUtilityTests.cs
@@ -382,5 +382,81 @@ namespace NuGet.Packaging.Test
 
             return 0;
         }
+
+        [Fact]
+        public void GetCrlDistributionPointUrls_WithNoExtension_ReturnsEmpty()
+        {
+            using (var certificate = SigningTestUtility.GenerateCertificate("test", generator => { }))
+            {
+                var urls = CertificateUtility.GetCrlDistributionPointUrls(certificate);
+
+                Assert.Empty(urls);
+            }
+        }
+
+        [Fact]
+        public void GetCrlDistributionPointUrls_WithExtension_ReturnsUrls()
+        {
+            using (var certificate = SigningTestUtility.GenerateCertificate("test",
+                generator =>
+                {
+                    generator.Extensions.Add(
+                        CertificateRevocationListBuilder.BuildCrlDistributionPointExtension(
+                            new[] { "http://crl.example.com/test.crl", "http://crl2.example.com/test.crl" }));
+                }))
+            {
+                var urls = CertificateUtility.GetCrlDistributionPointUrls(certificate);
+
+                Assert.Equal(2, urls.Count);
+                Assert.Equal("http://crl.example.com/test.crl", urls[0]);
+                Assert.Equal("http://crl2.example.com/test.crl", urls[1]);
+            }
+        }
+
+        [Fact]
+        public void GetOcspUrls_WithNoExtension_ReturnsEmpty()
+        {
+            using (var certificate = SigningTestUtility.GenerateCertificate("test", generator => { }))
+            {
+                var urls = CertificateUtility.GetOcspUrls(certificate);
+
+                Assert.Empty(urls);
+            }
+        }
+
+        [Fact]
+        public void GetOcspUrls_WithExtension_ReturnsUrl()
+        {
+            using (var certificate = SigningTestUtility.GenerateCertificate("test",
+                generator =>
+                {
+                    generator.Extensions.Add(
+                        new Microsoft.Internal.NuGet.Testing.SignedPackages.X509AuthorityInformationAccessExtension(
+                            new Uri("http://ocsp.example.com"), caIssuersUrl: null));
+                }))
+            {
+                var urls = CertificateUtility.GetOcspUrls(certificate);
+
+                Assert.Single(urls);
+                Assert.Equal("http://ocsp.example.com", urls[0]);
+            }
+        }
+
+        [Fact]
+        public void GetOcspUrls_WithCaIssuersOnly_ReturnsEmpty()
+        {
+            using (var certificate = SigningTestUtility.GenerateCertificate("test",
+                generator =>
+                {
+                    generator.Extensions.Add(
+                        new Microsoft.Internal.NuGet.Testing.SignedPackages.X509AuthorityInformationAccessExtension(
+                            ocspResponderUrl: null, caIssuersUrl: new Uri("http://ca.example.com/cert.crt")));
+                }))
+            {
+                var urls = CertificateUtility.GetOcspUrls(certificate);
+
+                Assert.Empty(urls);
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14780

## Description

Display the URLs that might be accessed to verify a package certificate is valid. When NuGet asks .NET to verify a certificate chain, those lower level libraries are supposed to check with those URLs if those certificates have been revoked, so this is an easy way to find those URLs.

It's not output at minimal verbosity. At normal verbosity, it's output for the top certificates, and at detailed verbosity it's output for each of the certificates in the full chain.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14797
