### PR TITLE
Simplify localization docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,7 @@
 - When creating pull requests, always follow the [PR template](PULL_REQUEST_TEMPLATE.md).
 - Always format before submitting a pull request.
 - Before implementing any code changes, read all files in the `docs/` folder. It contains the NuGet development guidelines, including rules for SDKAnalysisLevel gating, public API policies, error handling patterns, and feature design requirements.
+- Do not edit xlf files directly. These are generated from resx files and any manual changes will be overwritten. Instead, edit the resx files and build to update the xlf files.
 
 ## Coding Standards
 

--- a/docs/localizability.md
+++ b/docs/localizability.md
@@ -24,7 +24,7 @@ You can have multiple locked messages by repeating the blocks, for example `{Loc
 ## Fixing translation errors
 
 All translations go through Microsoft's [OneLocBuild][1] system, so do not create a pull request updating xlf files in this repo.
-Instead, file a bug at [https://github.com/NuGet/Home] and we'll file an internal bug with the OneLoc team to get it fixed.
+Instead, file a bug at [NuGet/Home](https://github.com/NuGet/Home) and we'll file an internal bug with the OneLoc team to get it fixed.
 After they action the change in their backend, an automated system will create a pull request updating the xlf files.
 
 ## Do's and Don'ts

--- a/docs/localizability.md
+++ b/docs/localizability.md
@@ -1,96 +1,31 @@
 # Localizability
 
-To enable localization, your strings must first be localizable.  Practically speaking, this means:
-
-* You put the string in a resource file (.resx).
-* You added necessary functional and contextual comments for the resource string.
-* You used the string resource instead of a string literal or format string literal.
-
-## Resource commenting
-
-[This internal site][0] has a good explanation of the what, why, and how of resource commenting.  In brief, resource comments can contain both:
-
-* functional comments, which enable tools to understand your intent
-* contextual comments, which enable human translators to understand your intent
-
-Both are important.
-
-For Arcade-based builds that use [OneLocBuild][1], adding resource comments can be done using the same Visual Studio Resource Editor that you use to add and modify resource strings in .resx files.
-
-Unfortunately, NuGet.Client does not use OneLocBuild, and any resource comments in its .resx files are [ignored][2].  The only way to comment resource strings is by editing .lci files in the NuGet.Build.Localization repository [here][3] using [lcxadmin.exe][4].  Having resource strings in one repository (NuGet.Client) and resource comments in another repository (NuGet.Build.Localization) is suboptimal.
-
-## How NuGet assemblies get localized (high-level)
-
-Although the steps below are for the dev branch, the process is similar for release branches.
-
-1. A PR merges into the dev branch.
-1. A NuGet.Client build generates a `localizationArtifacts` artifact.  This artifact contains newly built assemblies and .lcg files.  The .lcg files contain information extracted from .resx files and are the primary input for later localization.
-1. The localization team grabs the `localizationArtifacts` artifact from a NuGet.Client build.
-1. The localization team localizes strings and merges a ["LEGO" PR][5] with localized strings (in .lcl files).
-1. During the next NuGet.Client build, the build adds the [NuGet.Build.Localization][6] repository as a submodule of the NuGet.Client repository and checks out a branch of the same name as the NuGet.Client repository (e.g.:  dev, release-6.7.x, etc.).  Localized resources are [made available][7] to localized builds through the `NuGetBuildLocalizationRepository` property.
-1. When the build completes, the product is localized using localizations based on an earlier commit.  (This means strings added since then won't be localized.)
-
-Typically, the data flow would look something like this.  However, because NuGet.Client's build ignores resource comments in .resx files, those comments and .lce files do not contribute to the localization process.
-
-```mermaid
-flowchart LR;
-    A[Assembly] --> B[[LCXAdmin]];
-    C[.resx] --> D[[Visual Studio Resource Editor]];
-    B --> E[.lci];
-    D --> F[.resx with comments];
-    F --> G[[MicroBuild - 1st build]];
-    G --> H[.lce];
-    E --> I[[MicroBuild - 1st build]];
-    H --> I;
-    I --> J[.lcg];
-    J --> K[[Localization]];
-    K --> L[.lcl];
-    L --> N[[MicroBuild - 2nd build]];
-    M[Assembly] --> N;
-    N --> O([.resources.dll]);
-```
-
-File Type | Contains | Created By | Location
--- | -- | -- | --
-.resx | resource strings | engineers using Visual Studio | NuGet/NuGet.Client repo
-.lci | resource comments | engineers using [lcxadmin.exe][4] | [NuGet.Build.Localization][6] repo
-.lce | resource comments (extracted from .resx file) | MicroBuild | build artifact
-.lcg | resource comments (from .lci and .lce files) | MicroBuild | build artifact
-.lcl | localized strings | translators | [NuGet.Build.Localization][6] repository
-.resources.dll | localized resource assembly | MicroBuild | build artifact
+NuGet follows Microsoft's policy of being available in a number of different languages.
+Therefore, all strings that are displayed to users must use resx file resources, so they can be translated.
 
 ## How to add resource comments
 
-In this walkthrough, we will add resource comments for the `ConflictingAllowUntrustedRoot` resource string in NuGet.Packaging.dll.
+1. Edit the appropriate *.resx* file.
+   Only provide the English translation.
+   - If you're using Visual Studio, it has a built-in resource editor and you can double click the *.resx* file in Solution Explorer.
+     A GUI will appear where you can add a new string
+   - If you're using anything else, for example VSCode, you can edit the resx file as an XML file.
+     The entries in the resx are not sorted, so you can add the new string as the last element in the file.
+1. Build the project.
+   If you did not use Visual Studio to edit the *resx* file, this will update the corresponding *.Designer.cs* file with a new class property that can be used to get the string value.
+   Regardless of how you edited the resx file, building will update all the *xlf* files, copying the English translation.
+   This is normal.
+   It sets an attribute to specify that the resource is new, and the [OneLocBuild][1] workflow will later create a pull request with the actual translations.
+1. Use the string in whatever output message the code change requires.
 
-1. Find the latest NuGet.Client build for the commit containing strings you want to localize and having a `localizationArtifacts` artifact.
-1. Download the `localizationArtifacts` artifact.
-1. Extract the contents of the downloaded artifact ZIP file.
-1. Clone the [NuGet.Build.Localization][6] repository.
-1. Make sure you're in the dev branch and pull the latest changes.
-1. Create a new branch off of dev where you will make your changes.
-1. In the NuGet.Build.Localization repository, launch the LCXAdmin tool (`tools\lcxadmin.exe`).  Note:  the first time you launch the tool you will be prompted to install .NET Framework 3.5.
-1. Navigate on LCXAdmin's main menu to File | "Open Source File..."
-1. In the subsequent "Open Source File" dialog, from the extracted `localizationArtifacts` directory open localizationArtifacts\artifacts\localize\ENU\NuGet.Packaging\bin\release\net472\NuGet.Packaging.dll.lcg.
-1. When prompted with "Do you want to open Comments file?" click Yes.
-1. In the subsequent "Open Comments File" dialog, from the NuGet.Build.Localization repository root directory select localize\comments\15\NuGet.Packaging.dll.lci.
-1. In LCXAdmin's left-hand tree pane, navigate to Files | NuGet.Packaging.dll.lcg | "Managed Resources" | NuGet.Packaging.Strings.resources | Strings.
-1. In LCXAdmin's right-hand details pane and in the Resources tab, find the row with Resource ID `0; ConflictingAllowUntrustedRoot` and double-click it.
-1. In the subsequent "String Properties" dialog, on the main toolbar click the Locked button (🔒).
-1. In the subsequent "Add Locked Rule" dialog, enter `allowUntrustedRoot` for the `Parameters` property value and click OK.
-1. Repeat the previous step for `false`.
-1. Back in the subsequent "String Properties" dialog in the "LcxAdmin Comment" tab, you'll see functional comments for the resource string.  Add contextual comments, like so.
-   ```text
-   {Locked="allowUntrustedRoot"} is the name of an option in NuGet.config file, while {Locked="false"} is a literal value for the option.
-   ```
-1. In the "Resource String" textbox, verify that the substrings you locked are still highlighted.  (If your edits in the previous step impacted functional comment parsing, you might not see some substrings highlighted.)
-1. In the Verification tab, verify that no issues are listed.  It is possible that in the step where you added contextual comments you also introduced a problem that blocks tools from parsing functional comments correctly.  If you did, you'd see one or more issues here.  Fix all issues.
-1. Click OK.
-1. On LCXAdmin's main menu, select File | "Save Comments File..."
-1. Review and commit branch changes (with git).
-1. Create a PR targeting the dev branch.
+If the string has words or phrases that should not be translated in any language, in the comment section of the resx, use something like `{Locked="allowUntrustedRoot"}`.
+You can have multiple locked messages by repeating the blocks, for example `{Locked="one"}{Locked="two"}`.
 
-After saving the comments file, you may have noticed other unrelated changes in the .lci file.  LCXAdmin can detect when the .lci file is out of sync with the .lcg file.  For example, if a resource string has been removed, it will not be in the .lcg file.  LCXAdmin will notice this and remove the resource string from the .lci file.  These "extra" changes are fairly common.  Because our .lci files haven't been updated in a long time, it's likely you'll see an unusually high number of .lci file changes the next time you update it.
+## Fixing translation errors
+
+All translations go through Microsoft's [OneLocBuild][1] system, so do not create a pull request updating xlf files in this repo.
+Instead, file a bug at [https://github.com/NuGet/Home] and we'll file an internal bug with the OneLoc team to get it fixed.
+After they action the change in their backend, an automated system will create a pull request updating the xlf files.
 
 ## Do's and Don'ts
 
@@ -132,21 +67,33 @@ private void DoSomething(ILogger logger)
 
 ✔️ Do add appropriate functional and contextual comments.  [Here][8] is an example of a functional comment.  Our .resx files contain contextual comments, but the comments do not flow automatically into .lcg files.  [Here][9] is an example of a .resx comment (in a different repository) which has both functional and contextual commenting.
 
+✔️ Do use helper methods for strings that are used in multiple places.  Example:
+
+```C#
+internal string Error_InvalidOptionValue(string actualValue, string allowedValues)
+{
+    string message = string.Format(Strings.Error_InvalidOptionValue, actualValue, allowedValues);
+    return message;
+}
+```
+
+By using `Strings.Error_InvalidOptionValue` in only a single place, it means that if the string is modified to add additional `{x}` placeholders, compiler errors will prevent runtime errors if not all usage is updated.
+
+## Resource commenting
+
+[This internal site][0] has a good explanation of the what, why, and how of resource commenting.  In brief, resource comments can contain both:
+
+- functional comments, which enable tools to understand your intent
+- contextual comments, which enable human translators to understand your intent
+
+Both are important.
+
+Starting from NuGet 7.0, we use [OneLocBuild][1], like other .NET Arcade-enabled repos, and adding resource comments can be done using the same Visual Studio Resource Editor that you use to add and modify resource strings in .resx files.
+
 ## Resources
 
-* [All About Localization][10]
-* [Simplified Resource Commenting][0]
-* [MicroBuild Localization][11]
+- [All About Localization][2]
 
 [0]: https://aka.ms/commenting
 [1]: https://github.com/dotnet/arcade/blob/main/Documentation/OneLocBuild.md
-[2]: https://github.com/search?q=repo%3ANuGet%2FNuGet.Client%20HasLceComments&type=code
-[3]: https://github.com/NuGet/NuGet.Build.Localization/tree/dev/localize/comments
-[4]: https://github.com/NuGet/NuGet.Build.Localization/blob/dev/tools/lcxadmin.exe
-[5]: https://github.com/NuGet/NuGet.Build.Localization/pulls?q=is%3Apr+LEGO
-[6]: https://github.com/NuGet/NuGet.Build.Localization
-[7]: https://github.com/search?q=repo%3ANuGet%2FNuGet.Client%20NuGetBuildLocalizationRepository&type=code
-[8]: https://github.com/NuGet/NuGet.Build.Localization/blob/931c5f21742fff61c7f53a19039b89dddc7a01cd/localize/comments/15/NuGet.Packaging.dll.lci#L58-L66
-[9]: https://github.com/dotnet/sign/blob/ef0e6b3ef8281dff1d62cea34445bd88fc3e6714/src/Sign.Core/Resources.resx#L131-L134
-[10]: https://aka.ms/allaboutloc
-[11]: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/20709/MicroBuild-Localization
+[2]: https://aka.ms/allaboutloc


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: repo specific docs

## Description

Copilot keeps editing xlf files directly, whereas I want it to only edit the resx file, and then build the project and let the tools auto-generate the xlf files.

Sometimes copilot reads docs/localizability.md, so I also updated it to remove a lot of stale data now that NuGet 7+ uses OneLocBuild and xlf files in the same repo. Rather than trying to be a detailed steps by step guide for every use case, I wanted it to be simple, so that external contributors don't feel overwhelmed, and it's less likely to confuse AI into doing the wrong thing.

Also added a section explaining that translation errors need to be fixed in Microsoft's backend, so contributors shouldn't edit the xlf files directly.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
