### PR TITLE
Initialize resource when GetInstalledVersions is called first

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -361,12 +361,12 @@ namespace NuGet.Commands
             FindPackageByIdDependencyInfo packageInfo = null;
             try
             {
-                await EnsureResource(cancellationToken);
-
                 if (_throttle != null)
                 {
                     await _throttle.WaitAsync(cancellationToken);
                 }
+
+                await EnsureResource(cancellationToken);
 
                 // Read package info, this will download the package if needed.
                 packageInfo = await _findPackagesByIdResource.GetDependencyInfoAsync(
@@ -459,12 +459,12 @@ namespace NuGet.Commands
 
             try
             {
-                await EnsureResource(cancellationToken);
-
                 if (_throttle != null)
                 {
                     await _throttle.WaitAsync(cancellationToken);
                 }
+
+                await EnsureResource(cancellationToken);
 
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -630,12 +630,13 @@ namespace NuGet.Commands
         {
             try
             {
-                await EnsureResource(cancellationToken);
-
                 if (_throttle != null)
                 {
                     await _throttle.WaitAsync(cancellationToken);
                 }
+
+                await EnsureResource(cancellationToken);
+
                 return await _findPackagesByIdResource.GetAllVersionsAsync(
                     id,
                     cacheContext,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -630,13 +630,11 @@ namespace NuGet.Commands
         {
             try
             {
+                await EnsureResource(cancellationToken);
+
                 if (_throttle != null)
                 {
                     await _throttle.WaitAsync(cancellationToken);
-                }
-                if (_findPackagesByIdResource == null)
-                {
-                    return null;
                 }
                 return await _findPackagesByIdResource.GetAllVersionsAsync(
                     id,

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
@@ -662,6 +662,56 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public async Task GetAllVersionsAsync_EnsuresResourceIsInitialized_ReturnsVersions()
+        {
+            // Arrange
+            // This test verifies that GetAllVersionsAsync properly calls EnsureResource
+            // to initialize _findPackagesByIdResource. Previously, EnsureResource was not called
+            // and GetAllVersionsInternalAsync would see _findPackagesByIdResource as null,
+            // silently returning null instead of the actual versions.
+            var testLogger = new TestLogger();
+            var cacheContext = new SourceCacheContext();
+            var expectedVersions = new[] { NuGetVersion.Parse("1.0.0"), NuGetVersion.Parse("2.0.0") };
+
+            var findResource = new Mock<FindPackageByIdResource>();
+            findResource.Setup(s => s.GetAllVersionsAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<SourceCacheContext>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedVersions);
+
+            var source = new Mock<SourceRepository>();
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
+                .ReturnsAsync(findResource.Object);
+            source.SetupGet(s => s.PackageSource)
+                .Returns(new PackageSource("http://test/index.json"));
+
+            var provider = new SourceRepositoryDependencyProvider(
+                source.Object,
+                testLogger,
+                cacheContext,
+                ignoreFailedSources: true,
+                ignoreWarning: true);
+
+            // Act
+            var versions = await provider.GetAllVersionsAsync(
+                "x",
+                cacheContext,
+                testLogger,
+                CancellationToken.None);
+
+            // Assert
+            versions.Should().BeEquivalentTo(expectedVersions);
+            source.Verify(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None), Times.Once);
+            findResource.Verify(s => s.GetAllVersionsAsync(
+                "x",
+                It.IsAny<SourceCacheContext>(),
+                It.IsAny<ILogger>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
         public async Task FindLibraryAsync_WhenASourceIsInaccessible_AndFailuresAreNotIgnored_EveryCallLogsAnErrorMessage()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14837

## Description

This could lead to some false negatives in some cases. 
Note that in all non-lock file scenarios other methods would be called first in the restore codepaths, so it's fortuituously initialized. 
In lock file scenarios with 1 package, that's not the case and that's what my test is/was.
https://github.com/NuGet/Home/issues/14107#issuecomment-4165366327

This is not very likely to be a thing in practice, as it would effectively require a single package scenarios so that other calls to the source don't end up initializing things.

Note that I switched the throttle semaphore acquisition and the EnsureResource calls in a few places. Tests were failing without it.
If EnsureResource failed, we'd release the semaphore despite never acquiring it, leading to SemaphoreFullException.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
