### PR TITLE
Remove BOM from localized files

### DIFF
--- a/eng/Localize/RemoveUtf8Bom.ps1
+++ b/eng/Localize/RemoveUtf8Bom.ps1
@@ -1,0 +1,20 @@
+# Removes UTF-8 BOM from localized files produced by the XLoc tool.
+# Used via the xLocCustomPowerShellScript input in the OneLocBuild task.
+# The XLocFileList environment variable is set by the task and contains
+# the path to a text file listing all localized files to process.
+
+function RemoveUtf8Bom
+{
+    param(
+        [string]$FilePath
+    )
+
+    $encoding = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+    $content = Get-Content -Path $FilePath -Encoding UTF8
+    [System.IO.File]::WriteAllText($FilePath, $content -join "`n", $encoding)
+}
+
+foreach ($locFile in (Get-Content -Path $env:XLocFileList))
+{
+    RemoveUtf8Bom -FilePath $locFile
+}

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -67,6 +67,7 @@ stages:
         MirrorRepo: 'NuGet.Client'
         MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
         GitHubOrg: 'NuGet'
+        xLocCustomPowerShellScript: 'eng/Localize/RemoveUtf8Bom.ps1'
 
 - stage: Build_Insertable
   displayName: Build NuGet inserted into VS and .NET SDK


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
This PR removes BOM from localized files, since OneLoc task returns localized files with BOM and since VMR change removes the BOM we get loop PR's

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
