### PR TITLE
Handle missing TargetFramework in nomination

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -158,7 +158,7 @@ namespace NuGet.SolutionRestoreManager
                 FrameworkReferences = frameworkReferences,
                 Imports = imports,
                 RuntimeIdentifierGraphPath = GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.RuntimeIdentifierGraphPath),
-                TargetAlias = GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.TargetFramework),
+                TargetAlias = GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.TargetFramework) ?? string.Empty,
                 Warn = warn,
                 PackagesToPrune = packagesToPrune,
             };
@@ -191,7 +191,7 @@ namespace NuGet.SolutionRestoreManager
             var tfi = new ProjectRestoreMetadataFrameworkInfo
             {
                 FrameworkName = GetTargetFramework(targetFrameworkInfo.Properties, projectFullPath),
-                TargetAlias = GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.TargetFramework)
+                TargetAlias = GetPropertyValueOrNull(targetFrameworkInfo.Properties, ProjectBuildProperties.TargetFramework) ?? string.Empty,
             };
 
             if (targetFrameworkInfo.Items?.TryGetValue(ProjectItems.ProjectReference, out var projectReferences) ?? false)

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/TestProjectRestoreInfoBuilder.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/TestProjectRestoreInfoBuilder.cs
@@ -14,6 +14,7 @@ internal class TestProjectRestoreInfoBuilder
 {
     List<IVsTargetFrameworkInfo4> _targetFrameworks = new();
     List<VsReferenceItem2>? _toolReferences = null;
+    bool _useTargetFrameworks;
 
     public IVsProjectRestoreInfo3 Build()
     {
@@ -22,7 +23,7 @@ internal class TestProjectRestoreInfoBuilder
             throw new InvalidOperationException("At least one target framework must be added before building the project restore info.");
         }
 
-        var originalTargetFrameworks = _targetFrameworks.Count > 1 ? string.Join(";", _targetFrameworks.Select(tf => tf.Properties[ProjectBuildProperties.TargetFramework])) : null;
+        var originalTargetFrameworks = (_useTargetFrameworks || _targetFrameworks.Count > 1) ? string.Join(";", _targetFrameworks.Select(tf => tf.Properties[ProjectBuildProperties.TargetFramework])) : null;
 
         var pri = new VsProjectRestoreInfo3
         {
@@ -32,6 +33,11 @@ internal class TestProjectRestoreInfoBuilder
             OriginalTargetFrameworks = originalTargetFrameworks
         };
         return pri;
+    }
+
+    public void WithTargetFrameworksProperty()
+    {
+        _useTargetFrameworks = true;
     }
 
     public TestProjectRestoreInfoBuilder WithTargetFrameworkInfo(

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/TestProjectRestoreInfoBuilder.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/TestProjectRestoreInfoBuilder.cs
@@ -22,7 +22,7 @@ internal class TestProjectRestoreInfoBuilder
             throw new InvalidOperationException("At least one target framework must be added before building the project restore info.");
         }
 
-        var originalTargetFrameworks = string.Join(";", _targetFrameworks.Select(tf => tf.Properties[ProjectBuildProperties.TargetFramework]));
+        var originalTargetFrameworks = _targetFrameworks.Count > 1 ? string.Join(";", _targetFrameworks.Select(tf => tf.Properties[ProjectBuildProperties.TargetFramework])) : null;
 
         var pri = new VsProjectRestoreInfo3
         {
@@ -118,7 +118,7 @@ internal class TestProjectRestoreInfoBuilder
 
         public TargetFrameworkBuilder WithProperty(string key, string value)
         {
-            if (string.IsNullOrEmpty(key))
+            if (string.IsNullOrEmpty(value))
             {
                 Properties.Remove(key);
             }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -255,6 +255,7 @@ namespace NuGet.SolutionRestoreManager.Test
             {
                 builder.WithTargetFrameworkInfo(targetFramework);
             }
+            builder.WithTargetFrameworksProperty();
 
             var projectRestoreInfo = builder.Build();
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1822,12 +1822,17 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Fact]
-        public async Task NominateProjectAsync_WithMissingTargetFramework_AliasRemainsEmpty()
+        public async Task NominateProjectAsync_SimulatedCPPProject_WithMissingTargetFramework_AliasRemainsEmpty()
         {
             var projectRestoreInfo = new TestProjectRestoreInfoBuilder()
-                .WithTargetFrameworkInfo("netcoreapp1.0", builder =>
+                .WithTargetFrameworkInfo(CommonFrameworks.Native.GetShortFolderName(), builder =>
                 {
                     builder
+                    .WithProperty(ProjectBuildProperties.MSBuildProjectExtensionsPath, @"y:\src\some\project\obj")
+                    .WithProperty("MSBuildProjectFullPath", @"y:\src\some\project\project.vcxproj")
+                    .WithProperty("TargetFrameworkIdentifier", "NETFramework")
+                    .WithProperty("TargetFrameworkMoniker", ".NETFramework,Version=v4.8")
+                    .WithProperty("UsingMicrosoftNETSdk", "false")
                     .WithProperty("TargetFramework", null!);
                 })
                 .Build();
@@ -1847,12 +1852,61 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.Single(actualProjectSpec.TargetFrameworks);
             var actualTfi = actualProjectSpec.TargetFrameworks.Single();
 
-            var expectedFramework = NuGetFramework.Parse("netcoreapp1.0");
+            var expectedFramework = CommonFrameworks.Native;
             Assert.Equal(expectedFramework, actualTfi.FrameworkName);
             Assert.Equal(string.Empty, actualTfi.TargetAlias);
 
+            Assert.Single(actualProjectSpec.RestoreMetadata.TargetFrameworks);
+            var actualPRMFI = actualProjectSpec.RestoreMetadata.TargetFrameworks.Single();
+            Assert.Equal(expectedFramework, actualPRMFI.FrameworkName);
+            Assert.Equal(string.Empty, actualPRMFI.TargetAlias);
         }
 
+        [Fact]
+        public async Task NominateProjectAsync_SimulatedCPPProject_WithMissingTargetFrameworkAndAssetTargetFallback_AliasRemainsEmpty()
+        {
+            var projectRestoreInfo = new TestProjectRestoreInfoBuilder()
+                .WithTargetFrameworkInfo(CommonFrameworks.Native.GetShortFolderName(), builder =>
+                {
+                    builder
+                    .WithProperty(ProjectBuildProperties.MSBuildProjectExtensionsPath, @"y:\src\some\project\obj")
+                    .WithProperty("MSBuildProjectFullPath", @"y:\src\some\project\project.vcxproj")
+                    .WithProperty("TargetFrameworkIdentifier", "NETFramework")
+                    .WithProperty("TargetFrameworkMoniker", ".NETFramework,Version=v4.8")
+                    .WithProperty("UsingMicrosoftNETSdk", "false")
+                    .WithProperty("TargetFramework", null!)
+                    .WithProperty("AssetTargetFallback", "net48");
+                })
+                .Build();
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectRestoreInfo);
+
+            // Assert
+            SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
+
+            var actualProjectSpec = actualRestoreSpec.Projects.Single();
+            Assert.Equal("1.0.0", actualProjectSpec.Version.ToString());
+
+            var actualMetadata = actualProjectSpec.RestoreMetadata;
+            Assert.NotNull(actualMetadata);
+            Assert.Equal(ProjectStyle.PackageReference, actualMetadata.ProjectStyle);
+
+            Assert.Single(actualProjectSpec.TargetFrameworks);
+            var actualTfi = actualProjectSpec.TargetFrameworks.Single();
+
+            var expectedFramework = CommonFrameworks.Native;
+            Assert.Equal(expectedFramework, actualTfi.FrameworkName);
+            Assert.Equal(string.Empty, actualTfi.TargetAlias);
+            Assert.IsType<AssetTargetFallbackFramework>(actualTfi.FrameworkName);
+            var assetTargetFallback = (AssetTargetFallbackFramework)actualTfi.FrameworkName;
+            Assert.Equal(expectedFramework, assetTargetFallback.RootFramework);
+            Assert.Equal([CommonFrameworks.Net48], assetTargetFallback.Fallback);
+
+            Assert.Single(actualProjectSpec.RestoreMetadata.TargetFrameworks);
+            var actualPRMFI = actualProjectSpec.RestoreMetadata.TargetFrameworks.Single();
+            Assert.Equal(expectedFramework, actualPRMFI.FrameworkName);
+            Assert.Equal(string.Empty, actualPRMFI.TargetAlias);
+        }
 
         private async Task<DependencyGraphSpec> CaptureNominateResultAsync(
             IVsProjectRestoreInfo3 pri,

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1821,6 +1821,39 @@ namespace NuGet.SolutionRestoreManager.Test
             resultB.Value.VersionRange.Should().Be(VersionRange.Parse("(, 1.0.0]"));
         }
 
+        [Fact]
+        public async Task NominateProjectAsync_WithMissingTargetFramework_AliasRemainsEmpty()
+        {
+            var projectRestoreInfo = new TestProjectRestoreInfoBuilder()
+                .WithTargetFrameworkInfo("netcoreapp1.0", builder =>
+                {
+                    builder
+                    .WithProperty("TargetFramework", null!);
+                })
+                .Build();
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectRestoreInfo);
+
+            // Assert
+            SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
+
+            var actualProjectSpec = actualRestoreSpec.Projects.Single();
+            Assert.Equal("1.0.0", actualProjectSpec.Version.ToString());
+
+            var actualMetadata = actualProjectSpec.RestoreMetadata;
+            Assert.NotNull(actualMetadata);
+            Assert.Equal(ProjectStyle.PackageReference, actualMetadata.ProjectStyle);
+
+            Assert.Single(actualProjectSpec.TargetFrameworks);
+            var actualTfi = actualProjectSpec.TargetFrameworks.Single();
+
+            var expectedFramework = NuGetFramework.Parse("netcoreapp1.0");
+            Assert.Equal(expectedFramework, actualTfi.FrameworkName);
+            Assert.Equal(string.Empty, actualTfi.TargetAlias);
+
+        }
+
+
         private async Task<DependencyGraphSpec> CaptureNominateResultAsync(
             IVsProjectRestoreInfo3 pri,
             Mock<IProjectSystemCache>? cache = null)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/nuget/home/issues/14788

## Description

When we changed the main parts of restore to use TargetAlias as the pivot instead of the NuGetFramework it basically meant that TargetAlias needs to either be empty or have a value. 

In many places in restore we default to empty if there's no value (non SDK projects) 

https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs#L445

https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs#L734

In legacy PR, we don't set it.

In CPSPackageReference projects however, we set it, expecting that it's only invoked in SDK based scenarios but unfortunately that's not the case. 

Enter C++/CLI PackageReference hacks!

The confirmed scenario in question seems to be C++/CLI PackageReference (.NET Framework projects).

C++/CLI (.NET Core) supports PackageReference projects: https://devblogs.microsoft.com/cppblog/announcing-nuget-packagereference-support-for-c-cli-msbuild-projects-targeting-net-core/ . The way that works is the C++/CPS/project-system teams worked so that the nomination code from the managed lang system is being utilized to provide this restore data to NuGet. In the end for NuGet, while we did add some special compatibility rules, these restores appear the same as a normal SDK based project.

Note that native C++ PackageReference is not supported, https://developercommunity.visualstudio.com/t/Add-PackageReference-support-for-native-/10165376 . Similarly to many scenarios, it can work on the commandline, but project reference protocol and VS scenarios just won't work. Customers haven't really cared about that limitation.
They have been using all kinds of workarounds: [Use PackageReference in vcxproj - Developer Community](https://developercommunity.visualstudio.com/t/use-packagereference-in-vcxproj/351636#T-N10713858)  https://github.com/NuGet/Home/issues/8874 .

They basically set things like Capability, and all kinds of stuff to try to work around the implementation limiting when restore works.
These things are all unsupported. We have been clear about that, since not all scenarios are handled in C++ PackageReference today.
NuGet generates assets file, nuget.g.props, nuget.g.targets and none of those are guaranteed to be loaded or refreshed in these scenarios. So restore happens, but whether the build or intellisense actually works the way they wanted is not guaranteed.


That being said, this did get broken and the fix is rather straightforward, so we'll fix it, but we won't service stable, but insiders only. 

There is a workaround and that is setting the TargetFramework value.

sample nomination data for a C++/CLI project, https://github.com/jwfx/NuGetRestoreRepro/blob/master/Directory.Build.props.

```txt
BEGIN Nominate Restore for E:\Code\Temp\NuGetRestoreRepro\NuGetRestoreRepro\NuGetRestoreRepro.vcxproj
    MSBuildProjectExtensionsPath:     E:\Code\Temp\NuGetRestoreRepro\NuGetRestoreRepro\obj\
    OriginalTargetFrameworks:         
    Target Frameworks (1)
        native,Version=v0.0
            Framework References
            Package Downloads
            Project References
            Package References
                Newtonsoft.Json -- (Aliases: | ExcludeAssets: | GeneratePathProperty: | IncludeAssets: | IsImplicitlyDefined: | Name: | NoWarn: | PrivateAssets: | Version:13.0.4 | VersionOverride: | Visible:)
            NuGet Audit Suppressions
            Prune Package References
            Package Versions -- 0 (count only)
            Target Framework Properties -- (RestoreLockedMode: | RestorePackagesWithLockFile: | NuGetAudit:true | RestoreEnablePackagePruning:false | RestoreAdditionalProjectFallbackFolders: | TargetPlatformIdentifier:Windows | RestorePackagesPath: | MSBuildProjectDirectory:E:\Code\Temp\NuGetRestoreRepro\NuGetRestoreRepro | RestoreAdditionalProjectSources: | CentralPackageFloatingVersionsEnabled: | PackageId: | RuntimeIdentifier: | NoWarn:;NU1701;NU1702 | RestoreAdditionalProjectFallbackFoldersExcludes: | TargetFrameworkIdentifier:.NETFramework | VersionSuffix: | DotnetCliToolTargetFramework: | CLRSupport:true | VersionPrefix: | TargetPlatformVersion:10.0.26100.0 | Version:1.0.0.0 | NuGetAuditMode:direct | CentralPackageVersionOverrideEnabled: | NETCoreSdkVersion: | RestoreFallbackFolders: | MSBuildProjectFile:NuGetRestoreRepro.vcxproj | NuGetAuditLevel:low | TargetFrameworkMoniker:.NETFramework,Version=v4.8 | WarningsNotAsErrors: | TargetPlatformMoniker:Windows,Version=10.0.26100.0 | TargetPlatformMinVersion:7.0 | EmitAssetsLogMessages: | RestorePackagePruningDefault:false | TargetFramework:native | UsingMicrosoftNETSdk: | PackageTargetFallback: | ProjectAssetsFile:E:\Code\Temp\NuGetRestoreRepro\NuGetRestoreRepro\obj\project.assets.json | RestoreUseLegacyDependencyResolver: | WindowsTargetPlatformMinVersion:7.0 | ManagePackageVersionsCentrally: | TreatWarningsAsErrors: | TargetFrameworkProfile: | RestoreSources: | TargetFrameworks: | NuGetTargetMoniker:native,Version=v0.0 | RuntimeIdentifierGraphPath: | MSBuildProjectExtensionsPath:E:\Code\Temp\NuGetRestoreRepro\NuGetRestoreRepro\obj\ | TargetFrameworkVersion:v4.8 | NuGetLockFilePath: | RuntimeIdentifiers:win;win-x86;win-x64;win-arm64 | PackageVersion: | SdkAnalysisLevel: | CentralPackageTransitivePinningEnabled: | WarningsAsErrors: | AssetTargetFallback:net48)
    Tool References
```

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
