### PR TITLE
Add install, update gate tests

### DIFF
--- a/build/runsettings.proj
+++ b/build/runsettings.proj
@@ -24,7 +24,7 @@
         <MSBuild
             Projects="template.runsettingsproj"
             Properties="RunName=NuGet.Tests.Apex.Gate;
-            FileName=NuGet.Tests.Apex.dll;
+            FileName=NuGet.Tests.Apex.dll;NuGet.Tests.Apex.Daily.dll;
             TestCaseFilter=TestCategory=Gate;" />
 
         <!-- NuGet.Tests.Apex.Daily.runsettings -->

--- a/build/runsettings.proj
+++ b/build/runsettings.proj
@@ -24,7 +24,7 @@
         <MSBuild
             Projects="template.runsettingsproj"
             Properties="RunName=NuGet.Tests.Apex.Gate;
-            FileName=NuGet.Tests.Apex.dll;NuGet.Tests.Apex.Daily.dll;
+            FileName=NuGet.Tests.Apex.dll;
             TestCaseFilter=TestCategory=Gate;" />
 
         <!-- NuGet.Tests.Apex.Daily.runsettings -->

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -908,37 +908,6 @@ namespace NuGet.Tests.Apex.Daily
             CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
         }
 
-        [TestMethod]
-        [Timeout(DefaultTimeout)]
-        public async Task VerifyDeletedAssetsFileIsBackByReloadingProject()
-        {
-            // Arrange
-            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
-
-            NuGetApexTestService nugetTestService = GetNuGetTestService();
-            _pathContext.Settings.SetPackageFormatToPackageReference();
-
-            SolutionService solutionService = VisualStudio.Get<SolutionService>();
-            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
-            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreConsoleApp, "TestProject");
-            VisualStudio.ClearOutputWindow();
-            solutionService.SaveAll();
-
-            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
-            NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
-            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
-
-            var assetsFilePath = CommonUtility.GetAssetsFilePath(project.FullPath);
-            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
-            File.Delete(assetsFilePath);
-
-            // Act
-            CommonUtility.AutoRestorePackageByReloadingProject(VisualStudio, project);
-
-            // Assert
-            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
-        }
-
         public override void Dispose()
         {
             _pathContext.Dispose();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -568,6 +568,7 @@ namespace NuGet.Tests.Apex.Daily
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
+        [TestCategory("Gate")]
         public async Task InstallTopLevelPackageFromUI()
         {
             // Arrange
@@ -598,6 +599,7 @@ namespace NuGet.Tests.Apex.Daily
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
+        [TestCategory("Gate")]
         public async Task UninstallTopLevelPackageFromUI()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -568,7 +568,6 @@ namespace NuGet.Tests.Apex.Daily
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
         public async Task InstallTopLevelPackageFromUI()
         {
             // Arrange
@@ -599,7 +598,6 @@ namespace NuGet.Tests.Apex.Daily
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
         public async Task UninstallTopLevelPackageFromUI()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
@@ -25,7 +25,6 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(LongerTimeout)]
-        [TestCategory("Gate")]
         public void SimpleInstallFromIVsInstaller()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -233,7 +233,62 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        // There  is a bug with VS or Apex where NetCoreConsoleApp and NetCoreClassLib create netcore 2.1 projects that are not supported by the sdk
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        [TestCategory("Gate")]
+        public async Task InstallPackageToNetCoreProjectFromUI_VerifiesRestore()
+        {
+            // Arrange
+            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetStandardClassLib, Logger, addNetStandardFeeds: true))
+            {
+                var packageName = "Contoso.A";
+                var packageVersion = "1.0.0";
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
+
+                // Act
+                CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+                var nugetTestService = GetNuGetTestService();
+                var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
+                uiwindow.InstallPackageFromUI(packageName, packageVersion);
+
+                // Assert
+                VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+                CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersion, Logger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, Logger);
+            }
+        }
+
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        [TestCategory("Gate")]
+        public async Task UpdatePackageToNetCoreProjectFromUI_VerifiesRestore()
+        {
+            // Arrange
+            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetStandardClassLib, Logger, addNetStandardFeeds: true))
+            {
+                var packageName = "Contoso.A";
+                var packageVersionV1 = "1.0.0";
+                var packageVersionV2 = "2.0.0";
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersionV1);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersionV2);
+
+                CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+                var nugetTestService = GetNuGetTestService();
+                var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
+                uiwindow.InstallPackageFromUI(packageName, packageVersionV1);
+
+                // Act
+                VisualStudio.ClearWindows();
+                uiwindow.UpdatePackageFromUI(packageName, packageVersionV2);
+
+                // Assert
+                VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+                CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersionV2, Logger);
+                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersionV2, Logger);
+            }
+        }
+
+
         // Commenting out any NetCoreConsoleApp or NetCoreClassLib template and swapping it for NetStandardClassLib as both are package ref.
 
         public static IEnumerable<object[]> GetNetCoreTemplates()

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -239,7 +239,7 @@ namespace NuGet.Tests.Apex
         public async Task InstallPackageToNetCoreProjectFromUI_VerifiesRestore()
         {
             // Arrange
-            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetStandardClassLib, Logger))
+            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger))
             {
                 var packageName = "Contoso.A";
                 var packageVersion = "1.0.0";
@@ -264,7 +264,7 @@ namespace NuGet.Tests.Apex
         public async Task UpdatePackageToNetCoreProjectFromUI_VerifiesRestore()
         {
             // Arrange
-            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetStandardClassLib, Logger))
+            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger))
             {
                 var packageName = "Contoso.A";
                 var packageVersionV1 = "1.0.0";

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -288,7 +288,7 @@ namespace NuGet.Tests.Apex
             }
         }
 
-
+        // There  is a bug with VS or Apex where NetCoreConsoleApp and NetCoreClassLib create netcore 2.1 projects that are not supported by the sdk
         // Commenting out any NetCoreConsoleApp or NetCoreClassLib template and swapping it for NetStandardClassLib as both are package ref.
 
         public static IEnumerable<object[]> GetNetCoreTemplates()

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -239,7 +239,7 @@ namespace NuGet.Tests.Apex
         public async Task InstallPackageToNetCoreProjectFromUI_VerifiesRestore()
         {
             // Arrange
-            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetStandardClassLib, Logger, addNetStandardFeeds: true))
+            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetStandardClassLib, Logger))
             {
                 var packageName = "Contoso.A";
                 var packageVersion = "1.0.0";
@@ -264,7 +264,7 @@ namespace NuGet.Tests.Apex
         public async Task UpdatePackageToNetCoreProjectFromUI_VerifiesRestore()
         {
             // Arrange
-            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetStandardClassLib, Logger, addNetStandardFeeds: true))
+            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetStandardClassLib, Logger))
             {
                 var packageName = "Contoso.A";
                 var packageVersionV1 = "1.0.0";

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -238,35 +238,33 @@ namespace NuGet.Tests.Apex
         [TestCategory("Gate")]
         public async Task InstallAndUpdatePackageFromUI_NetCoreProject_Succeeds()
         {
-            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger))
-            {
-                // Arrange
-                var packageName = "NetCoreUpdateTestPackage";
-                var packageVersion1 = "1.0.0";
-                var packageVersion2 = "2.0.0";
+            // Arrange
+            using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger);
+            var packageName = "NetCoreUpdateTestPackage";
+            var packageVersion1 = "1.0.0";
+            var packageVersion2 = "2.0.0";
 
-                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
-                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
+            await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
+            await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
 
-                VisualStudio.AssertNoErrors();
+            VisualStudio.AssertNoErrors();
 
-                // Act
-                CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
-                var nugetTestService = GetNuGetTestService();
-                var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
-                uiwindow.InstallPackageFromUI(packageName, packageVersion1);
-                testContext.SolutionService.Build();
-                testContext.NuGetApexTestService.WaitForAutoRestore();
-                CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersion1, Logger);
+            // Act
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+            var nugetTestService = GetNuGetTestService();
+            var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
+            uiwindow.InstallPackageFromUI(packageName, packageVersion1);
+            testContext.SolutionService.Build();
+            testContext.NuGetApexTestService.WaitForAutoRestore();
+            CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersion1, Logger);
 
-                uiwindow.UpdatePackageFromUI(packageName, packageVersion2);
-                testContext.SolutionService.Build();
-                testContext.NuGetApexTestService.WaitForAutoRestore();
+            uiwindow.UpdatePackageFromUI(packageName, packageVersion2);
+            testContext.SolutionService.Build();
+            testContext.NuGetApexTestService.WaitForAutoRestore();
 
-                // Assert
-                VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
-                CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersion2, Logger);
-            }
+            // Assert
+            VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+            CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersion2, Logger);
         }
 
         // There  is a bug with VS or Apex where NetCoreConsoleApp and NetCoreClassLib create netcore 2.1 projects that are not supported by the sdk

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -233,61 +233,6 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [TestMethod]
-        [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
-        public async Task InstallPackageToNetCoreProjectFromUI_VerifiesRestore()
-        {
-            // Arrange
-            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger))
-            {
-                var packageName = "Contoso.A";
-                var packageVersion = "1.0.0";
-                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion);
-
-                // Act
-                CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
-                var nugetTestService = GetNuGetTestService();
-                var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
-                uiwindow.InstallPackageFromUI(packageName, packageVersion);
-
-                // Assert
-                VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
-                CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersion, Logger);
-                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, Logger);
-            }
-        }
-
-        [TestMethod]
-        [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
-        public async Task UpdatePackageToNetCoreProjectFromUI_VerifiesRestore()
-        {
-            // Arrange
-            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger))
-            {
-                var packageName = "Contoso.A";
-                var packageVersionV1 = "1.0.0";
-                var packageVersionV2 = "2.0.0";
-                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersionV1);
-                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersionV2);
-
-                CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
-                var nugetTestService = GetNuGetTestService();
-                var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
-                uiwindow.InstallPackageFromUI(packageName, packageVersionV1);
-
-                // Act
-                VisualStudio.ClearWindows();
-                uiwindow.UpdatePackageFromUI(packageName, packageVersionV2);
-
-                // Assert
-                VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
-                CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersionV2, Logger);
-                CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersionV2, Logger);
-            }
-        }
-
         // There  is a bug with VS or Apex where NetCoreConsoleApp and NetCoreClassLib create netcore 2.1 projects that are not supported by the sdk
         // Commenting out any NetCoreConsoleApp or NetCoreClassLib template and swapping it for NetStandardClassLib as both are package ref.
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -233,6 +233,42 @@ namespace NuGet.Tests.Apex
             }
         }
 
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        [TestCategory("Gate")]
+        public async Task InstallAndUpdatePackageFromUI_NetCoreProject_Succeeds()
+        {
+            using (var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger))
+            {
+                // Arrange
+                var packageName = "NetCoreUpdateTestPackage";
+                var packageVersion1 = "1.0.0";
+                var packageVersion2 = "2.0.0";
+
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
+
+                VisualStudio.AssertNoErrors();
+
+                // Act
+                CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+                var nugetTestService = GetNuGetTestService();
+                var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
+                uiwindow.InstallPackageFromUI(packageName, packageVersion1);
+                testContext.SolutionService.Build();
+                testContext.NuGetApexTestService.WaitForAutoRestore();
+                CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersion1, Logger);
+
+                uiwindow.UpdatePackageFromUI(packageName, packageVersion2);
+                testContext.SolutionService.Build();
+                testContext.NuGetApexTestService.WaitForAutoRestore();
+
+                // Assert
+                VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+                CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersion2, Logger);
+            }
+        }
+
         // There  is a bug with VS or Apex where NetCoreConsoleApp and NetCoreClassLib create netcore 2.1 projects that are not supported by the sdk
         // Commenting out any NetCoreConsoleApp or NetCoreClassLib template and swapping it for NetStandardClassLib as both are package ref.
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -23,6 +23,7 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
+        [TestCategory("Gate")]
         public async Task SearchPackageFromUI()
         {
             // Arrange
@@ -49,6 +50,7 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
+        [TestCategory("Gate")]
         public async Task InstallPackageFromUI()
         {
             // Arrange
@@ -107,6 +109,7 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
+        [TestCategory("Gate")]
         public async Task UninstallPackageFromUI()
         {
             // Arrange
@@ -140,6 +143,7 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
+        [TestCategory("Gate")]
         public async Task UpdatePackageFromUI()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -23,7 +23,6 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
         public async Task SearchPackageFromUI()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -49,7 +49,6 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
         public async Task InstallPackageFromUI()
         {
             // Arrange
@@ -108,7 +107,6 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
         public async Task UninstallPackageFromUI()
         {
             // Arrange
@@ -142,7 +140,6 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
         public async Task UpdatePackageFromUI()
         {
             // Arrange
@@ -372,6 +369,37 @@ namespace NuGet.Tests.Apex
 
             // Assert
             CommonUtility.AssertPackageInPackagesConfig(VisualStudio, project, TestPackageName, TestPackageVersionV2, Logger);
+        }
+
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        [TestCategory("Gate")]
+        public async Task VerifyDeletedAssetsFileIsBackByReloadingProject()
+        {
+            // Arrange
+            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+
+            SolutionService solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreConsoleApp, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+            NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+
+            var assetsFilePath = CommonUtility.GetAssetsFilePath(project.FullPath);
+            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
+            File.Delete(assetsFilePath);
+
+            // Act
+            CommonUtility.AutoRestorePackageByReloadingProject(VisualStudio, project);
+
+            // Assert
+            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
         }
 
         public override void Dispose()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3725
Related: https://github.com/NuGet/Client.Engineering/issues/3543

## Description
Previously we added a drop for that will be used by the gate tests: https://github.com/NuGet/NuGet.Client/pull/7247. And the drop has a runsetting that specifies a test catagory "Gate". This PR adds more tests to that catagory.

Two gate tests `([TestCategory("Gate")])` to NuGet.Tests.Apex

 1. `InstallAndUpdatePackageFromUI_NetCoreProject_Succeeds` : Verifies a package can be installed and updated to a newer version
 2. `VerifyDeletedAssetsFileIsBackByReloadingProject` : Verifies that auto-restore regenerates project.assets.json when 
it is deleted

Both tests are simplified single-template versions copied from NuGet.Tests.Apex.Daily. 

Also removed `SimpleInstallFromIVsInstaller` which was added just for testing the piepline.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
