### PR TITLE
Lazily load unconfigured project only when it's needed

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -28,6 +28,7 @@ using NuGet.Versioning;
 using NuGet.VisualStudio;
 using PackageReference = NuGet.Packaging.PackageReference;
 using Task = System.Threading.Tasks.Task;
+using VSThreading = Microsoft.VisualStudio.Threading;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -43,14 +44,14 @@ namespace NuGet.PackageManagement.VisualStudio
         private const string TargetFrameworkCondition = "TargetFramework";
 
         private readonly IProjectSystemCache _projectSystemCache;
-        private readonly Microsoft.VisualStudio.Threading.AsyncLazy<UnconfiguredProject> _unconfiguredProject;
+        private readonly VSThreading.AsyncLazy<UnconfiguredProject> _unconfiguredProject;
 
         public CpsPackageReferenceProject(
             string projectName,
             string projectUniqueName,
             string projectFullPath,
             IProjectSystemCache projectSystemCache,
-            Microsoft.VisualStudio.Threading.AsyncLazy<UnconfiguredProject> unconfiguredProject,
+            VSThreading.AsyncLazy<UnconfiguredProject> unconfiguredProject,
             INuGetProjectServices projectServices,
             string projectId)
             : base(projectName,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -84,7 +84,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             var packageSpec = GetPackageSpec();
             if (packageSpec == null)
-            { 
+            {
                 if (shouldThrow)
                 {
                     throw new ProjectNotNominatedException(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -84,7 +84,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             var packageSpec = GetPackageSpec();
             if (packageSpec == null)
-            {
+            { 
                 if (shouldThrow)
                 {
                     throw new ProjectNotNominatedException(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProject.cs
@@ -43,14 +43,14 @@ namespace NuGet.PackageManagement.VisualStudio
         private const string TargetFrameworkCondition = "TargetFramework";
 
         private readonly IProjectSystemCache _projectSystemCache;
-        private readonly UnconfiguredProject _unconfiguredProject;
+        private readonly Microsoft.VisualStudio.Threading.AsyncLazy<UnconfiguredProject> _unconfiguredProject;
 
         public CpsPackageReferenceProject(
             string projectName,
             string projectUniqueName,
             string projectFullPath,
             IProjectSystemCache projectSystemCache,
-            UnconfiguredProject unconfiguredProject,
+            Microsoft.VisualStudio.Threading.AsyncLazy<UnconfiguredProject> unconfiguredProject,
             INuGetProjectServices projectServices,
             string projectId)
             : base(projectName,
@@ -269,7 +269,8 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 // This is the "partial install" case. That is, install the package to only a subset of the frameworks
                 // supported by this project.
-                var conditionalService = _unconfiguredProject
+                var unconfiguredProject = await _unconfiguredProject.GetValueAsync(token);
+                var conditionalService = unconfiguredProject
                     .Services
                     .ExportProvider
                     .GetExportedValue<IConditionalPackageReferencesService>();
@@ -315,7 +316,8 @@ namespace NuGet.PackageManagement.VisualStudio
             else
             {
                 // Install the package to all frameworks.
-                var configuredProject = await _unconfiguredProject.GetSuggestedConfiguredProjectAsync();
+                var unconfiguredProject = await _unconfiguredProject.GetValueAsync(token);
+                var configuredProject = await unconfiguredProject.GetSuggestedConfiguredProjectAsync();
 
                 var result = await configuredProject
                     .Services
@@ -367,7 +369,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (installationContext.SuccessfulFrameworks.Any() && installationContext.UnsuccessfulFrameworks.Any())
             {
-                var conditionalService = _unconfiguredProject
+                var unconfiguredProject = await _unconfiguredProject.GetValueAsync(token);
+                var conditionalService = unconfiguredProject
                     .Services
                     .ExportProvider
                     .GetExportedValue<IConditionalPackageReferencesService>();
@@ -387,7 +390,8 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             else
             {
-                var configuredProject = await _unconfiguredProject.GetSuggestedConfiguredProjectAsync();
+                var unconfiguredProject = await _unconfiguredProject.GetValueAsync(token);
+                var configuredProject = await unconfiguredProject.GetSuggestedConfiguredProjectAsync();
 
                 await configuredProject?.Services.PackageReferences.RemoveAsync(packageId);
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -9,6 +9,7 @@ using Microsoft;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities;
 using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
@@ -80,16 +81,21 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             var fullProjectPath = vsProject.FullProjectPath;
-            var unconfiguredProject = GetUnconfiguredProject(vsProject.Project);
 
             var projectServices = new CpsProjectSystemServices(vsProject, _scriptExecutor);
+
+            var lazyUnconfiguredProject = new AsyncLazy<UnconfiguredProject>(async () =>
+            {
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                return GetUnconfiguredProject(vsProject.Project);
+            }, NuGetUIThreadHelper.JoinableTaskFactory);
 
             return new CpsPackageReferenceProject(
                 vsProject.ProjectName,
                 vsProject.CustomUniqueName,
                 fullProjectPath,
                 _projectSystemCache,
-                unconfiguredProject,
+                lazyUnconfiguredProject,
                 projectServices,
                 vsProject.ProjectId);
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -4421,7 +4421,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         {
             // Arrange
             var projectSystemCache = new Mock<IProjectSystemCache>();
-            var unconfiguredProject = new Mock<UnconfiguredProject>();
             var nugetProjectServices = new Mock<INuGetProjectServices>();
             var projectGuid = Guid.NewGuid();
             var cacheContext = new DependencyGraphCacheContext();
@@ -4432,7 +4431,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 @"src\TestProject\TestProject.csproj",
                 @"c:\repo\src\TestProject\TestProject.csproj",
                 projectSystemCache.Object,
-                unconfiguredProject.Object,
+                null,
                 nugetProjectServices.Object,
                 projectGuid.ToString());
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/CpsPackageReferenceProjectTests.cs
@@ -4431,7 +4431,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 @"src\TestProject\TestProject.csproj",
                 @"c:\repo\src\TestProject\TestProject.csproj",
                 projectSystemCache.Object,
-                null,
+                unconfiguredProject: null,
                 nugetProjectServices.Object,
                 projectGuid.ToString());
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -157,13 +157,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 Initialize(packageSources);
 
-                var unconfiguredProject = new Mock<UnconfiguredProject>();
+                var mockUnconfiguredProject = new Mock<UnconfiguredProject>();
                 var configuredProject = new Mock<ConfiguredProject>();
                 var projectServices = new Mock<ConfiguredProjectServices>();
                 var packageReferencesService = new Mock<IPackageReferencesService>();
                 var result = new Mock<IUnresolvedPackageReference>();
 
-                unconfiguredProject.Setup(x => x.GetSuggestedConfiguredProjectAsync())
+                mockUnconfiguredProject.Setup(x => x.GetSuggestedConfiguredProjectAsync())
                     .ReturnsAsync(configuredProject.Object);
 
                 configuredProject.SetupGet(x => x.Services)
@@ -174,6 +174,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 packageReferencesService.Setup(x => x.AddAsync(It.IsNotNull<string>(), It.IsNotNull<string>()))
                     .ReturnsAsync(new AddReferenceResult<IUnresolvedPackageReference>(result.Object, added: true));
+
+                var unconfiguredProject = new Microsoft.VisualStudio.Threading.AsyncLazy<UnconfiguredProject>(
+                    () => Task.FromResult(mockUnconfiguredProject.Object));
 
                 var nuGetProjectServices = new Mock<INuGetProjectServices>();
 
@@ -188,7 +191,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     projectUniqueName: projectFullPath,
                     projectFullPath: projectFullPath,
                     projectSystemCache,
-                    unconfiguredProject.Object,
+                    unconfiguredProject,
                     nuGetProjectServices.Object,
                     projectId);
 
@@ -429,13 +432,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 Initialize(packageSources);
 
-                var unconfiguredProject = new Mock<UnconfiguredProject>();
+                var mockUnconfiguredProject = new Mock<UnconfiguredProject>();
                 var configuredProject = new Mock<ConfiguredProject>();
                 var projectServices = new Mock<ConfiguredProjectServices>();
                 var packageReferencesService = new Mock<IPackageReferencesService>();
                 var result = new Mock<IUnresolvedPackageReference>();
 
-                unconfiguredProject.Setup(x => x.GetSuggestedConfiguredProjectAsync())
+                mockUnconfiguredProject.Setup(x => x.GetSuggestedConfiguredProjectAsync())
                     .ReturnsAsync(configuredProject.Object);
 
                 configuredProject.SetupGet(x => x.Services)
@@ -446,6 +449,9 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 packageReferencesService.Setup(x => x.AddAsync(It.IsNotNull<string>(), It.IsNotNull<string>()))
                     .ReturnsAsync(new AddReferenceResult<IUnresolvedPackageReference>(result.Object, added: true));
+
+                var unconfiguredProject = new Microsoft.VisualStudio.Threading.AsyncLazy<UnconfiguredProject>(
+                    () => Task.FromResult(mockUnconfiguredProject.Object));
 
                 var nuGetProjectServices = new Mock<INuGetProjectServices>();
 
@@ -460,7 +466,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     projectUniqueName: projectFullPath,
                     projectFullPath: projectFullPath,
                     projectSystemCache,
-                    unconfiguredProject.Object,
+                    unconfiguredProject,
                     nuGetProjectServices.Object,
                     projectId);
 

--- a/test/TestUtilities/VisualStudio.Test.Utility/TestCpsPackageReferenceProject.cs
+++ b/test/TestUtilities/VisualStudio.Test.Utility/TestCpsPackageReferenceProject.cs
@@ -51,7 +51,7 @@ namespace Test.Utility
             string projectUniqueName,
             string projectFullPath,
             IProjectSystemCache projectSystemCache,
-            UnconfiguredProject unconfiguredProject,
+            Microsoft.VisualStudio.Threading.AsyncLazy<UnconfiguredProject> unconfiguredProject,
             INuGetProjectServices projectServices,
             string projectId,
             string assetsFilePath,

--- a/test/TestUtilities/VisualStudio.Test.Utility/TestCpsPackageReferenceProject.cs
+++ b/test/TestUtilities/VisualStudio.Test.Utility/TestCpsPackageReferenceProject.cs
@@ -22,6 +22,7 @@ using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
+using VSThreading = Microsoft.VisualStudio.Threading;
 
 namespace Test.Utility
 {
@@ -51,7 +52,7 @@ namespace Test.Utility
             string projectUniqueName,
             string projectFullPath,
             IProjectSystemCache projectSystemCache,
-            Microsoft.VisualStudio.Threading.AsyncLazy<UnconfiguredProject> unconfiguredProject,
+            VSThreading.AsyncLazy<UnconfiguredProject> unconfiguredProject,
             INuGetProjectServices projectServices,
             string projectId,
             string assetsFilePath,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14831

## Description

We cast the DTE.Project to IVsBrowseObjectContext which forces a project load in C++ project systems.

This is done at solution load time and it's not ideal as C++ tries to support PackageReference in native projects.
We don't need UnconfiguredProject at this time really.
We just need it when we install a package so we can delay this load.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ - Existing tests are fine.
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
