### PR TITLE
Add ability to disable the writing of the dependency graph spec file

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -1083,6 +1083,7 @@ namespace NuGet.Build.Tasks.Console
             restoreMetadata.UsingMicrosoftNETSdk = MSBuildRestoreUtility.GetUsingMicrosoftNETSdk(project.GetProperty("UsingMicrosoftNETSdk"));
             restoreMetadata.SdkAnalysisLevel = MSBuildRestoreUtility.GetSdkAnalysisLevel(project.GetProperty("SdkAnalysisLevel"));
             restoreMetadata.UseLegacyDependencyResolver = project.IsPropertyTrue("RestoreUseLegacyDependencyResolver");
+            restoreMetadata.RestoreDoNotWriteDependencyGraphSpec = project.IsPropertyTrue("RestoreDoNotWriteDependencyGraphSpec");
 
             return (restoreMetadata, targetFrameworkInfos);
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -961,6 +961,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <UsingMicrosoftNETSdk>$(UsingMicrosoftNETSdk)</UsingMicrosoftNETSdk>
         <NETCoreSdkVersion>$(NETCoreSdkVersion)</NETCoreSdkVersion>
         <RestoreUseLegacyDependencyResolver>$(RestoreUseLegacyDependencyResolver)</RestoreUseLegacyDependencyResolver>
+        <RestoreDoNotWriteDependencyGraphSpec>$(RestoreDoNotWriteDependencyGraphSpec)</RestoreDoNotWriteDependencyGraphSpec>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -344,7 +344,8 @@ namespace NuGet.Commands
                     restoreTime.Elapsed)
                 {
                     AuditRan = auditRan,
-                    DidDGHashChange = !noOpCacheFileEvaluation
+                    DidDGHashChange = !noOpCacheFileEvaluation,
+                    DoNotWriteDependencyGraphSpec = _request.Project.RestoreMetadata.RestoreDoNotWriteDependencyGraphSpec
                 };
 
                 telemetry.TelemetryEvent[UpdatedAssetsFile] = restoreResult._isAssetsFileDirty.Value;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -97,7 +97,6 @@ namespace NuGet.Commands
         /// </summary>
         internal bool DoNotWriteDependencyGraphSpec { get; init; }
 
-
         private readonly string _dependencyGraphSpecFilePath;
 
         private readonly DependencyGraphSpec _dependencyGraphSpec;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -92,6 +92,11 @@ namespace NuGet.Commands
         /// </summary>
         internal bool DidDGHashChange { get; init; }
 
+        /// <summary>
+        /// If true, the dg spec file should not be written to disk.
+        /// </summary>
+        internal bool DoNotWriteDependencyGraphSpec { get; init; }
+
 
         private readonly string _dependencyGraphSpecFilePath;
 
@@ -317,7 +322,7 @@ namespace NuGet.Commands
 
         private async Task CommitDgSpecFileAsync(ILogger log, bool toolCommit)
         {
-            if (!toolCommit && _dependencyGraphSpecFilePath != null && _dependencyGraphSpec != null && (DidDGHashChange || !File.Exists(_dependencyGraphSpecFilePath)))
+            if (!toolCommit && !DoNotWriteDependencyGraphSpec && _dependencyGraphSpecFilePath != null && _dependencyGraphSpec != null && (DidDGHashChange || !File.Exists(_dependencyGraphSpecFilePath)))
             {
                 log.LogVerbose($"Persisting dg to {_dependencyGraphSpecFilePath}");
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -293,6 +293,7 @@ namespace NuGet.Commands
                 result.RestoreMetadata.UsingMicrosoftNETSdk = GetUsingMicrosoftNETSdk(specItem.GetProperty("UsingMicrosoftNETSdk"));
                 result.RestoreMetadata.SdkAnalysisLevel = GetSdkAnalysisLevel(specItem.GetProperty("SdkAnalysisLevel"));
                 result.RestoreMetadata.UseLegacyDependencyResolver = IsPropertyTrue(specItem, "RestoreUseLegacyDependencyResolver");
+                result.RestoreMetadata.RestoreDoNotWriteDependencyGraphSpec = IsPropertyTrue(specItem, "RestoreDoNotWriteDependencyGraphSpec");
                 result.RestoreSettings.SdkVersion = GetSdkAnalysisLevel(specItem.GetProperty("NETCoreSdkVersion"));
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -225,8 +225,9 @@ namespace NuGet.Commands
         /// <returns>The path for the dgspec.json. Null if not appropriate.</returns>
         internal static string GetPersistedDGSpecFilePath(RestoreRequest request)
         {
-            if (request.ProjectStyle == ProjectStyle.ProjectJson
+            if ((request.ProjectStyle == ProjectStyle.ProjectJson
                 || request.ProjectStyle == ProjectStyle.PackageReference)
+                && !request.Project.RestoreMetadata.RestoreDoNotWriteDependencyGraphSpec)
             {
                 var outputRoot = request.MSBuildProjectExtensionsPath ?? request.RestoreOutputPath;
                 var projFileName = Path.GetFileName(request.Project.RestoreMetadata.ProjectPath);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -225,9 +225,8 @@ namespace NuGet.Commands
         /// <returns>The path for the dgspec.json. Null if not appropriate.</returns>
         internal static string GetPersistedDGSpecFilePath(RestoreRequest request)
         {
-            if ((request.ProjectStyle == ProjectStyle.ProjectJson
+            if (request.ProjectStyle == ProjectStyle.ProjectJson
                 || request.ProjectStyle == ProjectStyle.PackageReference)
-                && !request.Project.RestoreMetadata.RestoreDoNotWriteDependencyGraphSpec)
             {
                 var outputRoot = request.MSBuildProjectExtensionsPath ?? request.RestoreOutputPath;
                 var projFileName = Path.GetFileName(request.Project.RestoreMetadata.ProjectPath);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
@@ -182,6 +182,7 @@ namespace NuGet.Commands.Restore.Utility
             restoreMetadata.UsingMicrosoftNETSdk = MSBuildRestoreUtility.GetUsingMicrosoftNETSdk(outerBuild.GetProperty("UsingMicrosoftNETSdk"));
             restoreMetadata.SdkAnalysisLevel = MSBuildRestoreUtility.GetSdkAnalysisLevel(outerBuild.GetProperty("SdkAnalysisLevel"));
             restoreMetadata.UseLegacyDependencyResolver = outerBuild.IsPropertyTrue("RestoreUseLegacyDependencyResolver");
+            restoreMetadata.RestoreDoNotWriteDependencyGraphSpec = outerBuild.IsPropertyTrue("RestoreDoNotWriteDependencyGraphSpec");
 
             return (restoreMetadata, targetFrameworkInfos);
 

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -95,6 +95,7 @@ namespace NuGet.ProjectModel
         private static readonly byte[] SdkAnalysisLevel = Encoding.UTF8.GetBytes("SdkAnalysisLevel");
         private static readonly byte[] UsingMicrosoftNETSdk = Encoding.UTF8.GetBytes("UsingMicrosoftNETSdk");
         private static readonly byte[] UseLegacyDependencyResolverPropertyName = Encoding.UTF8.GetBytes("restoreUseLegacyDependencyResolver");
+        private static readonly byte[] RestoreDoNotWriteDependencyGraphSpecPropertyName = Encoding.UTF8.GetBytes("restoreDoNotWriteDependencyGraphSpec");
         private static readonly byte[] PackagesToPrunePropertyName = Encoding.UTF8.GetBytes("packagesToPrune");
 
         internal static PackageSpec GetPackageSpecUtf8JsonStreamReader(Stream stream, string name, string packageSpecPath, IEnvironmentVariableReader environmentVariableReader, string snapshotValue = null)
@@ -775,6 +776,7 @@ namespace NuGet.ProjectModel
             bool usingMicrosoftNetSdk = true;
             NuGetVersion sdkAnalysisLevel = null;
             bool useLegacyDependencyResolver = false;
+            bool restoreDoNotWriteDependencyGraphSpec = false;
 
             if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
             {
@@ -1033,6 +1035,10 @@ namespace NuGet.ProjectModel
                     {
                         useLegacyDependencyResolver = jsonReader.ReadNextTokenAsBoolOrThrowAnException(UseLegacyDependencyResolverPropertyName, Strings.Invalid_AttributeValue);
                     }
+                    else if (jsonReader.ValueTextEquals(RestoreDoNotWriteDependencyGraphSpecPropertyName))
+                    {
+                        restoreDoNotWriteDependencyGraphSpec = jsonReader.ReadNextTokenAsBoolOrThrowAnException(RestoreDoNotWriteDependencyGraphSpecPropertyName, Strings.Invalid_AttributeValue);
+                    }
                     else
                     {
                         jsonReader.Skip();
@@ -1061,6 +1067,7 @@ namespace NuGet.ProjectModel
             msbuildMetadata.SdkAnalysisLevel = sdkAnalysisLevel;
             msbuildMetadata.UsingMicrosoftNETSdk = usingMicrosoftNetSdk;
             msbuildMetadata.UseLegacyDependencyResolver = useLegacyDependencyResolver;
+            msbuildMetadata.RestoreDoNotWriteDependencyGraphSpec = restoreDoNotWriteDependencyGraphSpec;
 
             if (configFilePaths != null)
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -170,6 +170,7 @@ namespace NuGet.ProjectModel
             SetValueIfTrue(writer, "CentralPackageTransitivePinningEnabled", msbuildMetadata.CentralPackageTransitivePinningEnabled);
             SetValueIfFalse(writer, "UsingMicrosoftNETSdk", msbuildMetadata.UsingMicrosoftNETSdk);
             SetValueIfTrue(writer, "restoreUseLegacyDependencyResolver", msbuildMetadata.UseLegacyDependencyResolver);
+            SetValueIfTrue(writer, "restoreDoNotWriteDependencyGraphSpec", msbuildMetadata.RestoreDoNotWriteDependencyGraphSpec);
         }
 
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -149,6 +149,12 @@ namespace NuGet.ProjectModel
 
         public bool UseLegacyDependencyResolver { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the dependency graph spec file should not be written during restore.
+        /// The default value is <see langword="false" />.
+        /// </summary>
+        public bool RestoreDoNotWriteDependencyGraphSpec { get; set; }
+
         public override int GetHashCode()
         {
             StringComparer osStringComparer = PathUtility.GetStringComparerBasedOnOS();
@@ -182,6 +188,7 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(UsingMicrosoftNETSdk);
             hashCode.AddObject(SdkAnalysisLevel);
             hashCode.AddObject(UseLegacyDependencyResolver);
+            hashCode.AddObject(RestoreDoNotWriteDependencyGraphSpec);
 
             return hashCode.CombinedHash;
         }
@@ -230,7 +237,8 @@ namespace NuGet.ProjectModel
                    RestoreAuditProperties == other.RestoreAuditProperties &&
                    UsingMicrosoftNETSdk == other.UsingMicrosoftNETSdk &&
                    EqualityUtility.EqualsWithNullCheck(SdkAnalysisLevel, other.SdkAnalysisLevel) &&
-                   UseLegacyDependencyResolver == other.UseLegacyDependencyResolver;
+                   UseLegacyDependencyResolver == other.UseLegacyDependencyResolver &&
+                   RestoreDoNotWriteDependencyGraphSpec == other.RestoreDoNotWriteDependencyGraphSpec;
         }
 
         private HashSet<string> GetSources(IList<PackageSource> sources)
@@ -284,6 +292,7 @@ namespace NuGet.ProjectModel
             clone.SdkAnalysisLevel = SdkAnalysisLevel;
             clone.UsingMicrosoftNETSdk = UsingMicrosoftNETSdk;
             clone.UseLegacyDependencyResolver = UseLegacyDependencyResolver;
+            clone.RestoreDoNotWriteDependencyGraphSpec = RestoreDoNotWriteDependencyGraphSpec;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -7,3 +7,5 @@ const NuGet.ProjectModel.LockFileFormat.LegacyVersion = 3 -> int
 ~static NuGet.ProjectModel.PackageSpecOperations.AddOrUpdateDependency(NuGet.ProjectModel.PackageSpec spec, NuGet.Packaging.Core.PackageIdentity identity, System.Collections.Generic.IEnumerable<string> frameworksToAdd) -> void
 ~NuGet.ProjectModel.PackagesLockFileTarget.TargetAlias.get -> string
 ~NuGet.ProjectModel.PackagesLockFileTarget.TargetAlias.set -> void
+NuGet.ProjectModel.ProjectRestoreMetadata.RestoreDoNotWriteDependencyGraphSpec.get -> bool
+NuGet.ProjectModel.ProjectRestoreMetadata.RestoreDoNotWriteDependencyGraphSpec.set -> void

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -4873,6 +4873,52 @@ namespace NuGet.Commands.Test
             return new MSBuildItem(Guid.NewGuid().ToString(), properties);
         }
 
+        [Theory]
+        [InlineData("true", true)]
+        [InlineData("false", false)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        public void MSBuildRestoreUtility_GetPackageSpec_RestoreDoNotWriteDependencyGraphSpec(
+            string propertyValue,
+            bool expectedValue)
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+
+                var items = new List<IDictionary<string, string>>();
+
+                var properties = new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "Version", "2.0.0" },
+                    { "ProjectName", "a" },
+                    { "ProjectStyle", "PackageReference" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "net46" },
+                };
+
+                if (propertyValue != null)
+                {
+                    properties["RestoreDoNotWriteDependencyGraphSpec"] = propertyValue;
+                }
+
+                items.Add(properties);
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+
+                // Assert
+                project1Spec.RestoreMetadata.RestoreDoNotWriteDependencyGraphSpec.Should().Be(expectedValue);
+            }
+        }
+
         private Dictionary<string, string> WithUniqueName(Dictionary<string, string> item, string uniqueName)
         {
             var newItem = new Dictionary<string, string>(item, StringComparer.OrdinalIgnoreCase);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
@@ -382,7 +382,7 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
-        public async Task CommitAsync_WhenRestoreWriteDependencyGraphSpecIsFalse_DoesNotWriteDgSpec()
+        public async Task CommitAsync_WhenDoNotWriteDependencyGraphSpecIsTrue_DoesNotWriteDgSpec()
         {
             // Arrange
             using var td = TestDirectory.Create();
@@ -414,10 +414,13 @@ namespace NuGet.Commands.Test
                 cacheFilePath: cachePath,
                 packagesLockFilePath: null,
                 packagesLockFile: null,
-                dependencyGraphSpecFilePath: null,
+                dependencyGraphSpecFilePath: dgSpecPath,
                 dependencyGraphSpec: dgSpec,
                 projectStyle: ProjectStyle.Unknown,
-                elapsedTime: TimeSpan.MinValue);
+                elapsedTime: TimeSpan.MinValue)
+            {
+                DoNotWriteDependencyGraphSpec = true
+            };
 
             // Act
             await result.CommitAsync(logger, CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
@@ -382,6 +382,54 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public async Task CommitAsync_WhenRestoreWriteDependencyGraphSpecIsFalse_DoesNotWriteDgSpec()
+        {
+            // Arrange
+            using var td = TestDirectory.Create();
+            var path = Path.Combine(td, "project.assets.json");
+            var cachePath = Path.Combine(td, "project.csproj.nuget.cache");
+            var dgSpecPath = Path.Combine(td, "project1.nuget.g.dgspec.json");
+            var dgSpec = new DependencyGraphSpec();
+            var configJson = @"
+                {
+                     ""frameworks"": {
+                        ""net45"": { }
+                    }
+                }";
+
+            var spec = JsonPackageSpecReader.GetPackageSpec(configJson, "TestProject", Path.Combine(td, "project.csproj")).WithTestRestoreMetadata();
+            dgSpec.AddProject(spec);
+            dgSpec.AddRestore(spec.Name);
+
+            var logger = new TestLogger();
+            var result = new RestoreResult(
+                success: true,
+                restoreGraphs: null,
+                compatibilityCheckResults: null,
+                lockFile: new LockFile(),
+                previousLockFile: null,
+                lockFilePath: path,
+                msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
+                cacheFile: new CacheFile("NotSoRandomString"),
+                cacheFilePath: cachePath,
+                packagesLockFilePath: null,
+                packagesLockFile: null,
+                dependencyGraphSpecFilePath: null,
+                dependencyGraphSpec: dgSpec,
+                projectStyle: ProjectStyle.Unknown,
+                elapsedTime: TimeSpan.MinValue);
+
+            // Act
+            await result.CommitAsync(logger, CancellationToken.None);
+
+            // Assert
+            Assert.DoesNotContain(
+                logger.VerboseMessages,
+                m => m.Contains("Persisting dg"));
+            Assert.False(File.Exists(dgSpecPath));
+        }
+
+        [Fact]
         public void WhenRestoreResult_LogMessagesAreSourcedFromTheAssetsFile()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -171,6 +171,62 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        public void Write_ReadWrite_RestoreDoNotWriteDependencyGraphSpec_True()
+        {
+            // Arrange
+            var json = @"{
+                            ""restore"": {
+    ""projectUniqueName"": ""projectUniqueName"",
+    ""projectName"": ""projectName"",
+    ""projectPath"": ""projectPath"",
+    ""packagesPath"": ""packagesPath"",
+    ""outputPath"": ""outputPath"",
+    ""projectStyle"": ""PackageReference"",
+    ""restoreDoNotWriteDependencyGraphSpec"": true,
+    ""frameworks"": {
+      ""net45"": {
+        ""framework"": ""net45"",
+        ""projectReferences"": {}
+      }
+    }
+  }
+}";
+            // Act & Assert
+            VerifyJsonPackageSpecRoundTrip(json);
+        }
+
+        [Fact]
+        public void Write_ReadWrite_RestoreDoNotWriteDependencyGraphSpec_DefaultFalse_NotWritten()
+        {
+            // Arrange - when RestoreDoNotWriteDependencyGraphSpec is false (default), it should not appear in output
+            var json = @"{
+                            ""restore"": {
+    ""projectUniqueName"": ""projectUniqueName"",
+    ""projectName"": ""projectName"",
+    ""projectPath"": ""projectPath"",
+    ""packagesPath"": ""packagesPath"",
+    ""outputPath"": ""outputPath"",
+    ""projectStyle"": ""PackageReference"",
+    ""frameworks"": {
+      ""net45"": {
+        ""framework"": ""net45"",
+        ""projectReferences"": {}
+      }
+    }
+  }
+}";
+            // Act
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.csproj");
+
+            // Assert - default value should be false
+            spec.RestoreMetadata.RestoreDoNotWriteDependencyGraphSpec.Should().BeFalse();
+
+            // And it should not appear in the serialized output
+            var output = GetJsonString(spec);
+            output.Should().NotContain("restoreDoNotWriteDependencyGraphSpec");
+        }
+
+        [Fact]
         public void Write_SerializesMembersAsJson()
         {
             // Arrange && Act

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
@@ -833,5 +833,40 @@ namespace NuGet.ProjectModel.Test
                 leftSide.GetHashCode().Should().NotBe(rightSide.GetHashCode());
             }
         }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(false, false, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        public void Equals_WithRestoreDoNotWriteDependencyGraphSpec(bool left, bool right, bool expected)
+        {
+            var leftSide = new ProjectRestoreMetadata
+            {
+                RestoreDoNotWriteDependencyGraphSpec = left
+            };
+
+            var rightSide = new ProjectRestoreMetadata
+            {
+                RestoreDoNotWriteDependencyGraphSpec = right
+            };
+
+            AssertEquality(expected, leftSide, rightSide);
+            AssertHashCode(expected, leftSide, rightSide);
+        }
+
+        [Fact]
+        public void Clone_WithRestoreDoNotWriteDependencyGraphSpec()
+        {
+            var original = new ProjectRestoreMetadata
+            {
+                RestoreDoNotWriteDependencyGraphSpec = true
+            };
+
+            var clone = original.Clone();
+
+            clone.RestoreDoNotWriteDependencyGraphSpec.Should().Be(true);
+            AssertEquality(true, original, clone);
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14114

## Description
This will allow users to disable the writing of the DGSpec file since for large restores it can add a measurable amount of overhead.  The guidance would be to only enable this option in a hosted build environment like:

```xml
<PropertyGroup>
  <!-- Do not write out NuGet's dgspec file in our hosted build environment -->
  <RestoreDoNotWriteDependencyGraphSpec Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</RestoreDoNotWriteDependencyGraphSpec>
</PropertyGroup>
```
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
