### PR TITLE
Publish NuGet test gate drop from official pipeline

### DIFF
--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -252,6 +252,16 @@ steps:
         }
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
+  - task: PowerShell@2
+    displayName: "Set test gate drop name"
+    inputs:
+      targetType: inline
+      script: |
+        $testsDropName = "$(MicroBuild.ManifestDropName)" -replace '^Products/', 'Tests/'
+        Write-Host "Tests Drop: $testsDropName"
+        Write-Host "##vso[task.setvariable variable=NuGetTestGateDropName]$testsDropName"
+    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+
   - task: MSBuild@1
     displayName: "Collect Build Symbols"
     inputs:

--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -252,16 +252,6 @@ steps:
         }
     condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
 
-  - task: PowerShell@2
-    displayName: "Set test gate drop name"
-    inputs:
-      targetType: inline
-      script: |
-        $testsDropName = "$(MicroBuild.ManifestDropName)" -replace '^Products/', 'Tests/'
-        Write-Host "Tests Drop: $testsDropName"
-        Write-Host "##vso[task.setvariable variable=NuGetTestGateDropName]$testsDropName"
-    condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-
   - task: MSBuild@1
     displayName: "Collect Build Symbols"
     inputs:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -132,6 +132,17 @@ stages:
         codeSignValidationEnabled: false
 
       - output: artifactsDrop
+        displayName: 'Publish test gate drop'
+        condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+        dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+        buildNumber: '$(NuGetTestGateDropName)'
+        sourcePath: '$(Build.StagingDirectory)\RunSettings'
+        toLowerCase: false
+        usePat: true
+        dropMetadataContainerName: 'DropMetadata-TestGate'
+        codeSignValidationEnabled: false
+
+      - output: artifactsDrop
         displayName: 'OptProfV2:  publish profiling inputs to artifact services'
         condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -85,6 +85,7 @@ stages:
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
       RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
+      NuGetTestGateDropName: 'TestGate/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)'
     pool:
       name: VSEng-MicroBuildVSStable
     templateContext:

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -225,11 +225,6 @@ steps:
           Write-Host "##vso[task.setvariable variable=RunSettingsDrop]$runSettingsDrop"
           Write-Host "##vso[task.setvariable variable=RunSettingsDrop;isOutput=true]$runSettingsDrop"
 
-          # Test gate drop — mirrors the product drop path with Tests/ prefix so the VS gate can find it by NuGet version
-          $testsDrop = "${env:MicroBuild_ManifestDropName}" -replace '^Products/', 'Tests/'
-          Write-Host "Tests Drop: $testsDrop"
-          Write-Host "##vso[task.setvariable variable=TestsDrop]$testsDrop"
-
           $vsBootstrapperBranch = dotnet msbuild -getProperty:VsTargetBranch build\config.props
           Write-Host "VS Bootstrapper Branch: $vsBootstrapperBranch"
           Write-Host "##vso[task.setvariable variable=VsBootstrapperBranch;isOutput=true]$vsBootstrapperBranch"
@@ -310,16 +305,6 @@ steps:
       toLowerCase: false
       usePat: true
       dropMetadataContainerName: "DropMetadata-RunSettings"
-
-  - task: artifactDropTask@0
-    displayName: "Publish test gate drop"
-    inputs:
-      dropServiceURI: "https://devdiv.artifacts.visualstudio.com"
-      buildNumber: "$(TestsDrop)"
-      sourcePath: '$(Build.StagingDirectory)\RunSettings'
-      toLowerCase: false
-      usePat: true
-      dropMetadataContainerName: "DropMetadata-TestGate"
 
   - task: PublishPipelineArtifact@1
     displayName: "Publish E2E tests"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description


Move the test gate drop publish from vs-test/build.ym to the official pipeline

 - vs-test/build.yml is only used by integration tests - official builds never ran it, so the test gate drop was never published. https://github.com/NuGet/NuGet.Client/commit/13353c236dca85b5852313d8ec371e0c76b2e061constructed drop path by replacing Product with Test in `Product/Project/Repo..` and it was failing to do the replacement. That resulted in two the same drop paths. The current drop path is as follows and it just simply constructs "TestGate/.." url 
-  Drop path: `TestGate/Project/Repo/dev/<NuGet version>`. This is reconstructible from the NuGet version

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
