### PR TITLE
Add --allow-untrusted-root flag to nuget sign and dotnet nuget sign

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
@@ -60,8 +60,8 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "SignCommandOverwriteDescription")]
         public bool Overwrite { get; set; }
 
-        [Option(typeof(NuGetCommand), "SignCommandAllowUntrustedSigningDescription")]
-        public bool AllowUntrustedSigning { get; set; }
+        [Option(typeof(NuGetCommand), "SignCommandAllowUntrustedRootDescription")]
+        public bool AllowUntrustedRoot { get; set; }
 
         public override async Task ExecuteCommandAsync()
         {
@@ -105,7 +105,7 @@ namespace NuGet.CommandLine
                 SignatureHashAlgorithm = hashAlgorithm,
                 Logger = Console,
                 Overwrite = Overwrite,
-                AllowUntrustedRoot = AllowUntrustedSigning,
+                AllowUntrustedRoot = AllowUntrustedRoot,
                 NonInteractive = NonInteractive,
                 Timestamper = Timestamper,
                 TimestampHashAlgorithm = timestampHashAlgorithm,

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SignCommand.cs
@@ -60,6 +60,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "SignCommandOverwriteDescription")]
         public bool Overwrite { get; set; }
 
+        [Option(typeof(NuGetCommand), "SignCommandAllowUntrustedSigningDescription")]
+        public bool AllowUntrustedSigning { get; set; }
+
         public override async Task ExecuteCommandAsync()
         {
             var signArgs = GetSignArgs();
@@ -102,6 +105,7 @@ namespace NuGet.CommandLine
                 SignatureHashAlgorithm = hashAlgorithm,
                 Logger = Console,
                 Overwrite = Overwrite,
+                AllowUntrustedRoot = AllowUntrustedSigning,
                 NonInteractive = NonInteractive,
                 Timestamper = Timestamper,
                 TimestampHashAlgorithm = timestampHashAlgorithm,

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -1701,9 +1701,9 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to Allow signing with certificates whose root certificate is not in a trusted root store...
         /// </summary>
-        internal static string SignCommandAllowUntrustedSigningDescription {
+        internal static string SignCommandAllowUntrustedRootDescription {
             get {
-                return ResourceManager.GetString("SignCommandAllowUntrustedSigningDescription", resourceCulture);
+                return ResourceManager.GetString("SignCommandAllowUntrustedRootDescription", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -1699,6 +1699,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow signing with certificates whose root certificate is not in a trusted root store...
+        /// </summary>
+        internal static string SignCommandAllowUntrustedSigningDescription {
+            get {
+                return ResourceManager.GetString("SignCommandAllowUntrustedSigningDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Signs a NuGet package..
         /// </summary>
         internal static string SignCommandSummary {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -698,7 +698,7 @@ nuget sign MyPackage.nupkg -CertificateFingerprint certificate_fingerprint -Outp
   <data name="SignCommandOverwriteDescription" xml:space="preserve">
     <value>Switch to indicate if the current signature should be overwritten. By default the command will fail if the package already has a signature.</value>
   </data>
-  <data name="SignCommandAllowUntrustedSigningDescription" xml:space="preserve">
+  <data name="SignCommandAllowUntrustedRootDescription" xml:space="preserve">
     <value>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</value>
   </data>
   <data name="SignCommandHashAlgorithmDescription" xml:space="preserve">

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -698,6 +698,9 @@ nuget sign MyPackage.nupkg -CertificateFingerprint certificate_fingerprint -Outp
   <data name="SignCommandOverwriteDescription" xml:space="preserve">
     <value>Switch to indicate if the current signature should be overwritten. By default the command will fail if the package already has a signature.</value>
   </data>
+  <data name="SignCommandAllowUntrustedSigningDescription" xml:space="preserve">
+    <value>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</value>
+  </data>
   <data name="SignCommandHashAlgorithmDescription" xml:space="preserve">
     <value>Hash algorithm to be used to sign the package. Defaults to SHA256.</value>
   </data>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.cs.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.cs.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [možnosti]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.cs.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.cs.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [možnosti]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.de.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.de.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.de.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.de.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.es.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.es.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.es.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.es.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.fr.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.fr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.fr.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.fr.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.it.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.it.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [opzioni]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.it.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.it.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [opzioni]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ja.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ja.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [オプション]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ja.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ja.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [オプション]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ko.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ko.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9feedb3a -Source http://example.
         <target state="translated">&lt;API 키&gt; [옵션]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ko.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ko.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9feedb3a -Source http://example.
         <target state="translated">&lt;API 키&gt; [옵션]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.pl.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [opcje]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.pl.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.pl.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [opcje]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.pt-BR.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.pt-BR.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ru.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ru.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.ru.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.tr.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.tr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.tr.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.tr.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.zh-Hans.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API 密钥&gt; [选项]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.zh-Hans.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API 密钥&gt; [选项]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.zh-Hant.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../NuGetCommand.resx">
     <body>
@@ -909,7 +909,7 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.CommandLine/xlf/NuGetCommand.zh-Hant.xlf
@@ -909,6 +909,11 @@ nuget setapikey 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -Source http://example.com/
         <target state="translated">&lt;API key&gt; [options]</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate.
 The certificate store can be specified by -CertificateStoreName and -CertificateStoreLocation options.</source>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
@@ -86,6 +86,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.SignCommandOverwriteDescription,
                     CommandOptionType.NoValue);
 
+                CommandOption allowUntrustedSigning = signCmd.Option(
+                    "--allow-untrusted-signing",
+                    Strings.SignCommandAllowUntrustedSigningDescription,
+                    CommandOptionType.NoValue);
+
                 CommandOption verbosity = signCmd.Option(
                     "-v|--verbosity",
                     Strings.Verbosity_Description,
@@ -123,6 +128,7 @@ namespace NuGet.CommandLine.XPlat
                         SignatureHashAlgorithm = hashAlgorithm,
                         Logger = logger,
                         Overwrite = overwrite.HasValue(),
+                        AllowUntrustedRoot = allowUntrustedSigning.HasValue(),
                         //The interactive option is not enabled at first, so the NonInteractive is always set to true. This is tracked by https://github.com/NuGet/Home/issues/10620
                         NonInteractive = true,
                         Timestamper = timestamper.Value(),

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
@@ -86,9 +86,9 @@ namespace NuGet.CommandLine.XPlat
                     Strings.SignCommandOverwriteDescription,
                     CommandOptionType.NoValue);
 
-                CommandOption allowUntrustedSigning = signCmd.Option(
-                    "--allow-untrusted-signing",
-                    Strings.SignCommandAllowUntrustedSigningDescription,
+                CommandOption allowUntrustedRoot = signCmd.Option(
+                    "--allow-untrusted-root",
+                    Strings.SignCommandAllowUntrustedRootDescription,
                     CommandOptionType.NoValue);
 
                 CommandOption verbosity = signCmd.Option(
@@ -128,7 +128,7 @@ namespace NuGet.CommandLine.XPlat
                         SignatureHashAlgorithm = hashAlgorithm,
                         Logger = logger,
                         Overwrite = overwrite.HasValue(),
-                        AllowUntrustedRoot = allowUntrustedSigning.HasValue(),
+                        AllowUntrustedRoot = allowUntrustedRoot.HasValue(),
                         //The interactive option is not enabled at first, so the NonInteractive is always set to true. This is tracked by https://github.com/NuGet/Home/issues/10620
                         NonInteractive = true,
                         Timestamper = timestamper.Value(),

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -2235,9 +2235,9 @@ namespace NuGet.CommandLine.XPlat {
         /// <summary>
         ///   Looks up a localized string similar to Allow signing with certificates whose root certificate is not in a trusted root store...
         /// </summary>
-        internal static string SignCommandAllowUntrustedSigningDescription {
+        internal static string SignCommandAllowUntrustedRootDescription {
             get {
-                return ResourceManager.GetString("SignCommandAllowUntrustedSigningDescription", resourceCulture);
+                return ResourceManager.GetString("SignCommandAllowUntrustedRootDescription", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -2233,6 +2233,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow signing with certificates whose root certificate is not in a trusted root store...
+        /// </summary>
+        internal static string SignCommandAllowUntrustedSigningDescription {
+            get {
+                return ResourceManager.GetString("SignCommandAllowUntrustedSigningDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Signs NuGet packages at &lt;package-paths&gt; with the specified certificate..
         /// </summary>
         internal static string SignCommandPackagePathDescription {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -661,7 +661,7 @@ The search is a case-insensitive string comparison using the supplied value, whi
   <data name="SignCommandOverwriteDescription" xml:space="preserve">
     <value>Switch to indicate if the current signature should be overwritten. By default the command will fail if the package already has a signature.</value>
   </data>
-  <data name="SignCommandAllowUntrustedSigningDescription" xml:space="preserve">
+  <data name="SignCommandAllowUntrustedRootDescription" xml:space="preserve">
     <value>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</value>
   </data>
   <data name="SignCommandPackagePathDescription" xml:space="preserve">

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -661,6 +661,9 @@ The search is a case-insensitive string comparison using the supplied value, whi
   <data name="SignCommandOverwriteDescription" xml:space="preserve">
     <value>Switch to indicate if the current signature should be overwritten. By default the command will fail if the package already has a signature.</value>
   </data>
+  <data name="SignCommandAllowUntrustedSigningDescription" xml:space="preserve">
+    <value>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</value>
+  </data>
   <data name="SignCommandPackagePathDescription" xml:space="preserve">
     <value>Signs NuGet packages at &lt;package-paths&gt; with the specified certificate.</value>
     <comment>Please don't localize '&lt;package-paths&gt;'</comment>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
@@ -1134,6 +1134,11 @@ Další informace najdete tady: https://docs.nuget.org/docs/reference/command-li
         <target state="translated">Odebere zdroj NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">Otisk SHA-256, SHA-384 nebo SHA-512 certifikátu použitý k hledání místního úložiště certifikátů tohoto certifikátu Úložiště certifikátů lze zadat pomocí parametrů --certificate-store-name a --certificate-store-location.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ Další informace najdete tady: https://docs.nuget.org/docs/reference/command-li
         <target state="translated">Odebere zdroj NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
@@ -1134,6 +1134,11 @@ Weitere Informationen finden Sie unter: https://docs.nuget.org/docs/reference/co
         <target state="translated">Hiermit entfernen Sie eine NuGet-Quelle.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">SHA-256-, SHA-384- oder SHA-512-Fingerabdruck des Zertifikats, das zum Durchsuchen eines lokalen Zertifikatspeichers nach dem Zertifikat verwendet wird. Der Zertifikatspeicher kann mit den Optionen --certificate-store-name und --certificate-store-location angegeben werden.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ Weitere Informationen finden Sie unter: https://docs.nuget.org/docs/reference/co
         <target state="translated">Hiermit entfernen Sie eine NuGet-Quelle.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ Para obtener más información, visite https://docs.nuget.org/docs/reference/com
         <target state="translated">Quite un origen de NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
@@ -1134,6 +1134,11 @@ Para obtener más información, visite https://docs.nuget.org/docs/reference/com
         <target state="translated">Quite un origen de NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">Huella digital SHA-256, SHA-384 o SHA-512 del certificado usado para buscar un almacén de certificados local para el certificado. El almacén de certificados se puede especificar por las opciones --certificate-store-name y --certificate-store-location.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ Pour plus d'informations, visitez https://docs.nuget.org/docs/reference/command-
         <target state="translated">Supprimez une source NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
@@ -1134,6 +1134,11 @@ Pour plus d'informations, visitez https://docs.nuget.org/docs/reference/command-
         <target state="translated">Supprimez une source NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">Empreinte SHA-256, SHA-384 ou SHA-512 du certificat utilisé pour rechercher le certificat dans un magasin de certificats local. Vous pouvez spécifier le magasin de certificats à l’aide des options --certificat-magasin-nom et--certificat-magasin-emplacement.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
@@ -1134,6 +1134,11 @@ Per altre informazioni, vedere https://docs.nuget.org/docs/reference/command-lin
         <target state="translated">Rimuove un'origine NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">Impronta digitale SHA-256, SHA-384 o SHA-512 del certificato usata per effettuare ricerche in un archivio certificati locale. L'archivio certificati può essere specificato nelle opzioni --certificate-store-name e --certificate-store-location.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ Per altre informazioni, vedere https://docs.nuget.org/docs/reference/command-lin
         <target state="translated">Rimuove un'origine NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
@@ -1134,6 +1134,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">NuGet ソースを削除します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">証明書のローカル証明書ストアの検索に使用される証明書の SHA-256、SHA-384、または SHA-512 フィンガープリントです。証明書ストアは、--certificate-store-name と --certificate-store-location のオプションによって指定できます。</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">NuGet ソースを削除します。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
@@ -1134,6 +1134,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">NuGet 소스를 제거합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">인증서에 대한 로컬 인증서 저장소를 검색하는 데 사용되는 인증서의 SHA-256, SHA-384 또는 SHA-512 지문입니다. 인증서 저장소는 --certificate-store-name 및 --certificate-store-location 옵션으로 지정할 수 있습니다.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">NuGet 소스를 제거합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ Aby uzyskać więcej informacji, odwiedź stronę https://docs.nuget.org/docs/re
         <target state="translated">Usuń źródło pakietu NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
@@ -1134,6 +1134,11 @@ Aby uzyskać więcej informacji, odwiedź stronę https://docs.nuget.org/docs/re
         <target state="translated">Usuń źródło pakietu NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">Odcisk cyfrowy certyfikatu SHA-256, SHA-384 lub SHA-512 używany do przeszukiwania lokalnego magazynu certyfikatów w zakresie danego certyfikatu. Magazyn certyfikatów można określić za pomocą opcji --certificate-store-name i --certificate-store-location.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ Para obter mais informações, acesse https://docs.nuget.org/docs/reference/comm
         <target state="translated">Remover uma origem do NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
@@ -1134,6 +1134,11 @@ Para obter mais informações, acesse https://docs.nuget.org/docs/reference/comm
         <target state="translated">Remover uma origem do NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">Impressão digital SHA-256, SHA-384 ou SHA-512 do certificado usado para pesquisar o certificado em um repositório de certificados local. O armazenamento de certificados pode ser especificado pelas opções --certificate-store-name e --certificate-store-location.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
@@ -1134,6 +1134,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">Удалите источник NuGet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">Отпечаток сертификата SHA-256, SHA-384 или SHA-512, используемый для поиска сертификата в локальном хранилище. Хранилище сертификатов можно указать в параметрах --certificate-store-name и --certificate-store-location.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">Удалите источник NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
@@ -1135,7 +1135,7 @@ Daha fazla bilgi için bkz. https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">NuGet kaynağını kaldırın.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
@@ -1135,6 +1135,11 @@ Daha fazla bilgi için bkz. https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">NuGet kaynağını kaldırın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">Sertifika için yerel sertifika deposunda arama yapmak üzere kullanılan sertifikanın SHA-256, SHA-384 veya SHA-512 parmak izi. Sertifika deposu, --certificate-store-name ve --certificate-store-location seçenekleri ile belirtilebilir.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
@@ -1134,6 +1134,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">移除 NuGet 源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">用于在本地证书存储中搜索证书的 SHA-256、SHA-384 或 SHA-512 证书指纹。证书存储可通过 --certificate-store-name 和 --certificate-store-location 选项指定。</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">移除 NuGet 源。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
@@ -1134,7 +1134,7 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">移除 NuGet 來源。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+      <trans-unit id="SignCommandAllowUntrustedRootDescription">
         <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
         <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
         <note />

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
@@ -1134,6 +1134,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">移除 NuGet 來源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SignCommandAllowUntrustedSigningDescription">
+        <source>Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</source>
+        <target state="new">Allow signing with certificates whose root certificate is not in a trusted root store. The certificate chain is still built and validated for structure, but UntrustedRoot status is treated as a warning.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SignCommandCertificateFingerprintDescription">
         <source>SHA-256, SHA-384 or SHA-512 fingerprint of the certificate used to search a local certificate store for the certificate. The certificate store can be specified by --certificate-store-name and --certificate-store-location options.</source>
         <target state="translated">要用來在本機憑證存放區搜尋憑證的憑證 SHA-256、SHA-384 或 SHA-512 指紋。憑證存放區可由 --certificate-store-name 以及 --certificate-store-location 選項指定。</target>

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+NuGet.Commands.SignArgs.AllowUntrustedRoot.get -> bool
+NuGet.Commands.SignArgs.AllowUntrustedRoot.set -> void

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+NuGet.Commands.SignArgs.AllowUntrustedRoot.get -> bool
+NuGet.Commands.SignArgs.AllowUntrustedRoot.set -> void

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateFindOptions.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateFindOptions.cs
@@ -60,5 +60,10 @@ namespace NuGet.Commands
         /// </summary>
         public CancellationToken Token { get; set; }
 
+        /// <summary>
+        /// When true, allow certificates with untrusted roots through store discovery.
+        /// </summary>
+        public bool AllowUntrustedRoot { get; set; }
+
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/CertificateProvider.cs
@@ -217,7 +217,7 @@ namespace NuGet.Commands
 
             store.Close();
 
-            resultCollection = GetValidCertificates(resultCollection);
+            resultCollection = GetValidCertificates(resultCollection, options.AllowUntrustedRoot);
 
             return resultCollection;
         }
@@ -244,13 +244,13 @@ namespace NuGet.Commands
             }
         }
 
-        private static X509Certificate2Collection GetValidCertificates(X509Certificate2Collection certificates)
+        private static X509Certificate2Collection GetValidCertificates(X509Certificate2Collection certificates, bool allowUntrustedRoot = false)
         {
             var validCertificates = new X509Certificate2Collection();
 
             foreach (var certificate in certificates)
             {
-                if (IsValid(certificate, certificates))
+                if (IsValid(certificate, certificates, allowUntrustedRoot))
                 {
                     validCertificates.Add(certificate);
                 }
@@ -259,7 +259,7 @@ namespace NuGet.Commands
             return validCertificates;
         }
 
-        private static bool IsValid(X509Certificate2 certificate, X509Certificate2Collection extraStore)
+        private static bool IsValid(X509Certificate2 certificate, X509Certificate2Collection extraStore, bool allowUntrustedRoot = false)
         {
             try
             {
@@ -267,7 +267,8 @@ namespace NuGet.Commands
                     certificate,
                     extraStore,
                     NullLogger.Instance,
-                    CertificateType.Signature))
+                    CertificateType.Signature,
+                    allowUntrustedRoot))
                 {
                     return chain != null && chain.Count > 0;
                 }

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignArgs.cs
@@ -77,6 +77,12 @@ namespace NuGet.Commands
         public bool Overwrite { get; set; }
 
         /// <summary>
+        /// Allow signing with certificates whose root is not in a trusted root store.
+        /// When true, UntrustedRoot chain status is treated as a warning instead of an error.
+        /// </summary>
+        public bool AllowUntrustedRoot { get; set; }
+
+        /// <summary>
         /// Switch used to indicate that we should not prompt for user input or confirmations.
         /// </summary>
         public bool NonInteractive { get; set; }

--- a/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/SignCommand/SignCommandRunner.cs
@@ -69,6 +69,7 @@ namespace NuGet.Commands
 
                 using (var signRequest = new AuthorSignPackageRequest(cert, signArgs.SignatureHashAlgorithm, signArgs.TimestampHashAlgorithm))
                 {
+                    signRequest.AllowUntrustedRoot = signArgs.AllowUntrustedRoot;
                     return await ExecuteCommandAsync(
                         packagesToSign,
                         signRequest,
@@ -189,7 +190,8 @@ namespace NuGet.Commands
                 SubjectName = signArgs.CertificateSubjectName,
                 NonInteractive = signArgs.NonInteractive,
                 PasswordProvider = signArgs.PasswordProvider,
-                Token = signArgs.Token
+                Token = signArgs.Token,
+                AllowUntrustedRoot = signArgs.AllowUntrustedRoot,
             };
 
             // get matching certificates

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -3,4 +3,7 @@ NuGet.Packaging.PackageBuilder.PackageBuilder(System.IO.Stream! stream, string? 
 NuGet.Packaging.PackageBuilder.PackageBuilder(string! path, System.Func<string!, string!>? propertyProvider, bool includeEmptyDirectories, bool deterministic, NuGet.Common.ILogger! logger, string! versionOverride) -> void
 NuGet.Packaging.PackageBuilder.PackageBuilder(string! path, string? basePath, System.Func<string!, string!>? propertyProvider, bool includeEmptyDirectories, bool deterministic, NuGet.Common.ILogger! logger, string! versionOverride) -> void
 NuGet.Packaging.PackageBuilder.PackageBuilder(string! path, string? basePath, System.Func<string!, string!>? propertyProvider, bool includeEmptyDirectories, bool deterministic, string! versionOverride) -> void
+NuGet.Packaging.Signing.SignPackageRequest.AllowUntrustedRoot.get -> bool
+NuGet.Packaging.Signing.SignPackageRequest.AllowUntrustedRoot.set -> void
 static NuGet.Packaging.Manifest.ReadFrom(System.IO.Stream! stream, System.Func<string!, string!>? propertyProvider, bool validateSchema, NuGet.Versioning.NuGetVersion? overrideVersion) -> NuGet.Packaging.Manifest!
+~static NuGet.Packaging.Signing.CertificateChainUtility.GetCertificateChain(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, NuGet.Common.ILogger logger, NuGet.Packaging.Signing.CertificateType certificateType, bool allowUntrustedRoot) -> NuGet.Packaging.Signing.IX509CertificateChain

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -3,4 +3,7 @@ NuGet.Packaging.PackageBuilder.PackageBuilder(System.IO.Stream! stream, string? 
 NuGet.Packaging.PackageBuilder.PackageBuilder(string! path, System.Func<string!, string!>? propertyProvider, bool includeEmptyDirectories, bool deterministic, NuGet.Common.ILogger! logger, string! versionOverride) -> void
 NuGet.Packaging.PackageBuilder.PackageBuilder(string! path, string? basePath, System.Func<string!, string!>? propertyProvider, bool includeEmptyDirectories, bool deterministic, NuGet.Common.ILogger! logger, string! versionOverride) -> void
 NuGet.Packaging.PackageBuilder.PackageBuilder(string! path, string? basePath, System.Func<string!, string!>? propertyProvider, bool includeEmptyDirectories, bool deterministic, string! versionOverride) -> void
+NuGet.Packaging.Signing.SignPackageRequest.AllowUntrustedRoot.get -> bool
+NuGet.Packaging.Signing.SignPackageRequest.AllowUntrustedRoot.set -> void
 static NuGet.Packaging.Manifest.ReadFrom(System.IO.Stream! stream, System.Func<string!, string!>? propertyProvider, bool validateSchema, NuGet.Versioning.NuGetVersion? overrideVersion) -> NuGet.Packaging.Manifest!
+~static NuGet.Packaging.Signing.CertificateChainUtility.GetCertificateChain(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, NuGet.Common.ILogger logger, NuGet.Packaging.Signing.CertificateType certificateType, bool allowUntrustedRoot) -> NuGet.Packaging.Signing.IX509CertificateChain

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SignPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Authoring/SignPackageRequest.cs
@@ -48,6 +48,12 @@ namespace NuGet.Packaging.Signing
         /// </summary>
         public System.Security.Cryptography.CngKey PrivateKey { get; set; }
 
+        /// <summary>
+        /// When true, allow signing with certificates whose root is not in a trusted root store.
+        /// UntrustedRoot chain status is treated as a warning instead of an error.
+        /// </summary>
+        public bool AllowUntrustedRoot { get; set; }
+
         protected SignPackageRequest(
             X509Certificate2 certificate,
             HashAlgorithmName signatureHashAlgorithm,
@@ -110,7 +116,8 @@ namespace NuGet.Packaging.Signing
                     Certificate,
                     AdditionalCertificates,
                     logger,
-                    CertificateType.Signature);
+                    CertificateType.Signature,
+                    AllowUntrustedRoot);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
@@ -40,8 +40,22 @@ namespace NuGet.Packaging.Signing
 
         /// <summary>
         /// Create a list of certificates in chain order with the leaf first and root last.
-        /// When allowUntrustedRoot is true, UntrustedRoot chain status is treated as a warning.
         /// </summary>
+        /// <param name="certificate">The certificate for which a chain should be built.</param>
+        /// <param name="extraStore">A certificate store containing additional certificates necessary
+        /// for chain building.</param>
+        /// <param name="logger">A logger.</param>
+        /// <param name="certificateType">The certificate type.</param>
+        /// <param name="allowUntrustedRoot">When <see langword="true" />, an <see cref="X509ChainStatusFlags.UntrustedRoot" />
+        /// chain status is treated as a warning instead of an error for signature certificates.
+        /// This has no effect for timestamp certificate chains.</param>
+        /// <returns>A certificate chain.</returns>
+        /// <remarks>This is intended to be used only during signing and timestamping operations,
+        /// not verification.</remarks>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="certificate" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="extraStore" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="certificateType" /> is undefined.</exception>
         public static IX509CertificateChain GetCertificateChain(
             X509Certificate2 certificate,
             X509Certificate2Collection extraStore,

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs
@@ -35,6 +35,20 @@ namespace NuGet.Packaging.Signing
             ILogger logger,
             CertificateType certificateType)
         {
+            return GetCertificateChain(certificate, extraStore, logger, certificateType, allowUntrustedRoot: false);
+        }
+
+        /// <summary>
+        /// Create a list of certificates in chain order with the leaf first and root last.
+        /// When allowUntrustedRoot is true, UntrustedRoot chain status is treated as a warning.
+        /// </summary>
+        public static IX509CertificateChain GetCertificateChain(
+            X509Certificate2 certificate,
+            X509Certificate2Collection extraStore,
+            ILogger logger,
+            CertificateType certificateType,
+            bool allowUntrustedRoot)
+        {
             if (certificate == null)
             {
                 throw new ArgumentNullException(nameof(certificate));
@@ -76,7 +90,7 @@ namespace NuGet.Packaging.Signing
                 X509ChainStatusFlags errorStatusFlags;
                 X509ChainStatusFlags warningStatusFlags;
 
-                GetChainStatusFlags(certificate, certificateType, out errorStatusFlags, out warningStatusFlags);
+                GetChainStatusFlags(certificate, certificateType, allowUntrustedRoot, out errorStatusFlags, out warningStatusFlags);
 
                 var fatalStatuses = new List<X509ChainStatus>();
                 var logCode = certificateType == CertificateType.Timestamp ? NuGetLogCode.NU3028 : NuGetLogCode.NU3018;
@@ -142,6 +156,7 @@ namespace NuGet.Packaging.Signing
         private static void GetChainStatusFlags(
             X509Certificate2 certificate,
             CertificateType certificateType,
+            bool allowUntrustedRoot,
             out X509ChainStatusFlags errorStatusFlags,
             out X509ChainStatusFlags warningStatusFlags)
         {
@@ -152,7 +167,7 @@ namespace NuGet.Packaging.Signing
 
             warningStatusFlags = X509ChainStatusFlags.RevocationStatusUnknown | X509ChainStatusFlags.OfflineRevocation;
 
-            if (certificateType == CertificateType.Signature && CertificateUtility.IsSelfIssued(certificate))
+            if (certificateType == CertificateType.Signature && (CertificateUtility.IsSelfIssued(certificate) || allowUntrustedRoot))
             {
                 warningStatusFlags |= X509ChainStatusFlags.UntrustedRoot;
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSignCommandTest.cs
@@ -505,5 +505,56 @@ namespace NuGet.CommandLine.Test
 
             return signCommand;
         }
+
+        [Fact]
+        public void SignCommandArgParsing_AllowUntrustedSigning_SetsAllowUntrustedRoot()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var certificateFingerprint = Sha256Hash;
+            var mockConsole = new Mock<IConsole>();
+            mockConsole.Setup(c => c.Verbosity).Returns(Verbosity.Detailed);
+
+            var signCommand = new SignCommand
+            {
+                Console = mockConsole.Object,
+                CertificateFingerprint = certificateFingerprint,
+                NonInteractive = true,
+                AllowUntrustedSigning = true,
+            };
+
+            signCommand.Arguments.Add(packagePath);
+
+            // Act
+            var signArgs = signCommand.GetSignArgs();
+
+            // Assert
+            Assert.True(signArgs.AllowUntrustedRoot);
+        }
+
+        [Fact]
+        public void SignCommandArgParsing_DefaultAllowUntrustedSigning_IsFalse()
+        {
+            // Arrange
+            var packagePath = @"\\path\package.nupkg";
+            var certificateFingerprint = Sha256Hash;
+            var mockConsole = new Mock<IConsole>();
+            mockConsole.Setup(c => c.Verbosity).Returns(Verbosity.Detailed);
+
+            var signCommand = new SignCommand
+            {
+                Console = mockConsole.Object,
+                CertificateFingerprint = certificateFingerprint,
+                NonInteractive = true,
+            };
+
+            signCommand.Arguments.Add(packagePath);
+
+            // Act
+            var signArgs = signCommand.GetSignArgs();
+
+            // Assert
+            Assert.False(signArgs.AllowUntrustedRoot);
+        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSignCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSignCommandTest.cs
@@ -507,7 +507,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public void SignCommandArgParsing_AllowUntrustedSigning_SetsAllowUntrustedRoot()
+        public void SignCommandArgParsing_AllowUntrustedRoot_SetsAllowUntrustedRoot()
         {
             // Arrange
             var packagePath = @"\\path\package.nupkg";
@@ -520,7 +520,7 @@ namespace NuGet.CommandLine.Test
                 Console = mockConsole.Object,
                 CertificateFingerprint = certificateFingerprint,
                 NonInteractive = true,
-                AllowUntrustedSigning = true,
+                AllowUntrustedRoot = true,
             };
 
             signCommand.Arguments.Add(packagePath);
@@ -533,7 +533,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public void SignCommandArgParsing_DefaultAllowUntrustedSigning_IsFalse()
+        public void SignCommandArgParsing_DefaultAllowUntrustedRoot_IsFalse()
         {
             // Arrange
             var packagePath = @"\\path\package.nupkg";

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
@@ -485,6 +485,46 @@ namespace NuGet.XPlat.FuncTest
                 });
         }
 
+        [Fact]
+        public void SignCommandArgParsing_AllowUntrustedSigning_SetsAllowUntrustedRoot()
+        {
+            var packagePath = @"\\path\package.nupkg";
+            var certificateFingerprint = Sha256Hash;
+
+            SignCommandArgs(
+                (mockCommandRunner, testApp, getLogLevel, getParsedArg, _) =>
+                {
+                    //Arrange
+                    var argList = new List<string>() { "sign", packagePath, "--certificate-fingerprint", certificateFingerprint, "--allow-untrusted-signing" };
+
+                    //Act
+                    testApp.Execute(argList.ToArray());
+
+                    //Assert
+                    Assert.True(getParsedArg().AllowUntrustedRoot);
+                });
+        }
+
+        [Fact]
+        public void SignCommandArgParsing_DefaultAllowUntrustedSigning_IsFalse()
+        {
+            var packagePath = @"\\path\package.nupkg";
+            var certificateFingerprint = Sha256Hash;
+
+            SignCommandArgs(
+                (mockCommandRunner, testApp, getLogLevel, getParsedArg, _) =>
+                {
+                    //Arrange
+                    var argList = new List<string>() { "sign", packagePath, "--certificate-fingerprint", certificateFingerprint };
+
+                    //Act
+                    testApp.Execute(argList.ToArray());
+
+                    //Assert
+                    Assert.False(getParsedArg().AllowUntrustedRoot);
+                });
+        }
+
         private void SignCommandArgs(Action<Mock<ISignCommandRunner>, CommandLineApplication, Func<LogLevel>, Func<SignArgs>, TestCommandOutputLogger> verify)
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatSignTests.cs
@@ -486,7 +486,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public void SignCommandArgParsing_AllowUntrustedSigning_SetsAllowUntrustedRoot()
+        public void SignCommandArgParsing_AllowUntrustedRoot_SetsAllowUntrustedRoot()
         {
             var packagePath = @"\\path\package.nupkg";
             var certificateFingerprint = Sha256Hash;
@@ -495,7 +495,7 @@ namespace NuGet.XPlat.FuncTest
                 (mockCommandRunner, testApp, getLogLevel, getParsedArg, _) =>
                 {
                     //Arrange
-                    var argList = new List<string>() { "sign", packagePath, "--certificate-fingerprint", certificateFingerprint, "--allow-untrusted-signing" };
+                    var argList = new List<string>() { "sign", packagePath, "--certificate-fingerprint", certificateFingerprint, "--allow-untrusted-root" };
 
                     //Act
                     testApp.Execute(argList.ToArray());
@@ -506,7 +506,7 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public void SignCommandArgParsing_DefaultAllowUntrustedSigning_IsFalse()
+        public void SignCommandArgParsing_DefaultAllowUntrustedRoot_IsFalse()
         {
             var packagePath = @"\\path\package.nupkg";
             var certificateFingerprint = Sha256Hash;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -145,6 +145,33 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
+        public void GetCertificateChain_WithUntrustedRoot_AllowUntrustedRoot_ReturnsChain()
+        {
+            using (X509ChainHolder chainHolder = X509ChainHolder.CreateForCodeSigning())
+            using (var rootCertificate = SigningTestUtility.GetCertificate("root.crt"))
+            using (var intermediateCertificate = SigningTestUtility.GetCertificate("intermediate.crt"))
+            using (var leafCertificate = SigningTestUtility.GetCertificate("leaf.crt"))
+            {
+                var chain = chainHolder.Chain2;
+                var extraStore = new X509Certificate2Collection() { rootCertificate, intermediateCertificate };
+                var logger = new TestLogger();
+
+                using (var certificateChain = CertificateChainUtility.GetCertificateChain(
+                    leafCertificate,
+                    extraStore,
+                    logger,
+                    CertificateType.Signature,
+                    allowUntrustedRoot: true))
+                {
+                    Assert.True(certificateChain.Count > 0);
+                }
+
+                Assert.Equal(0, logger.Errors);
+                SigningTestUtility.AssertUntrustedRoot(logger.LogMessages, LogLevel.Warning);
+            }
+        }
+
+        [Fact]
         public void GetCertificateChain_WhenCertChainNull_Throws()
         {
             var exception = Assert.Throws<ArgumentNullException>(

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/CertificateChainUtilityTests.cs
@@ -148,15 +148,15 @@ namespace NuGet.Packaging.Test
         public void GetCertificateChain_WithUntrustedRoot_AllowUntrustedRoot_ReturnsChain()
         {
             using (X509ChainHolder chainHolder = X509ChainHolder.CreateForCodeSigning())
-            using (var rootCertificate = SigningTestUtility.GetCertificate("root.crt"))
-            using (var intermediateCertificate = SigningTestUtility.GetCertificate("intermediate.crt"))
-            using (var leafCertificate = SigningTestUtility.GetCertificate("leaf.crt"))
+            using (X509Certificate2 rootCertificate = SigningTestUtility.GetCertificate("root.crt"))
+            using (X509Certificate2 intermediateCertificate = SigningTestUtility.GetCertificate("intermediate.crt"))
+            using (X509Certificate2 leafCertificate = SigningTestUtility.GetCertificate("leaf.crt"))
             {
-                var chain = chainHolder.Chain2;
+                IX509Chain chain = chainHolder.Chain2;
                 var extraStore = new X509Certificate2Collection() { rootCertificate, intermediateCertificate };
                 var logger = new TestLogger();
 
-                using (var certificateChain = CertificateChainUtility.GetCertificateChain(
+                using (IX509CertificateChain certificateChain = CertificateChainUtility.GetCertificateChain(
                     leafCertificate,
                     extraStore,
                     logger,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Feature

Fixes: <!-- TODO: Create issue at https://github.com/NuGet/Home/issues and paste URL here -->
https://github.com/NuGet/Home/pull/14798

## Description

Add an `--allow-untrusted-root` / `-AllowUntrustedRoot` flag to `dotnet nuget sign` and `nuget.exe sign` that allows signing with certificates whose root CA is not in a trusted root store.

### Problem

When signing NuGet packages with certificates issued by a root CA that isn't installed in `LocalMachine\Root` or `CurrentUser\Root`, `CertificateChainUtility.GetCertificateChain` fails with an `UntrustedRoot` chain status error. Installing root CAs into the trusted root store requires admin elevation (triggering a UAC prompt or failing in non-elevated CI containers), which is a significant friction point for build pipelines and developer machines.

### Solution

Add a new `allowUntrustedRoot` parameter that moves `UntrustedRoot` from the error status flags to the warning status flags in `GetChainStatusFlags`. This uses the **same mechanism** NuGet already applies to self-issued certificates (see [CertificateChainUtility.cs line 155](https://github.com/NuGet/NuGet.Client/blob/b761098d4c1b08bf1fb082d7dc7f276c41648c6a/src/NuGet.Core/NuGet.Packaging/Signing/Utility/CertificateChainUtility.cs#L155)), extending it to CA-issued certificates when explicitly opted in.

The flag is threaded through the full stack:

| Layer | Change |
|-------|--------|
| **NuGet.Packaging** | `SignPackageRequest.AllowUntrustedRoot` property; new `GetCertificateChain` overload accepting `bool allowUntrustedRoot` |
| **NuGet.Commands** | `SignArgs.AllowUntrustedRoot`; `CertificateSourceOptions.AllowUntrustedRoot`; wired through `CertificateProvider.IsValid()` so certs with untrusted roots aren't filtered out during store discovery |
| **NuGet.CommandLine** (nuget.exe) | `-AllowUntrustedRoot` option |
| **NuGet.CommandLine.XPlat** (dotnet nuget sign) | `--allow-untrusted-root` option |

### Key design decisions

- **Opt-in, defaults to `false`** — no behavioral change unless explicitly enabled
- **Works on all TFMs including net472** — no dependency on `X509ChainTrustMode.CustomRootTrust` (.NET 5+)
- **Follows existing precedent** — identical to how NuGet already handles `UntrustedRoot` for self-issued certificates

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14816