### PR TITLE
Use Ordinal string comparison for TargetAlias

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
@@ -41,7 +41,7 @@ namespace NuGet.ProjectModel
         public LockFileTarget GetTarget(string frameworkAlias, string runtimeIdentifier)
         {
             return Targets.FirstOrDefault(t =>
-                t.TargetAlias.Equals(frameworkAlias) &&
+                string.Equals(t.TargetAlias, frameworkAlias, StringComparison.Ordinal) &&
                 (string.IsNullOrEmpty(runtimeIdentifier) && string.IsNullOrEmpty(t.RuntimeIdentifier) ||
                  string.Equals(runtimeIdentifier, t.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase)));
         }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileTests.cs
@@ -920,6 +920,28 @@ namespace NuGet.ProjectModel.Test
             targetWithRid.TargetAlias.Should().Be("net5.0");
         }
 
+        [Fact]
+        public void LockFile_GetTarget_WithAlias_WhenTargetAliasIsNull_ReturnsNull()
+        {
+            // Arrange
+            LockFile lockFile = new LockFile()
+            {
+                Targets = new List<LockFileTarget>()
+                {
+                    new() {
+                        TargetFramework = FrameworkConstants.CommonFrameworks.Net50,
+                        TargetAlias = null
+                    },
+                }
+            };
+
+            // Act
+            LockFileTarget target = lockFile.GetTarget("net5.0", runtimeIdentifier: null);
+
+            // Assert
+            target.Should().BeNull();
+        }
+
         private LockFile Parse(string lockFileContent, string path)
         {
             var reader = new LockFileFormat();


### PR DESCRIPTION
Replace the instance Equals call with string.Equals(t.TargetAlias, frameworkAlias, StringComparison.Ordinal) to make the comparison explicit and culture-independent and to avoid potential NullReferenceException when TargetAlias is null.


```
 Error MSB4018 : The "ResolvePackageAssets" task failed unexpectedly.
System.NullReferenceException: Object reference not set to an instance of an object.
   at NuGet.ProjectModel.LockFile.<>c__DisplayClass39_0.<GetTarget>b__0(LockFileTarget t)
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at NuGet.ProjectModel.LockFile.GetTarget(String frameworkAlias, String runtimeIdentifier)
   at Microsoft.NET.Build.Tasks.LockFileExtensions.GetTargetAndReturnNullIfNotFound(LockFile lockFile, String
frameworkAlias, String runtimeIdentifier)
   at Microsoft.NET.Build.Tasks.LockFileExtensions.GetTargetAndThrowIfNotFound(LockFile lockFile, String
frameworkAlias, String runtimeIdentifier)
   at Microsoft.NET.Build.Tasks.ResolvePackageAssets.CacheWriter..ctor(ResolvePackageAssets task)
   at Microsoft.NET.Build.Tasks.ResolvePackageAssets.CacheReader.CreateReaderFromDisk(ResolvePackageAssets task, Byte[]
 settingsHash)
   at Microsoft.NET.Build.Tasks.ResolvePackageAssets.CacheReader..ctor(ResolvePackageAssets task)
   at Microsoft.NET.Build.Tasks.ResolvePackageAssets.ReadItemGroups()
   at Microsoft.NET.Build.Tasks.ResolvePackageAssets.ExecuteCore()
   at Microsoft.NET.Build.Tasks.TaskBase.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(TaskExecutionHost taskExecutionHost,
TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
```

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
