### PR TITLE
 Publish NuGet gate tests to version-based drop path

### DIFF
--- a/build/runsettings.proj
+++ b/build/runsettings.proj
@@ -20,6 +20,13 @@
             Properties="RunName=NuGet.Tests.Apex;
             FileName=NuGet.Tests.Apex.dll;" />
 
+        <!-- NuGet.Tests.Apex.Canary.runsettings. use Category=Canary -->
+        <MSBuild
+            Projects="template.runsettingsproj"
+            Properties="RunName=NuGet.Tests.Apex.Gate;
+            FileName=NuGet.Tests.Apex.dll;
+            TestCaseFilter=TestCategory=Gate;" />
+
         <!-- NuGet.Tests.Apex.Daily.runsettings -->
         <MSBuild
             Projects="template.runsettingsproj"

--- a/build/runsettings.proj
+++ b/build/runsettings.proj
@@ -20,7 +20,7 @@
             Properties="RunName=NuGet.Tests.Apex;
             FileName=NuGet.Tests.Apex.dll;" />
 
-        <!-- NuGet.Tests.Apex.Canary.runsettings. use Category=Canary -->
+        <!-- NuGet.Tests.Apex.Gate.runsettings (VS test gate - runs only [TestCategory("Gate")] tests) -->
         <MSBuild
             Projects="template.runsettingsproj"
             Properties="RunName=NuGet.Tests.Apex.Gate;

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -225,14 +225,8 @@ steps:
           Write-Host "##vso[task.setvariable variable=RunSettingsDrop]$runSettingsDrop"
           Write-Host "##vso[task.setvariable variable=RunSettingsDrop;isOutput=true]$runSettingsDrop"
 
-          # Publish test binaries under a Tests/ drop path for VS test gate consumption
-          $manifestDropName = "${env:MicroBuild_ManifestDropName}"
-          if ($manifestDropName -and $manifestDropName -match '^Products/') {
-              $testsDrop = $manifestDropName -replace '^Products/', 'Tests/'
-          } else {
-              # Fallback for PR/dev builds where MicroBuild.ManifestDropName may not be set
-              $testsDrop = "Tests/${env:System_TeamProject}/${env:Build_Repository_Name}/${env:Build_SourceBranchName}/${env:Build_BuildNumber}"
-          }
+          # Test gate drop — mirrors the product drop path with Tests/ prefix so the VS gate can find it by NuGet version
+          $testsDrop = "${env:MicroBuild_ManifestDropName}" -replace '^Products/', 'Tests/'
           Write-Host "Tests Drop: $testsDrop"
           Write-Host "##vso[task.setvariable variable=TestsDrop]$testsDrop"
 

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -325,7 +325,7 @@ steps:
       sourcePath: '$(Build.StagingDirectory)\RunSettings'
       toLowerCase: false
       usePat: true
-      dropMetadataContainerName: "DropMetadata-Tests"
+      dropMetadataContainerName: "DropMetadata-TestGate"
 
   - task: PublishPipelineArtifact@1
     displayName: "Publish E2E tests"

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -225,6 +225,11 @@ steps:
           Write-Host "##vso[task.setvariable variable=RunSettingsDrop]$runSettingsDrop"
           Write-Host "##vso[task.setvariable variable=RunSettingsDrop;isOutput=true]$runSettingsDrop"
 
+          # Drop tests with build number instead of build ID to make it easier to find the drop
+          $testsDrop = "Tests/${env:System_TeamProject}/${env:Build_Repository_Name}/${env:Build_SourceBranchName}/${env:Build_BuildNumber}"
+          Write-Host "Tests Drop: $testsDrop"
+          Write-Host "##vso[task.setvariable variable=TestsDrop]$testsDrop"
+
           $vsBootstrapperBranch = dotnet msbuild -getProperty:VsTargetBranch build\config.props
           Write-Host "VS Bootstrapper Branch: $vsBootstrapperBranch"
           Write-Host "##vso[task.setvariable variable=VsBootstrapperBranch;isOutput=true]$vsBootstrapperBranch"
@@ -305,6 +310,16 @@ steps:
       toLowerCase: false
       usePat: true
       dropMetadataContainerName: "DropMetadata-RunSettings"
+
+  - task: artifactDropTask@0
+    displayName: "Publish mirrored test drop"
+    inputs:
+      dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
+      buildNumber: "$(TestsDrop)"
+      sourcePath: '$(Build.StagingDirectory)\RunSettings'
+      toLowerCase: false
+      usePat: true
+      dropMetadataContainerName: "DropMetadata-Tests"
 
   - task: PublishPipelineArtifact@1
     displayName: "Publish E2E tests"

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -225,8 +225,14 @@ steps:
           Write-Host "##vso[task.setvariable variable=RunSettingsDrop]$runSettingsDrop"
           Write-Host "##vso[task.setvariable variable=RunSettingsDrop;isOutput=true]$runSettingsDrop"
 
-          # Drop tests with build number instead of build ID to make it easier to find the drop
-          $testsDrop = "Tests/${env:System_TeamProject}/${env:Build_Repository_Name}/${env:Build_SourceBranchName}/${env:Build_BuildNumber}"
+          # Publish test binaries under a Tests/ drop path for VS test gate consumption
+          $manifestDropName = "${env:MicroBuild_ManifestDropName}"
+          if ($manifestDropName -and $manifestDropName -match '^Products/') {
+              $testsDrop = $manifestDropName -replace '^Products/', 'Tests/'
+          } else {
+              # Fallback for PR/dev builds where MicroBuild.ManifestDropName may not be set
+              $testsDrop = "Tests/${env:System_TeamProject}/${env:Build_Repository_Name}/${env:Build_SourceBranchName}/${env:Build_BuildNumber}"
+          }
           Write-Host "Tests Drop: $testsDrop"
           Write-Host "##vso[task.setvariable variable=TestsDrop]$testsDrop"
 
@@ -312,7 +318,7 @@ steps:
       dropMetadataContainerName: "DropMetadata-RunSettings"
 
   - task: artifactDropTask@0
-    displayName: "Publish mirrored test drop"
+    displayName: "Publish test gate drop"
     inputs:
       dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
       buildNumber: "$(TestsDrop)"

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
@@ -25,6 +25,7 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(LongerTimeout)]
+        [TestCategory("Gate")]
         public void SimpleInstallFromIVsInstaller()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 
Related: https://github.com/NuGet/Client.Engineering/issues/3543

## Description


 Publishes gate test binaries and runsettings to a `Tests/` drop pathvderived from the NuGet product version, enabling the runners to locate test drops by version.
 
 - Add `NuGet.Tests.Apex.Gate.runsettings` for gate-filtered tests
 - Publish test drop alongside existing product drop
 - Tag test with `[TestCategory("Gate")]`

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
