### PR TITLE
Fix flaky ResolverGather_TimeoutFromPrimaryRepositoryThrows test

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
@@ -59,13 +59,21 @@ namespace NuGet.Test
                 ResolutionContext = new ResolutionContext()
             };
 
-            var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
 
             // Act and Assert
-            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            // Under CPU contention, cancellation checks in the main loop may fire
+            // before worker tasks convert OperationCanceledException to
+            // InvalidOperationException.  Both outcomes correctly indicate failure.
+            Exception exception = await Record.ExceptionAsync(async () =>
             {
                 await ResolverGather.GatherAsync(context, cts.Token);
             });
+
+            Assert.NotNull(exception);
+            Assert.True(
+                exception is InvalidOperationException || exception is OperationCanceledException,
+                $"Expected InvalidOperationException or OperationCanceledException but got {exception.GetType().Name}: {exception.Message}");
         }
 
         [Fact]
@@ -108,7 +116,7 @@ namespace NuGet.Test
                 ResolutionContext = new ResolutionContext()
             };
 
-            var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(5000));
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(5000));
 
             // Act
             var results = await ResolverGather.GatherAsync(context, cts.Token);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/14833

## Description

The test `ResolverGather_TimeoutFromPrimaryRepositoryThrows` asserts that a primary source timeout throws `InvalidOperationException`.  `GatherPackageAsync(...)` converts `OperationCanceledException` to `InvalidOperationException`, but cancellation checks in the main loop and worker task entry can fire first under CPU contention, producing a raw `OperationCanceledException` that bypasses the conversion.  Both exception types correctly indicate the gather operation failed.

This change accepts either `InvalidOperationException` or `OperationCanceledException` as passing.

This change also disposes `CancellationTokenSource` instances.

## PR Checklist

- [X] Meaningful title, helpful description and a linked NuGet/Home issue
- N/A ~~[ ] Added tests~~
- N/A ~~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~