### PR TITLE
Enabling nullability in NuGet.Packaging - Annotate ContentModel, LicenseMetadata & some extraction types

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/LicenseMetadataFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/LicenseMetadataFormatter.cs
@@ -69,10 +69,10 @@ namespace NuGet.VisualStudio.Internal.Contracts
             }
 
             return new LicenseMetadata(type,
-                license,
+                license!,
                 licenseExpression,
                 warningsAndErrors,
-                version);
+                version!);
         }
 
         protected override void SerializeCore(ref MessagePackWriter writer, LicenseMetadata value, MessagePackSerializerOptions options)

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/Asset.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/Asset.cs
@@ -1,16 +1,18 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
+using System;
 
 namespace NuGet.ContentModel
 {
     public class Asset
     {
-        public string Path { get; set; }
-        public string Link { get; set; }
+        public required string Path { get; set; }
 
-        public override string ToString()
+        [Obsolete("This is unused and will be removed in a future release.")]
+        public string? Link { get; set; }
+
+        public override string? ToString()
         {
             return Path;
         }

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentPropertyDefinition.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentPropertyDefinition.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,34 +13,34 @@ namespace NuGet.ContentModel
     /// </summary>
     public class ContentPropertyDefinition
     {
-        private static readonly Func<object, object, bool> EqualsTest = (left, right) => Equals(left, right);
+        private static readonly Func<object?, object?, bool> EqualsTest = (left, right) => Equals(left, right);
 
         internal ContentPropertyDefinition(
             string name,
-            Func<ReadOnlyMemory<char>, PatternTable, bool, object> parser)
+            Func<ReadOnlyMemory<char>, PatternTable?, bool, object?> parser)
             : this(name, parser, null, null, null, false)
         {
         }
 
         internal ContentPropertyDefinition(
             string name,
-            Func<ReadOnlyMemory<char>, PatternTable, bool, object> parser,
-            Func<object, object, bool> compatibilityTest)
+            Func<ReadOnlyMemory<char>, PatternTable?, bool, object?> parser,
+            Func<object?, object?, bool>? compatibilityTest)
             : this(name, parser, compatibilityTest, null, null, false)
         {
         }
 
         internal ContentPropertyDefinition(string name,
-            Func<ReadOnlyMemory<char>, PatternTable, bool, object> parser,
-            Func<object, object, bool> compatibilityTest,
-            Func<object, object, object, int> compareTest)
+            Func<ReadOnlyMemory<char>, PatternTable?, bool, object?> parser,
+            Func<object?, object?, bool>? compatibilityTest,
+            Func<object?, object?, object?, int>? compareTest)
             : this(name, parser, compatibilityTest, compareTest, null, false)
         {
         }
 
         internal ContentPropertyDefinition(
             string name,
-            Func<ReadOnlyMemory<char>, PatternTable, bool, object> parser,
+            Func<ReadOnlyMemory<char>, PatternTable?, bool, object?> parser,
             IEnumerable<string> fileExtensions)
             : this(name, parser, null, null, fileExtensions, false)
         {
@@ -50,10 +48,10 @@ namespace NuGet.ContentModel
 
         internal ContentPropertyDefinition(
             string name,
-            Func<ReadOnlyMemory<char>, PatternTable, bool, object> parser,
-            Func<object, object, bool> compatibilityTest,
-            Func<object, object, object, int> compareTest,
-            IEnumerable<string> fileExtensions,
+            Func<ReadOnlyMemory<char>, PatternTable?, bool, object?> parser,
+            Func<object?, object?, bool>? compatibilityTest,
+            Func<object?, object?, object?, int>? compareTest,
+            IEnumerable<string>? fileExtensions,
             bool allowSubfolders)
         {
             Name = name;
@@ -66,7 +64,7 @@ namespace NuGet.ContentModel
 
         public string Name { get; }
 
-        public List<string> FileExtensions { get; }
+        public List<string>? FileExtensions { get; }
 
         public bool FileExtensionAllowSubFolders { get; }
 
@@ -76,7 +74,7 @@ namespace NuGet.ContentModel
         /// If the bool is true, the return object will be non-null, and match what the ReadOnlyMemory char represents.
         /// If the bool is false, the return object will be non-null if the ReadOnlyMemory char represents a valid value for this definition. This is a performance optimization.
         /// </summary>
-        internal Func<ReadOnlyMemory<char>, PatternTable, bool, object> Parser { get; }
+        internal Func<ReadOnlyMemory<char>, PatternTable?, bool, object?> Parser { get; }
 
         /// <summary>
         /// Looks up a definition for the given substring.
@@ -90,7 +88,7 @@ namespace NuGet.ContentModel
         /// <param name="matchOnly">Whether this is a grouping match, or we actually want to actualize the value of name as a string.</param>
         /// <param name="value">The out param. If matchonly, it will always be null. Otherwise, set to actualized value of name if the return is true, set to null if false.</param>
         /// <returns>True if the name matches the definition. False otherwise.</returns>
-        internal virtual bool TryLookup(ReadOnlyMemory<char> name, PatternTable table, bool matchOnly, out object value)
+        internal virtual bool TryLookup(ReadOnlyMemory<char> name, PatternTable? table, bool matchOnly, out object? value)
         {
             if (name.IsEmpty)
             {
@@ -148,19 +146,19 @@ namespace NuGet.ContentModel
             return containsSlash;
         }
 
-        public Func<object, object, bool> CompatibilityTest { get; }
+        public Func<object?, object?, bool> CompatibilityTest { get; }
 
         /// <summary>
         /// Find the nearest compatible candidate.
         /// </summary>
-        public Func<object, object, object, int> CompareTest { get; }
+        public Func<object?, object?, object?, int>? CompareTest { get; }
 
-        public virtual bool IsCriteriaSatisfied(object critieriaValue, object candidateValue)
+        public virtual bool IsCriteriaSatisfied(object? critieriaValue, object? candidateValue)
         {
             return CompatibilityTest.Invoke(critieriaValue, candidateValue);
         }
 
-        public virtual int Compare(object criteriaValue, object candidateValue1, object candidateValue2)
+        public virtual int Compare(object? criteriaValue, object? candidateValue1, object? candidateValue2)
         {
             var betterCoverageFromValue1 = IsCriteriaSatisfied(candidateValue1, candidateValue2);
             var betterCoverageFromValue2 = IsCriteriaSatisfied(candidateValue2, candidateValue1);

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -15,7 +13,7 @@ namespace NuGet.ContentModel.Infrastructure
     {
         private readonly List<Segment> _segments = new List<Segment>();
         private readonly Dictionary<string, object> _defaults;
-        private readonly PatternTable _table;
+        private readonly PatternTable? _table;
 
         public PatternExpression(PatternDefinition pattern)
         {
@@ -66,9 +64,9 @@ namespace NuGet.ContentModel.Infrastructure
             }
         }
 
-        internal ContentItem Match(string path, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions)
+        internal ContentItem? Match(string path, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions)
         {
-            ContentItem item = null;
+            ContentItem? item = null;
             var startIndex = 0;
             foreach (var segment in _segments)
             {
@@ -109,7 +107,7 @@ namespace NuGet.ContentModel.Infrastructure
 
         private abstract class Segment
         {
-            internal abstract bool TryMatch(ref ContentItem item, string path, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex);
+            internal abstract bool TryMatch(ref ContentItem? item, string path, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex);
         }
 
         [DebuggerDisplay("{_pattern.Substring(_start, _length)}")]
@@ -127,7 +125,7 @@ namespace NuGet.ContentModel.Infrastructure
             }
 
             internal override bool TryMatch(
-                ref ContentItem item,
+                ref ContentItem? item,
                 string path,
                 IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions,
                 int startIndex,
@@ -152,11 +150,11 @@ namespace NuGet.ContentModel.Infrastructure
             private readonly string _token;
             private readonly char _delimiter;
             private readonly bool _matchOnly;
-            private readonly PatternTable _table;
+            private readonly PatternTable? _table;
             private readonly bool _preserveRawValue = false;
-            private readonly string _rawToken;
+            private readonly string? _rawToken;
 
-            public TokenSegment(string token, char delimiter, bool matchOnly, PatternTable table, bool preserveRawValues)
+            public TokenSegment(string token, char delimiter, bool matchOnly, PatternTable? table, bool preserveRawValues)
             {
                 _token = token;
                 _delimiter = delimiter;
@@ -170,13 +168,13 @@ namespace NuGet.ContentModel.Infrastructure
             }
 
             internal override bool TryMatch(
-                ref ContentItem item,
+                ref ContentItem? item,
                 string path,
                 IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions,
                 int startIndex,
                 out int endIndex)
             {
-                ContentPropertyDefinition propertyDefinition;
+                ContentPropertyDefinition? propertyDefinition;
                 if (!propertyDefinitions.TryGetValue(_token, out propertyDefinition))
                 {
                     throw new Exception(string.Format(CultureInfo.CurrentCulture, "Unable to find property definition for {{{0}}}", _token));
@@ -200,7 +198,7 @@ namespace NuGet.ContentModel.Infrastructure
                         break;
                     }
                     ReadOnlyMemory<char> substring = path.AsMemory(startIndex, delimiterIndex - startIndex);
-                    object value;
+                    object? value;
                     if (propertyDefinition.TryLookup(substring, _table, _matchOnly, out value))
                     {
                         if (!_matchOnly)
@@ -215,9 +213,9 @@ namespace NuGet.ContentModel.Infrastructure
                             }
                             if (_preserveRawValue)
                             {
-                                item.Add(_rawToken, substring.ToString());
+                                item.Add(_rawToken!, substring.ToString());
                             }
-                            item.Add(_token, value);
+                            item.Add(_token, value!);
                         }
                         endIndex = delimiterIndex;
                         return true;

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -68,7 +66,7 @@ namespace NuGet.Client
 
         private static readonly FrameworkReducer FrameworkReducer = new();
 
-        private RuntimeGraph _runtimeGraph;
+        private RuntimeGraph? _runtimeGraph;
 
         private Dictionary<ReadOnlyMemory<char>, NuGetFramework> _frameworkCache = new(ReadOnlyMemoryCharComparerOrdinal.Instance);
 
@@ -76,7 +74,7 @@ namespace NuGet.Client
         public IReadOnlyDictionary<string, ContentPropertyDefinition> Properties { get; }
         public ManagedCodePatterns Patterns { get; }
 
-        public ManagedCodeConventions(RuntimeGraph runtimeGraph)
+        public ManagedCodeConventions(RuntimeGraph? runtimeGraph)
         {
             _runtimeGraph = runtimeGraph;
 
@@ -105,7 +103,7 @@ namespace NuGet.Client
             Patterns = new ManagedCodePatterns(this);
         }
 
-        private bool RuntimeIdentifier_CompatibilityTest(object criteria, object available)
+        private bool RuntimeIdentifier_CompatibilityTest(object? criteria, object? available)
         {
             if (_runtimeGraph == null)
             {
@@ -129,11 +127,11 @@ namespace NuGet.Client
         /// If matchOnly is true, then an empty string may be returned as a performance optimization.
         /// If matchOnly is false, the parsed result will be returned.
         /// </summary>
-        private static object CodeLanguage_Parser(ReadOnlyMemory<char> name, PatternTable table, bool matchOnly)
+        private static object? CodeLanguage_Parser(ReadOnlyMemory<char> name, PatternTable? table, bool matchOnly)
         {
             if (table != null)
             {
-                object val;
+                object? val;
                 if (table.TryLookup(PropertyNames.CodeLanguage, name, out val))
                 {
                     return val;
@@ -162,11 +160,11 @@ namespace NuGet.Client
         /// If matchOnly is true, then an empty string may be returned as a performance optimization.
         /// If matchOnly is false, the parsed result will be returned.
         /// </summary>
-        internal static object Locale_Parser(ReadOnlyMemory<char> name, PatternTable table, bool matchOnly)
+        internal static object? Locale_Parser(ReadOnlyMemory<char> name, PatternTable? table, bool matchOnly)
         {
             if (table != null)
             {
-                object val;
+                object? val;
                 if (table.TryLookup(PropertyNames.Locale, name, out val))
                 {
                     return val;
@@ -213,15 +211,13 @@ namespace NuGet.Client
 
         private object TargetFrameworkName_Parser(
             ReadOnlyMemory<char> name,
-            PatternTable table,
+            PatternTable? table,
             bool matchOnly)
         {
-            object obj = null;
-
             // Check for replacements
             if (table != null)
             {
-                if (table.TryLookup(PropertyNames.TargetFrameworkMoniker, name, out obj))
+                if (table.TryLookup(PropertyNames.TargetFrameworkMoniker, name, out var obj))
                 {
                     return obj;
                 }
@@ -230,8 +226,7 @@ namespace NuGet.Client
             // Check the cache for an exact match
             if (!name.IsEmpty)
             {
-                NuGetFramework cachedResult;
-                if (!_frameworkCache.TryGetValue(name, out cachedResult))
+                if (!_frameworkCache.TryGetValue(name, out NuGetFramework? cachedResult))
                 {
                     // Parse and add the framework to the cache
                     cachedResult = TargetFrameworkName_ParserCore(name.ToString());
@@ -272,7 +267,7 @@ namespace NuGet.Client
         /// If matchOnly is true, then an empty string is returned as a performance optimization.
         /// If matchOnly is false, the string will be actualized.
         /// </summary>
-        private static object IdentityParser(ReadOnlyMemory<char> s, PatternTable _, bool matchOnly)
+        private static object IdentityParser(ReadOnlyMemory<char> s, PatternTable? _, bool matchOnly)
         {
             if (matchOnly)
             {
@@ -286,7 +281,7 @@ namespace NuGet.Client
         /// If matchOnly is true, then an empty string is returned as a performance optimization.
         /// If matchOnly is false, the parsed result will be returned.
         /// </summary>
-        private static object AllowEmptyFolderParser(ReadOnlyMemory<char> s, PatternTable table, bool matchOnly)
+        private static object? AllowEmptyFolderParser(ReadOnlyMemory<char> s, PatternTable? _, bool matchOnly)
         {
             // Accept "_._" as a pseudo-assembly
             if (MemoryExtensions.Equals(PackagingCoreConstants.EmptyFolder.AsSpan(), s.Span, StringComparison.Ordinal))
@@ -301,7 +296,7 @@ namespace NuGet.Client
             return null;
         }
 
-        private static bool TargetFrameworkName_CompatibilityTest(object criteria, object available)
+        private static bool TargetFrameworkName_CompatibilityTest(object? criteria, object? available)
         {
             var criteriaFrameworkName = criteria as NuGetFramework;
             var availableFrameworkName = available as NuGetFramework;
@@ -334,7 +329,7 @@ namespace NuGet.Client
             return false;
         }
 
-        private static int TargetFrameworkName_NearestCompareTest(object projectFramework, object criteria, object available)
+        private static int TargetFrameworkName_NearestCompareTest(object? projectFramework, object? criteria, object? available)
         {
             var projectFrameworkName = projectFramework as NuGetFramework;
             var criteriaFrameworkName = criteria as NuGetFramework;
@@ -376,7 +371,7 @@ namespace NuGet.Client
                 _conventions = conventions;
             }
 
-            public SelectionCriteria ForFrameworkAndRuntime(NuGetFramework framework, string runtimeIdentifier)
+            public SelectionCriteria ForFrameworkAndRuntime(NuGetFramework framework, string? runtimeIdentifier)
             {
                 if (framework is FallbackFramework)
                 {

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/PatternTable.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/PatternTable.cs
@@ -1,11 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
 
@@ -33,7 +32,7 @@ namespace NuGet.ContentModel
 
             foreach (var entry in entries)
             {
-                Dictionary<ReadOnlyMemory<char>, object> byProp;
+                Dictionary<ReadOnlyMemory<char>, object>? byProp;
                 if (!_table.TryGetValue(entry.PropertyName, out byProp))
                 {
                     byProp = new Dictionary<ReadOnlyMemory<char>, object>(ReadOnlyMemoryCharComparerOrdinal.Instance);
@@ -50,7 +49,7 @@ namespace NuGet.ContentModel
         /// <param name="propertyName">Property moniker</param>
         /// <param name="name">Token name</param>
         /// <param name="value">Replacement value</param>
-        internal bool TryLookup(string propertyName, ReadOnlyMemory<char> name, out object value)
+        internal bool TryLookup(string propertyName, ReadOnlyMemory<char> name, [NotNullWhen(true)] out object? value)
         {
             if (propertyName == null)
             {
@@ -58,10 +57,10 @@ namespace NuGet.ContentModel
             }
             Debug.Assert(MemoryMarshal.TryGetString(name, out _, out _, out _));
 
-            Dictionary<ReadOnlyMemory<char>, object> byProp;
+            Dictionary<ReadOnlyMemory<char>, object>? byProp;
             if (_table.TryGetValue(propertyName, out byProp))
             {
-                return byProp.TryGetValue(name, out value);
+                return byProp.TryGetValue(name, out value!);
             }
 
             value = null;

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/PatternTableEntry.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/PatternTableEntry.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.ContentModel

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/SelectionCriteria.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/SelectionCriteria.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Collections.Generic;
 
 namespace NuGet.ContentModel

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/SelectionCriteriaBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/SelectionCriteriaBuilder.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 
@@ -42,25 +40,25 @@ namespace NuGet.ContentModel
             Entry = entry;
         }
 
-        public SelectionCriteriaEntryBuilder this[string key, string value]
+        public SelectionCriteriaEntryBuilder this[string key, string? value]
         {
             get
             {
-                ContentPropertyDefinition propertyDefinition;
+                ContentPropertyDefinition? propertyDefinition;
                 if (!Builder.Properties.TryGetValue(key, out propertyDefinition))
                 {
                     throw new Exception("Undefined property used for criteria");
                 }
                 if (value == null)
                 {
-                    Entry.Properties[key] = null;
+                    Entry.Properties[key] = null!;
                 }
                 else
                 {
-                    object valueLookup;
+                    object? valueLookup;
                     if (propertyDefinition.TryLookup(value.AsMemory(), table: null, matchOnly: false, value: out valueLookup))
                     {
-                        Entry.Properties[key] = valueLookup;
+                        Entry.Properties[key] = valueLookup!;
                     }
                     else
                     {
@@ -75,7 +73,7 @@ namespace NuGet.ContentModel
         {
             get
             {
-                ContentPropertyDefinition propertyDefinition;
+                ContentPropertyDefinition? propertyDefinition;
                 if (!Builder.Properties.TryGetValue(key, out propertyDefinition))
                 {
                     throw new Exception("Undefined property used for criteria");

--- a/src/NuGet.Core/NuGet.Packaging/FallbackPackagePathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/FallbackPackagePathResolver.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -23,7 +21,7 @@ namespace NuGet.Packaging
         /// </summary>
         /// <param name="pathContext">NuGet paths loaded from NuGet.Config settings.</param>
         public FallbackPackagePathResolver(INuGetPathContext pathContext)
-            : this(pathContext?.UserPackageFolder, pathContext?.FallbackPackageFolders)
+            : this(pathContext.UserPackageFolder, pathContext.FallbackPackageFolders)
         {
 
         }
@@ -77,7 +75,7 @@ namespace NuGet.Packaging
         /// <param name="packageId">Package id.</param>
         /// <param name="version">Package version.</param>
         /// <returns>Returns the path if the package exists in any of the folders. Null if the package does not exist.</returns>
-        public string GetPackageDirectory(string packageId, string version)
+        public string? GetPackageDirectory(string packageId, string version)
         {
             return GetPackageDirectory(packageId, NuGetVersion.Parse(version));
         }
@@ -88,7 +86,7 @@ namespace NuGet.Packaging
         /// <param name="packageId">Package id.</param>
         /// <param name="version">Package version.</param>
         /// <returns>Returns the path if the package exists in any of the folders. Null if the package does not exist.</returns>
-        public string GetPackageDirectory(string packageId, NuGetVersion version)
+        public string? GetPackageDirectory(string packageId, NuGetVersion version)
         {
             // Find the package
             var info = GetPackageInfo(packageId, version);
@@ -103,7 +101,7 @@ namespace NuGet.Packaging
         /// <param name="packageId">Package id.</param>
         /// <param name="version">Package version.</param>
         /// <returns>Returns the package info if the package exists in any of the folders. Null if the package does not exist.</returns>
-        public FallbackPackagePathInfo GetPackageInfo(string packageId, NuGetVersion version)
+        public FallbackPackagePathInfo? GetPackageInfo(string packageId, NuGetVersion version)
         {
             if (string.IsNullOrEmpty(packageId))
             {

--- a/src/NuGet.Core/NuGet.Packaging/MinClientVersionUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/MinClientVersionUtility.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using NuGet.Common;
@@ -16,7 +14,7 @@ namespace NuGet.Packaging
     /// </summary>
     public static class MinClientVersionUtility
     {
-        private static NuGetVersion _clientVersion;
+        private static NuGetVersion? _clientVersion;
 
         /// <summary>
         /// Check the package minClientVersion and throw if it is greater than the current client version.
@@ -37,7 +35,7 @@ namespace NuGet.Packaging
                 throw new MinClientVersionException(
                     string.Format(CultureInfo.CurrentCulture, Strings.PackageMinVersionNotSatisfied,
                         packageIdentity.Id + " " + packageIdentity.Version.ToNormalizedString(),
-                        packageMinClientVersion.ToNormalizedString(), clientVersion.ToNormalizedString()));
+                        packageMinClientVersion!.ToNormalizedString(), clientVersion.ToNormalizedString()));
             }
         }
 
@@ -83,7 +81,7 @@ namespace NuGet.Packaging
             {
                 var versionString = ClientVersionUtility.GetNuGetAssemblyVersion();
 
-                NuGetVersion clientVersion;
+                NuGetVersion? clientVersion;
                 if (!NuGetVersion.TryParse(versionString, out clientVersion))
                 {
                     throw new InvalidOperationException(Strings.UnableToParseClientVersion);

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/LicenseMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/LicenseMetadata.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -35,19 +33,19 @@ namespace NuGet.Packaging
         /// <summary>
         /// The license expression, could be null if the version is higher than the current supported or if the expression is not parseable.
         /// </summary>
-        public NuGetLicenseExpression LicenseExpression { get; }
+        public NuGetLicenseExpression? LicenseExpression { get; }
 
         /// <summary>
         /// Non-null when the expression parsing yielded some issues. This will be used to display the errors/warnings in the UI. Only populated when the metadata element is returned by the nuspec reader;
         /// </summary>
-        public IReadOnlyList<string> WarningsAndErrors { get; }
+        public IReadOnlyList<string>? WarningsAndErrors { get; }
 
         /// <summary>
         /// LicenseMetadata (expression) version. Never null.
         /// </summary>
         public Version Version { get; }
 
-        public LicenseMetadata(LicenseType type, string license, NuGetLicenseExpression expression, IReadOnlyList<string> warningsAndErrors, Version version)
+        public LicenseMetadata(LicenseType type, string license, NuGetLicenseExpression? expression, IReadOnlyList<string>? warningsAndErrors, Version version)
         {
             Type = type;
             License = license ?? throw new ArgumentNullException(nameof(license));
@@ -56,7 +54,7 @@ namespace NuGet.Packaging
             Version = version ?? throw new ArgumentNullException(nameof(version));
         }
 
-        public bool Equals(LicenseMetadata other)
+        public bool Equals(LicenseMetadata? other)
         {
             if (ReferenceEquals(this, other))
             {
@@ -75,7 +73,7 @@ namespace NuGet.Packaging
                    Version == other.Version;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as LicenseMetadata);
         }
@@ -93,7 +91,7 @@ namespace NuGet.Packaging
             return combiner.CombinedHash;
         }
 
-        public Uri LicenseUrl
+        public Uri? LicenseUrl
         {
             get
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageExtractionContext.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageExtractionContext.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
@@ -17,7 +15,7 @@ namespace NuGet.Packaging
 
         public XmlDocFileSaveMode XmlDocFileSaveMode { get; set; }
 
-        public ClientPolicyContext ClientPolicyContext { get; }
+        public ClientPolicyContext? ClientPolicyContext { get; }
 
         public bool CopySatelliteFiles { get; set; } = true;
 
@@ -25,12 +23,12 @@ namespace NuGet.Packaging
         /// This property should only be used to override the default verifier on tests.
         /// It is public only so that NuGet.Commands.RestoreRequest can pass this property through
         /// </remarks>
-        public IPackageSignatureVerifier SignedPackageVerifier { get; set; }
+        public IPackageSignatureVerifier? SignedPackageVerifier { get; set; }
 
         public PackageExtractionContext(
             PackageSaveMode packageSaveMode,
             XmlDocFileSaveMode xmlDocFileSaveMode,
-            ClientPolicyContext clientPolicyContext,
+            ClientPolicyContext? clientPolicyContext,
             ILogger logger)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackagePathHelper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackagePathHelper.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -94,7 +92,7 @@ namespace NuGet.Packaging
         {
             var packageId = packageIdentity.Id;
             var name = Path.GetFileNameWithoutExtension(path);
-            NuGetVersion parsedVersion;
+            NuGetVersion? parsedVersion;
 
             // When matching by pattern, we will always have a version token. Packages without versions would be matched early on by the version-less path resolver 
             // when doing an exact match.
@@ -160,7 +158,7 @@ namespace NuGet.Packaging
             return filesMatchingFullName;
         }
 
-        public static string GetInstalledPackageFilePath(PackageIdentity packageIdentity, PackagePathResolver packagePathResolver)
+        public static string? GetInstalledPackageFilePath(PackageIdentity packageIdentity, PackagePathResolver packagePathResolver)
         {
             var packageLookupPaths = GetPackageLookupPaths(packageIdentity, packagePathResolver);
             // TODO: Not handling nuspec-only scenarios

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.IO.MemoryMappedFiles;
@@ -81,7 +79,7 @@ namespace NuGet.Packaging
                 }
 
                 var directory = Path.GetDirectoryName(fileFullPath);
-                if (!Directory.Exists(directory))
+                if (directory != null && !Directory.Exists(directory))
                 {
                     Directory.CreateDirectory(directory);
                 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -47,7 +45,7 @@ namespace NuGet.Packaging
                 return Uri.UnescapeDataString(path);
             }
 
-            return path;
+            return path!;
         }
 
         public static Stream OpenFile(this ZipArchive zipArchive, string path)
@@ -85,7 +83,7 @@ namespace NuGet.Packaging
             internal Testable(IEnvironmentVariableReader environmentVariableReader)
             {
                 _updateFileTimeFromEntryMaxRetries = 9;
-                string value = environmentVariableReader.GetEnvironmentVariable("NUGET_UPDATEFILETIME_MAXRETRIES");
+                string? value = environmentVariableReader.GetEnvironmentVariable("NUGET_UPDATEFILETIME_MAXRETRIES");
                 if (int.TryParse(value, out int maxRetries) && maxRetries > 0)
                 {
                     _updateFileTimeFromEntryMaxRetries = maxRetries;

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -38,7 +36,7 @@ namespace NuGet.Packaging
             {
                 var satelliteFilesInGroup = libItemGroup.Items
                     .Where(item =>
-                        Path.GetDirectoryName(item)
+                        Path.GetDirectoryName(item)!
                             .Split(Path.DirectorySeparatorChar)
                             .Contains(packageLanguage, StringComparer.OrdinalIgnoreCase));
 

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,33 +1,33 @@
 #nullable enable
 NuGet.Client.ManagedCodeConventions
-~NuGet.Client.ManagedCodeConventions.Criteria.get -> NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria
-~NuGet.Client.ManagedCodeConventions.ManagedCodeConventions(NuGet.RuntimeModel.RuntimeGraph runtimeGraph) -> void
+NuGet.Client.ManagedCodeConventions.Criteria.get -> NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria!
+NuGet.Client.ManagedCodeConventions.ManagedCodeConventions(NuGet.RuntimeModel.RuntimeGraph? runtimeGraph) -> void
 NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria
-~NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForFramework(NuGet.Frameworks.NuGetFramework framework) -> NuGet.ContentModel.SelectionCriteria
-~NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForFrameworkAndRuntime(NuGet.Frameworks.NuGetFramework framework, string runtimeIdentifier) -> NuGet.ContentModel.SelectionCriteria
-~NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForRuntime(string runtimeIdentifier) -> NuGet.ContentModel.SelectionCriteria
+NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForFramework(NuGet.Frameworks.NuGetFramework! framework) -> NuGet.ContentModel.SelectionCriteria!
+NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForFrameworkAndRuntime(NuGet.Frameworks.NuGetFramework! framework, string? runtimeIdentifier) -> NuGet.ContentModel.SelectionCriteria!
+NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForRuntime(string! runtimeIdentifier) -> NuGet.ContentModel.SelectionCriteria!
 NuGet.Client.ManagedCodeConventions.ManagedCodePatterns
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.AnyTargettedFile.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.CompileLibAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.CompileRefAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ContentFiles.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.EmbedAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildFiles.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildMultiTargetingFiles.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildTransitiveFiles.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.NativeLibraries.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ResourceAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.RuntimeAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ToolsAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.Patterns.get -> NuGet.Client.ManagedCodeConventions.ManagedCodePatterns
-~NuGet.Client.ManagedCodeConventions.Properties.get -> System.Collections.Generic.IReadOnlyDictionary<string, NuGet.ContentModel.ContentPropertyDefinition>
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.AnyTargettedFile.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.CompileLibAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.CompileRefAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ContentFiles.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.EmbedAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildFiles.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildMultiTargetingFiles.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildTransitiveFiles.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.NativeLibraries.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ResourceAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.RuntimeAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ToolsAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.Patterns.get -> NuGet.Client.ManagedCodeConventions.ManagedCodePatterns!
+NuGet.Client.ManagedCodeConventions.Properties.get -> System.Collections.Generic.IReadOnlyDictionary<string!, NuGet.ContentModel.ContentPropertyDefinition!>!
 NuGet.Client.ManagedCodeConventions.PropertyNames
 NuGet.ContentModel.Asset
 NuGet.ContentModel.Asset.Asset() -> void
-~NuGet.ContentModel.Asset.Link.get -> string
-~NuGet.ContentModel.Asset.Link.set -> void
-~NuGet.ContentModel.Asset.Path.get -> string
-~NuGet.ContentModel.Asset.Path.set -> void
+NuGet.ContentModel.Asset.Link.get -> string?
+NuGet.ContentModel.Asset.Link.set -> void
+NuGet.ContentModel.Asset.Path.get -> string!
+NuGet.ContentModel.Asset.Path.set -> void
 NuGet.ContentModel.ContentItem
 NuGet.ContentModel.ContentItem.ContentItem() -> void
 NuGet.ContentModel.ContentItem.Path.get -> string!
@@ -45,13 +45,13 @@ NuGet.ContentModel.ContentItemGroup.ContentItemGroup() -> void
 NuGet.ContentModel.ContentItemGroup.Items.get -> System.Collections.Generic.IList<NuGet.ContentModel.ContentItem!>!
 NuGet.ContentModel.ContentItemGroup.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 NuGet.ContentModel.ContentPropertyDefinition
-~NuGet.ContentModel.ContentPropertyDefinition.CompareTest.get -> System.Func<object, object, object, int>
-~NuGet.ContentModel.ContentPropertyDefinition.CompatibilityTest.get -> System.Func<object, object, bool>
+NuGet.ContentModel.ContentPropertyDefinition.CompareTest.get -> System.Func<object?, object?, object?, int>?
+NuGet.ContentModel.ContentPropertyDefinition.CompatibilityTest.get -> System.Func<object?, object?, bool>!
 NuGet.ContentModel.ContentPropertyDefinition.FileExtensionAllowSubFolders.get -> bool
-~NuGet.ContentModel.ContentPropertyDefinition.FileExtensions.get -> System.Collections.Generic.List<string>
-~NuGet.ContentModel.ContentPropertyDefinition.Name.get -> string
+NuGet.ContentModel.ContentPropertyDefinition.FileExtensions.get -> System.Collections.Generic.List<string!>?
+NuGet.ContentModel.ContentPropertyDefinition.Name.get -> string!
 NuGet.ContentModel.Infrastructure.PatternExpression
-~NuGet.ContentModel.Infrastructure.PatternExpression.PatternExpression(NuGet.ContentModel.PatternDefinition pattern) -> void
+NuGet.ContentModel.Infrastructure.PatternExpression.PatternExpression(NuGet.ContentModel.PatternDefinition! pattern) -> void
 NuGet.ContentModel.PatternDefinition
 NuGet.ContentModel.PatternDefinition.Defaults.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>!
 NuGet.ContentModel.PatternDefinition.Pattern.get -> string!
@@ -67,28 +67,28 @@ NuGet.ContentModel.PatternSet.PropertyDefinitions.get -> System.Collections.Gene
 NuGet.ContentModel.PatternSet.PropertyDefinitions.set -> void
 NuGet.ContentModel.PatternTable
 NuGet.ContentModel.PatternTable.PatternTable() -> void
-~NuGet.ContentModel.PatternTable.PatternTable(System.Collections.Generic.IEnumerable<NuGet.ContentModel.PatternTableEntry> entries) -> void
+NuGet.ContentModel.PatternTable.PatternTable(System.Collections.Generic.IEnumerable<NuGet.ContentModel.PatternTableEntry!>! entries) -> void
 NuGet.ContentModel.PatternTableEntry
-~NuGet.ContentModel.PatternTableEntry.Name.get -> string
-~NuGet.ContentModel.PatternTableEntry.PatternTableEntry(string propertyName, string name, object value) -> void
-~NuGet.ContentModel.PatternTableEntry.PropertyName.get -> string
-~NuGet.ContentModel.PatternTableEntry.Value.get -> object
+NuGet.ContentModel.PatternTableEntry.Name.get -> string!
+NuGet.ContentModel.PatternTableEntry.PatternTableEntry(string! propertyName, string! name, object! value) -> void
+NuGet.ContentModel.PatternTableEntry.PropertyName.get -> string!
+NuGet.ContentModel.PatternTableEntry.Value.get -> object!
 NuGet.ContentModel.SelectionCriteria
-~NuGet.ContentModel.SelectionCriteria.Entries.get -> System.Collections.Generic.IList<NuGet.ContentModel.SelectionCriteriaEntry>
-~NuGet.ContentModel.SelectionCriteria.Entries.set -> void
+NuGet.ContentModel.SelectionCriteria.Entries.get -> System.Collections.Generic.IList<NuGet.ContentModel.SelectionCriteriaEntry!>!
+NuGet.ContentModel.SelectionCriteria.Entries.set -> void
 NuGet.ContentModel.SelectionCriteria.SelectionCriteria() -> void
 NuGet.ContentModel.SelectionCriteriaBuilder
-~NuGet.ContentModel.SelectionCriteriaBuilder.Properties.get -> System.Collections.Generic.IReadOnlyDictionary<string, NuGet.ContentModel.ContentPropertyDefinition>
-~NuGet.ContentModel.SelectionCriteriaBuilder.SelectionCriteriaBuilder(System.Collections.Generic.IReadOnlyDictionary<string, NuGet.ContentModel.ContentPropertyDefinition> properties) -> void
+NuGet.ContentModel.SelectionCriteriaBuilder.Properties.get -> System.Collections.Generic.IReadOnlyDictionary<string!, NuGet.ContentModel.ContentPropertyDefinition!>!
+NuGet.ContentModel.SelectionCriteriaBuilder.SelectionCriteriaBuilder(System.Collections.Generic.IReadOnlyDictionary<string!, NuGet.ContentModel.ContentPropertyDefinition!>! properties) -> void
 NuGet.ContentModel.SelectionCriteriaEntry
-~NuGet.ContentModel.SelectionCriteriaEntry.Properties.get -> System.Collections.Generic.IDictionary<string, object>
-~NuGet.ContentModel.SelectionCriteriaEntry.Properties.set -> void
+NuGet.ContentModel.SelectionCriteriaEntry.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
+NuGet.ContentModel.SelectionCriteriaEntry.Properties.set -> void
 NuGet.ContentModel.SelectionCriteriaEntry.SelectionCriteriaEntry() -> void
 NuGet.ContentModel.SelectionCriteriaEntryBuilder
-~NuGet.ContentModel.SelectionCriteriaEntryBuilder.Builder.get -> NuGet.ContentModel.SelectionCriteriaBuilder
-~NuGet.ContentModel.SelectionCriteriaEntryBuilder.Entry.get -> NuGet.ContentModel.SelectionCriteriaEntry
-~NuGet.ContentModel.SelectionCriteriaEntryBuilder.this[string key, object value].get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder
-~NuGet.ContentModel.SelectionCriteriaEntryBuilder.this[string key, string value].get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder
+NuGet.ContentModel.SelectionCriteriaEntryBuilder.Builder.get -> NuGet.ContentModel.SelectionCriteriaBuilder!
+NuGet.ContentModel.SelectionCriteriaEntryBuilder.Entry.get -> NuGet.ContentModel.SelectionCriteriaEntry!
+NuGet.ContentModel.SelectionCriteriaEntryBuilder.this[string! key, object! value].get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder!
+NuGet.ContentModel.SelectionCriteriaEntryBuilder.this[string! key, string? value].get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder!
 NuGet.Packaging.CollectionExtensions
 NuGet.Packaging.Core.ContentFilesEntry
 NuGet.Packaging.Core.ContentFilesEntry.BuildAction.get -> string?
@@ -1387,10 +1387,10 @@ const NuGet.Packaging.PackageSigningTelemetryEvent.EventName = "SigningInformati
 ~const NuGet.Packaging.Signing.Oids.TSTInfoContentType = "1.2.840.113549.1.9.16.1.4" -> string
 ~const NuGet.Packaging.Signing.Oids.TimeStampingEku = "1.3.6.1.5.5.7.3.8" -> string
 ~const NuGet.Packaging.Signing.Rfc3161TimestampTokenInfo.TimestampTokenInfoId = "1.2.840.113549.1.9.16.1.4" -> string
-~override NuGet.ContentModel.Asset.ToString() -> string
+override NuGet.ContentModel.Asset.ToString() -> string?
 override NuGet.ContentModel.ContentItem.ToString() -> string!
-~override NuGet.ContentModel.SelectionCriteriaEntryBuilder.Add.get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder
-~override NuGet.ContentModel.SelectionCriteriaEntryBuilder.Criteria.get -> NuGet.ContentModel.SelectionCriteria
+override NuGet.ContentModel.SelectionCriteriaEntryBuilder.Add.get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder!
+override NuGet.ContentModel.SelectionCriteriaEntryBuilder.Criteria.get -> NuGet.ContentModel.SelectionCriteria!
 override NuGet.Packaging.Core.PackageDependency.Equals(object? obj) -> bool
 override NuGet.Packaging.Core.PackageDependency.GetHashCode() -> int
 override NuGet.Packaging.Core.PackageDependency.ToString() -> string!
@@ -1746,14 +1746,14 @@ static NuGet.Packaging.Signing.VerificationUtility.IsVerificationTarget(NuGet.Pa
 ~static NuGet.RuntimeModel.JsonRuntimeFormat.WriteRuntimeGraph(string filePath, NuGet.RuntimeModel.RuntimeGraph runtimeGraph) -> void
 static NuGet.RuntimeModel.RuntimeDescription.Merge(NuGet.RuntimeModel.RuntimeDescription! left, NuGet.RuntimeModel.RuntimeDescription! right) -> NuGet.RuntimeModel.RuntimeDescription!
 static NuGet.RuntimeModel.RuntimeGraph.Merge(NuGet.RuntimeModel.RuntimeGraph! left, NuGet.RuntimeModel.RuntimeGraph! right) -> NuGet.RuntimeModel.RuntimeGraph!
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.AnyValue -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.CodeLanguage -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.Locale -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.MSBuild -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.ManagedAssembly -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.RuntimeIdentifier -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.SatelliteAssembly -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker -> string
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.AnyValue -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.CodeLanguage -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.Locale -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.MSBuild -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.ManagedAssembly -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.RuntimeIdentifier -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.SatelliteAssembly -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker -> string!
 static readonly NuGet.Packaging.Core.NuspecUtility.FrameworkReference -> string!
 static readonly NuGet.Packaging.Core.NuspecUtility.FrameworkReferences -> string!
 static readonly NuGet.Packaging.Core.NuspecUtility.Group -> string!
@@ -1826,10 +1826,10 @@ static readonly NuGet.Packaging.PackagingConstants.TargetFrameworkPropertyKey ->
 ~static readonly NuGet.Packaging.Signing.SigningSpecifications.V1 -> NuGet.Packaging.Signing.SigningSpecificationsV1
 static readonly NuGet.RuntimeModel.RuntimeGraph.Empty -> NuGet.RuntimeModel.RuntimeGraph!
 static readonly NuGet.RuntimeModel.RuntimeGraph.RuntimeGraphFileName -> string!
-~virtual NuGet.ContentModel.ContentPropertyDefinition.Compare(object criteriaValue, object candidateValue1, object candidateValue2) -> int
-~virtual NuGet.ContentModel.ContentPropertyDefinition.IsCriteriaSatisfied(object critieriaValue, object candidateValue) -> bool
-~virtual NuGet.ContentModel.SelectionCriteriaBuilder.Add.get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder
-~virtual NuGet.ContentModel.SelectionCriteriaBuilder.Criteria.get -> NuGet.ContentModel.SelectionCriteria
+virtual NuGet.ContentModel.ContentPropertyDefinition.Compare(object? criteriaValue, object? candidateValue1, object? candidateValue2) -> int
+virtual NuGet.ContentModel.ContentPropertyDefinition.IsCriteriaSatisfied(object? critieriaValue, object? candidateValue) -> bool
+virtual NuGet.ContentModel.SelectionCriteriaBuilder.Add.get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder!
+virtual NuGet.ContentModel.SelectionCriteriaBuilder.Criteria.get -> NuGet.ContentModel.SelectionCriteria!
 ~virtual NuGet.Packaging.Core.NuspecCoreReader.GetDependencies() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.PackageDependency>
 virtual NuGet.Packaging.Core.NuspecCoreReaderBase.GetDevelopmentDependency() -> bool
 ~virtual NuGet.Packaging.Core.NuspecCoreReaderBase.GetId() -> string

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -222,11 +222,11 @@ NuGet.Packaging.FallbackPackagePathInfo.Id.get -> string!
 NuGet.Packaging.FallbackPackagePathInfo.PathResolver.get -> NuGet.Packaging.VersionFolderPathResolver!
 NuGet.Packaging.FallbackPackagePathInfo.Version.get -> NuGet.Versioning.NuGetVersion!
 NuGet.Packaging.FallbackPackagePathResolver
-~NuGet.Packaging.FallbackPackagePathResolver.FallbackPackagePathResolver(NuGet.Common.INuGetPathContext pathContext) -> void
-~NuGet.Packaging.FallbackPackagePathResolver.FallbackPackagePathResolver(string userPackageFolder, System.Collections.Generic.IEnumerable<string> fallbackPackageFolders) -> void
-~NuGet.Packaging.FallbackPackagePathResolver.GetPackageDirectory(string packageId, NuGet.Versioning.NuGetVersion version) -> string
-~NuGet.Packaging.FallbackPackagePathResolver.GetPackageDirectory(string packageId, string version) -> string
-~NuGet.Packaging.FallbackPackagePathResolver.GetPackageInfo(string packageId, NuGet.Versioning.NuGetVersion version) -> NuGet.Packaging.FallbackPackagePathInfo
+NuGet.Packaging.FallbackPackagePathResolver.FallbackPackagePathResolver(NuGet.Common.INuGetPathContext! pathContext) -> void
+NuGet.Packaging.FallbackPackagePathResolver.FallbackPackagePathResolver(string! userPackageFolder, System.Collections.Generic.IEnumerable<string!>! fallbackPackageFolders) -> void
+NuGet.Packaging.FallbackPackagePathResolver.GetPackageDirectory(string! packageId, NuGet.Versioning.NuGetVersion! version) -> string?
+NuGet.Packaging.FallbackPackagePathResolver.GetPackageDirectory(string! packageId, string! version) -> string?
+NuGet.Packaging.FallbackPackagePathResolver.GetPackageInfo(string! packageId, NuGet.Versioning.NuGetVersion! version) -> NuGet.Packaging.FallbackPackagePathInfo?
 NuGet.Packaging.FrameworkAssemblyReference
 ~NuGet.Packaging.FrameworkAssemblyReference.AssemblyName.get -> string
 ~NuGet.Packaging.FrameworkAssemblyReference.FrameworkAssemblyReference(string assemblyName, System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> supportedFrameworks) -> void
@@ -327,14 +327,14 @@ NuGet.Packaging.IPackageResolver.Resolve(System.Collections.Generic.IEnumerable<
 NuGet.Packaging.InvalidPackageIdException
 NuGet.Packaging.InvalidPackageIdException.InvalidPackageIdException(string! message) -> void
 NuGet.Packaging.LicenseMetadata
-~NuGet.Packaging.LicenseMetadata.Equals(NuGet.Packaging.LicenseMetadata other) -> bool
-~NuGet.Packaging.LicenseMetadata.License.get -> string
-~NuGet.Packaging.LicenseMetadata.LicenseExpression.get -> NuGet.Packaging.Licenses.NuGetLicenseExpression
-~NuGet.Packaging.LicenseMetadata.LicenseMetadata(NuGet.Packaging.LicenseType type, string license, NuGet.Packaging.Licenses.NuGetLicenseExpression expression, System.Collections.Generic.IReadOnlyList<string> warningsAndErrors, System.Version version) -> void
-~NuGet.Packaging.LicenseMetadata.LicenseUrl.get -> System.Uri
+NuGet.Packaging.LicenseMetadata.Equals(NuGet.Packaging.LicenseMetadata? other) -> bool
+NuGet.Packaging.LicenseMetadata.License.get -> string!
+NuGet.Packaging.LicenseMetadata.LicenseExpression.get -> NuGet.Packaging.Licenses.NuGetLicenseExpression?
+NuGet.Packaging.LicenseMetadata.LicenseMetadata(NuGet.Packaging.LicenseType type, string! license, NuGet.Packaging.Licenses.NuGetLicenseExpression? expression, System.Collections.Generic.IReadOnlyList<string!>? warningsAndErrors, System.Version! version) -> void
+NuGet.Packaging.LicenseMetadata.LicenseUrl.get -> System.Uri?
 NuGet.Packaging.LicenseMetadata.Type.get -> NuGet.Packaging.LicenseType
-~NuGet.Packaging.LicenseMetadata.Version.get -> System.Version
-~NuGet.Packaging.LicenseMetadata.WarningsAndErrors.get -> System.Collections.Generic.IReadOnlyList<string>
+NuGet.Packaging.LicenseMetadata.Version.get -> System.Version!
+NuGet.Packaging.LicenseMetadata.WarningsAndErrors.get -> System.Collections.Generic.IReadOnlyList<string!>?
 NuGet.Packaging.LicenseType
 NuGet.Packaging.LicenseType.Expression = 1 -> NuGet.Packaging.LicenseType
 NuGet.Packaging.LicenseType.File = 0 -> NuGet.Packaging.LicenseType
@@ -623,15 +623,15 @@ NuGet.Packaging.PackageDependencyGroup.Packages.get -> System.Collections.Generi
 NuGet.Packaging.PackageDependencyGroup.TargetFramework.get -> NuGet.Frameworks.NuGetFramework!
 NuGet.Packaging.PackageExtraction.PackageExtractionBehavior
 NuGet.Packaging.PackageExtractionContext
-~NuGet.Packaging.PackageExtractionContext.ClientPolicyContext.get -> NuGet.Packaging.Signing.ClientPolicyContext
+NuGet.Packaging.PackageExtractionContext.ClientPolicyContext.get -> NuGet.Packaging.Signing.ClientPolicyContext?
 NuGet.Packaging.PackageExtractionContext.CopySatelliteFiles.get -> bool
 NuGet.Packaging.PackageExtractionContext.CopySatelliteFiles.set -> void
-~NuGet.Packaging.PackageExtractionContext.Logger.get -> NuGet.Common.ILogger
-~NuGet.Packaging.PackageExtractionContext.PackageExtractionContext(NuGet.Packaging.PackageSaveMode packageSaveMode, NuGet.Packaging.XmlDocFileSaveMode xmlDocFileSaveMode, NuGet.Packaging.Signing.ClientPolicyContext clientPolicyContext, NuGet.Common.ILogger logger) -> void
+NuGet.Packaging.PackageExtractionContext.Logger.get -> NuGet.Common.ILogger!
+NuGet.Packaging.PackageExtractionContext.PackageExtractionContext(NuGet.Packaging.PackageSaveMode packageSaveMode, NuGet.Packaging.XmlDocFileSaveMode xmlDocFileSaveMode, NuGet.Packaging.Signing.ClientPolicyContext? clientPolicyContext, NuGet.Common.ILogger! logger) -> void
 NuGet.Packaging.PackageExtractionContext.PackageSaveMode.get -> NuGet.Packaging.PackageSaveMode
 NuGet.Packaging.PackageExtractionContext.PackageSaveMode.set -> void
-~NuGet.Packaging.PackageExtractionContext.SignedPackageVerifier.get -> NuGet.Packaging.Signing.IPackageSignatureVerifier
-~NuGet.Packaging.PackageExtractionContext.SignedPackageVerifier.set -> void
+NuGet.Packaging.PackageExtractionContext.SignedPackageVerifier.get -> NuGet.Packaging.Signing.IPackageSignatureVerifier?
+NuGet.Packaging.PackageExtractionContext.SignedPackageVerifier.set -> void
 NuGet.Packaging.PackageExtractionContext.XmlDocFileSaveMode.get -> NuGet.Packaging.XmlDocFileSaveMode
 NuGet.Packaging.PackageExtractionContext.XmlDocFileSaveMode.set -> void
 NuGet.Packaging.PackageExtractionResult
@@ -1410,7 +1410,7 @@ override NuGet.Packaging.FrameworkReferenceGroup.Equals(object? obj) -> bool
 override NuGet.Packaging.FrameworkReferenceGroup.GetHashCode() -> int
 override NuGet.Packaging.FrameworkSpecificGroup.Equals(object? obj) -> bool
 override NuGet.Packaging.FrameworkSpecificGroup.GetHashCode() -> int
-~override NuGet.Packaging.LicenseMetadata.Equals(object obj) -> bool
+override NuGet.Packaging.LicenseMetadata.Equals(object? obj) -> bool
 override NuGet.Packaging.LicenseMetadata.GetHashCode() -> int
 override NuGet.Packaging.Licenses.LogicalOperator.ToString() -> string!
 override NuGet.Packaging.Licenses.NuGetLicense.ToString() -> string!
@@ -1543,10 +1543,10 @@ static NuGet.Packaging.Licenses.NuGetLicenseExpressionExtensions.OnEachLeafNode(
 ~static NuGet.Packaging.ManifestSchemaUtility.GetVersionFromNamespace(string namespace) -> int
 ~static NuGet.Packaging.ManifestSchemaUtility.IsKnownSchema(string schemaNamespace) -> bool
 ~static NuGet.Packaging.ManifestVersionUtility.GetManifestVersion(NuGet.Packaging.ManifestMetadata metadata) -> int
-~static NuGet.Packaging.MinClientVersionUtility.GetNuGetClientVersion() -> NuGet.Versioning.NuGetVersion
-~static NuGet.Packaging.MinClientVersionUtility.IsMinClientVersionCompatible(NuGet.Packaging.Core.NuspecCoreReaderBase nuspecReader) -> bool
-~static NuGet.Packaging.MinClientVersionUtility.IsMinClientVersionCompatible(NuGet.Versioning.NuGetVersion packageMinClientVersion) -> bool
-~static NuGet.Packaging.MinClientVersionUtility.VerifyMinClientVersion(NuGet.Packaging.Core.NuspecCoreReaderBase nuspecReader) -> void
+static NuGet.Packaging.MinClientVersionUtility.GetNuGetClientVersion() -> NuGet.Versioning.NuGetVersion!
+static NuGet.Packaging.MinClientVersionUtility.IsMinClientVersionCompatible(NuGet.Packaging.Core.NuspecCoreReaderBase! nuspecReader) -> bool
+static NuGet.Packaging.MinClientVersionUtility.IsMinClientVersionCompatible(NuGet.Versioning.NuGetVersion! packageMinClientVersion) -> bool
+static NuGet.Packaging.MinClientVersionUtility.VerifyMinClientVersion(NuGet.Packaging.Core.NuspecCoreReaderBase! nuspecReader) -> void
 ~static NuGet.Packaging.NupkgMetadataFileFormat.Read(System.IO.Stream stream, NuGet.Common.ILogger log, string path) -> NuGet.Packaging.NupkgMetadataFile
 ~static NuGet.Packaging.NupkgMetadataFileFormat.Read(string filePath) -> NuGet.Packaging.NupkgMetadataFile
 ~static NuGet.Packaging.NupkgMetadataFileFormat.Read(string filePath, NuGet.Common.ILogger log) -> NuGet.Packaging.NupkgMetadataFile
@@ -1571,15 +1571,15 @@ static NuGet.Packaging.PackageExtraction.PackageExtractionBehavior.XmlDocFileSav
 ~static NuGet.Packaging.PackageHelper.IsRoot(string path) -> bool
 ~static NuGet.Packaging.PackageIdValidator.IsValidPackageId(string packageId) -> bool
 ~static NuGet.Packaging.PackageIdValidator.ValidatePackageId(string packageId) -> void
-~static NuGet.Packaging.PackagePathHelper.GetInstalledPackageFilePath(NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Packaging.PackagePathResolver packagePathResolver) -> string
-~static NuGet.Packaging.PackagePathHelper.GetPackageLookupPaths(NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Packaging.PackagePathResolver packagePathResolver) -> System.Collections.Generic.IEnumerable<string>
+static NuGet.Packaging.PackagePathHelper.GetInstalledPackageFilePath(NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Packaging.PackagePathResolver! packagePathResolver) -> string?
+static NuGet.Packaging.PackagePathHelper.GetPackageLookupPaths(NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Packaging.PackagePathResolver! packagePathResolver) -> System.Collections.Generic.IEnumerable<string!>!
 ~static NuGet.Packaging.PackageReaderBase.GetNuspecFile(System.Collections.Generic.IEnumerable<string> files) -> string
 ~static NuGet.Packaging.PackageReaderBase.IsAllowedBuildFile(string packageId, string path) -> bool
 ~static NuGet.Packaging.PackageReaderBase.IsReferenceAssembly(string path) -> bool
 ~static NuGet.Packaging.PackageReaderBase.ValidatePackageEntries(string normalizedDestination, System.Collections.Generic.IEnumerable<string> packageFiles, NuGet.Packaging.Core.PackageIdentity packageIdentity) -> void
 ~static NuGet.Packaging.PackageReaderBase.ValidatePackageEntry(string normalizedDestination, string normalizedFilePath, NuGet.Packaging.Core.PackageIdentity packageIdentity) -> void
-~static NuGet.Packaging.PackageReaderExtensions.GetPackageFilesAsync(this NuGet.Packaging.Core.IAsyncPackageCoreReader packageReader, NuGet.Packaging.PackageSaveMode packageSaveMode, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
-~static NuGet.Packaging.PackageReaderExtensions.GetSatelliteFilesAsync(this NuGet.Packaging.IAsyncPackageContentReader packageReader, string packageLanguage, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
+static NuGet.Packaging.PackageReaderExtensions.GetPackageFilesAsync(this NuGet.Packaging.Core.IAsyncPackageCoreReader! packageReader, NuGet.Packaging.PackageSaveMode packageSaveMode, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
+static NuGet.Packaging.PackageReaderExtensions.GetSatelliteFilesAsync(this NuGet.Packaging.IAsyncPackageContentReader! packageReader, string! packageLanguage, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
 static NuGet.Packaging.PackagesConfig.BoolAttribute(System.Xml.Linq.XElement! node, string! name, bool defaultValue = false) -> bool
 static NuGet.Packaging.PackagesConfig.HasAttributeValue(System.Xml.Linq.XElement! node, string! attributeName, string! targetValue, out System.Xml.Linq.XElement? element) -> bool
 static NuGet.Packaging.PackagesConfig.TryGetAttribute(System.Xml.Linq.XElement! node, string! name, out string? value) -> bool
@@ -1727,23 +1727,23 @@ static NuGet.Packaging.Signing.PrimarySignature.ThrowForInvalidPrimarySignature(
 static NuGet.Packaging.Signing.VerificationUtility.GetSignatureVerificationStatus(NuGet.Packaging.Signing.SignatureVerificationStatusFlags flags) -> NuGet.Packaging.Signing.SignatureVerificationStatus
 static NuGet.Packaging.Signing.VerificationUtility.IsVerificationTarget(NuGet.Packaging.Signing.SignatureType signatureType, NuGet.Packaging.Signing.VerificationTarget target) -> bool
 ~static NuGet.Packaging.Signing.X509TrustStore.InitializeForDotNetSdk(NuGet.Common.ILogger logger) -> void
-~static NuGet.Packaging.StreamExtensions.CopyToFile(this System.IO.Stream inputStream, string fileFullPath) -> string
-~static NuGet.Packaging.TopologicalSortUtility.SortPackagesByDependencyOrder(System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.PackageDependencyInfo> packages) -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageDependencyInfo>
-~static NuGet.Packaging.TopologicalSortUtility.SortPackagesByDependencyOrder<T>(System.Collections.Generic.IEnumerable<T> items, System.StringComparer comparer, System.Func<T, string> getId, System.Func<T, string[]> getDependencies) -> System.Collections.Generic.IReadOnlyList<T>
+static NuGet.Packaging.StreamExtensions.CopyToFile(this System.IO.Stream! inputStream, string! fileFullPath) -> string!
+static NuGet.Packaging.TopologicalSortUtility.SortPackagesByDependencyOrder(System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.PackageDependencyInfo!>! packages) -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageDependencyInfo!>!
+static NuGet.Packaging.TopologicalSortUtility.SortPackagesByDependencyOrder<T>(System.Collections.Generic.IEnumerable<T!>! items, System.StringComparer! comparer, System.Func<T!, string!>! getId, System.Func<T!, string![]!>! getDependencies) -> System.Collections.Generic.IReadOnlyList<T!>!
 ~static NuGet.Packaging.XElementExtensions.ElementsNoNamespace(this System.Xml.Linq.XContainer container, string localName) -> System.Collections.Generic.IEnumerable<System.Xml.Linq.XElement>
 ~static NuGet.Packaging.XElementExtensions.Except(this System.Xml.Linq.XElement source, System.Xml.Linq.XElement target) -> System.Xml.Linq.XElement
 ~static NuGet.Packaging.XElementExtensions.GetOptionalAttributeValue(this System.Xml.Linq.XElement element, string localName, string namespaceName = null) -> string
-~static NuGet.Packaging.ZipArchiveExtensions.GetFiles(this System.IO.Compression.ZipArchive zipArchive) -> System.Collections.Generic.IEnumerable<string>
-~static NuGet.Packaging.ZipArchiveExtensions.LookupEntry(this System.IO.Compression.ZipArchive zipArchive, string path) -> System.IO.Compression.ZipArchiveEntry
-~static NuGet.Packaging.ZipArchiveExtensions.OpenFile(this System.IO.Compression.ZipArchive zipArchive, string path) -> System.IO.Stream
-~static NuGet.Packaging.ZipArchiveExtensions.SaveAsFile(this System.IO.Compression.ZipArchiveEntry entry, string fileFullPath, NuGet.Common.ILogger logger) -> string
-~static NuGet.Packaging.ZipArchiveExtensions.UpdateFileTimeFromEntry(this System.IO.Compression.ZipArchiveEntry entry, string fileFullPath, NuGet.Common.ILogger logger) -> void
-~static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(Newtonsoft.Json.Linq.JToken json) -> NuGet.RuntimeModel.RuntimeGraph
-~static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(System.IO.Stream stream) -> NuGet.RuntimeModel.RuntimeGraph
-~static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(System.IO.TextReader textReader) -> NuGet.RuntimeModel.RuntimeGraph
-~static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(string filePath) -> NuGet.RuntimeModel.RuntimeGraph
-~static NuGet.RuntimeModel.JsonRuntimeFormat.WriteRuntimeGraph(NuGet.RuntimeModel.IObjectWriter writer, NuGet.RuntimeModel.RuntimeGraph runtimeGraph) -> void
-~static NuGet.RuntimeModel.JsonRuntimeFormat.WriteRuntimeGraph(string filePath, NuGet.RuntimeModel.RuntimeGraph runtimeGraph) -> void
+static NuGet.Packaging.ZipArchiveExtensions.GetFiles(this System.IO.Compression.ZipArchive! zipArchive) -> System.Collections.Generic.IEnumerable<string!>!
+static NuGet.Packaging.ZipArchiveExtensions.LookupEntry(this System.IO.Compression.ZipArchive! zipArchive, string! path) -> System.IO.Compression.ZipArchiveEntry!
+static NuGet.Packaging.ZipArchiveExtensions.OpenFile(this System.IO.Compression.ZipArchive! zipArchive, string! path) -> System.IO.Stream!
+static NuGet.Packaging.ZipArchiveExtensions.SaveAsFile(this System.IO.Compression.ZipArchiveEntry! entry, string! fileFullPath, NuGet.Common.ILogger! logger) -> string!
+static NuGet.Packaging.ZipArchiveExtensions.UpdateFileTimeFromEntry(this System.IO.Compression.ZipArchiveEntry! entry, string! fileFullPath, NuGet.Common.ILogger! logger) -> void
+static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(Newtonsoft.Json.Linq.JToken! json) -> NuGet.RuntimeModel.RuntimeGraph!
+static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(System.IO.Stream! stream) -> NuGet.RuntimeModel.RuntimeGraph!
+static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(System.IO.TextReader! textReader) -> NuGet.RuntimeModel.RuntimeGraph!
+static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(string! filePath) -> NuGet.RuntimeModel.RuntimeGraph!
+static NuGet.RuntimeModel.JsonRuntimeFormat.WriteRuntimeGraph(NuGet.RuntimeModel.IObjectWriter! writer, NuGet.RuntimeModel.RuntimeGraph! runtimeGraph) -> void
+static NuGet.RuntimeModel.JsonRuntimeFormat.WriteRuntimeGraph(string! filePath, NuGet.RuntimeModel.RuntimeGraph! runtimeGraph) -> void
 static NuGet.RuntimeModel.RuntimeDescription.Merge(NuGet.RuntimeModel.RuntimeDescription! left, NuGet.RuntimeModel.RuntimeDescription! right) -> NuGet.RuntimeModel.RuntimeDescription!
 static NuGet.RuntimeModel.RuntimeGraph.Merge(NuGet.RuntimeModel.RuntimeGraph! left, NuGet.RuntimeModel.RuntimeGraph! right) -> NuGet.RuntimeModel.RuntimeGraph!
 static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.AnyValue -> string!
@@ -1785,10 +1785,10 @@ static readonly NuGet.Packaging.Core.PackagingCoreConstants.NupkgExtension -> st
 static readonly NuGet.Packaging.Core.PackagingCoreConstants.NupkgMetadataFileExtension -> string!
 static readonly NuGet.Packaging.Core.PackagingCoreConstants.NuspecExtension -> string!
 static readonly NuGet.Packaging.Core.PackagingCoreConstants.PackageDownloadMarkerFileExtension -> string!
-~static readonly NuGet.Packaging.LicenseMetadata.CurrentVersion -> System.Version
-~static readonly NuGet.Packaging.LicenseMetadata.EmptyVersion -> System.Version
-~static readonly NuGet.Packaging.LicenseMetadata.LicenseFileDeprecationUrl -> System.Uri
-~static readonly NuGet.Packaging.LicenseMetadata.LicenseServiceLinkTemplate -> string
+static readonly NuGet.Packaging.LicenseMetadata.CurrentVersion -> System.Version!
+static readonly NuGet.Packaging.LicenseMetadata.EmptyVersion -> System.Version!
+static readonly NuGet.Packaging.LicenseMetadata.LicenseFileDeprecationUrl -> System.Uri!
+static readonly NuGet.Packaging.LicenseMetadata.LicenseServiceLinkTemplate -> string!
 static readonly NuGet.Packaging.Licenses.NuGetLicenseData.ExceptionList -> System.Collections.Generic.IReadOnlyDictionary<string!, NuGet.Packaging.Licenses.ExceptionData!>!
 static readonly NuGet.Packaging.Licenses.NuGetLicenseData.LicenseList -> System.Collections.Generic.IReadOnlyDictionary<string!, NuGet.Packaging.Licenses.LicenseData!>!
 static readonly NuGet.Packaging.NupkgMetadataFileFormat.Version -> int

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -222,11 +222,11 @@ NuGet.Packaging.FallbackPackagePathInfo.Id.get -> string!
 NuGet.Packaging.FallbackPackagePathInfo.PathResolver.get -> NuGet.Packaging.VersionFolderPathResolver!
 NuGet.Packaging.FallbackPackagePathInfo.Version.get -> NuGet.Versioning.NuGetVersion!
 NuGet.Packaging.FallbackPackagePathResolver
-~NuGet.Packaging.FallbackPackagePathResolver.FallbackPackagePathResolver(NuGet.Common.INuGetPathContext pathContext) -> void
-~NuGet.Packaging.FallbackPackagePathResolver.FallbackPackagePathResolver(string userPackageFolder, System.Collections.Generic.IEnumerable<string> fallbackPackageFolders) -> void
-~NuGet.Packaging.FallbackPackagePathResolver.GetPackageDirectory(string packageId, NuGet.Versioning.NuGetVersion version) -> string
-~NuGet.Packaging.FallbackPackagePathResolver.GetPackageDirectory(string packageId, string version) -> string
-~NuGet.Packaging.FallbackPackagePathResolver.GetPackageInfo(string packageId, NuGet.Versioning.NuGetVersion version) -> NuGet.Packaging.FallbackPackagePathInfo
+NuGet.Packaging.FallbackPackagePathResolver.FallbackPackagePathResolver(NuGet.Common.INuGetPathContext! pathContext) -> void
+NuGet.Packaging.FallbackPackagePathResolver.FallbackPackagePathResolver(string! userPackageFolder, System.Collections.Generic.IEnumerable<string!>! fallbackPackageFolders) -> void
+NuGet.Packaging.FallbackPackagePathResolver.GetPackageDirectory(string! packageId, NuGet.Versioning.NuGetVersion! version) -> string?
+NuGet.Packaging.FallbackPackagePathResolver.GetPackageDirectory(string! packageId, string! version) -> string?
+NuGet.Packaging.FallbackPackagePathResolver.GetPackageInfo(string! packageId, NuGet.Versioning.NuGetVersion! version) -> NuGet.Packaging.FallbackPackagePathInfo?
 NuGet.Packaging.FrameworkAssemblyReference
 ~NuGet.Packaging.FrameworkAssemblyReference.AssemblyName.get -> string
 ~NuGet.Packaging.FrameworkAssemblyReference.FrameworkAssemblyReference(string assemblyName, System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> supportedFrameworks) -> void
@@ -327,14 +327,14 @@ NuGet.Packaging.IPackageResolver.Resolve(System.Collections.Generic.IEnumerable<
 NuGet.Packaging.InvalidPackageIdException
 NuGet.Packaging.InvalidPackageIdException.InvalidPackageIdException(string! message) -> void
 NuGet.Packaging.LicenseMetadata
-~NuGet.Packaging.LicenseMetadata.Equals(NuGet.Packaging.LicenseMetadata other) -> bool
-~NuGet.Packaging.LicenseMetadata.License.get -> string
-~NuGet.Packaging.LicenseMetadata.LicenseExpression.get -> NuGet.Packaging.Licenses.NuGetLicenseExpression
-~NuGet.Packaging.LicenseMetadata.LicenseMetadata(NuGet.Packaging.LicenseType type, string license, NuGet.Packaging.Licenses.NuGetLicenseExpression expression, System.Collections.Generic.IReadOnlyList<string> warningsAndErrors, System.Version version) -> void
-~NuGet.Packaging.LicenseMetadata.LicenseUrl.get -> System.Uri
+NuGet.Packaging.LicenseMetadata.Equals(NuGet.Packaging.LicenseMetadata? other) -> bool
+NuGet.Packaging.LicenseMetadata.License.get -> string!
+NuGet.Packaging.LicenseMetadata.LicenseExpression.get -> NuGet.Packaging.Licenses.NuGetLicenseExpression?
+NuGet.Packaging.LicenseMetadata.LicenseMetadata(NuGet.Packaging.LicenseType type, string! license, NuGet.Packaging.Licenses.NuGetLicenseExpression? expression, System.Collections.Generic.IReadOnlyList<string!>? warningsAndErrors, System.Version! version) -> void
+NuGet.Packaging.LicenseMetadata.LicenseUrl.get -> System.Uri?
 NuGet.Packaging.LicenseMetadata.Type.get -> NuGet.Packaging.LicenseType
-~NuGet.Packaging.LicenseMetadata.Version.get -> System.Version
-~NuGet.Packaging.LicenseMetadata.WarningsAndErrors.get -> System.Collections.Generic.IReadOnlyList<string>
+NuGet.Packaging.LicenseMetadata.Version.get -> System.Version!
+NuGet.Packaging.LicenseMetadata.WarningsAndErrors.get -> System.Collections.Generic.IReadOnlyList<string!>?
 NuGet.Packaging.LicenseType
 NuGet.Packaging.LicenseType.Expression = 1 -> NuGet.Packaging.LicenseType
 NuGet.Packaging.LicenseType.File = 0 -> NuGet.Packaging.LicenseType
@@ -623,15 +623,15 @@ NuGet.Packaging.PackageDependencyGroup.Packages.get -> System.Collections.Generi
 NuGet.Packaging.PackageDependencyGroup.TargetFramework.get -> NuGet.Frameworks.NuGetFramework!
 NuGet.Packaging.PackageExtraction.PackageExtractionBehavior
 NuGet.Packaging.PackageExtractionContext
-~NuGet.Packaging.PackageExtractionContext.ClientPolicyContext.get -> NuGet.Packaging.Signing.ClientPolicyContext
+NuGet.Packaging.PackageExtractionContext.ClientPolicyContext.get -> NuGet.Packaging.Signing.ClientPolicyContext?
 NuGet.Packaging.PackageExtractionContext.CopySatelliteFiles.get -> bool
 NuGet.Packaging.PackageExtractionContext.CopySatelliteFiles.set -> void
-~NuGet.Packaging.PackageExtractionContext.Logger.get -> NuGet.Common.ILogger
-~NuGet.Packaging.PackageExtractionContext.PackageExtractionContext(NuGet.Packaging.PackageSaveMode packageSaveMode, NuGet.Packaging.XmlDocFileSaveMode xmlDocFileSaveMode, NuGet.Packaging.Signing.ClientPolicyContext clientPolicyContext, NuGet.Common.ILogger logger) -> void
+NuGet.Packaging.PackageExtractionContext.Logger.get -> NuGet.Common.ILogger!
+NuGet.Packaging.PackageExtractionContext.PackageExtractionContext(NuGet.Packaging.PackageSaveMode packageSaveMode, NuGet.Packaging.XmlDocFileSaveMode xmlDocFileSaveMode, NuGet.Packaging.Signing.ClientPolicyContext? clientPolicyContext, NuGet.Common.ILogger! logger) -> void
 NuGet.Packaging.PackageExtractionContext.PackageSaveMode.get -> NuGet.Packaging.PackageSaveMode
 NuGet.Packaging.PackageExtractionContext.PackageSaveMode.set -> void
-~NuGet.Packaging.PackageExtractionContext.SignedPackageVerifier.get -> NuGet.Packaging.Signing.IPackageSignatureVerifier
-~NuGet.Packaging.PackageExtractionContext.SignedPackageVerifier.set -> void
+NuGet.Packaging.PackageExtractionContext.SignedPackageVerifier.get -> NuGet.Packaging.Signing.IPackageSignatureVerifier?
+NuGet.Packaging.PackageExtractionContext.SignedPackageVerifier.set -> void
 NuGet.Packaging.PackageExtractionContext.XmlDocFileSaveMode.get -> NuGet.Packaging.XmlDocFileSaveMode
 NuGet.Packaging.PackageExtractionContext.XmlDocFileSaveMode.set -> void
 NuGet.Packaging.PackageExtractionResult
@@ -1396,7 +1396,7 @@ override NuGet.Packaging.FrameworkReferenceGroup.Equals(object? obj) -> bool
 override NuGet.Packaging.FrameworkReferenceGroup.GetHashCode() -> int
 override NuGet.Packaging.FrameworkSpecificGroup.Equals(object? obj) -> bool
 override NuGet.Packaging.FrameworkSpecificGroup.GetHashCode() -> int
-~override NuGet.Packaging.LicenseMetadata.Equals(object obj) -> bool
+override NuGet.Packaging.LicenseMetadata.Equals(object? obj) -> bool
 override NuGet.Packaging.LicenseMetadata.GetHashCode() -> int
 override NuGet.Packaging.Licenses.LogicalOperator.ToString() -> string!
 override NuGet.Packaging.Licenses.NuGetLicense.ToString() -> string!
@@ -1527,10 +1527,10 @@ static NuGet.Packaging.Licenses.NuGetLicenseExpressionExtensions.OnEachLeafNode(
 ~static NuGet.Packaging.ManifestSchemaUtility.GetVersionFromNamespace(string namespace) -> int
 ~static NuGet.Packaging.ManifestSchemaUtility.IsKnownSchema(string schemaNamespace) -> bool
 ~static NuGet.Packaging.ManifestVersionUtility.GetManifestVersion(NuGet.Packaging.ManifestMetadata metadata) -> int
-~static NuGet.Packaging.MinClientVersionUtility.GetNuGetClientVersion() -> NuGet.Versioning.NuGetVersion
-~static NuGet.Packaging.MinClientVersionUtility.IsMinClientVersionCompatible(NuGet.Packaging.Core.NuspecCoreReaderBase nuspecReader) -> bool
-~static NuGet.Packaging.MinClientVersionUtility.IsMinClientVersionCompatible(NuGet.Versioning.NuGetVersion packageMinClientVersion) -> bool
-~static NuGet.Packaging.MinClientVersionUtility.VerifyMinClientVersion(NuGet.Packaging.Core.NuspecCoreReaderBase nuspecReader) -> void
+static NuGet.Packaging.MinClientVersionUtility.GetNuGetClientVersion() -> NuGet.Versioning.NuGetVersion!
+static NuGet.Packaging.MinClientVersionUtility.IsMinClientVersionCompatible(NuGet.Packaging.Core.NuspecCoreReaderBase! nuspecReader) -> bool
+static NuGet.Packaging.MinClientVersionUtility.IsMinClientVersionCompatible(NuGet.Versioning.NuGetVersion! packageMinClientVersion) -> bool
+static NuGet.Packaging.MinClientVersionUtility.VerifyMinClientVersion(NuGet.Packaging.Core.NuspecCoreReaderBase! nuspecReader) -> void
 ~static NuGet.Packaging.NupkgMetadataFileFormat.Read(System.IO.Stream stream, NuGet.Common.ILogger log, string path) -> NuGet.Packaging.NupkgMetadataFile
 ~static NuGet.Packaging.NupkgMetadataFileFormat.Read(string filePath) -> NuGet.Packaging.NupkgMetadataFile
 ~static NuGet.Packaging.NupkgMetadataFileFormat.Read(string filePath, NuGet.Common.ILogger log) -> NuGet.Packaging.NupkgMetadataFile
@@ -1555,15 +1555,15 @@ static NuGet.Packaging.PackageExtraction.PackageExtractionBehavior.XmlDocFileSav
 ~static NuGet.Packaging.PackageHelper.IsRoot(string path) -> bool
 ~static NuGet.Packaging.PackageIdValidator.IsValidPackageId(string packageId) -> bool
 ~static NuGet.Packaging.PackageIdValidator.ValidatePackageId(string packageId) -> void
-~static NuGet.Packaging.PackagePathHelper.GetInstalledPackageFilePath(NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Packaging.PackagePathResolver packagePathResolver) -> string
-~static NuGet.Packaging.PackagePathHelper.GetPackageLookupPaths(NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Packaging.PackagePathResolver packagePathResolver) -> System.Collections.Generic.IEnumerable<string>
+static NuGet.Packaging.PackagePathHelper.GetInstalledPackageFilePath(NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Packaging.PackagePathResolver! packagePathResolver) -> string?
+static NuGet.Packaging.PackagePathHelper.GetPackageLookupPaths(NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Packaging.PackagePathResolver! packagePathResolver) -> System.Collections.Generic.IEnumerable<string!>!
 ~static NuGet.Packaging.PackageReaderBase.GetNuspecFile(System.Collections.Generic.IEnumerable<string> files) -> string
 ~static NuGet.Packaging.PackageReaderBase.IsAllowedBuildFile(string packageId, string path) -> bool
 ~static NuGet.Packaging.PackageReaderBase.IsReferenceAssembly(string path) -> bool
 ~static NuGet.Packaging.PackageReaderBase.ValidatePackageEntries(string normalizedDestination, System.Collections.Generic.IEnumerable<string> packageFiles, NuGet.Packaging.Core.PackageIdentity packageIdentity) -> void
 ~static NuGet.Packaging.PackageReaderBase.ValidatePackageEntry(string normalizedDestination, string normalizedFilePath, NuGet.Packaging.Core.PackageIdentity packageIdentity) -> void
-~static NuGet.Packaging.PackageReaderExtensions.GetPackageFilesAsync(this NuGet.Packaging.Core.IAsyncPackageCoreReader packageReader, NuGet.Packaging.PackageSaveMode packageSaveMode, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
-~static NuGet.Packaging.PackageReaderExtensions.GetSatelliteFilesAsync(this NuGet.Packaging.IAsyncPackageContentReader packageReader, string packageLanguage, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
+static NuGet.Packaging.PackageReaderExtensions.GetPackageFilesAsync(this NuGet.Packaging.Core.IAsyncPackageCoreReader! packageReader, NuGet.Packaging.PackageSaveMode packageSaveMode, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
+static NuGet.Packaging.PackageReaderExtensions.GetSatelliteFilesAsync(this NuGet.Packaging.IAsyncPackageContentReader! packageReader, string! packageLanguage, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
 static NuGet.Packaging.PackagesConfig.BoolAttribute(System.Xml.Linq.XElement! node, string! name, bool defaultValue = false) -> bool
 static NuGet.Packaging.PackagesConfig.HasAttributeValue(System.Xml.Linq.XElement! node, string! attributeName, string! targetValue, out System.Xml.Linq.XElement? element) -> bool
 static NuGet.Packaging.PackagesConfig.TryGetAttribute(System.Xml.Linq.XElement! node, string! name, out string? value) -> bool
@@ -1711,23 +1711,23 @@ static NuGet.Packaging.Signing.PrimarySignature.ThrowForInvalidPrimarySignature(
 static NuGet.Packaging.Signing.VerificationUtility.GetSignatureVerificationStatus(NuGet.Packaging.Signing.SignatureVerificationStatusFlags flags) -> NuGet.Packaging.Signing.SignatureVerificationStatus
 static NuGet.Packaging.Signing.VerificationUtility.IsVerificationTarget(NuGet.Packaging.Signing.SignatureType signatureType, NuGet.Packaging.Signing.VerificationTarget target) -> bool
 ~static NuGet.Packaging.Signing.X509TrustStore.InitializeForDotNetSdk(NuGet.Common.ILogger logger) -> void
-~static NuGet.Packaging.StreamExtensions.CopyToFile(this System.IO.Stream inputStream, string fileFullPath) -> string
-~static NuGet.Packaging.TopologicalSortUtility.SortPackagesByDependencyOrder(System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.PackageDependencyInfo> packages) -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageDependencyInfo>
-~static NuGet.Packaging.TopologicalSortUtility.SortPackagesByDependencyOrder<T>(System.Collections.Generic.IEnumerable<T> items, System.StringComparer comparer, System.Func<T, string> getId, System.Func<T, string[]> getDependencies) -> System.Collections.Generic.IReadOnlyList<T>
+static NuGet.Packaging.StreamExtensions.CopyToFile(this System.IO.Stream! inputStream, string! fileFullPath) -> string!
+static NuGet.Packaging.TopologicalSortUtility.SortPackagesByDependencyOrder(System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.PackageDependencyInfo!>! packages) -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageDependencyInfo!>!
+static NuGet.Packaging.TopologicalSortUtility.SortPackagesByDependencyOrder<T>(System.Collections.Generic.IEnumerable<T!>! items, System.StringComparer! comparer, System.Func<T!, string!>! getId, System.Func<T!, string![]!>! getDependencies) -> System.Collections.Generic.IReadOnlyList<T!>!
 ~static NuGet.Packaging.XElementExtensions.ElementsNoNamespace(this System.Xml.Linq.XContainer container, string localName) -> System.Collections.Generic.IEnumerable<System.Xml.Linq.XElement>
 ~static NuGet.Packaging.XElementExtensions.Except(this System.Xml.Linq.XElement source, System.Xml.Linq.XElement target) -> System.Xml.Linq.XElement
 ~static NuGet.Packaging.XElementExtensions.GetOptionalAttributeValue(this System.Xml.Linq.XElement element, string localName, string namespaceName = null) -> string
-~static NuGet.Packaging.ZipArchiveExtensions.GetFiles(this System.IO.Compression.ZipArchive zipArchive) -> System.Collections.Generic.IEnumerable<string>
-~static NuGet.Packaging.ZipArchiveExtensions.LookupEntry(this System.IO.Compression.ZipArchive zipArchive, string path) -> System.IO.Compression.ZipArchiveEntry
-~static NuGet.Packaging.ZipArchiveExtensions.OpenFile(this System.IO.Compression.ZipArchive zipArchive, string path) -> System.IO.Stream
-~static NuGet.Packaging.ZipArchiveExtensions.SaveAsFile(this System.IO.Compression.ZipArchiveEntry entry, string fileFullPath, NuGet.Common.ILogger logger) -> string
-~static NuGet.Packaging.ZipArchiveExtensions.UpdateFileTimeFromEntry(this System.IO.Compression.ZipArchiveEntry entry, string fileFullPath, NuGet.Common.ILogger logger) -> void
-~static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(Newtonsoft.Json.Linq.JToken json) -> NuGet.RuntimeModel.RuntimeGraph
-~static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(System.IO.Stream stream) -> NuGet.RuntimeModel.RuntimeGraph
-~static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(System.IO.TextReader textReader) -> NuGet.RuntimeModel.RuntimeGraph
-~static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(string filePath) -> NuGet.RuntimeModel.RuntimeGraph
-~static NuGet.RuntimeModel.JsonRuntimeFormat.WriteRuntimeGraph(NuGet.RuntimeModel.IObjectWriter writer, NuGet.RuntimeModel.RuntimeGraph runtimeGraph) -> void
-~static NuGet.RuntimeModel.JsonRuntimeFormat.WriteRuntimeGraph(string filePath, NuGet.RuntimeModel.RuntimeGraph runtimeGraph) -> void
+static NuGet.Packaging.ZipArchiveExtensions.GetFiles(this System.IO.Compression.ZipArchive! zipArchive) -> System.Collections.Generic.IEnumerable<string!>!
+static NuGet.Packaging.ZipArchiveExtensions.LookupEntry(this System.IO.Compression.ZipArchive! zipArchive, string! path) -> System.IO.Compression.ZipArchiveEntry!
+static NuGet.Packaging.ZipArchiveExtensions.OpenFile(this System.IO.Compression.ZipArchive! zipArchive, string! path) -> System.IO.Stream!
+static NuGet.Packaging.ZipArchiveExtensions.SaveAsFile(this System.IO.Compression.ZipArchiveEntry! entry, string! fileFullPath, NuGet.Common.ILogger! logger) -> string!
+static NuGet.Packaging.ZipArchiveExtensions.UpdateFileTimeFromEntry(this System.IO.Compression.ZipArchiveEntry! entry, string! fileFullPath, NuGet.Common.ILogger! logger) -> void
+static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(Newtonsoft.Json.Linq.JToken! json) -> NuGet.RuntimeModel.RuntimeGraph!
+static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(System.IO.Stream! stream) -> NuGet.RuntimeModel.RuntimeGraph!
+static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(System.IO.TextReader! textReader) -> NuGet.RuntimeModel.RuntimeGraph!
+static NuGet.RuntimeModel.JsonRuntimeFormat.ReadRuntimeGraph(string! filePath) -> NuGet.RuntimeModel.RuntimeGraph!
+static NuGet.RuntimeModel.JsonRuntimeFormat.WriteRuntimeGraph(NuGet.RuntimeModel.IObjectWriter! writer, NuGet.RuntimeModel.RuntimeGraph! runtimeGraph) -> void
+static NuGet.RuntimeModel.JsonRuntimeFormat.WriteRuntimeGraph(string! filePath, NuGet.RuntimeModel.RuntimeGraph! runtimeGraph) -> void
 static NuGet.RuntimeModel.RuntimeDescription.Merge(NuGet.RuntimeModel.RuntimeDescription! left, NuGet.RuntimeModel.RuntimeDescription! right) -> NuGet.RuntimeModel.RuntimeDescription!
 static NuGet.RuntimeModel.RuntimeGraph.Merge(NuGet.RuntimeModel.RuntimeGraph! left, NuGet.RuntimeModel.RuntimeGraph! right) -> NuGet.RuntimeModel.RuntimeGraph!
 static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.AnyValue -> string!
@@ -1769,10 +1769,10 @@ static readonly NuGet.Packaging.Core.PackagingCoreConstants.NupkgExtension -> st
 static readonly NuGet.Packaging.Core.PackagingCoreConstants.NupkgMetadataFileExtension -> string!
 static readonly NuGet.Packaging.Core.PackagingCoreConstants.NuspecExtension -> string!
 static readonly NuGet.Packaging.Core.PackagingCoreConstants.PackageDownloadMarkerFileExtension -> string!
-~static readonly NuGet.Packaging.LicenseMetadata.CurrentVersion -> System.Version
-~static readonly NuGet.Packaging.LicenseMetadata.EmptyVersion -> System.Version
-~static readonly NuGet.Packaging.LicenseMetadata.LicenseFileDeprecationUrl -> System.Uri
-~static readonly NuGet.Packaging.LicenseMetadata.LicenseServiceLinkTemplate -> string
+static readonly NuGet.Packaging.LicenseMetadata.CurrentVersion -> System.Version!
+static readonly NuGet.Packaging.LicenseMetadata.EmptyVersion -> System.Version!
+static readonly NuGet.Packaging.LicenseMetadata.LicenseFileDeprecationUrl -> System.Uri!
+static readonly NuGet.Packaging.LicenseMetadata.LicenseServiceLinkTemplate -> string!
 static readonly NuGet.Packaging.Licenses.NuGetLicenseData.ExceptionList -> System.Collections.Generic.IReadOnlyDictionary<string!, NuGet.Packaging.Licenses.ExceptionData!>!
 static readonly NuGet.Packaging.Licenses.NuGetLicenseData.LicenseList -> System.Collections.Generic.IReadOnlyDictionary<string!, NuGet.Packaging.Licenses.LicenseData!>!
 static readonly NuGet.Packaging.NupkgMetadataFileFormat.Version -> int

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,33 +1,33 @@
 #nullable enable
 NuGet.Client.ManagedCodeConventions
-~NuGet.Client.ManagedCodeConventions.Criteria.get -> NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria
-~NuGet.Client.ManagedCodeConventions.ManagedCodeConventions(NuGet.RuntimeModel.RuntimeGraph runtimeGraph) -> void
+NuGet.Client.ManagedCodeConventions.Criteria.get -> NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria!
+NuGet.Client.ManagedCodeConventions.ManagedCodeConventions(NuGet.RuntimeModel.RuntimeGraph? runtimeGraph) -> void
 NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria
-~NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForFramework(NuGet.Frameworks.NuGetFramework framework) -> NuGet.ContentModel.SelectionCriteria
-~NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForFrameworkAndRuntime(NuGet.Frameworks.NuGetFramework framework, string runtimeIdentifier) -> NuGet.ContentModel.SelectionCriteria
-~NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForRuntime(string runtimeIdentifier) -> NuGet.ContentModel.SelectionCriteria
+NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForFramework(NuGet.Frameworks.NuGetFramework! framework) -> NuGet.ContentModel.SelectionCriteria!
+NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForFrameworkAndRuntime(NuGet.Frameworks.NuGetFramework! framework, string? runtimeIdentifier) -> NuGet.ContentModel.SelectionCriteria!
+NuGet.Client.ManagedCodeConventions.ManagedCodeCriteria.ForRuntime(string! runtimeIdentifier) -> NuGet.ContentModel.SelectionCriteria!
 NuGet.Client.ManagedCodeConventions.ManagedCodePatterns
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.AnyTargettedFile.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.CompileLibAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.CompileRefAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ContentFiles.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.EmbedAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildFiles.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildMultiTargetingFiles.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildTransitiveFiles.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.NativeLibraries.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ResourceAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.RuntimeAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ToolsAssemblies.get -> NuGet.ContentModel.PatternSet
-~NuGet.Client.ManagedCodeConventions.Patterns.get -> NuGet.Client.ManagedCodeConventions.ManagedCodePatterns
-~NuGet.Client.ManagedCodeConventions.Properties.get -> System.Collections.Generic.IReadOnlyDictionary<string, NuGet.ContentModel.ContentPropertyDefinition>
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.AnyTargettedFile.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.CompileLibAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.CompileRefAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ContentFiles.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.EmbedAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildFiles.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildMultiTargetingFiles.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.MSBuildTransitiveFiles.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.NativeLibraries.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ResourceAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.RuntimeAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.ToolsAssemblies.get -> NuGet.ContentModel.PatternSet!
+NuGet.Client.ManagedCodeConventions.Patterns.get -> NuGet.Client.ManagedCodeConventions.ManagedCodePatterns!
+NuGet.Client.ManagedCodeConventions.Properties.get -> System.Collections.Generic.IReadOnlyDictionary<string!, NuGet.ContentModel.ContentPropertyDefinition!>!
 NuGet.Client.ManagedCodeConventions.PropertyNames
 NuGet.ContentModel.Asset
 NuGet.ContentModel.Asset.Asset() -> void
-~NuGet.ContentModel.Asset.Link.get -> string
-~NuGet.ContentModel.Asset.Link.set -> void
-~NuGet.ContentModel.Asset.Path.get -> string
-~NuGet.ContentModel.Asset.Path.set -> void
+NuGet.ContentModel.Asset.Link.get -> string?
+NuGet.ContentModel.Asset.Link.set -> void
+NuGet.ContentModel.Asset.Path.get -> string!
+NuGet.ContentModel.Asset.Path.set -> void
 NuGet.ContentModel.ContentItem
 NuGet.ContentModel.ContentItem.ContentItem() -> void
 NuGet.ContentModel.ContentItem.Path.get -> string!
@@ -45,13 +45,13 @@ NuGet.ContentModel.ContentItemGroup.ContentItemGroup() -> void
 NuGet.ContentModel.ContentItemGroup.Items.get -> System.Collections.Generic.IList<NuGet.ContentModel.ContentItem!>!
 NuGet.ContentModel.ContentItemGroup.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 NuGet.ContentModel.ContentPropertyDefinition
-~NuGet.ContentModel.ContentPropertyDefinition.CompareTest.get -> System.Func<object, object, object, int>
-~NuGet.ContentModel.ContentPropertyDefinition.CompatibilityTest.get -> System.Func<object, object, bool>
+NuGet.ContentModel.ContentPropertyDefinition.CompareTest.get -> System.Func<object?, object?, object?, int>?
+NuGet.ContentModel.ContentPropertyDefinition.CompatibilityTest.get -> System.Func<object?, object?, bool>!
 NuGet.ContentModel.ContentPropertyDefinition.FileExtensionAllowSubFolders.get -> bool
-~NuGet.ContentModel.ContentPropertyDefinition.FileExtensions.get -> System.Collections.Generic.List<string>
-~NuGet.ContentModel.ContentPropertyDefinition.Name.get -> string
+NuGet.ContentModel.ContentPropertyDefinition.FileExtensions.get -> System.Collections.Generic.List<string!>?
+NuGet.ContentModel.ContentPropertyDefinition.Name.get -> string!
 NuGet.ContentModel.Infrastructure.PatternExpression
-~NuGet.ContentModel.Infrastructure.PatternExpression.PatternExpression(NuGet.ContentModel.PatternDefinition pattern) -> void
+NuGet.ContentModel.Infrastructure.PatternExpression.PatternExpression(NuGet.ContentModel.PatternDefinition! pattern) -> void
 NuGet.ContentModel.PatternDefinition
 NuGet.ContentModel.PatternDefinition.Defaults.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>!
 NuGet.ContentModel.PatternDefinition.Pattern.get -> string!
@@ -67,28 +67,28 @@ NuGet.ContentModel.PatternSet.PropertyDefinitions.get -> System.Collections.Gene
 NuGet.ContentModel.PatternSet.PropertyDefinitions.set -> void
 NuGet.ContentModel.PatternTable
 NuGet.ContentModel.PatternTable.PatternTable() -> void
-~NuGet.ContentModel.PatternTable.PatternTable(System.Collections.Generic.IEnumerable<NuGet.ContentModel.PatternTableEntry> entries) -> void
+NuGet.ContentModel.PatternTable.PatternTable(System.Collections.Generic.IEnumerable<NuGet.ContentModel.PatternTableEntry!>! entries) -> void
 NuGet.ContentModel.PatternTableEntry
-~NuGet.ContentModel.PatternTableEntry.Name.get -> string
-~NuGet.ContentModel.PatternTableEntry.PatternTableEntry(string propertyName, string name, object value) -> void
-~NuGet.ContentModel.PatternTableEntry.PropertyName.get -> string
-~NuGet.ContentModel.PatternTableEntry.Value.get -> object
+NuGet.ContentModel.PatternTableEntry.Name.get -> string!
+NuGet.ContentModel.PatternTableEntry.PatternTableEntry(string! propertyName, string! name, object! value) -> void
+NuGet.ContentModel.PatternTableEntry.PropertyName.get -> string!
+NuGet.ContentModel.PatternTableEntry.Value.get -> object!
 NuGet.ContentModel.SelectionCriteria
-~NuGet.ContentModel.SelectionCriteria.Entries.get -> System.Collections.Generic.IList<NuGet.ContentModel.SelectionCriteriaEntry>
-~NuGet.ContentModel.SelectionCriteria.Entries.set -> void
+NuGet.ContentModel.SelectionCriteria.Entries.get -> System.Collections.Generic.IList<NuGet.ContentModel.SelectionCriteriaEntry!>!
+NuGet.ContentModel.SelectionCriteria.Entries.set -> void
 NuGet.ContentModel.SelectionCriteria.SelectionCriteria() -> void
 NuGet.ContentModel.SelectionCriteriaBuilder
-~NuGet.ContentModel.SelectionCriteriaBuilder.Properties.get -> System.Collections.Generic.IReadOnlyDictionary<string, NuGet.ContentModel.ContentPropertyDefinition>
-~NuGet.ContentModel.SelectionCriteriaBuilder.SelectionCriteriaBuilder(System.Collections.Generic.IReadOnlyDictionary<string, NuGet.ContentModel.ContentPropertyDefinition> properties) -> void
+NuGet.ContentModel.SelectionCriteriaBuilder.Properties.get -> System.Collections.Generic.IReadOnlyDictionary<string!, NuGet.ContentModel.ContentPropertyDefinition!>!
+NuGet.ContentModel.SelectionCriteriaBuilder.SelectionCriteriaBuilder(System.Collections.Generic.IReadOnlyDictionary<string!, NuGet.ContentModel.ContentPropertyDefinition!>! properties) -> void
 NuGet.ContentModel.SelectionCriteriaEntry
-~NuGet.ContentModel.SelectionCriteriaEntry.Properties.get -> System.Collections.Generic.IDictionary<string, object>
-~NuGet.ContentModel.SelectionCriteriaEntry.Properties.set -> void
+NuGet.ContentModel.SelectionCriteriaEntry.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
+NuGet.ContentModel.SelectionCriteriaEntry.Properties.set -> void
 NuGet.ContentModel.SelectionCriteriaEntry.SelectionCriteriaEntry() -> void
 NuGet.ContentModel.SelectionCriteriaEntryBuilder
-~NuGet.ContentModel.SelectionCriteriaEntryBuilder.Builder.get -> NuGet.ContentModel.SelectionCriteriaBuilder
-~NuGet.ContentModel.SelectionCriteriaEntryBuilder.Entry.get -> NuGet.ContentModel.SelectionCriteriaEntry
-~NuGet.ContentModel.SelectionCriteriaEntryBuilder.this[string key, object value].get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder
-~NuGet.ContentModel.SelectionCriteriaEntryBuilder.this[string key, string value].get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder
+NuGet.ContentModel.SelectionCriteriaEntryBuilder.Builder.get -> NuGet.ContentModel.SelectionCriteriaBuilder!
+NuGet.ContentModel.SelectionCriteriaEntryBuilder.Entry.get -> NuGet.ContentModel.SelectionCriteriaEntry!
+NuGet.ContentModel.SelectionCriteriaEntryBuilder.this[string! key, object! value].get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder!
+NuGet.ContentModel.SelectionCriteriaEntryBuilder.this[string! key, string? value].get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder!
 NuGet.Packaging.CollectionExtensions
 NuGet.Packaging.Core.ContentFilesEntry
 NuGet.Packaging.Core.ContentFilesEntry.BuildAction.get -> string?
@@ -1373,10 +1373,10 @@ const NuGet.Packaging.PackageSigningTelemetryEvent.EventName = "SigningInformati
 ~const NuGet.Packaging.Signing.Oids.SubjectKeyIdentifier = "2.5.29.14" -> string
 ~const NuGet.Packaging.Signing.Oids.TSTInfoContentType = "1.2.840.113549.1.9.16.1.4" -> string
 ~const NuGet.Packaging.Signing.Oids.TimeStampingEku = "1.3.6.1.5.5.7.3.8" -> string
-~override NuGet.ContentModel.Asset.ToString() -> string
+override NuGet.ContentModel.Asset.ToString() -> string?
 override NuGet.ContentModel.ContentItem.ToString() -> string!
-~override NuGet.ContentModel.SelectionCriteriaEntryBuilder.Add.get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder
-~override NuGet.ContentModel.SelectionCriteriaEntryBuilder.Criteria.get -> NuGet.ContentModel.SelectionCriteria
+override NuGet.ContentModel.SelectionCriteriaEntryBuilder.Add.get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder!
+override NuGet.ContentModel.SelectionCriteriaEntryBuilder.Criteria.get -> NuGet.ContentModel.SelectionCriteria!
 override NuGet.Packaging.Core.PackageDependency.Equals(object? obj) -> bool
 override NuGet.Packaging.Core.PackageDependency.GetHashCode() -> int
 override NuGet.Packaging.Core.PackageDependency.ToString() -> string!
@@ -1730,14 +1730,14 @@ static NuGet.Packaging.Signing.VerificationUtility.IsVerificationTarget(NuGet.Pa
 ~static NuGet.RuntimeModel.JsonRuntimeFormat.WriteRuntimeGraph(string filePath, NuGet.RuntimeModel.RuntimeGraph runtimeGraph) -> void
 static NuGet.RuntimeModel.RuntimeDescription.Merge(NuGet.RuntimeModel.RuntimeDescription! left, NuGet.RuntimeModel.RuntimeDescription! right) -> NuGet.RuntimeModel.RuntimeDescription!
 static NuGet.RuntimeModel.RuntimeGraph.Merge(NuGet.RuntimeModel.RuntimeGraph! left, NuGet.RuntimeModel.RuntimeGraph! right) -> NuGet.RuntimeModel.RuntimeGraph!
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.AnyValue -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.CodeLanguage -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.Locale -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.MSBuild -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.ManagedAssembly -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.RuntimeIdentifier -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.SatelliteAssembly -> string
-~static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker -> string
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.AnyValue -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.CodeLanguage -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.Locale -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.MSBuild -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.ManagedAssembly -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.RuntimeIdentifier -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.SatelliteAssembly -> string!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker -> string!
 static readonly NuGet.Packaging.Core.NuspecUtility.FrameworkReference -> string!
 static readonly NuGet.Packaging.Core.NuspecUtility.FrameworkReferences -> string!
 static readonly NuGet.Packaging.Core.NuspecUtility.Group -> string!
@@ -1810,10 +1810,10 @@ static readonly NuGet.Packaging.PackagingConstants.TargetFrameworkPropertyKey ->
 ~static readonly NuGet.Packaging.Signing.SigningSpecifications.V1 -> NuGet.Packaging.Signing.SigningSpecificationsV1
 static readonly NuGet.RuntimeModel.RuntimeGraph.Empty -> NuGet.RuntimeModel.RuntimeGraph!
 static readonly NuGet.RuntimeModel.RuntimeGraph.RuntimeGraphFileName -> string!
-~virtual NuGet.ContentModel.ContentPropertyDefinition.Compare(object criteriaValue, object candidateValue1, object candidateValue2) -> int
-~virtual NuGet.ContentModel.ContentPropertyDefinition.IsCriteriaSatisfied(object critieriaValue, object candidateValue) -> bool
-~virtual NuGet.ContentModel.SelectionCriteriaBuilder.Add.get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder
-~virtual NuGet.ContentModel.SelectionCriteriaBuilder.Criteria.get -> NuGet.ContentModel.SelectionCriteria
+virtual NuGet.ContentModel.ContentPropertyDefinition.Compare(object? criteriaValue, object? candidateValue1, object? candidateValue2) -> int
+virtual NuGet.ContentModel.ContentPropertyDefinition.IsCriteriaSatisfied(object? critieriaValue, object? candidateValue) -> bool
+virtual NuGet.ContentModel.SelectionCriteriaBuilder.Add.get -> NuGet.ContentModel.SelectionCriteriaEntryBuilder!
+virtual NuGet.ContentModel.SelectionCriteriaBuilder.Criteria.get -> NuGet.ContentModel.SelectionCriteria!
 ~virtual NuGet.Packaging.Core.NuspecCoreReader.GetDependencies() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.PackageDependency>
 virtual NuGet.Packaging.Core.NuspecCoreReaderBase.GetDevelopmentDependency() -> bool
 ~virtual NuGet.Packaging.Core.NuspecCoreReaderBase.GetId() -> string

--- a/src/NuGet.Core/NuGet.Packaging/RuntimeModel/JsonRuntimeFormat.cs
+++ b/src/NuGet.Core/NuGet.Packaging/RuntimeModel/JsonRuntimeFormat.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -199,17 +197,17 @@ namespace NuGet.RuntimeModel
         private static RuntimeDescription ReadRuntimeDescription(KeyValuePair<string, JToken> json)
         {
             var name = json.Key;
-            List<string> inheritedRuntimes = null;
-            List<RuntimeDependencySet> additionalDependencies = null;
+            List<string>? inheritedRuntimes = null;
+            List<RuntimeDependencySet>? additionalDependencies = null;
             foreach (var property in EachProperty(json.Value))
             {
                 if (property.Key == "#import")
                 {
-                    var imports = property.Value as JArray;
+                    var imports = (JArray)property.Value;
                     foreach (var import in imports)
                     {
                         inheritedRuntimes ??= new List<string>(imports.Count);
-                        inheritedRuntimes.Add(import.Value<string>());
+                        inheritedRuntimes.Add(import.Value<string>()!);
                     }
                 }
                 else
@@ -231,10 +229,10 @@ namespace NuGet.RuntimeModel
 
         private static RuntimePackageDependency ReadRuntimePackageDependency(KeyValuePair<string, JToken> json)
         {
-            return new RuntimePackageDependency(json.Key, VersionRange.Parse(json.Value.Value<string>()));
+            return new RuntimePackageDependency(json.Key, VersionRange.Parse(json.Value.Value<string>()!));
         }
 
-        private static IEnumerable<KeyValuePair<string, JToken>> EachProperty(JToken json)
+        private static IEnumerable<KeyValuePair<string, JToken>> EachProperty(JToken? json)
         {
             return (json as IEnumerable<KeyValuePair<string, JToken>>)
                    ?? Enumerable.Empty<KeyValuePair<string, JToken>>();

--- a/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -197,10 +195,10 @@ namespace NuGet.Packaging
                 _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
             }
 
-            public int Compare(ItemDependencyInfo x, ItemDependencyInfo y)
+            public int Compare(ItemDependencyInfo? x, ItemDependencyInfo? y)
             {
                 // Order packages by parent count
-                if (x.ActiveParents < y.ActiveParents)
+                if (x!.ActiveParents < y!.ActiveParents)
                 {
                     return -1;
                 }
@@ -227,8 +225,8 @@ namespace NuGet.Packaging
             public string[] DependencyIds;
 
             public int ActiveParents;
-            public List<ItemDependencyInfo> Parents;
-            public List<ItemDependencyInfo> Children;
+            public List<ItemDependencyInfo>? Parents;
+            public List<ItemDependencyInfo>? Children;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ContentModelTests/PatternTableTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ContentModelTests/PatternTableTests.cs
@@ -18,7 +18,7 @@ namespace NuGet.Packaging.Test.ContentModelTests
             var table = new PatternTable();
 
             // Act
-            object obj;
+            object? obj;
             var b = table.TryLookup("tfm", "any".AsMemory(), out obj);
 
             // Assert
@@ -39,7 +39,7 @@ namespace NuGet.Packaging.Test.ContentModelTests
             var table = new PatternTable(data);
 
             // Act
-            object obj;
+            object? obj;
             var b = table.TryLookup("tfm", "any".AsMemory(), out obj);
 
             // Assert
@@ -59,7 +59,7 @@ namespace NuGet.Packaging.Test.ContentModelTests
             var table = new PatternTable(data);
 
             // Act
-            object obj;
+            object? obj;
             var b = table.TryLookup("tfm", "any".AsMemory(), out obj);
 
             // Assert

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/RelatedFileExtensionPropertyTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/RelatedFileExtensionPropertyTests.cs
@@ -77,8 +77,10 @@ namespace NuGet.Packaging.Test
             List<Asset> assets = new List<Asset>();
             foreach (string path in paths)
             {
-                Asset asset = new Asset();
-                asset.Path = path;
+                Asset asset = new Asset
+                {
+                    Path = path
+                };
                 assets.Add(asset);
             }
             return assets;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -227,7 +227,7 @@ namespace NuGet.Protocol.Tests
                     Assert.Equal(LicenseMetadata.EmptyVersion, result.LicenseMetadata.Version);
                 }
 
-                Assert.Equal(errorCount, result.LicenseMetadata.WarningsAndErrors.Count);
+                Assert.Equal(errorCount, result.LicenseMetadata.WarningsAndErrors!.Count);
                 Assert.Contains(errorMessage, result.LicenseMetadata.WarningsAndErrors[0]);
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

Progress: https://github.com/NuGet/Home/issues/14778

## Description

Continuation of https://github.com/NuGet/NuGet.Client/pull/7178. 

The gist here is the NuspecReader, PackageArchiveReader and coming soon and those are a bit more complex so just pushing a PR with the relatively simpler types.

- Annotate LicenseMetadata. Simple enough type and well documented. Advantage of a post project.json prototype types :D 
- Annotated src/NuGet.Core/NuGet.Packaging/ContentModel - This is the brunt work here. Note that I added a required keyword to the Asset type and that's not an ABI breaking change since required is enforced at compile time. I don't see any usage of these types otherwise. 
- Annotated some src/NuGet.Core/NuGet.Packaging/PackageExtraction APIs. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
