### PR TITLE
﻿Remove admin elevation requirement from signed package tests

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/X509ChainHolderTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/X509ChainHolderTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using NuGet.Common;
 using NuGet.Packaging.Signing;
 using Xunit;
 
@@ -43,27 +42,16 @@ namespace Dotnet.Integration.Test
 
         private void Verify(X509ChainPolicy policy, string expectedFingerprint)
         {
-            if (RuntimeEnvironmentHelper.IsWindows)
-            {
-                Assert.Equal(X509ChainTrustMode.System, policy.TrustMode);
-            }
-            else if (RuntimeEnvironmentHelper.IsLinux || RuntimeEnvironmentHelper.IsMacOSX)
-            {
-                Assert.Equal(X509ChainTrustMode.CustomRootTrust, policy.TrustMode);
+            Assert.Equal(X509ChainTrustMode.CustomRootTrust, policy.TrustMode);
 
-                using (SHA256 hashAlgorithm = SHA256.Create())
+            using (SHA256 hashAlgorithm = SHA256.Create())
+            {
+                Assert.Contains(policy.CustomTrustStore, certificate =>
                 {
-                    Assert.Contains(policy.CustomTrustStore, certificate =>
-                    {
-                        string actualFingerprint = certificate.GetCertHashString(HashAlgorithmName.SHA256);
+                    string actualFingerprint = certificate.GetCertHashString(HashAlgorithmName.SHA256);
 
-                        return string.Equals(expectedFingerprint, actualFingerprint, StringComparison.OrdinalIgnoreCase);
-                    });
-                }
-            }
-            else
-            {
-                throw new PlatformNotSupportedException();
+                    return string.Equals(expectedFingerprint, actualFingerprint, StringComparison.OrdinalIgnoreCase);
+                });
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedRepoTestCert = fixture.TrustedRepositoryCertificate;
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_AuthorSignedPackage_WithCertificateInAllowList_SuccessAsync()
         {
             // Arrange
@@ -77,7 +77,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [MemberData(nameof(EmptyNullAndRequiredListCombinations))]
         public async Task GetTrustResultAsync_AuthorSignedPackage_RequirementsAsync(
             SignedPackageVerifierSettings verifierSettings,
@@ -125,7 +125,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_AuthorSignedPackage_VerifyWithoutCertificateInAllowList_AllowUntrusted_WarnAsync()
         {
             // Arrange
@@ -171,7 +171,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_AuthorSignedPackage_VerifyWithoutCertificateInAllowList_NotAllowUntrusted_ErrorAsync()
         {
             // Arrange
@@ -217,7 +217,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositorySignedPackage_AllowListWithAuthorTarget_AndPrimaryPlacement_ErrorAsync()
         {
             // Arrange
@@ -265,7 +265,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositorySignedPackage_AllowListWithRepositoryTarget_AndCounterPlacementOnly_ErrorAsync()
         {
             // Arrange
@@ -313,7 +313,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositorySignedPackage_AllowListWithRepositoryTarget_AndPrimaryPlacement_SuccessAsync()
         {
             // Arrange
@@ -359,7 +359,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_AllowListWithAuthorTarget_AndPrimaryPlacement_ErrorAsync()
         {
             // Arrange
@@ -409,7 +409,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_AllowListWithRepositoryTarget_AndPrimaryPlacementOnly_ErrorAsync()
         {
             // Arrange
@@ -459,7 +459,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_AllowListWithRepositoryTarget_AndCounterPlacement_SuccessAsync()
         {
             // Arrange
@@ -507,7 +507,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -551,7 +551,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertNotFromAllowList_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -602,7 +602,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithOwnerInOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -652,7 +652,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithOwnerNotInOwnersList_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -703,7 +703,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithNoOwnersInPackage_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -752,7 +752,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithOwnerInOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -804,7 +804,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithOwnerNotInOwnersList_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -857,7 +857,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithOwnerNotInOwnersList_AuthorInList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -911,7 +911,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithNoOwnersInPackage_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -963,7 +963,7 @@ namespace NuGet.Packaging.FuncTest
         }
 
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithEmptyOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -1013,7 +1013,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList__WithNullOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/ClientPolicyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/ClientPolicyTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedRepoTestCert.Dispose();
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData(SigningTestType.Author, "accept", true, 0)]
         [InlineData(SigningTestType.Author, "require", false, 1)]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0)]
@@ -91,7 +91,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData(SigningTestType.Author, "accept", true, 0, 1)]
         [InlineData(SigningTestType.Author, "require", false, 1, 0)]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0, 1)]
@@ -152,7 +152,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData(SigningTestType.Author, SignaturePlacement.PrimarySignature, "accept")]
         [InlineData(SigningTestType.Author, SignaturePlacement.PrimarySignature, "require")]
         [InlineData(SigningTestType.RepositoryPrimary, SignaturePlacement.PrimarySignature, "accept")]
@@ -223,7 +223,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData(SigningTestType.RepositoryPrimary, "accept")]
         [InlineData(SigningTestType.RepositoryPrimary, "require")]
         [InlineData(SigningTestType.RepositoryCountersigned, "accept")]
@@ -283,7 +283,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0, 1)]
         [InlineData(SigningTestType.RepositoryPrimary, "require", false, 1, 0)]
         [InlineData(SigningTestType.RepositoryCountersigned, "accept", true, 0, 1)]
@@ -343,7 +343,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0, 1)]
         [InlineData(SigningTestType.RepositoryPrimary, "require", false, 1, 0)]
         [InlineData(SigningTestType.RepositoryCountersigned, "accept", true, 0, 1)]

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
@@ -61,7 +61,7 @@ namespace NuGet.Packaging.FuncTest
             return SignedPackageVerifierSettings.GetDefault(TestEnvironmentVariableReader.EmptyInstance);
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnSignedPackageAsync(string policyString)
@@ -87,7 +87,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileDeletedAsync(string policyString)
@@ -121,7 +121,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileAddedAsync(string policyString)
@@ -166,7 +166,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileAppendedAsync(string policyString)
@@ -210,7 +210,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileTruncatedAsync(string policyString)
@@ -251,7 +251,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileMetadataModifiedAsync(string policyString)
@@ -295,7 +295,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData("command", false)]
         [InlineData("vs", true)]
         public async Task Signer_VerifyOnTamperedPackage_SignatureRemovedAsync(string policyString, bool expectedValidity)
@@ -339,7 +339,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyTheory]
+        [Theory]
         [InlineData("command", false)]
         [InlineData("vs", true)]
         public async Task Signer_VerifyOnTamperedPackage_SignatureTamperedAsync(string policyString, bool expectedValidity)

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
@@ -25,7 +25,7 @@ namespace NuGet.Packaging.FuncTest
     [Collection(SigningTestCollection.Name)]
     public class PackageSignatureVerifierTests
     {
-        [CIOnlyFact]
+        [Fact]
         public void Constructor_WhenArgumentIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
@@ -55,7 +55,7 @@ namespace NuGet.Packaging.FuncTest
                 };
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_ValidCertificate_SuccessAsync()
             {
                 // Arrange
@@ -80,7 +80,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_ValidCertificateAndTimestamp_SuccessAsync()
             {
                 // Arrange
@@ -110,7 +110,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_ValidCertificateAndTimestampWithDifferentHashAlgorithms_SuccessAsync()
             {
                 var packageContext = new SimpleTestPackageContext();
@@ -241,7 +241,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Verify a package meeting minimum signature requirements.
             // This signature is neither an author nor repository signature.
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_WithBasicSignedCms_SucceedsAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -290,7 +290,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_SettingsRequireTimestamp_NoTimestamp_FailsAsync()
             {
                 // Arrange
@@ -331,7 +331,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_SettingsNotRequireCheckCountersignature_WithValidPrimarySignatureAndInvalidCountersignature_SucceedsAsync()
             {
                 // Arrange
@@ -381,7 +381,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_SettingsRequireCheckCountersignature_WithValidPrimarySignatureAndInvalidCountersignature_FailsAsync()
             {
                 // Arrange
@@ -431,7 +431,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_SettingsRequireCheckCountersignature_WithValidPrimarySignatureAndValidCountersignature_SucceedsAsync()
             {
                 // Arrange
@@ -481,7 +481,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_WithExpiredPrimarySignature_ValidCountersignature_AndPrimarySignatureValidAtCountersignTime_SucceedsAsync()
             {
                 // Arrange
@@ -534,7 +534,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_WithExpiredAndUntrustedPrimarySignature_ValidCountersignature_AndPrimarySignatureValidAtCountersignTime_SucceedsAsync()
             {
                 var nupkg = new SimpleTestPackageContext();
@@ -582,7 +582,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_WithExpiredPrimarySignature_ValidCountersignature_AndPrimarySignatureExpiredAtCountersignTime_FailsAsync()
             {
                 // Arrange
@@ -637,7 +637,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_WithSignedAndCountersignedPackage_SucceedsAsync()
             {
                 // Arrange
@@ -676,7 +676,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_WithSignedTimestampedCountersignedAndCountersignatureTimestampedPackage_SucceedsAsync()
             {
                 // Arrange
@@ -718,7 +718,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_WithExpiredTimestamp_NotAllowIgnoreTimestamp_ShouldNotBeAnErrorAsync()
             {
                 using (var nupkgStream = new MemoryStream(GetResource("UntrustedTimestampPackage.nupkg")))
@@ -739,7 +739,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task VerifySignaturesAsync_WithTimestampChainingToUntrustedRoot_NotAllowIgnoreTimestamp_FailAsync()
             {
                 using (var nupkgStream = new MemoryStream(GetResource("UntrustedTimestampPackage.nupkg")))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PrimarySignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PrimarySignatureTests.cs
@@ -33,7 +33,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedTestCert = _testFixture.TrustedTestCertificate;
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task Signature_HasTimestampAsync()
         {
             // Arrange
@@ -62,7 +62,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task Signature_HasNoTimestampAsync()
         {
             // Arrange
@@ -86,7 +86,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task Load_WithPrimarySignatureWithNoCertificates_ThrowsAsync()
         {
             var packageContext = new SimpleTestPackageContext();
@@ -116,7 +116,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task Load_WithReissuedSigningCertificate_ThrowsAsync()
         {
             var certificates = _testFixture.TrustedTestCertificateWithReissuedCertificate;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Packaging.FuncTest
             _untrustedTestCertificate = _testFixture.UntrustedTestCertificate;
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task Verify_WithUntrustedSelfSignedCertificateAndNotAllowUntrusted_FailsAsync()
         {
             var settings = new SignatureVerifySettings(
@@ -57,7 +57,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task Verify_WithUntrustedSelfSignedCertificateAndAllowUntrusted_SucceedsAndWarnsAsync()
         {
             var settings = new SignatureVerifySettings(
@@ -82,7 +82,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task Verify_WithUntrustedSelfSignedCertificateAndAllowUntrustedAndNotReportUntrustedRoot_SucceedsAsync()
         {
             var settings = new SignatureVerifySettings(
@@ -107,7 +107,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetSigningCertificateFingerprint_WithUnsupportedHashAlgorithm_Throws()
         {
             using (var test = await VerifyTest.CreateAsync(_untrustedTestCertificate.Cert))
@@ -116,7 +116,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetSigningCertificateFingerprint_SuccessfullyHashesMultipleAlgorithms()
         {
             using (var test = await VerifyTest.CreateAsync(_untrustedTestCertificate.Cert))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -42,7 +42,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedTestCert = _testFixture.TrustedTestCertificate;
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_WithInvalidSignature_ThrowsAsync()
         {
             var package = new SimpleTestPackageContext();
@@ -77,7 +77,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_SettingsRequireExactlyOneTimestamp_MultipleTimestamps_FailsAsync()
         {
             // Arrange
@@ -132,7 +132,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_PrimarySignatureWithUntrustedRoot_EmptyAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -167,7 +167,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryCountersignatureWithUntrustedRoot_EmptyAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -204,7 +204,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_PrimarySignatureWithUntrustedRoot_NotInAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -240,7 +240,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryCountersignatureWithUntrustedRoot_NotInAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -278,7 +278,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_PrimarySignatureWithUntrustedRoot_InAllowedUntrustedRootList_AllowUntrustedFalse_SucceedsAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -316,7 +316,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_RepositoryCountersignatureWithUntrustedRoot_InAllowedUntrustedRootList_AllowUntrustedFalse_SucceedsAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -520,7 +520,7 @@ namespace NuGet.Packaging.FuncTest
             SigningTestUtility.AssertRevocationStatusUnknown(matchingIssues, LogLevel.Information, NuGetLogCode.Undefined);
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_WithTrustedButExpiredPrimaryAndTimestampCertificates_WithUnavailableRevocationInformationAndAllowUnknownRevocation_WarnsAsync()
         {
             List<SignatureLog> matchingIssues = await VerifyUnavailableRevocationInfoAsync(
@@ -543,7 +543,7 @@ namespace NuGet.Packaging.FuncTest
             SigningTestUtility.AssertRevocationStatusUnknown(matchingIssues, LogLevel.Warning, NuGetLogCode.NU3018);
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTrustResultAsync_WithNoIgnoringTimestamp_TimestampWithGeneralizedTimeOutsideCertificateValidity_FailAsync()
         {
             var verificationProvider = new SignatureTrustAndValidityVerificationProvider();
@@ -588,7 +588,7 @@ namespace NuGet.Packaging.FuncTest
                 _provider = new SignatureTrustAndValidityVerificationProvider();
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithRepositorySignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -616,7 +616,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithValidSignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -646,7 +646,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [Theory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithValidSignatureButNoTimestamp_ReturnsStatusAsync(
@@ -677,7 +677,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [Theory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithUntrustedSignature_ReturnsStatusAsync(
@@ -797,7 +797,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithTamperedRepositoryPrimarySignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -855,7 +855,7 @@ namespace NuGet.Packaging.FuncTest
                 _provider = new SignatureTrustAndValidityVerificationProvider();
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithAuthorSignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -883,7 +883,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithValidSignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -913,7 +913,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [Theory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithValidSignatureButNoTimestamp_ReturnsStatusAsync(
@@ -945,7 +945,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [Theory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithUntrustedSignature_ReturnsStatusAsync(
@@ -1065,7 +1065,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithTamperedRepositoryPrimarySignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1104,7 +1104,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithAlwaysVerifyCountersignatureBehavior_ReturnsDisallowedAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1143,7 +1143,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithExpiredSignature_ReturnsValidAsync()
             {
                 using (X509Certificate2 certificate = await GetExpiringCertificateAsync(_fixture))
@@ -1183,7 +1183,7 @@ namespace NuGet.Packaging.FuncTest
                 _provider = new SignatureTrustAndValidityVerificationProvider();
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithAuthorSignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1211,7 +1211,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithValidCountersignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1243,7 +1243,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithValidCountersignatureAndUntrustedPrimarySignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1275,7 +1275,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [Theory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithValidCountersignatureButNoTimestamp_ReturnsStatusAsync(
@@ -1310,7 +1310,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyTheory]
+            [Theory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithUntrustedCountersignature_ReturnsStatusAsync(
@@ -1437,7 +1437,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithTamperedRepositoryCountersignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1478,7 +1478,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithExpiredPrimaryCertificateAndExpiredRepositoryCertificateAndValidTimestamps_ReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1504,7 +1504,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithExpiredRepositoryCertificateAndNoTimestamp_ReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1561,7 +1561,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case1: primary signature (trusted + non-expired) doesn't fall back to countersignature (trusted + non-expired).
             // The verification result is the primary signature status(valid).
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithGoodPrimarySignatureAndGoodCountersignature_NoFallbackAndReturnsValidAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1582,7 +1582,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case2: primary signature (trusted + non-expired) doesn't fall back to countersignature untrusted + non-expired).
             // The verification result is the primary signature status(valid).
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithGoodPrimarySignatureAndUntrustedCountersignature_NoFallbackAndReturnsValidAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1603,7 +1603,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case3: primary signature (untrusted + non-expired) falls back to countersignature (trusted + non-expired).
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithUntrustedPrimarySignatureAndGoodCountersignature_FallbackAndReturnsValidAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1624,7 +1624,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case4: primary signature (untrusted + non-expired) falls back to countersignature (untrusted + non-expired).
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithUntrustedPrimarySignatureAndUntrustedCountersignature_FallbackAndReturnsDisallowedAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1646,7 +1646,7 @@ namespace NuGet.Packaging.FuncTest
             // Case5: primary signature (trusted + expired) falls back to countersignature (trusted + non-expired).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1673,7 +1673,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case6: primary signature (trusted + expired) falls back to countersignature (untrusted + non-expired).
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndUntrustedCountersignatureWithTimestamp_FallbackAndReturnsDisallowedAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1701,7 +1701,7 @@ namespace NuGet.Packaging.FuncTest
             // Case7: primary signature (trusted + expired) falls back to countersignature (trusted + non-expired).
             // But the timestamp on countersignature could NOT fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
             {
                 using (X509Certificate2 authorSigningCertificate = await GetExpiringCertificateAsync(_fixture))
@@ -1725,7 +1725,7 @@ namespace NuGet.Packaging.FuncTest
             // Case8: primary signature (trusted + expired) falls back to countersignature (trusted + expired but protected by a timestamp).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndExpiredCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1755,7 +1755,7 @@ namespace NuGet.Packaging.FuncTest
             // Case9: primary signature (untrusted + expired) falls back to countersignature (trusted + non-expired).
             // But the timestamp on countersignature could NOT fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithUntrustedExpiredPrimarySignatureAndGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
             {
                 using (X509Certificate2 authorSigningCertificate = _fixture.CreateUntrustedTestCertificateThatWillExpireSoon().Cert)
@@ -1779,7 +1779,7 @@ namespace NuGet.Packaging.FuncTest
             // Case10: primary signature (untrusted + expired) falls back to countersignature (trusted + non-expired).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            [CIOnlyFact]
+            [Fact]
             public async Task GetTrustResultAsync_WithUntrustedExpiredPrimarySignatureAndGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageArchiveTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageArchiveTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Packaging.FuncTest
             _fixture = fixture;
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task RemoveSignatureAsync_RemovesPackageSignatureAsync()
         {
             using (var test = await Test.CreateAsync(_fixture))
@@ -44,7 +44,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task RemoveSignatureAsync_WithCancelledToken_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_fixture))
@@ -54,7 +54,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task RemoveSignatureAsync_WithUnsignedPackage_ThrowsAsync()
         {
             using (var test = await Test.CreateUnsignedAsync())

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -58,7 +58,7 @@ namespace NuGet.Packaging.FuncTest
                 revocationMode: RevocationMode.Online);
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsLastAndFileHeaderIsLastAsync()
         {
             // Arrange
@@ -92,7 +92,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsFirstAndFileHeaderIsFirstAsync()
         {
             // Arrange
@@ -119,7 +119,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsLastAndFileHeaderIsFirstAsync()
         {
             // Arrange
@@ -153,7 +153,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsFirstAndFileHeaderIsLastAsync()
         {
             // Arrange
@@ -187,7 +187,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsMiddleAndFileHeaderIsMiddleAsync()
         {
             // Arrange
@@ -222,7 +222,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAsync()
         {
             // Arrange
@@ -261,7 +261,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAssertExceptionAsync()
         {
             // Arrange
@@ -288,7 +288,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAndCompressedAsync()
         {
             // Arrange
@@ -327,7 +327,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAndCompressedAssertExceptionAsync()
         {
             // Arrange
@@ -354,7 +354,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidExternalFileAttributesAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -383,7 +383,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidGeneralPurposeFlagBitsAsync()
         {
             // Arrange
@@ -427,7 +427,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidGeneralPurposeFlagBitsAssertExceptionAsync()
         {
             // Arrange
@@ -459,7 +459,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidCompressionMethodAsync()
         {
             // Arrange
@@ -491,7 +491,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidCompressedSizeAsync()
         {
             // Arrange
@@ -535,7 +535,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidCompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -567,7 +567,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidUncompressedSizeAsync()
         {
             // Arrange
@@ -611,7 +611,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidUncompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -643,7 +643,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidGeneralPurposeFlagBitsAsync()
         {
             // Arrange
@@ -687,7 +687,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidGeneralPurposeFlagBitsAssertExceptionAsync()
         {
             // Arrange
@@ -719,7 +719,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressionMethodAsync()
         {
             // Arrange
@@ -763,7 +763,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressionMethodAssertExceptionAsync()
         {
             // Arrange
@@ -795,7 +795,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressedSizeAsync()
         {
             // Arrange
@@ -839,7 +839,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -871,7 +871,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidUncompressedSizeAsync()
         {
             // Arrange
@@ -918,7 +918,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidUncompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -949,7 +949,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyPackageContentHash_SignedPackagesAsync()
         {
             // Arrange
@@ -983,7 +983,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task ReadSignedArchiveMetadata_InvalidSignatureFileEntry_IgnoreVerifySignatureEntry()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
@@ -24,7 +24,7 @@ namespace NuGet.Packaging.FuncTest
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
         }
 
-        [CIOnlyFact]
+        [Fact]
         public void Verify_WithValidInput_DoesNotThrow()
         {
 #if NET9_0_OR_GREATER
@@ -38,7 +38,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task SignAsync_AddsPackageAuthorSignatureAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -54,7 +54,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task SignAsync_AddsPackageRepositorySignatureAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -70,7 +70,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task SignAsync_WhenRepositoryCountersigningPrimarySignature_SucceedsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -99,7 +99,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task SignAsync_WithExpiredCertificate_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificateExpired.Source.Cert))
@@ -117,7 +117,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task SignAsync_WithNotYetValidCertificate_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificateNotYetValid.Source.Cert))
@@ -135,7 +135,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task SignAsync_WhenRepositoryCountersigningRepositorySignedPackage_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -165,7 +165,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task SignAsync_WhenRepositoryCountersigningRepositoryCountersignedPackage_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedTestCert = _testFixture.TrustedTestCertificate;
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_WithValidInput_ReturnsTimestampAsync()
         {
             var logger = new TestLogger();
@@ -69,7 +69,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_AssertCompleteChain_SuccessAsync()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
@@ -128,7 +128,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_WhenRequestNull_ThrowsAsync()
         {
             var logger = new TestLogger();
@@ -166,7 +166,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_WhenLoggerNull_ThrowsAsync()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
@@ -197,7 +197,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_WhenCancelled_ThrowsAsync()
         {
             var logger = new TestLogger();
@@ -228,7 +228,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_WhenRevocationInformationUnavailable_SuccessAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -258,7 +258,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_WhenTimestampSigningCertificateRevoked_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -282,7 +282,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_WithFailureReponse_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -304,7 +304,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_WhenSigningCertificateNotReturned_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -324,7 +324,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_WhenSignatureHashAlgorithmIsSha1_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -346,7 +346,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_WhenCertificateSignatureAlgorithmIsSha1_ThrowsAsync()
         {
             Oid sha1 = new(Oids.Sha1);
@@ -372,7 +372,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetTimestampAsync_TimestampGeneralizedTimeOutsideCertificateValidityPeriod_FailAsync()
         {
             // Arrange
@@ -402,7 +402,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task TimestampSignatureAsync_TimestampingPrimarySignature_SuccedsAsync()
         {
             var logger = new TestLogger();
@@ -450,7 +450,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task TimestampSignatureAsync_TimestampingCountersignature_SucceedsAsync()
         {
             var logger = new TestLogger();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/DotNetDefaultTrustStoreX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/DotNetDefaultTrustStoreX509ChainFactoryTests.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Packaging.Signing;
-using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.Packaging.FuncTest.SigningTests
@@ -21,7 +20,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
             _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
         }
 
-        [CIOnlyFact]
+        [Fact]
         public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsNull()
         {
             DotNetDefaultTrustStoreX509ChainFactory factory = new();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/FallbackCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/FallbackCertificateBundleX509ChainFactoryTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
         {
         }
 
-        [CIOnlyFact]
+        [Fact]
         public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsLogMessage()
         {
             using (TestDirectory directory = TestDirectory.Create())

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/InMemoryTrustStoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/InMemoryTrustStoreTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET5_0_OR_GREATER
+
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Internal.NuGet.Testing.SignedPackages;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Xunit;
+
+using X509StorePurpose = Microsoft.Internal.NuGet.Testing.SignedPackages.X509StorePurpose;
+
+namespace NuGet.Packaging.FuncTest.SigningTests
+{
+    [Collection(SigningTestCollection.Name)]
+    public class InMemoryTrustStoreTests
+    {
+        private readonly SigningTestFixture _fixture;
+
+        public InMemoryTrustStoreTests(SigningTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public void ChainBuilding_WithInMemoryTrustStore_SucceedsWithoutElevation()
+        {
+            TestFallbackCertificateBundleX509ChainFactories.SetTryUseAsDefault(tryUseAsDefault: true);
+
+            try
+            {
+                TestCertificate testCert = TestCertificate.Generate(
+                    X509StorePurpose.CodeSigning,
+                    SigningTestUtility.CertificateModificationGeneratorForCodeSigningEkuCert);
+
+                using (TrustedTestCert<TestCertificate> trustedCert = testCert.WithTrust())
+                {
+                    IX509ChainFactory factory = X509TrustStore.GetX509ChainFactory(
+                        Signing.X509StorePurpose.CodeSigning, NullLogger.Instance);
+
+                    using (IX509Chain chain = factory.Create())
+                    {
+                        Assert.Equal(X509ChainTrustMode.CustomRootTrust, chain.ChainPolicy.TrustMode);
+
+                        bool built = chain.Build(trustedCert.TrustedCert);
+
+                        Assert.True(built, "Chain building should succeed with in-memory trust store on all platforms.");
+                    }
+                }
+            }
+            finally
+            {
+                TestFallbackCertificateBundleX509ChainFactories.SetTryUseAsDefault(tryUseAsDefault: true);
+            }
+        }
+
+        [Fact]
+        public void DefaultFactory_WhenTestFactoryNotActive_UsesDotNetDefaultWithSystemTrust()
+        {
+            TestFallbackCertificateBundleX509ChainFactories.SetTryUseAsDefault(tryUseAsDefault: false);
+
+            try
+            {
+                X509TrustStore.SetCodeSigningX509ChainFactory(chainFactory: null!);
+
+                TestLogger logger = new();
+                IX509ChainFactory factory = X509TrustStore.CreateX509ChainFactory(
+                    Signing.X509StorePurpose.CodeSigning, logger);
+
+                Assert.IsType<DotNetDefaultTrustStoreX509ChainFactory>(factory);
+
+                using (IX509Chain chain = factory.Create())
+                {
+                    Assert.Equal(X509ChainTrustMode.System, chain.ChainPolicy.TrustMode);
+                }
+            }
+            finally
+            {
+                TestFallbackCertificateBundleX509ChainFactories.SetTryUseAsDefault(tryUseAsDefault: true);
+            }
+        }
+    }
+}
+
+#endif

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/NoCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/NoCertificateBundleX509ChainFactoryTests.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
-using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.Packaging.FuncTest.SigningTests
@@ -20,7 +19,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
         {
         }
 
-        [CIOnlyFact]
+        [Fact]
         public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsLogMessage()
         {
             NoCertificateBundleX509ChainFactory factory = new();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/SystemCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/SystemCertificateBundleX509ChainFactoryTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
         {
         }
 
-        [CIOnlyFact]
+        [Fact]
         public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsLogMessage()
         {
             using (TestDirectory directory = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
@@ -331,7 +331,7 @@ namespace NuGet.Commands.Test
             ex.Message.Should().Be(Strings.Error_PackageNotSigned);
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_TargetRepository_NonRepositorySignedPackage_ThrowsAsync()
         {
             // Arrange
@@ -363,7 +363,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_NameAlreadyExists_ThrowsAsync()
         {
             // Arrange
@@ -402,7 +402,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_ServiceIndexAlreadyExists_ThrowsAsync()
         {
             // Arrange
@@ -442,7 +442,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_WithUnknownPrimarySignature_ThrowsAsync()
         {
             // Arrange
@@ -490,7 +490,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_RepositorySignedPackage_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -535,7 +535,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_RepositorySignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -581,7 +581,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_RepositorySignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -627,7 +627,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -674,7 +674,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -722,7 +722,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -770,7 +770,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_AuthorSignedPackage_AddsAuthorCorrectlyAsync()
         {
             // Arrange
@@ -812,7 +812,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task AddTrustedSignerAsync_AuthorSignedPackage_WithAllowUntrustedRoot_AddsAuthorCorrectlyAsync()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
@@ -617,7 +617,7 @@ namespace Commands.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task Test_ExtractionHonorsFileTimestamp()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1866,7 +1866,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task GetContentHash_IsSameForUnsignedAndSignedPackageAsync()
         {
             // this test will create an unsigned package, copy it, then sign it. then compare the contentHash

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -1208,7 +1208,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task ExtractPackageAsync_PreservesZipEntryTimeAsync()
         {
             // Arrange
@@ -1824,7 +1824,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task ExtractPackageAsync_UnsignedPackage_WhenRepositorySaysAllPackagesSigned_WithEnvVar_Error()
         {
             // Arrange
@@ -1999,7 +1999,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task ExtractPackageAsync_UnsignedPackage_RequireMode_WithEnvVar_Error()
         {
             // Arrange
@@ -2198,7 +2198,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task ExtractPackageAsync_RequireMode_NoMatchInClientAllowList_WithEnvVar_Error()
         {
             // Arrange
@@ -2261,7 +2261,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyTheory(Skip = "https://github.com/NuGet/Home/issues/11700")]
+        [Theory(Skip = "https://github.com/NuGet/Home/issues/11700")]
         [MemberData(nameof(KnownClientPolicyModesList))]
         public async Task ExtractPackageAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromRepositoryAllowList_SuccessAsync(SignatureValidationMode clientPolicyMode)
         {
@@ -2404,7 +2404,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task ExtractPackageAsync_WithAllowUntrusted_SucceedsWithoutSigningWarningsOrErrors_WithEnvVar()
         {
             // Arrange
@@ -2618,7 +2618,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task ExtractPackageAsync_RequireMode_UnsignedPackage_PackageArchiveReader_WhenUnsignedPackagesDisallowed_WithEnvVar_Errors()
         {
             // Arrange
@@ -3726,7 +3726,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task ExtractPackageAsyncByStream_InvalidSignPackageWithUnzip_WithOptInEnvVar_Throws()
         {
             // Arrange
@@ -3969,7 +3969,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task ExtractPackageAsyncByPackageReader_InvalidSignPackageWithUnzip_WithEnvVar_Throws()
         {
             // Arrange
@@ -4165,7 +4165,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task ExtractPackageAsyncByPackageReaderAndStream_InvalidSignPackageWithUnzip_WithEnvVar_Throws()
         {
             // Arrange
@@ -4314,7 +4314,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [CIOnlyFact]
+        [Fact]
         public async Task VerifyPackageSignatureAsync_PassesCommonSettingsWhenNoRepoSignatureInfo_WithEnvVar_DoVerify()
         {
             // Arrange

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/CodeSigningRootX509Store.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/CodeSigningRootX509Store.cs
@@ -1,11 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Security.Cryptography.X509Certificates;
-
-#if !NET5_0_OR_GREATER
 using System;
-#endif
+using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Internal.NuGet.Testing.SignedPackages
 {
@@ -30,7 +27,15 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages
         public void Remove(StoreLocation storeLocation, X509Certificate2 certificate)
         {
 #if NET5_0_OR_GREATER
-            TestFallbackCertificateBundleX509ChainFactories.Instance.CodeSigningX509ChainFactory.Certificates.Remove(certificate);
+            // X509Certificate2Collection.Remove() throws if the certificate is not found.
+            // Another thread or a prior call for a different purpose may have already removed it.
+            try
+            {
+                TestFallbackCertificateBundleX509ChainFactories.Instance.CodeSigningX509ChainFactory.Certificates.Remove(certificate);
+            }
+            catch (ArgumentException)
+            {
+            }
 #else
             throw new NotSupportedException();
 #endif

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/TestFallbackCertificateBundleX509ChainFactories.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/TestFallbackCertificateBundleX509ChainFactories.cs
@@ -6,10 +6,6 @@
 using NuGet.Packaging.Signing;
 #pragma warning disable CS1591
 
-#if NET5_0_OR_GREATER
-using NuGet.Common;
-#endif
-
 namespace Microsoft.Internal.NuGet.Testing.SignedPackages
 {
     public sealed class TestFallbackCertificateBundleX509ChainFactories
@@ -25,7 +21,7 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages
             IX509ChainFactory timestampingFactory = null;
 
 #if NET5_0_OR_GREATER
-            if (tryUseAsDefault && !RuntimeEnvironmentHelper.IsWindows)
+            if (tryUseAsDefault)
             {
                 codeSigningFactory = Instance.CodeSigningX509ChainFactory;
                 timestampingFactory = Instance.TimestampingX509ChainFactory;

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/TimestampingRootX509Store.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/TimestampingRootX509Store.cs
@@ -1,11 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Security.Cryptography.X509Certificates;
-
-#if !NET5_0_OR_GREATER
 using System;
-#endif
+using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Internal.NuGet.Testing.SignedPackages
 {
@@ -30,7 +27,15 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages
         public void Remove(StoreLocation storeLocation, X509Certificate2 certificate)
         {
 #if NET5_0_OR_GREATER
-            TestFallbackCertificateBundleX509ChainFactories.Instance.TimestampingX509ChainFactory.Certificates.Remove(certificate);
+            // X509Certificate2Collection.Remove() throws if the certificate is not found.
+            // Another thread or a prior call for a different purpose may have already removed it.
+            try
+            {
+                TestFallbackCertificateBundleX509ChainFactories.Instance.TimestampingX509ChainFactory.Certificates.Remove(certificate);
+            }
+            catch (ArgumentException)
+            {
+            }
 #else
             throw new NotSupportedException();
 #endif

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/X509StoreUtilities.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/X509StoreUtilities.cs
@@ -5,16 +5,24 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
-using NuGet.Common;
+#if NET5_0_OR_GREATER
+using System.Security.Principal;
+#endif
 
 namespace Microsoft.Internal.NuGet.Testing.SignedPackages
 {
+    // On .NET 5+, root certificates are always added to both in-memory stores (code signing
+    // and timestamping) regardless of the requested purpose.  This matches the platform root
+    // store behavior where a single store serves all purposes.  When elevated, certificates
+    // are also added to the platform root store so that out-of-process tools (e.g. dotnet.exe,
+    // nuget.exe) spawned as child processes can find them.
     public static class X509StoreUtilities
     {
-        private static readonly IRootX509Store CodeSigningRootX509Store =
-            RuntimeEnvironmentHelper.IsWindows ? PlatformX509Store.Instance : new CodeSigningRootX509Store();
-        private static readonly IRootX509Store TimestampingRootX509Store =
-            RuntimeEnvironmentHelper.IsWindows ? PlatformX509Store.Instance : new TimestampingRootX509Store();
+#if NET5_0_OR_GREATER
+        private static readonly bool s_isElevated = GetIsElevated();
+        private static readonly IRootX509Store InMemoryCodeSigningRootX509Store = new CodeSigningRootX509Store();
+        private static readonly IRootX509Store InMemoryTimestampingRootX509Store = new TimestampingRootX509Store();
+#endif
         private static readonly IX509Store OtherX509Store = PlatformX509Store.Instance;
 
         public static void AddCertificateToStore(
@@ -30,19 +38,17 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages
 
             if (storeName == StoreName.Root)
             {
-                switch (storePurpose)
+#if NET5_0_OR_GREATER
+                InMemoryCodeSigningRootX509Store.Add(storeLocation, certificate);
+                InMemoryTimestampingRootX509Store.Add(storeLocation, certificate);
+
+                if (s_isElevated)
                 {
-                    case X509StorePurpose.CodeSigning:
-                        CodeSigningRootX509Store.Add(storeLocation, certificate);
-                        break;
-
-                    case X509StorePurpose.Timestamping:
-                        TimestampingRootX509Store.Add(storeLocation, certificate);
-                        break;
-
-                    default:
-                        throw new ArgumentException("Invalid value", nameof(storePurpose));
+                    PlatformX509Store.Instance.Add(storeLocation, certificate);
                 }
+#else
+                PlatformX509Store.Instance.Add(storeLocation, certificate);
+#endif
             }
             else
             {
@@ -63,24 +69,36 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages
 
             if (storeName == StoreName.Root)
             {
-                switch (storePurpose)
+#if NET5_0_OR_GREATER
+                InMemoryCodeSigningRootX509Store.Remove(storeLocation, certificate);
+                InMemoryTimestampingRootX509Store.Remove(storeLocation, certificate);
+
+                if (s_isElevated)
                 {
-                    case X509StorePurpose.CodeSigning:
-                        CodeSigningRootX509Store.Remove(storeLocation, certificate);
-                        break;
-
-                    case X509StorePurpose.Timestamping:
-                        TimestampingRootX509Store.Remove(storeLocation, certificate);
-                        break;
-
-                    default:
-                        throw new ArgumentException("Invalid value", nameof(storePurpose));
+                    PlatformX509Store.Instance.Remove(storeLocation, certificate);
                 }
+#else
+                PlatformX509Store.Instance.Remove(storeLocation, certificate);
+#endif
             }
             else
             {
                 OtherX509Store.Remove(storeLocation, storeName, certificate);
             }
         }
+
+#if NET5_0_OR_GREATER
+        private static bool GetIsElevated()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+                WindowsPrincipal principal = new(identity);
+                return principal.IsInRole(WindowsBuiltInRole.Administrator);
+            }
+
+            return false;
+        }
+#endif
     }
 }

--- a/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
+++ b/test/TestUtilities/Test.Utility/Signing/SignedArchiveTestUtility.cs
@@ -24,7 +24,7 @@ namespace Test.Utility.Signing
     {
         /// <summary>
         /// Generates an author signed copy of a package and returns the path to that package
-        /// This method can timestamp a package and should only be used with tests marked with [CIOnlyFact]
+        /// This method can timestamp a package and should only be used with tests marked with [Fact]
         /// </summary>
         /// <param name="certificate">Certificate to be used while signing the package</param>
         /// <param name="nupkg">Package to be signed</param>
@@ -54,7 +54,7 @@ namespace Test.Utility.Signing
         }
         /// <summary>
         /// Generates an author signed copy of a package and returns the path to that package
-        /// This method can timestamp a package and should only be used with tests marked with [CIOnlyFact]
+        /// This method can timestamp a package and should only be used with tests marked with [Fact]
         /// </summary>
         /// <param name="certificate">Certificate to be used while signing the package</param>
         /// <param name="packageStream">Stream of package to be signed</param>
@@ -113,7 +113,7 @@ namespace Test.Utility.Signing
 
         /// <summary>
         /// Generates an repository signed copy of a package and returns the path to that package
-        /// This method can timestamp a package and should only be used with tests marked with [CIOnlyFact]
+        /// This method can timestamp a package and should only be used with tests marked with [Fact]
         /// </summary>
         /// <param name="certificate">Certificate to be used while signing the package</param>
         /// <param name="nupkg">Package to be signed</param>
@@ -162,7 +162,7 @@ namespace Test.Utility.Signing
 
         /// <summary>
         /// Generates an repository signed copy of a package and returns the path to that package
-        /// This method can timestamp a package and should only be used with tests marked with [CIOnlyFact]
+        /// This method can timestamp a package and should only be used with tests marked with [Fact]
         /// </summary>
         /// <remarks>If the package is already author signed this method will repository countersign it</remarks>
         /// <param name="certificate">Certificate to be used while signing the package</param>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  N/A

## Description

This PR enables in-memory trust stores on Windows for .NET 5+ by removing two platform gates in test infrastructure.  Change `[CIOnlyFact]`/`[CIOnlyTheory]` to `[Fact]`/`[Theory]` so signing tests run on developer machines without elevation.

There are no product code changes.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [X] Added tests
- N/A ~~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~

CC @zivkan, @nkolev92.  Did you already have an issue for this or shall I create one?