### PR TITLE
AOT compatible: make NuGet.Commandline.Xplat Aot compatible

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
@@ -268,9 +268,9 @@ namespace NuGet.CommandLine.XPlat
             return packageSources;
         }
 
-        private static string GetEnumValues<T>() where T : Enum
+        private static string GetEnumValues<T>() where T : struct, Enum
         {
-            var enumValues = ((T[])Enum.GetValues(typeof(T)))
+            var enumValues = Enum.GetValues<T>()
                .Select(x => x.ToString());
 
             return string.Join(", ", enumValues).ToLower(CultureInfo.CurrentCulture);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/PackageSearchJsonContext.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/PackageSearchJsonContext.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace NuGet.CommandLine.XPlat
+{
+    [JsonSerializable(typeof(SearchMainOutput))]
+    internal partial class PackageSearchJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/PackageSearchProblem.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/PackageSearchProblem.cs
@@ -13,7 +13,7 @@ namespace NuGet.CommandLine.XPlat
         public string Text { get; private set; }
 
         [JsonPropertyName("problemType")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter<PackageSearchProblemType>))]
         public PackageSearchProblemType ProblemType { get; }
 
         internal PackageSearchProblem(PackageSearchProblemType packageSearchProblemType, string text)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultJsonRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultJsonRenderer.cs
@@ -54,7 +54,7 @@ namespace NuGet.CommandLine.XPlat
                 Converters = { new SearchResultPackagesConverter(_verbosity, _exactMatch) },
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
-            var json = JsonSerializer.Serialize(_packageSearchMainOutput, options);
+            var json = JsonSerializer.Serialize(_packageSearchMainOutput, new PackageSearchJsonContext(options).SearchMainOutput);
             _logger.LogMinimal(json);
         }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/SignCommand.cs
@@ -184,7 +184,7 @@ namespace NuGet.CommandLine.XPlat
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                         Strings.Err_InvalidValue,
                         location.LongName,
-                        string.Join(",", Enum.GetValues(typeof(StoreLocation)).Cast<StoreLocation>().ToList())));
+                        string.Join(",", Enum.GetValues<StoreLocation>().ToList())));
                 }
             }
 
@@ -203,7 +203,7 @@ namespace NuGet.CommandLine.XPlat
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                         Strings.Err_InvalidValue,
                         store.LongName,
-                        string.Join(",", Enum.GetValues(typeof(StoreName)).Cast<StoreName>().ToList())));
+                        string.Join(",", Enum.GetValues<StoreName>().ToList())));
                 }
             }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -7,7 +7,6 @@
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
     <XPLATProject>true</XPLATProject>
-    <IsAotCompatible>false</IsAotCompatible>
     <UseMSBuildLocator Condition=" '$(UseMSBuildLocator)' == '' And '$(Configuration)' == 'Debug' and '$(CI)' != 'true' ">true</UseMSBuildLocator>
     <!-- Microsoft.Extensions.CommandLineUtils.Sources causes nullability warnings, so we have to disable it for the project and enable in each file until we can remove the package  -->
     <Nullable>disable</Nullable>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 
Related: https://github.com/NuGet/Home/issues/14408

## Description

  This PR makes the xplat project AOT compatible.
   
   - use source generated `JsonSerializerContext`  (`PackageSearchJsonContext`) to avoid reflection based type discovery
   - Replace `Enum.GetValues(Type)` with `Enum.GetValues<TEnum>()`  in multiple places.
  
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
