### PR TITLE
Move all CI to VS stable agent pool

### DIFF
--- a/eng/pipelines/backup_build_artifacts.yml
+++ b/eng/pipelines/backup_build_artifacts.yml
@@ -12,7 +12,7 @@ jobs:
     displayName: "Backup Build Artifacts"
     timeoutInMinutes: 10
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
 
     steps:
       - checkout: none

--- a/eng/pipelines/compliance.yml
+++ b/eng/pipelines/compliance.yml
@@ -21,7 +21,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true
@@ -39,7 +39,7 @@ extends:
           notificationAliases: $(TsaNotificationAliases)
     pool:
       name: AzurePipelines-EO
-      image: VSEngSS-MicroBuild2022-1ES
+      image: VSEng-MicroBuildVSStable
       os: windows
     stages:
     - stage: compliance
@@ -49,7 +49,7 @@ extends:
         displayName: "Static Analysis"
         timeoutInMinutes: 180
         pool:
-          name: VSEngSS-MicroBuild2022-1ES
+          name: VSEng-MicroBuildVSStable
         templateContext:
           inputs:
             - input: pipelineArtifact

--- a/eng/pipelines/dailytests.yml
+++ b/eng/pipelines/dailytests.yml
@@ -40,7 +40,7 @@ stages:
   - job: Build
     timeoutInMinutes: 170
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
     steps:
     - template: vs-test/build.yml
 

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -31,7 +31,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -62,7 +62,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Unit
         testTargetFramework: net472
 
@@ -79,7 +79,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Unit
         testTargetFramework: net10.0
 
@@ -96,7 +96,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSVSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net472
         testProjectName: Msbuild.Integration.Test
@@ -114,7 +114,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.CommandLine.FuncTest
@@ -133,7 +133,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.CommandLine.Test
@@ -153,7 +153,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.Packaging.FuncTest
@@ -171,7 +171,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net10.0
         testProjectName: Dotnet.Integration.Test
@@ -190,7 +190,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net10.0
         testProjectName: NuGet.Packaging.FuncTest

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -28,7 +28,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -86,7 +86,7 @@ stages:
       RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
     templateContext:
       mb:
         localization:
@@ -204,7 +204,7 @@ stages:
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       BuildRTM: "true"
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
     templateContext:
       mb:
         localization:

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -72,7 +72,7 @@ stages:
   - job: Build
     timeoutInMinutes: 170
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
     steps:
     - template: vs-test/build.yml
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

Our CI pipelines are filled with warnings that VS2022's msbuild doesn't support targeting .NET 10, which a few of our projects do.  This should hopefully resolve that. But NuGet version 7 ships in VS 2026, so we should update the agent pool regardless.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
