### PR TITLE
Remove global.json sdk property

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,4 @@
 {
-  "sdk": {
-    "version": "10.0.100",
-    "rollForward": "latestMajor",
-    "allowPrerelease": true
-  },
   "tools": {
     "dotnet": "10.0.100",
     "pinned": true


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Infrastructure

## Description

CG within Microsoft sometimes flags us as using a .NET SDK with known vulnerabilities, even though it's configured to roll forward and our build script always installs the latest patch. The [.NET SDK repo's global.json](https://github.com/dotnet/sdk/blob/main/global.json) doesn't specify a version, so let's try removing it here to see if it reduces our compliance effort.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
