### PR TITLE
[6.12.x] Add azureSubscription input to Visual Studio bootstrapper

### DIFF
--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -10,11 +10,9 @@ resources:
       branches:
         include:
         - dev
-        - release-*
-        exclude:
-        - release-6.0.x
-        - release-6.3.x
-        - release-6.2.x
+        - release-6.14.x
+        - release-6.12.x
+        - release-5.11.x
   - pipeline: DartLab
     source: DartLab
     branch: main
@@ -110,11 +108,11 @@ stages:
 
           Write-Host "Target Visual Studio branch (full name): $VSBranch"
 
-          # The value will be something like 'main' or 'rel/d16.4';
+          # The value will be something like 'main' or 'rel/insiders';
           # however, the subsequent task which gets bootstrapper details has a parameter (VSBranch)
           # which (as of writing this) requires the branch "short" name.
           # For the 'main' branch, the short name is still 'main'.
-          # For the 'rel/d16.4' branch, the short name is 'd16.4'.
+          # For the 'rel/insiders' branch, the short name is 'insiders'.
           # Ideally, we would not need to figure out the branch short name ourselves,
           # but short-term we will to unblock ourselves.
           $branchParts = $VSBranch.Split('/')
@@ -184,10 +182,13 @@ stages:
     - task: MicroBuildBuildVSBootstrapper@3
       displayName: 'Build a Visual Studio bootstrapper'
       inputs:
+        azureSubscription: 'VSEng-VSDrop-MI'
         channelName: "$(VsTargetChannel)"
         vsMajorVersion: "$(VsTargetMajorVersion)"
         manifests: '$(Pipeline.Workspace)\ComponentBuildUnderTest\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
         outputFolder: '$(Pipeline.Workspace)\ComponentBuildUnderTest\VS15'
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     - task: PowerShell@2
       displayName: Set 'VisualStudio.InstallationUnderTest.BootstrapperURL'
       inputs:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

The Azure subscription fix, https://github.com/NuGet/NuGet.Client/pull/7066 was missing from this branch, which caused a failure for [6.12 OptProf ](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=13431903&view=results)

This also brings along the schedule change for OptProf which is not needed since the default branch sets the schedule, but might as well update the entire file.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
