### PR TITLE
Fix for non-compliant TSTInfo encoding

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TstInfoTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/TstInfoTests.cs
@@ -94,6 +94,46 @@ namespace NuGet.Packaging.Test
             Verify(testTstInfo);
         }
 
+        [Fact]
+        public void Encode_WithDefaultOrderingFalse_OmitsBooleanAndIsAcceptedByConsumers()
+        {
+            // DER X.690 §11.5: a value equal to the DEFAULT must not be encoded.
+            // 'ordering BOOLEAN DEFAULT FALSE' must be omitted when false.
+            TestTstInfo testTstInfo = CreateTestTstInfo();
+
+            AsnWriter writer = new(AsnEncodingRules.DER);
+            testTstInfo.Encode(writer);
+            byte[] bytes = writer.Encode();
+
+            // Verify the ordering boolean is not present in the encoded bytes
+            AsnReader reader = new(bytes, AsnEncodingRules.DER);
+            AsnReader sequence = reader.ReadSequence();
+
+            sequence.ReadInteger();          // version
+            sequence.ReadObjectIdentifier(); // policy
+            sequence.ReadSequence();         // messageImprint
+            sequence.ReadInteger();          // serialNumber
+            sequence.ReadGeneralizedTime();  // genTime
+            // accuracy is not present in this test data
+
+            bool hasBooleanTag = sequence.HasData && sequence.PeekTag() == Asn1Tag.Boolean;
+            Assert.False(hasBooleanTag,
+                "Ordering=false must not be explicitly encoded per DER rules (X.690 §11.5).");
+
+            // Verify NuGet's own parser accepts the encoding and reads ordering as false
+            TstInfo parsed = TstInfo.Read(bytes);
+            Assert.False(parsed.Ordering);
+
+#if IS_CORECLR
+            // Verify the BCL parser also accepts the encoding and reads ordering as false
+            Assert.True(
+                System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo.TryDecode(
+                    new ReadOnlyMemory<byte>(bytes), out System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo? bclTstInfo, out _),
+                "BCL Rfc3161TimestampTokenInfo.TryDecode rejected the encoded TSTInfo.");
+            Assert.False(bclTstInfo!.IsOrdering);
+#endif
+        }
+
         private static void Verify(TestTstInfo expectedTstInfo)
         {
             AsnWriter writer = new(AsnEncodingRules.DER);

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Asn1/TstInfo.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/Asn1/TstInfo.cs
@@ -97,7 +97,10 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages.Asn1
                     Accuracy.Encode(writer);
                 }
 
-                writer.WriteBoolean(Ordering);
+                if (Ordering)
+                {
+                    writer.WriteBoolean(Ordering);
+                }
 
                 if (Nonce is not null)
                 {


### PR DESCRIPTION

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14838.

## Description

Existing consumers of `TSTInfo` are rather lenient and don't fail even when it is generated not up to DER spec, so the test succeeds even without the fix, but the test verifies that the change does not break consumers after the fix, too.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
