### PR TITLE
Update E2E WebApplication templates to fix tests errors in project creation

### DIFF
--- a/test/EndToEnd/ProjectTemplates/EmptyWebApplicationProject40.zip/WebApplication.csproj
+++ b/test/EndToEnd/ProjectTemplates/EmptyWebApplicationProject40.zip/WebApplication.csproj
@@ -68,8 +68,13 @@ $endif$
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v17.0\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/EndToEnd/ProjectTemplates/EmptyWebApplicationProject40.zip/WebApplication.csproj
+++ b/test/EndToEnd/ProjectTemplates/EmptyWebApplicationProject40.zip/WebApplication.csproj
@@ -69,7 +69,7 @@ $endif$
   </ItemGroup>
   
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion))\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion))\WebApplications\Microsoft.WebApplication.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/EndToEnd/ProjectTemplates/EmptyWebApplicationProject40.zip/WebApplication.csproj
+++ b/test/EndToEnd/ProjectTemplates/EmptyWebApplicationProject40.zip/WebApplication.csproj
@@ -69,7 +69,7 @@ $endif$
   </ItemGroup>
   
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion))\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion))\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/EndToEnd/ProjectTemplates/EmptyWebApplicationProject40.zip/WebApplication.csproj
+++ b/test/EndToEnd/ProjectTemplates/EmptyWebApplicationProject40.zip/WebApplication.csproj
@@ -68,13 +68,8 @@ $endif$
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   
-  <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion))\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/EndToEnd/ProjectTemplates/WebApplicationProject40.zip/WebApplication.csproj
+++ b/test/EndToEnd/ProjectTemplates/WebApplicationProject40.zip/WebApplication.csproj
@@ -127,7 +127,7 @@
     <Content Include="Site.Master" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/EndToEnd/ProjectTemplates/WebApplicationProject40.zip/WebApplication.csproj
+++ b/test/EndToEnd/ProjectTemplates/WebApplicationProject40.zip/WebApplication.csproj
@@ -126,8 +126,13 @@
     <Content Include="Account\Web.config" />
     <Content Include="Site.Master" />
   </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v17.0\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/EndToEnd/ProjectTemplates/WebApplicationProject40.zip/WebApplication.csproj
+++ b/test/EndToEnd/ProjectTemplates/WebApplicationProject40.zip/WebApplication.csproj
@@ -126,13 +126,8 @@
     <Content Include="Account\Web.config" />
     <Content Include="Site.Master" />
   </ItemGroup>
-  <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/EndToEnd/ProjectTemplates/WebApplicationProject40.zip/WebApplication.csproj
+++ b/test/EndToEnd/ProjectTemplates/WebApplicationProject40.zip/WebApplication.csproj
@@ -127,7 +127,7 @@
     <Content Include="Site.Master" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\WebApplications\Microsoft.WebApplication.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/TestUtilities/CreateEndToEndTestPackage/CreateEndToEndTestPackage.proj
+++ b/test/TestUtilities/CreateEndToEndTestPackage/CreateEndToEndTestPackage.proj
@@ -36,10 +36,6 @@
                 FileMatch="*"
                 DestinationFolder="$([MSBuild]::NormalizeDirectory($(WorkingDirectory), 'Packages'))" />
 
-      <Artifact Include="$([MSBuild]::NormalizeDirectory($(EnlistmentRoot), 'test', 'EndToEnd', 'Packages'))"
-                FileMatch="*"
-                DestinationFolder="$([MSBuild]::NormalizeDirectory($(WorkingDirectory), 'Packages'))" />
-
       <Artifact Include="$([MSBuild]::NormalizeDirectory(%(APITestOutput.RootDir), %(APITestOutput.Directory)))"
                 FileMatch="API.Test.*"
                 DestinationFolder="$(WorkingDirectory)" />

--- a/test/TestUtilities/CreateEndToEndTestPackage/CreateEndToEndTestPackage.proj
+++ b/test/TestUtilities/CreateEndToEndTestPackage/CreateEndToEndTestPackage.proj
@@ -36,6 +36,10 @@
                 FileMatch="*"
                 DestinationFolder="$([MSBuild]::NormalizeDirectory($(WorkingDirectory), 'Packages'))" />
 
+      <Artifact Include="$([MSBuild]::NormalizeDirectory($(EnlistmentRoot), 'test', 'EndToEnd', 'Packages'))"
+                FileMatch="*"
+                DestinationFolder="$([MSBuild]::NormalizeDirectory($(WorkingDirectory), 'Packages'))" />
+
       <Artifact Include="$([MSBuild]::NormalizeDirectory(%(APITestOutput.RootDir), %(APITestOutput.Directory)))"
                 FileMatch="API.Test.*"
                 DestinationFolder="$(WorkingDirectory)" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

## 1. Fix legacy web project templates so they work under VS 18

   Some E2E tests create legacy ASP.NET web application projects through DTE using the templates under:

   - `test\EndToEnd\ProjectTemplates\EmptyWebApplicationProject40.zip`
   - `test\EndToEnd\ProjectTemplates\WebApplicationProject40.zip`

   The failing tests were surfacing this error:

   Operation could not be completed. The project file '...EmptyWebApplicationProject40_070f.csproj' cannot be migrated. See the migration report for details.

  That message is misleading. The project was not actually failing because of a real project migration problem.

  The real issue was that the legacy templates were hard-coding the VS 17 web targets path:
```xml
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v17.0\WebApplications\Microsoft.WebApplication.targets" />
```
  That works when the test runs against VS 17, but it breaks when the E2E harness uses VS 18. Under VS 18, the targets live under v18.0, so the project creation flow fails
  while Visual Studio is creating the temp project from the template, and DTE surfaces that inner import failure as a generic "cannot be migrated" error.

  This PR updates both templates to resolve the web targets dynamically through $(VisualStudioVersion) / $(VSToolsPath) instead:
```xml
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>

   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
```
  This keeps the old template behavior but allows the same asset to resolve correctly when the tests run against newer Visual Studio instances.

## 2. Fix InstallPackagesConfigLocal by packaging the current test metadata into EndToEnd.zip
`
  Test-InstallPackagesConfigLocal expects the local packages.config scenario to install packages A and B:
   $pathToPackagesConfig = Join-Path $context.RepositoryRoot "InstallPackagesConfigLocal\packages.config"

   $p | Install-Package $pathToPackagesConfig

   Assert-Package $p A 1.0.0
   Assert-Package $p B 1.0.0
`

  The source-controlled test data for that scenario is:

```xml
   <?xml version="1.0" encoding="utf-8"?>
   <packages>
     <package id="A" version="1.0.0" targetFramework="net45" userInstalled="true" />
     <package id="B" version="1.0.0" targetFramework="net45" userInstalled="true" />
   </packages>
```

  However, the generated runnable E2E bundle (EndToEnd.zip) was not reliably using the current test\EndToEnd\Packages metadata. Instead, CreateEndToEndTestPackage.proj was
  filling the bundled Packages folder from the restored NuGet.Client.EndToEnd.TestData package, which still contained stale scenario metadata.

  That meant the runnable test bundle had drifted from source control. The failure:
`
   Value is null. Package A 1.0.0 is not referenced in ClassLibrary_f4c0.
`

  was only the symptom. The real problem was that the assembled E2E environment was not feeding the test the expected packages.config, so A was never installed in the first place.

  The packaging logic previously did this:
```xml
   <Artifact Include="$([MSBuild]::NormalizeDirectory($(PkgNuGet_Client_EndToEnd_TestData), 'content', 'Packages'))"
             FileMatch="*"
             DestinationFolder="$([MSBuild]::NormalizeDirectory($(WorkingDirectory), 'Packages'))" />
```
  This PR keeps that copy, but then overlays the current source-controlled test\EndToEnd\Packages content on top of it:
```xml
   <Artifact Include="$([MSBuild]::NormalizeDirectory($(PkgNuGet_Client_EndToEnd_TestData), 'content', 'Packages'))"
             FileMatch="*"
             DestinationFolder="$([MSBuild]::NormalizeDirectory($(WorkingDirectory), 'Packages'))" />

   <Artifact Include="$([MSBuild]::NormalizeDirectory($(EnlistmentRoot), 'test', 'EndToEnd', 'Packages'))"
             FileMatch="*"
             DestinationFolder="$([MSBuild]::NormalizeDirectory($(WorkingDirectory), 'Packages'))" />
```
  This is intentionally narrow:

   - it preserves the packaged .nupkg payloads that already come from NuGet.Client.EndToEnd.TestData
   - it ensures that current repo metadata such as packages.config, nuspecs, and other scenario files win over stale packaged content


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
