### PR TITLE
AOT compatible: make NuGet.ProjectModel AOT compatible

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/CacheFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/CacheFileFormat.cs
@@ -9,12 +9,18 @@ using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using NuGet.Common;
 
 namespace NuGet.ProjectModel
 {
-    public static class CacheFileFormat
+    public static partial class CacheFileFormat
     {
+        [JsonSerializable(typeof(CacheFile))]
+        private sealed partial class CacheFileSourceGen : JsonSerializerContext
+        {
+        }
+
         private static JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
         {
             WriteIndented = true,
@@ -23,7 +29,8 @@ namespace NuGet.ProjectModel
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters = { new AssetsLogMessageConverter() },
             NumberHandling = JsonNumberHandling.AllowReadingFromString,
-            AllowTrailingCommas = true
+            AllowTrailingCommas = true,
+            TypeInfoResolver = CacheFileSourceGen.Default
         };
 
         /// <summary>
@@ -33,12 +40,12 @@ namespace NuGet.ProjectModel
         {
             public override IAssetsLogMessage Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
-                return JsonSerializer.Deserialize<AssetsLogMessage>(ref reader, options);
+                return JsonSerializer.Deserialize(ref reader, AssetsLogMessage.AssetsLogMessageSourceGen.Default.AssetsLogMessage);
             }
 
             public override void Write(Utf8JsonWriter writer, IAssetsLogMessage value, JsonSerializerOptions options)
             {
-                JsonSerializer.Serialize(writer, (AssetsLogMessage)value, options);
+                JsonSerializer.Serialize(writer, (AssetsLogMessage)value, AssetsLogMessage.AssetsLogMessageSourceGen.Default.AssetsLogMessage);
             }
         }
 
@@ -50,8 +57,7 @@ namespace NuGet.ProjectModel
 
             try
             {
-                var cacheFile = JsonSerializer.Deserialize<CacheFile>(utf8Json: stream, SerializerOptions);
-                return cacheFile;
+                return JsonSerializer.Deserialize(utf8Json: stream, (JsonTypeInfo<CacheFile>)SerializerOptions.GetTypeInfo(typeof(CacheFile)));
             }
             catch (Exception ex) when (ex is ArgumentNullException || ex is JsonException || ex is NotSupportedException)
             {
@@ -89,7 +95,7 @@ namespace NuGet.ProjectModel
 
         private static void Write(TextWriter textWriter, CacheFile cacheFile)
         {
-            textWriter.Write(JsonSerializer.Serialize(cacheFile, SerializerOptions));
+            textWriter.Write(JsonSerializer.Serialize(cacheFile, (JsonTypeInfo<CacheFile>)SerializerOptions.GetTypeInfo(typeof(CacheFile))));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/CacheFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/CacheFileFormat.cs
@@ -30,7 +30,9 @@ namespace NuGet.ProjectModel
             Converters = { new AssetsLogMessageConverter() },
             NumberHandling = JsonNumberHandling.AllowReadingFromString,
             AllowTrailingCommas = true,
-            TypeInfoResolver = CacheFileSourceGen.Default
+            TypeInfoResolver = JsonTypeInfoResolver.Combine(
+                CacheFileSourceGen.Default,
+                AssetsLogMessage.AssetsLogMessageSourceGen.Default)
         };
 
         /// <summary>
@@ -40,12 +42,12 @@ namespace NuGet.ProjectModel
         {
             public override IAssetsLogMessage Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
-                return JsonSerializer.Deserialize(ref reader, AssetsLogMessage.AssetsLogMessageSourceGen.Default.AssetsLogMessage);
+                return JsonSerializer.Deserialize(ref reader, (JsonTypeInfo<AssetsLogMessage>)options.GetTypeInfo(typeof(AssetsLogMessage)));
             }
 
             public override void Write(Utf8JsonWriter writer, IAssetsLogMessage value, JsonSerializerOptions options)
             {
-                JsonSerializer.Serialize(writer, (AssetsLogMessage)value, AssetsLogMessage.AssetsLogMessageSourceGen.Default.AssetsLogMessage);
+                JsonSerializer.Serialize(writer, (AssetsLogMessage)value, (JsonTypeInfo<AssetsLogMessage>)options.GetTypeInfo(typeof(AssetsLogMessage)));
             }
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/AssetsLogMessage.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/AssetsLogMessage.cs
@@ -76,7 +76,7 @@ namespace NuGet.ProjectModel
         }
 
         [JsonConstructor]
-        private AssetsLogMessage(
+        internal AssetsLogMessage(
             LogLevel level,
             NuGetLogCode code,
             string message,

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/AssetsLogMessage.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/AssetsLogMessage.cs
@@ -11,11 +11,11 @@ using NuGet.Shared;
 
 namespace NuGet.ProjectModel
 {
-    public class AssetsLogMessage : IAssetsLogMessage, IEquatable<IAssetsLogMessage>
+    public partial class AssetsLogMessage : IAssetsLogMessage, IEquatable<IAssetsLogMessage>
     {
-        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter<NuGetLogCode>))]
         public NuGetLogCode Code { get; }
-        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter<LogLevel>))]
         public LogLevel Level { get; }
         public string Message { get; }
         public string ProjectPath { get; set; }
@@ -68,6 +68,11 @@ namespace NuGet.ProjectModel
                 EndLineNumber = logMessage.EndLineNumber,
                 EndColumnNumber = logMessage.EndColumnNumber
             };
+        }
+
+        [JsonSerializable(typeof(AssetsLogMessage))]
+        internal sealed partial class AssetsLogMessageSourceGen : JsonSerializerContext
+        {
         }
 
         [JsonConstructor]

--- a/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
+++ b/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
@@ -7,7 +7,6 @@
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
     <XPLATProject>true</XPLATProject>
-    <IsAotCompatible>false</IsAotCompatible>
     <Description>NuGet's core types and interfaces for PackageReference-based restore, such as lock files, assets file and internal restore models.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 
Related: https://github.com/NuGet/Home/issues/14408
## Description

Copy of the work from https://github.com/NuGet/NuGet.Client/pull/7097

 Uses partial classes to let the compiler generate strongly typed, AOT-safe serialization code 
https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
