### PR TITLE
Fix dotnet add package incorrectly adding PrivateAssets to PackageVersion item in CPM projects

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -437,16 +437,16 @@ namespace NuGet.CommandLine.XPlat
 
         /// <summary>
         /// Add package name and version into the props file.
+        /// Only version metadata belongs on PackageVersion items; asset metadata (PrivateAssets, IncludeAssets)
+        /// belongs on the PackageReference item in the project file.
         /// </summary>
         /// <param name="itemGroup">Item group that needs to be modified in the props file.</param>
         /// <param name="libraryDependency">Package Dependency of the package to be added.</param>
         internal void AddPackageVersionIntoPropsItemGroup(ProjectItemGroupElement itemGroup,
             LibraryDependency libraryDependency)
         {
-            // Add both package reference information and version metadata using the PACKAGE_VERSION_TYPE_TAG.
             var item = itemGroup.AddItem(PACKAGE_VERSION_TYPE_TAG, libraryDependency.Name);
             var packageVersion = AddVersionMetadata(libraryDependency, item);
-            AddExtraMetadataToProjectItemElement(libraryDependency, item);
             Logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.Info_AddPkgAdded, libraryDependency.Name, packageVersion, itemGroup.ContainingProject.FullPath
             ));
         }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1779,24 +1779,8 @@ namespace NuGet.XPlat.FuncTest
   </PropertyGroup>
 </Project>");
 
-            // Build a DG file with CPM enabled so the restore-based code path detects the development dependency.
-            // Use the isolated UserPackagesFolder to avoid stale packages in the shared global cache.
-            var packageSpec = projectA.PackageSpec;
-            packageSpec.RestoreMetadata.CentralPackageVersionsEnabled = true;
-            packageSpec.RestoreMetadata.PackagesPath = pathContext.UserPackagesFolder;
-            var dgSpec = new DependencyGraphSpec();
-            var dgFilePath = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath)!, "temp.dg");
-            dgSpec.AddRestore(projectA.ProjectName);
-            dgSpec.AddProject(packageSpec);
-            dgSpec.Save(dgFilePath);
-
             var logger = new TestCommandOutputLogger(_testOutputHelper);
-            var packageArgs = new PackageReferenceArgs(projectA.ProjectPath, logger)
-            {
-                PackageId = packageX.Id,
-                PackageVersion = packageX.Version,
-                DgFilePath = dgFilePath,
-            };
+            var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(logger, packageX.Id, packageX.Version, projectA);
             var commandRunner = new AddPackageReferenceCommandRunner();
 
             // Act

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -1755,5 +1755,65 @@ namespace NuGet.XPlat.FuncTest
                 Assert.True(XPlatTestUtils.ValidateReference(itemGroup, "packageX", userInputVersion));
             }
         }
+
+        [Fact]
+        public async Task AddPkg_DevelopmentDependencyWithCPM_PrivateAssetsOnlyOnPackageReference()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+            var packageX = XPlatTestUtils.CreatePackage(developmentDependency: true);
+
+            // Generate Package
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                packageX);
+
+            // Create Directory.Packages.props to enable CPM
+            var directoryPackagesPropsPath = Path.Combine(pathContext.SolutionRoot, "Directory.Packages.props");
+            File.WriteAllText(directoryPackagesPropsPath,
+@"<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>");
+
+            // Build a DG file with CPM enabled so the restore-based code path detects the development dependency.
+            // Use the isolated UserPackagesFolder to avoid stale packages in the shared global cache.
+            var packageSpec = projectA.PackageSpec;
+            packageSpec.RestoreMetadata.CentralPackageVersionsEnabled = true;
+            packageSpec.RestoreMetadata.PackagesPath = pathContext.UserPackagesFolder;
+            var dgSpec = new DependencyGraphSpec();
+            var dgFilePath = Path.Combine(Path.GetDirectoryName(projectA.ProjectPath)!, "temp.dg");
+            dgSpec.AddRestore(projectA.ProjectName);
+            dgSpec.AddProject(packageSpec);
+            dgSpec.Save(dgFilePath);
+
+            var logger = new TestCommandOutputLogger(_testOutputHelper);
+            var packageArgs = new PackageReferenceArgs(projectA.ProjectPath, logger)
+            {
+                PackageId = packageX.Id,
+                PackageVersion = packageX.Version,
+                DgFilePath = dgFilePath,
+            };
+            var commandRunner = new AddPackageReferenceCommandRunner();
+
+            // Act
+            var result = await commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility(logger, virtualProjectBuilder: null));
+            var projectXml = File.ReadAllText(projectA.ProjectPath);
+            var propsXml = File.ReadAllText(directoryPackagesPropsPath);
+
+            // Assert
+            Assert.Equal(0, result);
+
+            // .csproj PackageReference should have PrivateAssets
+            Assert.Contains("PrivateAssets", projectXml);
+
+            // Directory.Packages.props PackageVersion should NOT have PrivateAssets or IncludeAssets
+            Assert.Contains($"<PackageVersion Include=\"{packageX.Id}\" Version=\"{packageX.Version}\"", propsXml);
+            Assert.DoesNotContain("PrivateAssets", propsXml);
+            Assert.DoesNotContain("IncludeAssets", propsXml);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -885,5 +885,71 @@ namespace NuGet.CommandLine.Xplat.Tests
             var version = result.First().TopLevelPackages.First().OriginalRequestedVersion;
             Assert.Equal("1.1.1", version);
         }
+
+        [PlatformFact(Platform.Windows)]
+        public void AddPackageVersionIntoPropsFile_WithDevelopmentDependency_DoesNotAddPrivateAssets()
+        {
+            // Arrange
+            using var testDirectory = TestDirectory.Create();
+            var projectCollection = new ProjectCollection(
+                            globalProperties: null,
+                            remoteLoggers: null,
+                            loggers: null,
+                            toolsetDefinitionLocations: ToolsetDefinitionLocations.Default,
+                            maxNodeCount: 1,
+                            onlyLogCriticalEvents: false,
+                            loadProjectsReadOnly: false);
+
+            var projectOptions = new ProjectOptions
+            {
+                LoadSettings = ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition,
+                ProjectCollection = projectCollection
+            };
+
+            // Arrange Directory.Packages.props file
+            var propsFile =
+@$"<Project>
+    <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+</Project>";
+            File.WriteAllText(Path.Combine(testDirectory, "Directory.Packages.props"), propsFile);
+
+            // Arrange project file
+            string projectContent =
+@$"<Project Sdk=""Microsoft.NET.Sdk"">
+	<PropertyGroup>
+	<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
+</Project>";
+            File.WriteAllText(Path.Combine(testDirectory, "projectA.csproj"), projectContent);
+            var project = Project.FromFile(Path.Combine(testDirectory, "projectA.csproj"), projectOptions);
+
+            // Add item group to Directory.Packages.props
+            var msObject = new MSBuildAPIUtility(logger: new TestLogger(), virtualProjectBuilder: null);
+            var directoryBuildPropsRootElement = MSBuildAPIUtility.GetDirectoryBuildPropsRootElement(project);
+            var propsItemGroup = directoryBuildPropsRootElement.AddItemGroup();
+
+            // Create a library dependency that simulates a development dependency (PrivateAssets=all)
+            var libraryDependency = new LibraryDependency
+            {
+                LibraryRange = new LibraryRange(
+                        name: "X",
+                        versionRange: VersionRange.Parse("1.0.0"),
+                        typeConstraint: LibraryDependencyTarget.Package),
+                SuppressParent = LibraryIncludeFlags.All,
+                IncludeType = LibraryIncludeFlags.All & ~(LibraryIncludeFlags.Compile | LibraryIncludeFlags.Runtime | LibraryIncludeFlags.BuildTransitive)
+            };
+
+            // Act
+            msObject.AddPackageVersionIntoPropsItemGroup(propsItemGroup, libraryDependency);
+            directoryBuildPropsRootElement.Save();
+
+            // Assert - PackageVersion should only have Version, not PrivateAssets or IncludeAssets
+            string propsContent = File.ReadAllText(Path.Combine(testDirectory, "Directory.Packages.props"));
+            Assert.Contains(@$"<PackageVersion Include=""X"" Version=""1.0.0"" />", propsContent);
+            Assert.DoesNotContain("PrivateAssets", propsContent);
+            Assert.DoesNotContain("IncludeAssets", propsContent);
+        }
     }
 }


### PR DESCRIPTION
## Bug

Fixes: https://github.com/NuGet/Home/issues/14601

## Description

When running dotnet add package for a development dependency (e.g., xunit.runner.visualstudio) in a CPM (Central Package Management) project, PrivateAssets and IncludeAssets metadata were incorrectly added to the <PackageVersion> item in Directory.Packages.props. These metadata should only appear on the <PackageReference> item in the project file.

Root cause: AddPackageVersionIntoPropsItemGroup() called AddExtraMetadataToProjectItemElement(), which writes asset metadata (PrivateAssets, IncludeAssets) to the item. For <PackageVersion> items, only version metadata should be present.

Fix: Removed the AddExtraMetadataToProjectItemElement call from AddPackageVersionIntoPropsItemGroup. The CPM flow already correctly adds asset metadata to <PackageReference> via AddPackageReferenceIntoItemGroupCPM.

## PR Checklist
- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc~