### PR TITLE
Reduce allocations in LicenseExpressionTokenizer.HasValidCharacters by caching Regex instance

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Licenses/LicenseExpressionTokenizer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Licenses/LicenseExpressionTokenizer.cs
@@ -10,6 +10,7 @@ namespace NuGet.Packaging.Licenses
 {
     internal class LicenseExpressionTokenizer
     {
+        private static readonly Regex ValidCharactersRegex = new Regex("^[a-zA-Z0-9\\.\\-\\s\\+\\(\\)]+$", RegexOptions.CultureInvariant);
         private readonly string _value;
 
         /// <summary>
@@ -34,8 +35,7 @@ namespace NuGet.Packaging.Licenses
         /// <returns>Whether the value has valid characters.</returns>
         internal bool HasValidCharacters()
         {
-            var regex = new Regex("^[a-zA-Z0-9\\.\\-\\s\\+\\(\\)]+$", RegexOptions.CultureInvariant);
-            return regex.IsMatch(_value);
+            return ValidCharactersRegex.IsMatch(_value);
         }
 
         /// <summary>


### PR DESCRIPTION
**&#129302; AI-Generated Pull Request &#129302;**

This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

---

- **Issue:** `LicenseExpressionTokenizer.HasValidCharacters()` constructs a `new Regex(...)` on every invocation using a hardcoded constant pattern string. Each `Regex` constructor call triggers internal parsing that allocates `RegexParser`, `RegexTree`, `RegexNode`, `RegexCharClass`, `RegexCode`, `StringBuilder`, and other objects (~12–15 short-lived objects per call).

  This method is called once per license expression parse via the call chain: `SearchObject.ProcessSearchResultsAsync` → `PackageSearchMetadataCacheItem` → `PackageSearchMetadataContextInfo.Create` → `PackageSearchMetadata.get_LicenseMetadata` → `NuGetLicenseExpressionParser.Parse` → `GetTokens` → `LicenseExpressionTokenizer.HasValidCharacters`.
  For a typical NuGet package search, this produces hundreds of Regex constructions — each allocating ~12–14 short-lived internal objects — contributing to measurable GC pressure on a path that the allocation telemetry specifically flagged.

  | Allocation site | Original (per search) | After fix (per search) |
  |---|---|---|
  | `new Regex(...)` internal objects | ~12–15 × N (N = license parses) | 1 (static, once per process) |

  This matches the allocation stack trace showing `StringBuilder` allocated inside `Regex..ctor` called by `HasValidCharacters` during NuGet package search:

```
nuget.packagemanagement.visualstudio.dll!SearchObject+<ProcessSearchResultsAsync>d__.MoveNext
nuget.packagemanagement.visualstudio.dll!SearchObject.CacheBackgroundData
nuget.packagemanagement.visualstudio.dll!PackageSearchMetadataCacheItem..ctor
nuget.packagemanagement.visualstudio.dll!PackageSearchMetadataCacheItem.GetVersionInfoContextInfoAsync
nuget.visualstudio.internal.contracts.dll!VersionInfoContextInfo+<CreateAsync>d__.MoveNext
nuget.visualstudio.internal.contracts.dll!PackageSearchMetadataContextInfo.Create
nuget.protocol.dll!PackageSearchMetadata.get_LicenseMetadata
nuget.packaging.dll!NuGetLicenseExpressionParser.Parse
nuget.packaging.dll!NuGetLicenseExpressionParser.GetTokens
nuget.packaging.dll!LicenseExpressionTokenizer.HasValidCharacters
└── system.dll!Regex..ctor
    └── system.dll!RegexParser.Parse → RegexParser.ScanCharClass
        └── RegexCharClass..ctor → TypeAllocated!System.Text.StringBuilder
```

- **Issue type:** Reduce repeated identical allocations from per-call `Regex` construction on a hot path

- **Proposed fix:** Promote the per-call `Regex` local variable to a `private static readonly Regex` field with `RegexOptions.CultureInvariant`. The pattern and matching behavior are identical; `Regex.IsMatch` is [documented thread-safe](https://learn.microsoft.com/dotnet/standard/base-types/thread-safety-in-regular-expressions) on constructed instances. `RegexOptions.Compiled` is intentionally omitted — the pattern is a trivial single character-class match where interpreted mode is sub-microsecond, and `Compiled` would add a non-collectible `DynamicMethod` on .NET Framework 4.7.2 with no measurable benefit for this pattern complexity and call frequency.

  This follows the existing convention in the codebase: `PackageIdValidator.IdRegex` uses the identical `private static readonly Regex` pattern for package ID validation.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&failureHash=0a3a4004-a626-c1ba-2b52-9f9f5c95f597)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2860123)