### PR TITLE
fix whitespace format warnings

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -941,25 +941,25 @@ namespace NuGet.Commands
             // Used when logging package id specific messages, we need to know the target graph name
             string targetGraphName = pair.Name;
 
-        // Used to start over when a dependency has multiple descendants of an item to be evicted.
-        //
-        // Project
-        // ├── A 1.0.0
-        // │   └── B 1.0.0
-        // │       └── C 1.0.0
-        // │           └── D 1.0.0
-        // └── X 2.0.0
-        //     └── Y 2.0.0
-        //         └── G 2.0.0
-        //             └── B 2.0.0
-        // The items are processed in the following order:
-        // Chose A 1.0.0 and X 1.0.0
-        // Chose B 1.0.0 and Y 2.0.0
-        // Chose C 1.0.0 and G 2.0.0
-        // Chose D 1.0.0 and B 2.0.0, but B 2.0.0 should evict C 1.0.0 and D 1.0.0
-        //
-        // In this case, the entire walk is started over and B 1.0.0 is left out of the graph, leading to C 1.0.0 and D 1.0.0 also being left out.
-        //
+            // Used to start over when a dependency has multiple descendants of an item to be evicted.
+            //
+            // Project
+            // ├── A 1.0.0
+            // │   └── B 1.0.0
+            // │       └── C 1.0.0
+            // │           └── D 1.0.0
+            // └── X 2.0.0
+            //     └── Y 2.0.0
+            //         └── G 2.0.0
+            //             └── B 2.0.0
+            // The items are processed in the following order:
+            // Chose A 1.0.0 and X 1.0.0
+            // Chose B 1.0.0 and Y 2.0.0
+            // Chose C 1.0.0 and G 2.0.0
+            // Chose D 1.0.0 and B 2.0.0, but B 2.0.0 should evict C 1.0.0 and D 1.0.0
+            //
+            // In this case, the entire walk is started over and B 1.0.0 is left out of the graph, leading to C 1.0.0 and D 1.0.0 also being left out.
+            //
         StartOver:
             restartCount++;
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug N/A (Engineering task)

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Whitespace format warnings

## Description
Building dev branch locally has produced below IDE0055: Fix formatting warnings. Used `dotnet format whitespace NuGet.sln` to fix these warnings.

> $\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(944,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(945,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(946,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(947,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(948,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(949,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(950,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(951,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(952,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(953,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(954,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(955,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(956,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(957,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(958,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(959,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(960,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(961,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(962,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net472]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(944,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(945,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(946,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(947,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(948,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(949,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(950,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(951,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(952,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(953,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(954,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(955,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(956,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(957,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(958,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(959,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(960,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(961,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
$\src\NuGet.Core\NuGet.Commands\RestoreCommand\DependencyGraphResolver.cs(962,9): warning IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [$\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj::TargetFramework=net8.0]
.vsixignore : warning : Missing 4 ignored file(s) 'Google.Protobuf.dll;Microsoft.Bcl.HashCode.dll;Microsoft.ML.Tokenizers.dll;Microsoft.VisualStudio.Copilot.dll' [$\src\NuGet.Clients\NuGet.VisualStudio.Client\NuGet.VisualStudio.Client.csproj]
    39 Warning(s)
    0 Error(s)


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[ ] Added tests~
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
