### PR TITLE
fix: Update Polish translations for vulnerability severity terms

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.Commands/xlf/Strings.pl.xlf
@@ -1419,27 +1419,27 @@ Uaktualnij zestaw .NET SDK lub usuń RestoreUseLegacyDependencyResolver, aby kor
       </trans-unit>
       <trans-unit id="Vulnerability_Severity_Critical">
         <source>critical</source>
-        <target state="translated">krytyczna</target>
+        <target state="translated">krytyczne</target>
         <note>As in "This package has a critical severity vulnerability"</note>
       </trans-unit>
       <trans-unit id="Vulnerability_Severity_High">
         <source>high</source>
-        <target state="translated">wysoka</target>
+        <target state="translated">wysokie</target>
         <note>As in "This package has a high severity vulnerability"</note>
       </trans-unit>
       <trans-unit id="Vulnerability_Severity_Low">
         <source>low</source>
-        <target state="translated">niska</target>
+        <target state="translated">niskie</target>
         <note>As in "This package has a low severity vulnerability"</note>
       </trans-unit>
       <trans-unit id="Vulnerability_Severity_Moderate">
         <source>moderate</source>
-        <target state="translated">umiarkowana</target>
+        <target state="translated">umiarkowane</target>
         <note>As in "This package has a moderate severity vulnerability"</note>
       </trans-unit>
       <trans-unit id="Vulnerability_Severity_unknown">
         <source>unknown</source>
-        <target state="translated">nieznany</target>
+        <target state="translated">nieznane</target>
         <note>As in "This package has a unknown severity vulnerability"</note>
       </trans-unit>
       <trans-unit id="WarningAsError">


### PR DESCRIPTION
This PR fixes a grammar issue in the Polish NU1903 warning message. Change makes sense from a Polish grammar perspective. In Warning_PackageWithKnownVulnerability, the {2} placeholder is inserted into the phrase ma znane {2} luki w zabezpieczeniach. The noun luki is plural, so the adjective must also be in the plural form. Because of that, wysokie is correct, while wysoka is not.

Current message:
OSTRZEŻENIE: NU1903: Pakiet „System.IO.Packaging 8.0.0 ma znane wysoka luki w zabezpieczeniach o ważności, https://github.com/advisories/GHSA-f32c-w444-8ppv

Updated message:
OSTRZEŻENIE: NU1903: Pakiet „System.IO.Packaging 8.0.0 ma znane wysokie luki w zabezpieczeniach o ważności, https://github.com/advisories/GHSA-f32c-w444-8ppv

This change replaces “wysoka” with “wysokie” to make the message grammatically correct in Polish.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
