### PR TITLE
Make virtual project builder parameter required in MSBuildAPIUtility

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -48,7 +48,7 @@ namespace NuGet.CommandLine.XPlat
 
         public IVirtualProjectBuilder VirtualProjectBuilder { get; }
 
-        public MSBuildAPIUtility(ILogger logger, IVirtualProjectBuilder virtualProjectBuilder = null)
+        public MSBuildAPIUtility(ILogger logger, IVirtualProjectBuilder virtualProjectBuilder)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             VirtualProjectBuilder = virtualProjectBuilder;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/CommitAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/CommitAsyncTests.cs
@@ -20,7 +20,7 @@ public class CommitAsyncTests
 {
     private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
     {
-        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null);
         var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
         return packageUpdateIO;
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetDependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetDependencyGraphSpecTests.cs
@@ -18,7 +18,7 @@ public class GetDependencyGraphSpecTests
 {
     private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
     {
-        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null);
         var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
         return packageUpdateIO;
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetKnownVulnerabilitiesAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetKnownVulnerabilitiesAsyncTests.cs
@@ -22,7 +22,7 @@ public class GetKnownVulnerabilitiesAsyncTests
 {
     private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
     {
-        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null);
         var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
         return packageUpdateIO;
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetLatestVersionAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetLatestVersionAsyncTests.cs
@@ -19,7 +19,7 @@ public class GetLatestVersionAsyncTests
 {
     private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
     {
-        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null);
         var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
         return packageUpdateIO;
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetNonVulnerableAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetNonVulnerableAsyncTests.cs
@@ -22,7 +22,7 @@ public class GetNonVulnerableAsyncTests
 {
     private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
     {
-        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null);
         var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
         return packageUpdateIO;
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetPackageSourceMappingTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetPackageSourceMappingTests.cs
@@ -16,7 +16,7 @@ public class GetPackageSourceMappingTests
 {
     private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
     {
-        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null);
         var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
         return packageUpdateIO;
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetProjectAssetsFileAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetProjectAssetsFileAsyncTests.cs
@@ -17,7 +17,7 @@ public class GetProjectAssetsFileAsyncTests
 {
     private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
     {
-        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null);
         var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
         return packageUpdateIO;
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/PreviewUpdatePackageReferenceAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/PreviewUpdatePackageReferenceAsyncTests.cs
@@ -18,7 +18,7 @@ public class PreviewUpdatePackageReferenceAsyncTests
 {
     private static PackageUpdateIO CreatePackageUpdateIO(string solutionRoot)
     {
-        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance);
+        var msbuildUtility = new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null);
         var packageUpdateIO = new PackageUpdateIO(solutionRoot, msbuildUtility, TestEnvironmentVariableReader.EmptyInstance);
         return packageUpdateIO;
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/ListPackageTests.cs
@@ -224,7 +224,7 @@ namespace NuGet.XPlat.FuncTest
             using TextWriter consoleOut = new StringWriter(output);
             using TextWriter consoleError = new StringWriter(error);
             var logger = new TestLogger(_testOutputHelper);
-            ListPackageCommandRunner listPackageCommandRunner = new(new MSBuildAPIUtility(logger));
+            ListPackageCommandRunner listPackageCommandRunner = new(new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
             var packageRefArgs = new ListPackageArgs(
                                         path: Path.Combine(pathContext.SolutionRoot, "solution.sln"),
                                         packageSources: [new(mockServer.ServiceIndexUri)],
@@ -333,7 +333,7 @@ namespace NuGet.XPlat.FuncTest
             using TextWriter consoleOut = new StringWriter(output);
             using TextWriter consoleError = new StringWriter(error);
             var logger = new TestLogger(_testOutputHelper);
-            ListPackageCommandRunner listPackageCommandRunner = new(new MSBuildAPIUtility(logger));
+            ListPackageCommandRunner listPackageCommandRunner = new(new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
             var packageRefArgs = new ListPackageArgs(
                                         path: solution.SolutionPath,
                                         packageSources: [new PackageSource(pathContext.PackageSource)],
@@ -428,7 +428,7 @@ namespace NuGet.XPlat.FuncTest
                 CancellationToken.None
             );
 
-            var listPackageCommandRunner = new ListPackageCommandRunner(new MSBuildAPIUtility(mockLogger.Object));
+            var listPackageCommandRunner = new ListPackageCommandRunner(new MSBuildAPIUtility(mockLogger.Object, virtualProjectBuilder: null));
 
 
             // Act
@@ -474,7 +474,7 @@ namespace NuGet.XPlat.FuncTest
                 CancellationToken.None
             );
 
-            var listPackageCommandRunner = new ListPackageCommandRunner(new MSBuildAPIUtility(mockLogger.Object));
+            var listPackageCommandRunner = new ListPackageCommandRunner(new MSBuildAPIUtility(mockLogger.Object, virtualProjectBuilder: null));
 
             // Act
             var result = await listPackageCommandRunner.GetReportDataAsync(listPackageArgs);
@@ -529,7 +529,7 @@ namespace NuGet.XPlat.FuncTest
                 CancellationToken.None
             );
 
-            var listPackageCommandRunner = new ListPackageCommandRunner(new MSBuildAPIUtility(mockLogger.Object));
+            var listPackageCommandRunner = new ListPackageCommandRunner(new MSBuildAPIUtility(mockLogger.Object, virtualProjectBuilder: null));
 
             // Act
             var result = await listPackageCommandRunner.GetReportDataAsync(listPackageArgs);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -262,7 +262,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
@@ -308,7 +308,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
@@ -344,7 +344,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act & Assert
-                var result = await Assert.ThrowsAsync<CommandException>(() => commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger)));
+                var result = await Assert.ThrowsAsync<CommandException>(() => commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null)));
                 Assert.Equal(string.Format(CultureInfo.CurrentCulture, Strings.PrereleaseVersionsAvailable, packages.Max(x => x.Identity.Version)), result.Message);
             }
         }
@@ -369,7 +369,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act & Assert
-                var result = await Assert.ThrowsAsync<CommandException>(() => commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger)));
+                var result = await Assert.ThrowsAsync<CommandException>(() => commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null)));
                 Assert.Equal(string.Format(CultureInfo.CurrentCulture, Strings.Error_NoVersionsAvailable, "packageY"), result.Message);
             }
         }
@@ -402,7 +402,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
@@ -460,7 +460,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
@@ -503,7 +503,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // If noRestore is set, then we do not perform compatibility check.
@@ -562,7 +562,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
@@ -606,7 +606,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXml = File.ReadAllText(projectA.ProjectPath);
                 var propsXml = File.ReadAllText(directoryPackagesPropsPath);
 
@@ -644,7 +644,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
@@ -685,7 +685,7 @@ namespace NuGet.XPlat.FuncTest
                 var commonFramework = XPlatTestUtils.GetCommonFramework(packageFrameworks, projectFrameworks);
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, commonFramework);
 
@@ -734,7 +734,7 @@ namespace NuGet.XPlat.FuncTest
                 var commonFramework = XPlatTestUtils.GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, commonFramework);
 
@@ -795,7 +795,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
 
                 // Assert
@@ -895,7 +895,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
 
                 // Assert
                 Assert.Equal(1, result);
@@ -932,7 +932,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
 
                 // Assert
                 Assert.Equal(0, result);
@@ -986,7 +986,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
 
                 // Assert
                 Assert.Equal(1, result);
@@ -1039,7 +1039,7 @@ namespace NuGet.XPlat.FuncTest
                 var commonFramework = XPlatTestUtils.GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, commonFramework);
 
@@ -1080,7 +1080,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
@@ -1111,7 +1111,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
@@ -1143,7 +1143,7 @@ namespace NuGet.XPlat.FuncTest
                     packageY);
 
                 var logger = new TestCommandOutputLogger(_testOutputHelper);
-                var msbuild = new MSBuildAPIUtility(logger);
+                var msbuild = new MSBuildAPIUtility(logger, virtualProjectBuilder: null);
 
                 var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
@@ -1188,7 +1188,7 @@ namespace NuGet.XPlat.FuncTest
                 var packageY = XPlatTestUtils.CreatePackage("PkgY", frameworkString: packageFrameworks);
 
                 var logger = new TestCommandOutputLogger(_testOutputHelper);
-                var msBuild = new MSBuildAPIUtility(logger);
+                var msBuild = new MSBuildAPIUtility(logger, virtualProjectBuilder: null);
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3Async(
@@ -1255,7 +1255,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
                 var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
@@ -1299,7 +1299,7 @@ namespace NuGet.XPlat.FuncTest
 
                 var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packages[0].Id, userInputVersionOld, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
-                var msBuild = new MSBuildAPIUtility(logger);
+                var msBuild = new MSBuildAPIUtility(logger, virtualProjectBuilder: null);
 
                 // Create a package ref with the old version
                 var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
@@ -1366,7 +1366,7 @@ namespace NuGet.XPlat.FuncTest
                 var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packages[0].Id, userInputVersionOld, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
-                var msBuild = new MSBuildAPIUtility(logger);
+                var msBuild = new MSBuildAPIUtility(logger, virtualProjectBuilder: null);
 
                 // Create a package ref with old version
                 var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
@@ -1415,7 +1415,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
                 // Assert
@@ -1447,7 +1447,7 @@ namespace NuGet.XPlat.FuncTest
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act
-            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
             var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
 
             // Assert
@@ -1478,7 +1478,7 @@ namespace NuGet.XPlat.FuncTest
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act
-            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
             result.Should().Be(1);
             logger.ErrorMessages.Should().Contain(string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_AddPkgProjectReference,
@@ -1509,7 +1509,7 @@ namespace NuGet.XPlat.FuncTest
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act
-            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
             var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root!;
             var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
@@ -1548,7 +1548,7 @@ namespace NuGet.XPlat.FuncTest
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act
-            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
             var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
 
             // Assert
@@ -1587,7 +1587,7 @@ namespace NuGet.XPlat.FuncTest
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act
-            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
             var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
             var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
@@ -1624,7 +1624,7 @@ namespace NuGet.XPlat.FuncTest
             var logger = new TestCommandOutputLogger(_testOutputHelper);
             var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, "packageX", userInputVersionOld, project);
             var commandRunner = new AddPackageReferenceCommandRunner();
-            var msBuild = new MSBuildAPIUtility(logger);
+            var msBuild = new MSBuildAPIUtility(logger, virtualProjectBuilder: null);
 
             // Create a package ref with old version
             var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
@@ -1678,7 +1678,7 @@ namespace NuGet.XPlat.FuncTest
             var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, "packageX", userInputVersionOld, project,
                 frameworks: userInputFrameworks);
             var commandRunner = new AddPackageReferenceCommandRunner();
-            var msBuild = new MSBuildAPIUtility(logger);
+            var msBuild = new MSBuildAPIUtility(logger, virtualProjectBuilder: null);
 
             // Create a package ref with old version
             var result = await commandRunner.ExecuteCommand(packageArgs, msBuild);
@@ -1742,7 +1742,7 @@ namespace NuGet.XPlat.FuncTest
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act
-            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
             var projectXmlRoot = XPlatTestUtils.LoadCSProj(project.ProjectPath).Root!;
 
             // Assert

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatWhyTests.cs
@@ -110,7 +110,7 @@ namespace NuGet.XPlat.FuncTest
             var logger = new TestCommandOutputLogger(_testOutputHelper);
             var addPackageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
             var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
-            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger));
+            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
 
             var console = new TestConsole();
             console.Width(500);
@@ -123,7 +123,7 @@ namespace NuGet.XPlat.FuncTest
                     CancellationToken.None);
 
             // Act
-            var result = await new WhyCommandRunner(new MSBuildAPIUtility(logger)).ExecuteCommand(whyCommandArgs);
+            var result = await new WhyCommandRunner(new MSBuildAPIUtility(logger, virtualProjectBuilder: null)).ExecuteCommand(whyCommandArgs);
 
             // Assert
             var output = console.Output;
@@ -158,7 +158,7 @@ namespace NuGet.XPlat.FuncTest
                     CancellationToken.None);
 
             // Act
-            var result = await new WhyCommandRunner(new MSBuildAPIUtility(NullLogger.Instance)).ExecuteCommand(whyCommandArgs);
+            var result = await new WhyCommandRunner(new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null)).ExecuteCommand(whyCommandArgs);
 
             // Assert
             var output = logger.Lines;
@@ -182,7 +182,7 @@ namespace NuGet.XPlat.FuncTest
                     CancellationToken.None);
 
             // Act
-            var result = await new WhyCommandRunner(new MSBuildAPIUtility(NullLogger.Instance)).ExecuteCommand(whyCommandArgs);
+            var result = await new WhyCommandRunner(new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null)).ExecuteCommand(whyCommandArgs);
 
             // Assert
             var errorOutput = logger.Lines;
@@ -209,7 +209,7 @@ namespace NuGet.XPlat.FuncTest
                     CancellationToken.None);
 
             // Act
-            var result = await new WhyCommandRunner(new MSBuildAPIUtility(NullLogger.Instance)).ExecuteCommand(whyCommandArgs);
+            var result = await new WhyCommandRunner(new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null)).ExecuteCommand(whyCommandArgs);
 
             // Assert
             var errorOutput = logger.Lines;
@@ -235,7 +235,7 @@ namespace NuGet.XPlat.FuncTest
                     CancellationToken.None);
 
             // Act
-            var result = await new WhyCommandRunner(new MSBuildAPIUtility(NullLogger.Instance)).ExecuteCommand(whyCommandArgs);
+            var result = await new WhyCommandRunner(new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null)).ExecuteCommand(whyCommandArgs);
 
             // Assert
             var errorOutput = logger.Lines;
@@ -269,7 +269,7 @@ namespace NuGet.XPlat.FuncTest
             var logger = new TestCommandOutputLogger(_testOutputHelper);
             var addPackageCommandArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, project);
             var addPackageCommandRunner = new AddPackageReferenceCommandRunner();
-            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageCommandArgs, new MSBuildAPIUtility(logger));
+            var addPackageResult = await addPackageCommandRunner.ExecuteCommand(addPackageCommandArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
 
             var console = new TestConsole();
             console.Width(500);
@@ -282,7 +282,7 @@ namespace NuGet.XPlat.FuncTest
                     CancellationToken.None);
 
             // Act
-            var result = await new WhyCommandRunner(new MSBuildAPIUtility(logger)).ExecuteCommand(whyCommandArgs);
+            var result = await new WhyCommandRunner(new MSBuildAPIUtility(logger, virtualProjectBuilder: null)).ExecuteCommand(whyCommandArgs);
 
             // Assert
             var output = console.Output;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
@@ -140,7 +140,7 @@ namespace NuGet.XPlat.FuncTest
                 Assert.True(XPlatTestUtils.ValidateNoReference(projectXmlRoot, unknownPackageId));
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
@@ -179,7 +179,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new RemovePackageReferenceCommandRunner();
 
                 // Act
-                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger));
+                var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
                 projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/ListPackageCommandRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/ListPackageCommandRunnerTests.cs
@@ -158,7 +158,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 // Act
                 var isFilteredSetNonEmpty = ListPackageCommandRunner.FilterPackages(allPackages, listPackageArgs);
 
-                var a = new ListPackageCommandRunner(new MSBuildAPIUtility(NullLogger.Instance));
+                var a = new ListPackageCommandRunner(new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null));
                 var b = a.UpdatePackagesWithSourceMetadata(allPackages, null, listPackageArgs);
 
                 // Assert
@@ -171,7 +171,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             public async Task UpdatePackages_WithNullSourceMetadata_Succeeds()
             {
                 // Arrange
-                ListPackageCommandRunner listPackageRunner = new ListPackageCommandRunner(new MSBuildAPIUtility(NullLogger.Instance));
+                ListPackageCommandRunner listPackageRunner = new ListPackageCommandRunner(new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null));
                 FrameworkPackages packages = new FrameworkPackages("net40", "net40");
                 List<InstalledPackageReference> topLevelPackages =
                     new List<InstalledPackageReference>
@@ -402,7 +402,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 logger: new Mock<ILogger>().Object,
                 cancellationToken: CancellationToken.None);
 
-            var listPackageRunner = new ListPackageCommandRunner(new MSBuildAPIUtility(NullLogger.Instance));
+            var listPackageRunner = new ListPackageCommandRunner(new MSBuildAPIUtility(NullLogger.Instance, virtualProjectBuilder: null));
 
             // Act & Assert - Call the method directly since it's now internal
             Exception exception = await Record.ExceptionAsync(async () =>

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -107,7 +107,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             File.WriteAllText(Path.Combine(testDirectory, "projectA.csproj"), projectContent);
             var project = Project.FromFile(Path.Combine(testDirectory, "projectA.csproj"), projectOptions);
 
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
             // Creating an item group in the project
             var itemGroup = MSBuildAPIUtility.CreateItemGroup(project, null);
 
@@ -164,7 +164,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             File.WriteAllText(Path.Combine(testDirectory, "projectA.csproj"), projectContent);
             var project = Project.FromFile(Path.Combine(testDirectory, "projectA.csproj"), projectOptions);
             var logger = new TestLogger();
-            var msObject = new MSBuildAPIUtility(logger: logger);
+            var msObject = new MSBuildAPIUtility(logger: logger, virtualProjectBuilder: null);
             // Getting all the item groups in a given project
             var itemGroups = MSBuildAPIUtility.GetItemGroups(project);
             // Getting an existing item group that has package reference(s)
@@ -231,7 +231,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             var project = Project.FromFile(Path.Combine(testDirectory, "projectA.csproj"), projectOptions);
 
             // Add item group to Directory.Packages.props
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
             var directoryBuildPropsRootElement = MSBuildAPIUtility.GetDirectoryBuildPropsRootElement(project);
             var propsItemGroup = directoryBuildPropsRootElement.AddItemGroup();
 
@@ -302,7 +302,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             var project = Project.FromFile(Path.Combine(testDirectory, "projectA.csproj"), projectOptions);
 
             // Get existing item group from Directory.Packages.props
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
             var directoryBuildPropsRootElement = MSBuildAPIUtility.GetDirectoryBuildPropsRootElement(project);
             var propsItemGroup = MSBuildAPIUtility.GetItemGroup(directoryBuildPropsRootElement.ItemGroups, "PackageVersion", condition: null);
 
@@ -370,7 +370,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             File.WriteAllText(Path.Combine(testDirectory, "projectA.csproj"), projectContent);
             var project = Project.FromFile(Path.Combine(testDirectory, "projectA.csproj"), projectOptions);
 
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
             // Get package version if it already exists in the props file. Returns null if there is no matching package version.
             ProjectItem packageVersionInProps = project.Items.LastOrDefault(i => i.ItemType == "PackageVersion" && i.EvaluatedInclude.Equals("X"));
 
@@ -439,7 +439,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             File.WriteAllText(Path.Combine(testDirectory, "projectA.csproj"), projectContent);
             var project = Project.FromFile(Path.Combine(testDirectory, "projectA.csproj"), projectOptions);
 
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
             // Get package version if it already exists in the props file. Returns null if there is no matching package version.
             ProjectItem packageVersionInProps = project.Items.LastOrDefault(i => i.ItemType == "PackageReference" && i.EvaluatedInclude.Equals("X"));
 
@@ -492,7 +492,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                     typeConstraint: LibraryDependencyTarget.Package)
             };
 
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
 
             // Act
             msObject.AddPackageReference(projectPath, libraryDependency, noVersion: false);
@@ -532,7 +532,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                     typeConstraint: LibraryDependencyTarget.Package)
             };
 
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
 
             // Act
             msObject.AddPackageReference(projectPath, libraryDependency, noVersion: false);
@@ -555,7 +555,7 @@ namespace NuGet.CommandLine.Xplat.Tests
 
             projectA.Save();
 
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
 
             // Act
             var projectList = msObject.GetListOfProjectsFromPathArgument(projectA.ProjectPath);
@@ -576,7 +576,7 @@ namespace NuGet.CommandLine.Xplat.Tests
 
             projectA.Save();
 
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
 
             // Act
             var projectList = msObject.GetListOfProjectsFromPathArgument(Path.GetDirectoryName(projectA.ProjectPath));
@@ -601,7 +601,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             solution.Projects.Add(projectB);
             solution.Create();
 
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
 
             // Act
             var projectList = msObject.GetListOfProjectsFromPathArgument(Path.GetDirectoryName(solution.SolutionPath));
@@ -627,7 +627,7 @@ namespace NuGet.CommandLine.Xplat.Tests
             solution.Projects.Add(projectB);
             solution.Create();
 
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
 
             // Act
             var projectList = msObject.GetListOfProjectsFromPathArgument(pathContext.SolutionRoot);
@@ -719,7 +719,7 @@ namespace NuGet.CommandLine.Xplat.Tests
                 File.Create(filePath);
             }
 
-            var msObject = new MSBuildAPIUtility(logger: new TestLogger());
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
 
             // Act & Assert
             Assert.Throws<ArgumentException>(() => msObject.GetListOfProjectsFromPathArgument(pathContext.SolutionRoot));


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

Follow up on https://github.com/NuGet/NuGet.Client/pull/7169#discussion_r2990206208.

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
