### PR TITLE
Fix cross product no-op

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -350,12 +350,20 @@ namespace NuGet.ProjectModel
         public string GetHash()
         {
             // Use the faster FNV hash function for hashing unless the user has specified to use the legacy SHA512 hash function
-            using (IHashFunction hashFunc = UseLegacyHashFunction == true ? new Sha512HashFunction() : new FnvHash64Function())
-            using (var writer = new HashObjectWriter(hashFunc))
+            return GetHash(() => UseLegacyHashFunction == true ? new Sha512HashFunction() : new FnvHash64Function());
+        }
+
+        internal string GetHash(Func<IHashFunction> getHashFunction)
+        {
+            if (getHashFunction == null)
             {
-                Write(writer, hashing: true, PackageSpecWriter.Write);
-                return writer.GetHash();
+                throw new ArgumentNullException(nameof(getHashFunction));
             }
+
+            using IHashFunction hashFunc = getHashFunction();
+            using var writer = new HashObjectWriter(hashFunc);
+            Write(writer, hashing: true, PackageSpecWriter.Write);
+            return writer.GetHash();
         }
 
         private void Write(RuntimeModel.IObjectWriter writer, bool hashing, Action<PackageSpec, RuntimeModel.IObjectWriter, bool, IEnvironmentVariableReader> writeAction)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -11,6 +11,7 @@ using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.RuntimeModel;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
@@ -589,19 +590,9 @@ namespace NuGet.ProjectModel
 
             writer.WriteObjectStart("centralPackageVersions");
 
-            if (hashing)
+            foreach (var dependency in centralPackageVersions.OrderBy(dep => dep.Name, StringComparer.OrdinalIgnoreCase))
             {
-                foreach (var dependency in centralPackageVersions)
-                {
-                    writer.WriteNameValue(name: dependency.Name, value: dependency.VersionRange.OriginalString ?? dependency.VersionRange.ToNormalizedString());
-                }
-            }
-            else
-            {
-                foreach (var dependency in centralPackageVersions.OrderBy(dep => dep.Name, StringComparer.OrdinalIgnoreCase))
-                {
-                    writer.WriteNameValue(name: dependency.Name, value: dependency.VersionRange.OriginalString ?? dependency.VersionRange.ToNormalizedString());
-                }
+                writer.WriteNameValue(name: dependency.Name, value: dependency.VersionRange.OriginalString ?? dependency.VersionRange.ToNormalizedString());
             }
 
             writer.WriteObjectEnd();
@@ -616,19 +607,9 @@ namespace NuGet.ProjectModel
 
             writer.WriteObjectStart("packagesToPrune");
 
-            if (hashing)
+            foreach (var dependency in packagesToPrune.OrderBy(dep => dep.Key, StringComparer.OrdinalIgnoreCase))
             {
-                foreach (var dependency in packagesToPrune)
-                {
-                    writer.WriteNameValue(name: dependency.Key, value: dependency.Value.VersionRange.OriginalString ?? dependency.Value.VersionRange.ToNormalizedString());
-                }
-            }
-            else
-            {
-                foreach (var dependency in packagesToPrune.OrderBy(dep => dep.Key, StringComparer.OrdinalIgnoreCase))
-                {
-                    writer.WriteNameValue(name: dependency.Key, value: dependency.Value.VersionRange.OriginalString ?? dependency.Value.VersionRange.ToNormalizedString());
-                }
+                writer.WriteNameValue(name: dependency.Key, value: dependency.Value.VersionRange.OriginalString ?? dependency.Value.VersionRange.ToNormalizedString());
             }
 
             writer.WriteObjectEnd();

--- a/test/EndToEnd/tests/NetCoreProjectTest.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTest.ps1
@@ -66,7 +66,6 @@ function Test-NetCoreConsoleAppRebuildDoesNotDeleteCacheFile {
 }
 
 function Test-NetCoreVSandMSBuildNoOp {
-    [SkipTest('https://github.com/NuGet/Home/issues/13003')]
     param ()
 
     # Arrange
@@ -92,7 +91,6 @@ function Test-NetCoreVSandMSBuildNoOp {
 }
 
 function Test-NetCoreTargetFrameworksVSandMSBuildNoOp {
-    [SkipTest('https://github.com/NuGet/Home/issues/13003')]
     param ()
 
     # Arrange
@@ -118,7 +116,6 @@ function Test-NetCoreTargetFrameworksVSandMSBuildNoOp {
 }
 
 function Test-NetCoreMultipleTargetFrameworksVSandMSBuildNoOp {
-    [SkipTest('https://github.com/NuGet/Home/issues/11231')]
     param ()
 
     # Arrange
@@ -144,7 +141,6 @@ function Test-NetCoreMultipleTargetFrameworksVSandMSBuildNoOp {
 }
 
 function Test-NetCoreToolsVSandMSBuildNoOp {
-    [SkipTest('https://github.com/NuGet/Home/issues/11231')]
     param ()
 
     # Arrange

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -9,9 +9,11 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Microsoft.Internal.NuGet.Testing.SignedPackages;
+using NuGet.Commands.Test;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Packaging;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Xunit;
@@ -447,6 +449,164 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(expectedJson, actualJson);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GetHash_WithCentralPackageVersionsAndPackagesToPrune_IgnoresDictionaryCreationOrder(bool useLegacyHashFunction)
+        {
+            // Arrange
+            DependencyGraphSpec first = CreateDependencyGraphSpecWithCentralDependenciesAndPruning(
+                centralPackageVersionNames: ["PackageB", "PackageA"],
+                packagesToPruneNames: ["TransitiveB", "TransitiveA"]);
+
+            DependencyGraphSpec second = CreateDependencyGraphSpecWithCentralDependenciesAndPruning(
+                centralPackageVersionNames: ["PackageA", "PackageB"],
+                packagesToPruneNames: ["TransitiveA", "TransitiveB"]);
+
+            // Act
+            string firstHash = GetHash(first, useLegacyHashFunction);
+            string secondHash = GetHash(second, useLegacyHashFunction);
+
+            // Assert
+            Assert.Equal(firstHash, secondHash);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GetHash_WithPackagesToPruneInDifferentJsonOrder_IgnoresInputOrder(bool useLegacyHashFunction)
+        {
+            // Arrange
+            DependencyGraphSpec first = CreateDependencyGraphSpecFromJson(@"
+            {
+              ""restore"": {
+                ""projectUniqueName"": ""Project1"",
+                ""centralPackageVersionsManagementEnabled"": true
+              },
+              ""frameworks"": {
+                ""net8.0"": {
+                  ""dependencies"": {
+                    ""PackageA"": {
+                      ""target"": ""Package"",
+                      ""version"": ""[1.0.0,)"",
+                      ""versionCentrallyManaged"": true
+                    }
+                  },
+                  ""centralPackageVersions"": {
+                    ""PackageA"": ""[1.0.0]"",
+                    ""PackageB"": ""[2.0.0]""
+                  },
+                  ""packagesToPrune"": {
+                    ""TransitiveB"": ""(,2.0.0]"",
+                    ""TransitiveA"": ""(,1.0.0]""
+                  }
+                }
+              }
+            }");
+
+            DependencyGraphSpec second = CreateDependencyGraphSpecFromJson(@"
+            {
+              ""restore"": {
+                ""projectUniqueName"": ""Project1"",
+                ""centralPackageVersionsManagementEnabled"": true
+              },
+              ""frameworks"": {
+                ""net8.0"": {
+                  ""dependencies"": {
+                    ""PackageA"": {
+                      ""target"": ""Package"",
+                      ""version"": ""[1.0.0,)"",
+                      ""versionCentrallyManaged"": true
+                    }
+                  },
+                  ""centralPackageVersions"": {
+                    ""PackageA"": ""[1.0.0]"",
+                    ""PackageB"": ""[2.0.0]""
+                  },
+                  ""packagesToPrune"": {
+                    ""TransitiveA"": ""(,1.0.0]"",
+                    ""TransitiveB"": ""(,2.0.0]""
+                  }
+                }
+              }
+            }");
+
+            // Act
+            string firstHash = GetHash(first, useLegacyHashFunction);
+            string secondHash = GetHash(second, useLegacyHashFunction);
+
+            // Assert
+            Assert.Equal(firstHash, secondHash);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GetHash_WithCentralPackageVersionsInDifferentJsonOrder_IgnoresInputOrder(bool useLegacyHashFunction)
+        {
+            // Arrange
+            DependencyGraphSpec first = CreateDependencyGraphSpecFromJson(@"
+            {
+              ""restore"": {
+                ""projectUniqueName"": ""Project1"",
+                ""centralPackageVersionsManagementEnabled"": true
+              },
+              ""frameworks"": {
+                ""net8.0"": {
+                  ""dependencies"": {
+                    ""PackageA"": {
+                      ""target"": ""Package"",
+                      ""version"": ""[1.0.0,)"",
+                      ""versionCentrallyManaged"": true
+                    }
+                  },
+                  ""centralPackageVersions"": {
+                    ""PackageB"": ""[2.0.0]"",
+                    ""PackageA"": ""[1.0.0]""
+                  },
+                  ""packagesToPrune"": {
+                    ""TransitiveA"": ""(,1.0.0]"",
+                    ""TransitiveB"": ""(,2.0.0]""
+                  }
+                }
+              }
+            }");
+
+            DependencyGraphSpec second = CreateDependencyGraphSpecFromJson(@"
+            {
+              ""restore"": {
+                ""projectUniqueName"": ""Project1"",
+                ""centralPackageVersionsManagementEnabled"": true
+              },
+              ""frameworks"": {
+                ""net8.0"": {
+                  ""dependencies"": {
+                    ""PackageA"": {
+                      ""target"": ""Package"",
+                      ""version"": ""[1.0.0,)"",
+                      ""versionCentrallyManaged"": true
+                    }
+                  },
+                  ""centralPackageVersions"": {
+                    ""PackageA"": ""[1.0.0]"",
+                    ""PackageB"": ""[2.0.0]""
+                  },
+                  ""packagesToPrune"": {
+                    ""TransitiveA"": ""(,1.0.0]"",
+                    ""TransitiveB"": ""(,2.0.0]""
+                  }
+                }
+              }
+            }");
+
+            // Act
+            string firstHash = GetHash(first, useLegacyHashFunction);
+            string secondHash = GetHash(second, useLegacyHashFunction);
+
+            // Assert
+            Assert.Equal(firstHash, secondHash);
+        }
+
         [Fact]
         public void AddProject_WhenRestoreMetadataIsNull_AddsProject()
         {
@@ -595,6 +755,45 @@ namespace NuGet.ProjectModel.Test
             return dgSpec;
         }
 
+        private static DependencyGraphSpec CreateDependencyGraphSpecWithCentralDependenciesAndPruning(
+            IReadOnlyList<string> centralPackageVersionNames,
+            IReadOnlyList<string> packagesToPruneNames)
+        {
+            string centralPackageVersions = string.Join(
+                $",{Environment.NewLine}",
+                centralPackageVersionNames.Select(packageId => $@"                    ""{packageId}"": ""[1.0.0]"""));
+            string packagesToPrune = string.Join(
+                $",{Environment.NewLine}",
+                packagesToPruneNames.Select(packageId => $@"                    ""{packageId}"": ""(,1.0.0]"""));
+
+            string rootProject = $@"
+            {{
+              ""restore"": {{
+                ""projectUniqueName"": ""Project1"",
+                ""centralPackageVersionsManagementEnabled"": true
+              }},
+              ""frameworks"": {{
+                ""net8.0"": {{
+                  ""dependencies"": {{
+                    ""PackageA"": {{
+                      ""version"": ""[1.0.0,)"",
+                      ""target"": ""Package"",
+                      ""versionCentrallyManaged"": true
+                    }}
+                  }},
+                  ""centralPackageVersions"": {{
+{centralPackageVersions}
+                  }},
+                  ""packagesToPrune"": {{
+{packagesToPrune}
+                  }}
+                }}
+              }}
+            }}";
+
+            return CreateDependencyGraphSpecFromJson(rootProject);
+        }
+
         private static TargetFrameworkInformation CreateTargetFrameworkInformation()
         {
             var nugetFramework = new NuGetFramework("net40");
@@ -652,6 +851,19 @@ namespace NuGet.ProjectModel.Test
             };
 
             return tfi;
+        }
+
+        private static DependencyGraphSpec CreateDependencyGraphSpecFromJson(string json)
+        {
+            PackageSpec packageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", @"c:\", json);
+            return ProjectTestHelpers.GetDGSpecForFirstProject(packageSpec);
+        }
+
+        private static string GetHash(DependencyGraphSpec dgSpec, bool useLegacyHashFunction)
+        {
+            return useLegacyHashFunction
+                ? dgSpec.GetHash(() => new Sha512HashFunction())
+                : dgSpec.GetHash(() => new FnvHash64Function());
         }
 
         private static string GetJson(DependencyGraphSpec dgSpec)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14840

## Description

In https://github.com/NuGet/NuGet.Client/pull/7246, I realized Test-NetCoreVSandMSBuildNoOp, which is the main way we check for no-op equivalency in VS vs CLI is not running. 

It was disabled in because of https://github.com/NuGet/Home/issues/13003 in https://github.com/NuGet/NuGet.Client/pull/5469 but we never enabled it back. 

That was `Nov 10, 2023`. 

Unfortunately there's been many changes in this space, including a new algorithm that have basically broken this test.

This has a *massive impact*, since a huge number of projects have CPM enabled and everyone .NET and above has pruning data. 

Some of the changes that may have regressed it: 

- https://github.com/NuGet/NuGet.Client/pull/5655
- https://github.com/NuGet/NuGet.Client/commit/15691b7351cf0aa2c0e7f613648fe46a3ccb18da#diff-eeff01cf2fa7c22008dca9b7fc2bf2d7546fa8f86e98af4127341ade6f7bd05bR143
- https://github.com/NuGet/NuGet.Client/pull/4523
- https://github.com/NuGet/NuGet.Client/commit/cf252fe9280540b55d30ea9abda3a47e000ef738

Related: https://github.com/NuGet/Home/issues/11231

This has a perf cost, but no-op is cheaper than the actual cost of doing a real restore. 
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
