### PR TITLE
Block path separators in aliases

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,7 @@
 
 - When creating pull requests, always follow the [PR template](PULL_REQUEST_TEMPLATE.md).
 - Always format before submitting a pull request.
+- Before implementing any code changes, read all files in the `docs/` folder. It contains the NuGet development guidelines, including rules for SDKAnalysisLevel gating, public API policies, error handling patterns, and feature design requirements.
 
 ## Coding Standards
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -898,7 +898,7 @@ namespace NuGet.Commands
 
         internal static bool IsAscii(string value)
         {
-            foreach (char c in value)
+            foreach (char c in value.AsSpan())
             {
                 if (c > 127)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -363,7 +363,7 @@ namespace NuGet.Commands
             success &= EvaluateHttpSourceUsage();
             success &= HasValidPlatformVersions();
             success &= PackageReferencesHaveVersions();
-            success &= EnsureNoAliasesWithPathSeparator();
+            success &= EnsureNoAliasesWithDisallowedCharacters();
 
             return success;
         }
@@ -845,33 +845,68 @@ namespace NuGet.Commands
             }
         }
 
-        private bool EnsureNoAliasesWithPathSeparator()
+        private bool EnsureNoAliasesWithDisallowedCharacters()
         {
-            return EnsureNoAliasesWithPathSeparator(_request.Project, _logger);
+            return EnsureNoAliasesWithDisallowedCharacters(_request.Project, _logger);
         }
 
-        internal static bool EnsureNoAliasesWithPathSeparator(PackageSpec project, ILogger logger)
+        internal static bool EnsureNoAliasesWithDisallowedCharacters(PackageSpec project, ILogger logger)
         {
             if (!SdkAnalysisLevelMinimums.IsEnabled(project.RestoreMetadata.SdkAnalysisLevel, project.RestoreMetadata.UsingMicrosoftNETSdk, SdkAnalysisLevelMinimums.V10_0_300))
             {
                 return true;
             }
 
+            bool nonAsciiIsError = SdkAnalysisLevelMinimums.IsEnabled(project.RestoreMetadata.SdkAnalysisLevel, project.RestoreMetadata.UsingMicrosoftNETSdk, SdkAnalysisLevelMinimums.V11_0_100);
             var success = true;
 
             foreach (TargetFrameworkInformation framework in project.TargetFrameworks)
             {
                 string alias = framework.TargetAlias;
-                if (!string.IsNullOrEmpty(alias) && (alias.Contains('/') || alias.Contains('\\')))
+                if (string.IsNullOrEmpty(alias))
+                {
+                    continue;
+                }
+
+                if (alias.Contains('/') || alias.Contains('\\'))
                 {
                     logger.Log(RestoreLogMessage.CreateError(
                         NuGetLogCode.NU1019,
-                        string.Format(CultureInfo.CurrentCulture, Strings.Log_AliasContainsPathSeparator, project.Name, alias)));
+                        string.Format(CultureInfo.CurrentCulture, Strings.Log_AliasContainsDisallowedCharacters, project.Name, alias)));
                     success = false;
+                }
+                else if (!IsAscii(alias))
+                {
+                    if (nonAsciiIsError)
+                    {
+                        logger.Log(RestoreLogMessage.CreateError(
+                            NuGetLogCode.NU1019,
+                            string.Format(CultureInfo.CurrentCulture, Strings.Log_AliasContainsDisallowedCharacters, project.Name, alias)));
+                        success = false;
+                    }
+                    else
+                    {
+                        logger.Log(RestoreLogMessage.CreateWarning(
+                            NuGetLogCode.NU1019,
+                            string.Format(CultureInfo.CurrentCulture, Strings.Log_AliasContainsDisallowedCharacters, project.Name, alias)));
+                    }
                 }
             }
 
             return success;
+        }
+
+        internal static bool IsAscii(string value)
+        {
+            foreach (char c in value)
+            {
+                if (c > 127)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         internal static void AnalyzePruningResults(PackageSpec project, TelemetryEvent telemetryEvent, ILogger logger)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -363,6 +363,7 @@ namespace NuGet.Commands
             success &= EvaluateHttpSourceUsage();
             success &= HasValidPlatformVersions();
             success &= PackageReferencesHaveVersions();
+            success &= EnsureNoAliasesWithPathSeparator();
 
             return success;
         }
@@ -842,6 +843,35 @@ namespace NuGet.Commands
             {
                 return true;
             }
+        }
+
+        private bool EnsureNoAliasesWithPathSeparator()
+        {
+            return EnsureNoAliasesWithPathSeparator(_request.Project, _logger);
+        }
+
+        internal static bool EnsureNoAliasesWithPathSeparator(PackageSpec project, ILogger logger)
+        {
+            if (!SdkAnalysisLevelMinimums.IsEnabled(project.RestoreMetadata.SdkAnalysisLevel, project.RestoreMetadata.UsingMicrosoftNETSdk, SdkAnalysisLevelMinimums.V10_0_300))
+            {
+                return true;
+            }
+
+            var success = true;
+
+            foreach (TargetFrameworkInformation framework in project.TargetFrameworks)
+            {
+                string alias = framework.TargetAlias;
+                if (!string.IsNullOrEmpty(alias) && (alias.Contains('/') || alias.Contains('\\')))
+                {
+                    logger.Log(RestoreLogMessage.CreateError(
+                        NuGetLogCode.NU1019,
+                        string.Format(CultureInfo.CurrentCulture, Strings.Log_AliasContainsPathSeparator, project.Name, alias)));
+                    success = false;
+                }
+            }
+
+            return success;
         }
 
         internal static void AnalyzePruningResults(PackageSpec project, TelemetryEvent telemetryEvent, ILogger logger)

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1215,11 +1215,11 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project {0} contains a TargetFramework &apos;{1}&apos; with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework..
+        ///   Looks up a localized string similar to The project {0} contains a TargetFramework &apos;{1}&apos; with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators..
         /// </summary>
-        internal static string Log_AliasContainsPathSeparator {
+        internal static string Log_AliasContainsDisallowedCharacters {
             get {
-                return ResourceManager.GetString("Log_AliasContainsPathSeparator", resourceCulture);
+                return ResourceManager.GetString("Log_AliasContainsDisallowedCharacters", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1215,6 +1215,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The project {0} contains a TargetFramework &apos;{1}&apos; with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework..
+        /// </summary>
+        internal static string Log_AliasContainsPathSeparator {
+            get {
+                return ResourceManager.GetString("Log_AliasContainsPathSeparator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All projects are up-to-date for restore..
         /// </summary>
         internal static string Log_AllProjectsUpToDate {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1171,4 +1171,7 @@ NuGet requires HTTPS sources. Refer to https://aka.ms/nuget-https-everywhere for
     <value>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</value>
   </data>
+  <data name="Log_AliasContainsPathSeparator" xml:space="preserve">
+    <value>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1171,7 +1171,7 @@ NuGet requires HTTPS sources. Refer to https://aka.ms/nuget-https-everywhere for
     <value>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</value>
   </data>
-  <data name="Log_AliasContainsPathSeparator" xml:space="preserve">
-    <value>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</value>
+  <data name="Log_AliasContainsDisallowedCharacters" xml:space="preserve">
+    <value>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Utility/SdkAnalysisLevelMinimums.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/SdkAnalysisLevelMinimums.cs
@@ -29,9 +29,18 @@ namespace NuGet.Commands
         /// Minimum SDK Analysis Level required for:
         /// <list type="bullet">
         /// <item>.NET SDK version that supports aliased assets files.</item>
+        /// <item>error when TargetFramework alias contains path separators characters</item>
         /// </list>
         /// </summary>
         internal static readonly NuGetVersion V10_0_300 = new("10.0.300");
+
+        /// <summary>
+        /// Minimum SDK Analysis Level required for:
+        /// <list type="bullet">
+        /// <item>error when TargetFramework alias contains non-ASCII characters</item>
+        /// </list>
+        /// </summary>
+        internal static readonly NuGetVersion V11_0_100 = new("11.0.100");
 
         /// <summary>
         /// Determines whether the feature is enabled based on the SDK analysis level.

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.cs.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ Další informace najdete tady: https://docs.nuget.org/docs/reference/command-li
         <target state="translated">Místní prostředky se částečně vymazaly.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.cs.xlf
@@ -678,6 +678,11 @@ Další informace najdete tady: https://docs.nuget.org/docs/reference/command-li
         <target state="translated">Místní prostředky se částečně vymazaly.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.de.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ Weitere Informationen finden Sie unter https://docs.nuget.org/docs/reference/com
         <target state="translated">Die lokalen Ressourcen wurden teilweise gelöscht.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.de.xlf
@@ -678,6 +678,11 @@ Weitere Informationen finden Sie unter https://docs.nuget.org/docs/reference/com
         <target state="translated">Die lokalen Ressourcen wurden teilweise gelöscht.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.es.xlf
@@ -678,6 +678,11 @@ Para obtener más información, visite https://docs.nuget.org/docs/reference/com
         <target state="translated">Recursos locales parcialmente borrados.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.es.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ Para obtener más información, visite https://docs.nuget.org/docs/reference/com
         <target state="translated">Recursos locales parcialmente borrados.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.fr.xlf
@@ -678,6 +678,11 @@ Pour plus d'informations, visitez https://docs.nuget.org/docs/reference/command-
         <target state="translated">Ressources locales partiellement effacées.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.fr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ Pour plus d'informations, visitez https://docs.nuget.org/docs/reference/command-
         <target state="translated">Ressources locales partiellement effacées.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.it.xlf
@@ -678,6 +678,11 @@ Per altre informazioni, vedere https://docs.nuget.org/docs/reference/command-lin
         <target state="translated">Le risorse locali sono state parzialmente cancellate.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.it.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ Per altre informazioni, vedere https://docs.nuget.org/docs/reference/command-lin
         <target state="translated">Le risorse locali sono state parzialmente cancellate.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.ja.xlf
@@ -678,6 +678,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">ローカル リソースが一部クリアされました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.ja.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">ローカル リソースが一部クリアされました。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.ko.xlf
@@ -678,6 +678,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">로컬 리소스를 부분적으로 지웠습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.ko.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">로컬 리소스를 부분적으로 지웠습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.pl.xlf
@@ -678,6 +678,11 @@ Aby uzyskać więcej informacji, odwiedź stronę https://docs.nuget.org/docs/re
         <target state="translated">Częściowo wyczyszczono zasoby lokalne.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ Aby uzyskać więcej informacji, odwiedź stronę https://docs.nuget.org/docs/re
         <target state="translated">Częściowo wyczyszczono zasoby lokalne.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.pt-BR.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ Para obter mais informações, visite https://docs.nuget.org/docs/reference/comm
         <target state="translated">Recursos locais parcialmente limpos.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.pt-BR.xlf
@@ -678,6 +678,11 @@ Para obter mais informações, visite https://docs.nuget.org/docs/reference/comm
         <target state="translated">Recursos locais parcialmente limpos.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.ru.xlf
@@ -678,6 +678,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">Локальные ресурсы частично удалены.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">Локальные ресурсы частично удалены.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.tr.xlf
@@ -678,6 +678,11 @@ Daha fazla bilgi için bkz. https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">Yerel kaynaklar kısmen temizlendi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.tr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ Daha fazla bilgi için bkz. https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">Yerel kaynaklar kısmen temizlendi.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hans.xlf
@@ -678,6 +678,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">本地资源已部分清除。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hans.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">本地资源已部分清除。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hant.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
@@ -678,9 +678,9 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">已部份清除本機資源。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Log_AliasContainsPathSeparator">
-        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
-        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+      <trans-unit id="Log_AliasContainsDisallowedCharacters">
+        <source>The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with disallowed characters. TargetFramework names must contain only ASCII characters and must not contain path separators.</target>
         <note />
       </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">

--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.zh-Hant.xlf
@@ -678,6 +678,11 @@ For more information, visit https://docs.nuget.org/docs/reference/command-line-r
         <target state="translated">已部份清除本機資源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Log_AliasContainsPathSeparator">
+        <source>The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</source>
+        <target state="new">The project {0} contains a TargetFramework '{1}' with a path separator character, which is not allowed. Remove the path separator characters from the TargetFramework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Log_AliasingSupportedInNewDependencyResolver">
         <source>The project {0} is attempting to restore duplicate frameworks, which are supported only in the default dependency resolver when the .NET SDK is version {1} or newer.
 Upgrade your .NET SDK or remove RestoreUseLegacyDependencyResolver to use this feature.</source>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -149,6 +149,11 @@ namespace NuGet.Common
         NU1018 = 1018,
 
         /// <summary>
+        /// TargetFramework alias contains a path separator character ('/' or '\'), which is not allowed.
+        /// </summary>
+        NU1019 = 1019,
+
+        /// <summary>
         /// Unable to resolve package, generic message for unknown type constraints.
         /// </summary>
         NU1100 = 1100,

--- a/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
 NuGet.Common.NuGetLogCode.NU1018 = 1018 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetLogCode.NU1019 = 1019 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5051 = 5051 -> NuGet.Common.NuGetLogCode

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_Aliases.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_Aliases.cs
@@ -936,6 +936,47 @@ namespace NuGet.Commands.FuncTest
             // result.LockFile.LogMessages[0].TargetGraphs.Should().HaveCount(2); https://github.com/NuGet/Home/issues/14815
         }
 
+        [Theory]
+        [InlineData("banana/3")]
+        [InlineData("foo\\bar")]
+        public async Task RestoreCommand_WithAliasContainingPathSeparator_FailsWithNU1019(string invalidAlias)
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Backslashes must be escaped for JSON embedding
+            string jsonAlias = invalidAlias.Replace("\\", "\\\\");
+
+            var rootProject = $@"
+            {{
+              ""frameworks"": {{
+                ""{jsonAlias}"": {{
+                    ""framework"": ""net10.0"",
+                    ""targetAlias"": ""{jsonAlias}"",
+                    ""dependencies"": {{
+                            ""x"": {{
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package""
+                            }}
+                    }}
+                }}
+              }}
+            }}";
+
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+            projectSpec.RestoreMetadata.SdkAnalysisLevel = NuGetVersion.Parse("10.0.300");
+            projectSpec.RestoreMetadata.UsingMicrosoftNETSdk = true;
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                new SimpleTestPackageContext("x", "1.0.0"));
+
+            var result = await RunRestoreAsync(pathContext, projectSpec);
+
+            result.Success.Should().BeFalse();
+            result.LockFile.LogMessages.Should().Contain(m => m.Code == NuGetLogCode.NU1019);
+            result.LockFile.LogMessages.Should().Contain(m => m.Message.Contains(invalidAlias));
+        }
+
         internal static Task<RestoreResult> RunRestoreAsync(SimpleTestPathContext pathContext, params PackageSpec[] projects)
         {
             return RunRestoreAsync(pathContext, forceEvaluate: false, new TestLogger(), projects);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -3660,7 +3660,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         [InlineData("foo\\bar")]
         [InlineData("a/b/c")]
         [InlineData("net10.0/linux-x64")]
-        public void EnsureNoAliasesWithPathSeparator_WithPathSeparatorInAlias_ReturnsFalseAndLogsNU1019(string invalidAlias)
+        public void EnsureNoAliasesWithDisallowedCharacters_WithPathSeparatorInAlias_ReturnsFalseAndLogsNU1019(string invalidAlias)
         {
             var logger = new TestLogger();
             var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>
@@ -3678,7 +3678,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 UsingMicrosoftNETSdk = true,
             };
 
-            var result = RestoreCommand.EnsureNoAliasesWithPathSeparator(packageSpec, logger);
+            var result = RestoreCommand.EnsureNoAliasesWithDisallowedCharacters(packageSpec, logger);
 
             result.Should().BeFalse();
             logger.ErrorMessages.Should().ContainSingle();
@@ -3691,7 +3691,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         [InlineData("banana")]
         [InlineData("net10.0")]
         [InlineData("net10.0-linux")]
-        public void EnsureNoAliasesWithPathSeparator_WithValidAlias_ReturnsTrueAndLogsNothing(string validAlias)
+        public void EnsureNoAliasesWithDisallowedCharacters_WithValidAlias_ReturnsTrueAndLogsNothing(string validAlias)
         {
             var logger = new TestLogger();
             var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>
@@ -3709,16 +3709,17 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 UsingMicrosoftNETSdk = true,
             };
 
-            var result = RestoreCommand.EnsureNoAliasesWithPathSeparator(packageSpec, logger);
+            var result = RestoreCommand.EnsureNoAliasesWithDisallowedCharacters(packageSpec, logger);
 
             result.Should().BeTrue();
             logger.ErrorMessages.Should().BeEmpty();
+            logger.WarningMessages.Should().BeEmpty();
         }
 
         [Theory]
         [InlineData("10.0.200")]
         [InlineData("9.0.100")]
-        public void EnsureNoAliasesWithPathSeparator_WithOldSdkAnalysisLevel_ReturnsTrueRegardlessOfAlias(string sdkAnalysisLevel)
+        public void EnsureNoAliasesWithDisallowedCharacters_WithOldSdkAnalysisLevel_ReturnsTrueRegardlessOfAlias(string sdkAnalysisLevel)
         {
             var logger = new TestLogger();
             var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>
@@ -3736,14 +3737,14 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 UsingMicrosoftNETSdk = true,
             };
 
-            var result = RestoreCommand.EnsureNoAliasesWithPathSeparator(packageSpec, logger);
+            var result = RestoreCommand.EnsureNoAliasesWithDisallowedCharacters(packageSpec, logger);
 
             result.Should().BeTrue();
             logger.ErrorMessages.Should().BeEmpty();
         }
 
         [Fact]
-        public void EnsureNoAliasesWithPathSeparator_WithMultipleInvalidAliases_LogsErrorForEach()
+        public void EnsureNoAliasesWithDisallowedCharacters_WithMultipleInvalidAliases_LogsErrorForEach()
         {
             var logger = new TestLogger();
             var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>
@@ -3766,12 +3767,101 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 UsingMicrosoftNETSdk = true,
             };
 
-            var result = RestoreCommand.EnsureNoAliasesWithPathSeparator(packageSpec, logger);
+            var result = RestoreCommand.EnsureNoAliasesWithDisallowedCharacters(packageSpec, logger);
 
             result.Should().BeFalse();
             logger.ErrorMessages.Should().HaveCount(2);
             logger.ErrorMessages.Should().Contain(m => m.Contains("foo/bar"));
             logger.ErrorMessages.Should().Contain(m => m.Contains("baz\\qux"));
+        }
+
+        [Theory]
+        [InlineData("café")]
+        [InlineData("net10.0-línux")]
+        [InlineData("日本語")]
+        public void EnsureNoAliasesWithDisallowedCharacters_WithNonAsciiAlias_AtV11_ReturnsErrorNU1019(string invalidAlias)
+        {
+            var logger = new TestLogger();
+            var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation
+                {
+                    FrameworkName = FrameworkConstants.CommonFrameworks.Net80,
+                    TargetAlias = invalidAlias
+                }
+            });
+            packageSpec.Name = "TestProject";
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata
+            {
+                SdkAnalysisLevel = NuGetVersion.Parse("11.0.100"),
+                UsingMicrosoftNETSdk = true,
+            };
+
+            var result = RestoreCommand.EnsureNoAliasesWithDisallowedCharacters(packageSpec, logger);
+
+            result.Should().BeFalse();
+            logger.ErrorMessages.Should().ContainSingle();
+            logger.ErrorMessages.Single().Should().Contain(invalidAlias);
+            logger.ErrorMessages.Single().Should().Contain("NU1019");
+        }
+
+        [Theory]
+        [InlineData("café")]
+        [InlineData("net10.0-línux")]
+        [InlineData("日本語")]
+        public void EnsureNoAliasesWithDisallowedCharacters_WithNonAsciiAlias_AtV10_0_300_ReturnsWarningNU1019(string invalidAlias)
+        {
+            var logger = new TestLogger();
+            var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation
+                {
+                    FrameworkName = FrameworkConstants.CommonFrameworks.Net80,
+                    TargetAlias = invalidAlias
+                }
+            });
+            packageSpec.Name = "TestProject";
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata
+            {
+                SdkAnalysisLevel = NuGetVersion.Parse("10.0.300"),
+                UsingMicrosoftNETSdk = true,
+            };
+
+            var result = RestoreCommand.EnsureNoAliasesWithDisallowedCharacters(packageSpec, logger);
+
+            result.Should().BeTrue();
+            logger.WarningMessages.Should().ContainSingle();
+            logger.WarningMessages.Single().Should().Contain(invalidAlias);
+            logger.WarningMessages.Single().Should().Contain("NU1019");
+            logger.ErrorMessages.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("café")]
+        [InlineData("日本語")]
+        public void EnsureNoAliasesWithDisallowedCharacters_WithNonAsciiAlias_AtOldSdk_ReturnsTrue(string alias)
+        {
+            var logger = new TestLogger();
+            var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation
+                {
+                    FrameworkName = FrameworkConstants.CommonFrameworks.Net80,
+                    TargetAlias = alias
+                }
+            });
+            packageSpec.Name = "TestProject";
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata
+            {
+                SdkAnalysisLevel = NuGetVersion.Parse("9.0.100"),
+                UsingMicrosoftNETSdk = true,
+            };
+
+            var result = RestoreCommand.EnsureNoAliasesWithDisallowedCharacters(packageSpec, logger);
+
+            result.Should().BeTrue();
+            logger.ErrorMessages.Should().BeEmpty();
+            logger.WarningMessages.Should().BeEmpty();
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -3654,5 +3654,124 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             return walker.WalkAsync(range, framework, runtimeIdentifier: null, runtimeGraph: null, recursive: true);
         }
+
+        [Theory]
+        [InlineData("banana/3")]
+        [InlineData("foo\\bar")]
+        [InlineData("a/b/c")]
+        [InlineData("net10.0/linux-x64")]
+        public void EnsureNoAliasesWithPathSeparator_WithPathSeparatorInAlias_ReturnsFalseAndLogsNU1019(string invalidAlias)
+        {
+            var logger = new TestLogger();
+            var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation
+                {
+                    FrameworkName = FrameworkConstants.CommonFrameworks.Net80,
+                    TargetAlias = invalidAlias
+                }
+            });
+            packageSpec.Name = "TestProject";
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata
+            {
+                SdkAnalysisLevel = NuGetVersion.Parse("10.0.300"),
+                UsingMicrosoftNETSdk = true,
+            };
+
+            var result = RestoreCommand.EnsureNoAliasesWithPathSeparator(packageSpec, logger);
+
+            result.Should().BeFalse();
+            logger.ErrorMessages.Should().ContainSingle();
+            logger.ErrorMessages.Single().Should().Contain(invalidAlias);
+            logger.ErrorMessages.Single().Should().Contain("NU1019");
+        }
+
+        [Theory]
+        [InlineData("apple")]
+        [InlineData("banana")]
+        [InlineData("net10.0")]
+        [InlineData("net10.0-linux")]
+        public void EnsureNoAliasesWithPathSeparator_WithValidAlias_ReturnsTrueAndLogsNothing(string validAlias)
+        {
+            var logger = new TestLogger();
+            var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation
+                {
+                    FrameworkName = FrameworkConstants.CommonFrameworks.Net80,
+                    TargetAlias = validAlias
+                }
+            });
+            packageSpec.Name = "TestProject";
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata
+            {
+                SdkAnalysisLevel = NuGetVersion.Parse("10.0.300"),
+                UsingMicrosoftNETSdk = true,
+            };
+
+            var result = RestoreCommand.EnsureNoAliasesWithPathSeparator(packageSpec, logger);
+
+            result.Should().BeTrue();
+            logger.ErrorMessages.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("10.0.200")]
+        [InlineData("9.0.100")]
+        public void EnsureNoAliasesWithPathSeparator_WithOldSdkAnalysisLevel_ReturnsTrueRegardlessOfAlias(string sdkAnalysisLevel)
+        {
+            var logger = new TestLogger();
+            var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation
+                {
+                    FrameworkName = FrameworkConstants.CommonFrameworks.Net80,
+                    TargetAlias = "banana/3"
+                }
+            });
+            packageSpec.Name = "TestProject";
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata
+            {
+                SdkAnalysisLevel = NuGetVersion.Parse(sdkAnalysisLevel),
+                UsingMicrosoftNETSdk = true,
+            };
+
+            var result = RestoreCommand.EnsureNoAliasesWithPathSeparator(packageSpec, logger);
+
+            result.Should().BeTrue();
+            logger.ErrorMessages.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void EnsureNoAliasesWithPathSeparator_WithMultipleInvalidAliases_LogsErrorForEach()
+        {
+            var logger = new TestLogger();
+            var packageSpec = new PackageSpec(new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation
+                {
+                    FrameworkName = FrameworkConstants.CommonFrameworks.Net80,
+                    TargetAlias = "foo/bar"
+                },
+                new TargetFrameworkInformation
+                {
+                    FrameworkName = FrameworkConstants.CommonFrameworks.Net80,
+                    TargetAlias = "baz\\qux"
+                }
+            });
+            packageSpec.Name = "TestProject";
+            packageSpec.RestoreMetadata = new ProjectRestoreMetadata
+            {
+                SdkAnalysisLevel = NuGetVersion.Parse("10.0.300"),
+                UsingMicrosoftNETSdk = true,
+            };
+
+            var result = RestoreCommand.EnsureNoAliasesWithPathSeparator(packageSpec, logger);
+
+            result.Should().BeFalse();
+            logger.ErrorMessages.Should().HaveCount(2);
+            logger.ErrorMessages.Should().Contain(m => m.Contains("foo/bar"));
+            logger.ErrorMessages.Should().Contain(m => m.Contains("baz\\qux"));
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/nuget/home/issues/14752

## Description

Block path separator in TargetFramework property values as they'll break the assets file format.
This was made as an agreement during the spec review. 

This does the typical, introduce new error, gate it behind an SDKAnalysisLevel. 
This is not really expected to impact anyone as custom aliases aren't really a thing yet.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. - https://github.com/NuGet/Home/issues/14836
