### PR TITLE
NuGet.Protocol nullability - Phase 1

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/AlternatePackageMetadataContextInfo.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/ContextInfos/AlternatePackageMetadataContextInfo.cs
@@ -22,7 +22,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
         {
             Assumes.NotNull(alternatePackageMetadata);
 
-            return new AlternatePackageMetadataContextInfo(alternatePackageMetadata.PackageId, alternatePackageMetadata.Range);
+            return new AlternatePackageMetadataContextInfo(alternatePackageMetadata.PackageId!, alternatePackageMetadata.Range!);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchFilterFormatter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/Formatters/SearchFilterFormatter.cs
@@ -63,9 +63,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
             return new SearchFilter(includePrerelease, filterType)
             {
-                SupportedFrameworks = supportedFrameworks,
+                SupportedFrameworks = supportedFrameworks ?? [],
                 OrderBy = searchOrderBy,
-                PackageTypes = packageTypes,
+                PackageTypes = packageTypes ?? [],
                 IncludeDelisted = includeDelisted,
             };
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultTableRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultTableRenderer.cs
@@ -114,7 +114,7 @@ namespace NuGet.CommandLine.XPlat
 
                     if (packageDeprecationMetadata is not null)
                     {
-                        deprecation = packageDeprecationMetadata.Message;
+                        deprecation = packageDeprecationMetadata.Message ?? "N/A";
                     }
 
                     table.AddRow(

--- a/src/NuGet.Core/NuGet.Protocol/Converters/SafeBoolConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/SafeBoolConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 
@@ -14,7 +12,7 @@ namespace NuGet.Protocol
         public override bool CanRead { get { return true; } }
         public override bool CanWrite { get { return false; } }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             switch (reader.TokenType)
             {
@@ -24,19 +22,19 @@ namespace NuGet.Protocol
                     return serializer.Deserialize<bool>(reader);
                 case JsonToken.String:
                     bool flag;
-                    if (Boolean.TryParse(reader.Value.ToString().Trim(), out flag))
+                    if (Boolean.TryParse(reader.Value?.ToString()?.Trim(), out flag))
                     {
                         return flag;
                     }
                     return false;
                 case JsonToken.Integer:
-                    return ((long)reader.Value) == 1;
+                    return ((long)reader.Value!) == 1;
                 default:
                     reader.Skip();
                     return false;
             }
         }
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Protocol/Converters/SafeUriConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/SafeUriConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 
@@ -14,15 +12,14 @@ namespace NuGet.Protocol
         public override bool CanRead { get { return true; } }
         public override bool CanWrite { get { return false; } }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             switch (reader.TokenType)
             {
                 case JsonToken.Null:
                     return null;
                 case JsonToken.String:
-                    Uri uri;
-                    if (Uri.TryCreate(reader.Value.ToString().Trim(), UriKind.Absolute, out uri))
+                    if (Uri.TryCreate(reader.Value?.ToString()?.Trim(), UriKind.Absolute, out Uri? uri))
                     {
                         return uri;
                     }
@@ -32,7 +29,7 @@ namespace NuGet.Protocol
                     return null;
             }
         }
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Protocol/Converters/VersionRangeConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/VersionRangeConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 using NuGet.Versioning;
@@ -29,10 +27,10 @@ namespace NuGet.Protocol
         /// <param name="existingValue">The existing value of the object.</param>
         /// <param name="serializer">A serializer.</param>
         /// <returns>A <see cref="VersionRange" /> object.</returns>
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
-            string value = serializer.Deserialize<string>(reader);
-            return !string.IsNullOrEmpty(value) ? VersionRange.Parse(value) : null;
+            string? value = serializer.Deserialize<string>(reader);
+            return !string.IsNullOrEmpty(value) ? VersionRange.Parse(value!) : null;
         }
 
         /// <summary>
@@ -41,9 +39,14 @@ namespace NuGet.Protocol
         /// <param name="writer">A JSON writer.</param>
         /// <param name="value">A value to serialize.</param>
         /// <param name="serializer">A serializer.</param>
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
-            var versionRange = VersionRange.Parse(value.ToString());
+            if (value is null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var versionRange = VersionRange.Parse(value.ToString()!);
             serializer.Serialize(writer, versionRange.ToString());
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnosticNupkgCopiedEvent.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnosticNupkgCopiedEvent.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 namespace NuGet.Protocol.Events
 {
     public sealed class ProtocolDiagnosticNupkgCopiedEvent

--- a/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnosticResourceEvent.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnosticResourceEvent.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Events

--- a/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnosticServiceIndexEntryEvent.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnosticServiceIndexEntryEvent.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 namespace NuGet.Protocol.Events
 {
     /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/FatalProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/FatalProtocolException.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Runtime.Serialization;
 

--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/InvalidCacheProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/InvalidCacheProtocolException.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Runtime.Serialization;
 using NuGet.Protocol.Core.Types;

--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/NuGetProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/NuGetProtocolException.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Runtime.Serialization;
 

--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/PackageNotFoundProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/PackageNotFoundProtocolException.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using NuGet.Packaging.Core;

--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/RetriableProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/RetriableProtocolException.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Runtime.Serialization;
 

--- a/src/NuGet.Core/NuGet.Protocol/FindPackageByIdDependencyInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/FindPackageByIdDependencyInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NuGet.Core/NuGet.Protocol/ILegacyFeedCapabilityResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ILegacyFeedCapabilityResource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;

--- a/src/NuGet.Core/NuGet.Protocol/Model/AlternatePackageMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/AlternatePackageMetadata.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using Newtonsoft.Json;
 using NuGet.Versioning;
 
@@ -10,10 +8,10 @@ namespace NuGet.Protocol
 {
     public class AlternatePackageMetadata
     {
-        [JsonProperty(PropertyName = JsonProperties.PackageId)]
-        public string PackageId { get; internal set; }
+        [JsonProperty(PropertyName = JsonProperties.PackageId, Required = Required.Always)]
+        public string PackageId { get; internal set; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.Range, ItemConverterType = typeof(VersionRangeConverter))]
-        public VersionRange Range { get; internal set; }
+        public VersionRange? Range { get; internal set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/AlternatePackageMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/AlternatePackageMetadata.cs
@@ -9,7 +9,7 @@ namespace NuGet.Protocol
     public class AlternatePackageMetadata
     {
         [JsonProperty(PropertyName = JsonProperties.PackageId)]
-        public string PackageId { get; internal set; } = null!;
+        public string? PackageId { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.Range, ItemConverterType = typeof(VersionRangeConverter))]
         public VersionRange? Range { get; internal set; }

--- a/src/NuGet.Core/NuGet.Protocol/Model/AlternatePackageMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/AlternatePackageMetadata.cs
@@ -8,7 +8,7 @@ namespace NuGet.Protocol
 {
     public class AlternatePackageMetadata
     {
-        [JsonProperty(PropertyName = JsonProperties.PackageId, Required = Required.Always)]
+        [JsonProperty(PropertyName = JsonProperties.PackageId)]
         public string PackageId { get; internal set; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.Range, ItemConverterType = typeof(VersionRangeConverter))]

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageDeprecationMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageDeprecationMetadata.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -11,8 +12,8 @@ namespace NuGet.Protocol
         [JsonProperty(PropertyName = JsonProperties.DeprecationMessage)]
         public string? Message { get; internal set; }
 
-        [JsonProperty(PropertyName = JsonProperties.DeprecationReasons, Required = Required.Always)]
-        public IEnumerable<string> Reasons { get; internal set; } = null!;
+        [JsonProperty(PropertyName = JsonProperties.DeprecationReasons)]
+        public IEnumerable<string> Reasons { get; internal set; } = Array.Empty<string>();
 
         [JsonProperty(PropertyName = JsonProperties.AlternatePackage)]
         public AlternatePackageMetadata? AlternatePackage { get; internal set; }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageDeprecationMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageDeprecationMetadata.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -11,12 +9,12 @@ namespace NuGet.Protocol
     public class PackageDeprecationMetadata
     {
         [JsonProperty(PropertyName = JsonProperties.DeprecationMessage)]
-        public string Message { get; internal set; }
+        public string? Message { get; internal set; }
 
-        [JsonProperty(PropertyName = JsonProperties.DeprecationReasons)]
-        public IEnumerable<string> Reasons { get; internal set; }
+        [JsonProperty(PropertyName = JsonProperties.DeprecationReasons, Required = Required.Always)]
+        public IEnumerable<string> Reasons { get; internal set; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.AlternatePackage)]
-        public AlternatePackageMetadata AlternatePackage { get; internal set; }
+        public AlternatePackageMetadata? AlternatePackage { get; internal set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/RepositoryCertificateInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/RepositoryCertificateInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 using NuGet.Packaging.Core;
@@ -11,22 +9,22 @@ namespace NuGet.Protocol
 {
     public class RepositoryCertificateInfo : IRepositoryCertificateInfo
     {
-        [JsonProperty(PropertyName = JsonProperties.Fingerprints)]
-        public Fingerprints Fingerprints { get; private set; }
+        [JsonProperty(PropertyName = JsonProperties.Fingerprints, Required = Required.Always)]
+        public Fingerprints Fingerprints { get; private set; } = null!;
 
-        [JsonProperty(PropertyName = JsonProperties.Subject)]
-        public string Subject { get; private set; }
+        [JsonProperty(PropertyName = JsonProperties.Subject, Required = Required.Always)]
+        public string Subject { get; private set; } = null!;
 
-        [JsonProperty(PropertyName = JsonProperties.Issuer)]
-        public string Issuer { get; private set; }
+        [JsonProperty(PropertyName = JsonProperties.Issuer, Required = Required.Always)]
+        public string Issuer { get; private set; } = null!;
 
-        [JsonProperty(PropertyName = JsonProperties.NotBefore)]
+        [JsonProperty(PropertyName = JsonProperties.NotBefore, Required = Required.Always)]
         public DateTimeOffset NotBefore { get; private set; }
 
-        [JsonProperty(PropertyName = JsonProperties.NotAfter)]
+        [JsonProperty(PropertyName = JsonProperties.NotAfter, Required = Required.Always)]
         public DateTimeOffset NotAfter { get; private set; }
 
-        [JsonProperty(PropertyName = JsonProperties.ContentUrl)]
-        public string ContentUrl { get; private set; }
+        [JsonProperty(PropertyName = JsonProperties.ContentUrl, Required = Required.Always)]
+        public string ContentUrl { get; private set; } = null!;
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/ServiceIndexEntry.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/ServiceIndexEntry.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using NuGet.Versioning;
 

--- a/src/NuGet.Core/NuGet.Protocol/Model/VersionInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/VersionInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using NuGet.Versioning;
 
 namespace NuGet.Protocol.Core.Types
@@ -14,7 +12,7 @@ namespace NuGet.Protocol.Core.Types
         {
         }
 
-        public VersionInfo(NuGetVersion version, string downloadCount)
+        public VersionInfo(NuGetVersion version, string? downloadCount)
         {
             Version = version;
 
@@ -41,6 +39,6 @@ namespace NuGet.Protocol.Core.Types
         /// here. For V3, the metadata property is null. Callers that receive this type need to be able to
         /// fetch this package metadata some other way if this property is null.
         /// </summary>
-        public IPackageSearchMetadata PackageSearchMetadata { get; set; }
+        public IPackageSearchMetadata? PackageSearchMetadata { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/NuGetResourceProviderPositions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/NuGetResourceProviderPositions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 namespace NuGet.Protocol.Core.Types
 {
     /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/NuGetTestMode.cs
+++ b/src/NuGet.Core/NuGet.Protocol/NuGetTestMode.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Core.Types

--- a/src/NuGet.Core/NuGet.Protocol/PackageProgressEventArgs.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackageProgressEventArgs.cs
@@ -1,18 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using NuGet.Configuration;
 using NuGet.Packaging.Core;
 
 namespace NuGet.Protocol.Core.Types
 {
+    [Obsolete("This type is unused and will be removed in a future version.")]
     public class PackageProgressEventArgs : EventArgs
     {
         private readonly PackageIdentity _identity;
-        private readonly PackageSource _source;
+        private readonly PackageSource? _source;
         private readonly double _complete;
 
         /// <summary>
@@ -21,7 +20,7 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="identity">package identity</param>
         /// <param name="source">repository source or null</param>
         /// <param name="complete">0.0 - 1.0</param>
-        public PackageProgressEventArgs(PackageIdentity identity, PackageSource source, double complete)
+        public PackageProgressEventArgs(PackageIdentity identity, PackageSource? source, double complete)
         {
             if (complete < 0
                 || complete > 1)
@@ -44,7 +43,7 @@ namespace NuGet.Protocol.Core.Types
             get { return _identity; }
         }
 
-        public PackageSource PackageSource
+        public PackageSource? PackageSource
         {
             get { return _source; }
         }

--- a/src/NuGet.Core/NuGet.Protocol/ProtocolConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ProtocolConstants.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 namespace NuGet.Protocol
 {
     public static class ProtocolConstants

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
 NuGet.Protocol.AlternatePackageMetadata
 NuGet.Protocol.AlternatePackageMetadata.AlternatePackageMetadata() -> void
-NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string!
+NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string?
 NuGet.Protocol.AlternatePackageMetadata.Range.get -> NuGet.Versioning.VersionRange?
 NuGet.Protocol.AmbientAuthenticationState
 NuGet.Protocol.AmbientAuthenticationState.AmbientAuthenticationState() -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -50,14 +50,14 @@ NuGet.Protocol.Core.Types.DownloadResourceResultStatus.AvailableWithoutStream = 
 NuGet.Protocol.Core.Types.DownloadResourceResultStatus.Cancelled = 3 -> NuGet.Protocol.Core.Types.DownloadResourceResultStatus
 NuGet.Protocol.Core.Types.DownloadResourceResultStatus.NotFound = 2 -> NuGet.Protocol.Core.Types.DownloadResourceResultStatus
 NuGet.Protocol.Core.Types.FatalProtocolException
-~NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string message) -> void
-~NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string message, System.Exception innerException) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string! message) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string! message, System.Exception! innerException) -> void
 NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo
-~NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.DependencyGroups.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.FindPackageByIdDependencyInfo(NuGet.Packaging.Core.PackageIdentity packageIdentity, System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup> dependencyGroups, System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup> frameworkReferenceGroups) -> void
-~NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.FrameworkReferenceGroups.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.FrameworkSpecificGroup>
-~NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.DependencyGroups.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.FindPackageByIdDependencyInfo(NuGet.Packaging.Core.PackageIdentity! packageIdentity, System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>! dependencyGroups, System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>! frameworkReferenceGroups) -> void
+NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.FrameworkReferenceGroups.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.FrameworkSpecificGroup!>!
+NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity!
 NuGet.Protocol.Core.Types.FindPackageByIdResource
 NuGet.Protocol.Core.Types.FindPackageByIdResource.FindPackageByIdResource() -> void
 NuGet.Protocol.Core.Types.HttpHandlerResource
@@ -68,8 +68,8 @@ NuGet.Protocol.Core.Types.HttpSourceCacheContext.MaxAge.get -> System.TimeSpan
 ~NuGet.Protocol.Core.Types.HttpSourceCacheContext.RootTempFolder.get -> string
 ~NuGet.Protocol.Core.Types.HttpSourceCacheContext.SourceCacheContext.get -> NuGet.Protocol.Core.Types.SourceCacheContext
 NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource
-~NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource.SupportsIsAbsoluteLatestVersionAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource.SupportsSearchAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
+NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource.SupportsIsAbsoluteLatestVersionAsync(NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource.SupportsSearchAsync(NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
 NuGet.Protocol.Core.Types.INuGetResource
 NuGet.Protocol.Core.Types.INuGetResourceProvider
 NuGet.Protocol.Core.Types.INuGetResourceProvider.After.get -> System.Collections.Generic.IEnumerable<string!>!
@@ -119,9 +119,9 @@ NuGet.Protocol.Core.Types.MetadataResource
 ~NuGet.Protocol.Core.Types.MetadataResource.GetVersions(string packageId, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
 NuGet.Protocol.Core.Types.MetadataResource.MetadataResource() -> void
 NuGet.Protocol.Core.Types.NuGetProtocolException
-~NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(string message) -> void
-~NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(string message, System.Exception innerException) -> void
+NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(string! message) -> void
+NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(string! message, System.Exception! innerException) -> void
 NuGet.Protocol.Core.Types.NuGetResourceProviderPositions
 NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.NuGetResourceProviderPositions() -> void
 NuGet.Protocol.Core.Types.NuGetTestMode
@@ -155,9 +155,9 @@ NuGet.Protocol.Core.Types.PackageProgressEventArgs
 NuGet.Protocol.Core.Types.PackageProgressEventArgs.Complete.get -> double
 NuGet.Protocol.Core.Types.PackageProgressEventArgs.HasPackageSource.get -> bool
 NuGet.Protocol.Core.Types.PackageProgressEventArgs.IsComplete.get -> bool
-~NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity
-~NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageProgressEventArgs(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Configuration.PackageSource source, double complete) -> void
-~NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageSource.get -> NuGet.Configuration.PackageSource
+NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity!
+NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageProgressEventArgs(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Configuration.PackageSource? source, double complete) -> void
+NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageSource.get -> NuGet.Configuration.PackageSource?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.Build() -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata
@@ -259,9 +259,9 @@ NuGet.Protocol.Core.Types.ResourceProvider.ResourceProvider(System.Type! resourc
 NuGet.Protocol.Core.Types.ResourceProvider.ResourceProvider(System.Type! resourceType, string! name, System.Collections.Generic.IEnumerable<string!>! before, System.Collections.Generic.IEnumerable<string!>! after) -> void
 NuGet.Protocol.Core.Types.ResourceProvider.ResourceProvider(System.Type! resourceType, string! name, string? before) -> void
 NuGet.Protocol.Core.Types.RetriableProtocolException
-~NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(string message) -> void
-~NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(string message, System.Exception innerException) -> void
+NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(string! message) -> void
+NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(string! message, System.Exception! innerException) -> void
 NuGet.Protocol.Core.Types.SearchFilter
 NuGet.Protocol.Core.Types.SearchFilter.Filter.get -> NuGet.Protocol.Core.Types.SearchFilterType?
 NuGet.Protocol.Core.Types.SearchFilter.IncludeDelisted.get -> bool
@@ -378,19 +378,19 @@ NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.IsRetry.get -> bool
 ~NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.Url.get -> System.Uri
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.FileSize.get -> long
-~NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.ProtocolDiagnosticNupkgCopiedEvent(string source, long fileSize) -> void
-~NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.Source.get -> string
+NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.ProtocolDiagnosticNupkgCopiedEvent(string! source, long fileSize) -> void
+NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.Source.get -> string!
 NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent
 NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Duration.get -> System.TimeSpan
-~NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Method.get -> string
-~NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.ProtocolDiagnosticResourceEvent(string source, string resourceType, string type, string method, System.TimeSpan duration) -> void
-~NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.ResourceType.get -> string
-~NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Source.get -> string
-~NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Type.get -> string
+NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Method.get -> string!
+NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.ProtocolDiagnosticResourceEvent(string! source, string! resourceType, string! type, string! method, System.TimeSpan duration) -> void
+NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.ResourceType.get -> string!
+NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Source.get -> string!
+NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Type.get -> string!
 NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent
 NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent.HttpsSourceHasHttpResource.get -> bool
-~NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent.ProtocolDiagnosticServiceIndexEntryEvent(string source, bool httpsSourceHasHttpResource) -> void
-~NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent.Source.get -> string
+NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent.ProtocolDiagnosticServiceIndexEntryEvent(string! source, bool httpsSourceHasHttpResource) -> void
+NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent.Source.get -> string!
 NuGet.Protocol.Events.ProtocolDiagnostics
 NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticHttpEventHandler
 NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticResourceEventHandler
@@ -581,9 +581,9 @@ NuGet.Protocol.IV2FeedParser
 NuGet.Protocol.IVulnerabilityInfoResource
 NuGet.Protocol.IVulnerabilityInfoResource.GetVulnerabilityInfoAsync(NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Model.GetVulnerabilityInfoResult!>!
 NuGet.Protocol.InvalidCacheProtocolException
-~NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(string message) -> void
-~NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(string message, System.Exception innerException) -> void
+NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(string! message) -> void
+NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(string! message, System.Exception! innerException) -> void
 NuGet.Protocol.JsonExtensions
 NuGet.Protocol.JsonProperties
 NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed
@@ -745,9 +745,9 @@ NuGet.Protocol.PackageMetadataResourceV3
 NuGet.Protocol.PackageMetadataResourceV3Provider
 NuGet.Protocol.PackageMetadataResourceV3Provider.PackageMetadataResourceV3Provider() -> void
 NuGet.Protocol.PackageNotFoundProtocolException
-~NuGet.Protocol.PackageNotFoundProtocolException.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity
-~NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity package) -> void
-~NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity package, System.Exception innerException) -> void
+NuGet.Protocol.PackageNotFoundProtocolException.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity!
+NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity! package) -> void
+NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity! package, System.Exception! innerException) -> void
 NuGet.Protocol.PackageSearchMetadata
 ~NuGet.Protocol.PackageSearchMetadata.Authors.get -> string
 ~NuGet.Protocol.PackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
@@ -1419,10 +1419,10 @@ NuGet.Protocol.SemaphoreSlimThrottle.Release() -> void
 NuGet.Protocol.ServerWarningLogHandler
 ~NuGet.Protocol.ServerWarningLogHandler.ServerWarningLogHandler(System.Net.Http.HttpClientHandler clientHandler) -> void
 NuGet.Protocol.ServiceIndexEntry
-~NuGet.Protocol.ServiceIndexEntry.ClientVersion.get -> NuGet.Versioning.SemanticVersion
-~NuGet.Protocol.ServiceIndexEntry.ServiceIndexEntry(System.Uri serviceUri, string serviceType, NuGet.Versioning.SemanticVersion clientVersion) -> void
-~NuGet.Protocol.ServiceIndexEntry.Type.get -> string
-~NuGet.Protocol.ServiceIndexEntry.Uri.get -> System.Uri
+NuGet.Protocol.ServiceIndexEntry.ClientVersion.get -> NuGet.Versioning.SemanticVersion!
+NuGet.Protocol.ServiceIndexEntry.ServiceIndexEntry(System.Uri! serviceUri, string! serviceType, NuGet.Versioning.SemanticVersion! clientVersion) -> void
+NuGet.Protocol.ServiceIndexEntry.Type.get -> string!
+NuGet.Protocol.ServiceIndexEntry.Uri.get -> System.Uri!
 NuGet.Protocol.ServiceIndexResourceV3
 ~NuGet.Protocol.ServiceIndexResourceV3.ServiceIndexResourceV3(Newtonsoft.Json.Linq.JObject index, System.DateTime requestTime) -> void
 NuGet.Protocol.ServiceIndexResourceV3Provider
@@ -1574,9 +1574,9 @@ abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleCancelResponse() ->
 abstract NuGet.Protocol.Plugins.Receiver.Connect() -> void
 abstract NuGet.Protocol.Plugins.Receiver.Dispose(bool disposing) -> void
 const NuGet.Protocol.CachingUtility.BufferSize = 8192 -> int
-~const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.First = "First" -> string
-~const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.Last = "Last" -> string
-~const NuGet.Protocol.Core.Types.NuGetTestMode.NuGetTestClientName = "NuGet Test Client" -> string
+const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.First = "First" -> string!
+const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.Last = "Last" -> string!
+const NuGet.Protocol.Core.Types.NuGetTestMode.NuGetTestClientName = "NuGet Test Client" -> string!
 const NuGet.Protocol.JsonExtensions.JsonSerializationMaxDepth = 512 -> int
 ~const NuGet.Protocol.JsonProperties.AdvisoryUrl = "advisoryUrl" -> string
 ~const NuGet.Protocol.JsonProperties.AllRepositorySigned = "allRepositorySigned" -> string
@@ -1898,7 +1898,7 @@ override NuGet.Protocol.VersionInfoConverter.CanWrite.get -> bool
 ~static NuGet.Protocol.Core.Types.HttpSourceCacheContext.Create(NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, bool isFirstAttempt) -> NuGet.Protocol.Core.Types.HttpSourceCacheContext
 ~static NuGet.Protocol.Core.Types.HttpSourceCacheContext.Create(NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, int retryCount) -> NuGet.Protocol.Core.Types.HttpSourceCacheContext
 static NuGet.Protocol.Core.Types.NuGetTestMode.Enabled.get -> bool
-~static NuGet.Protocol.Core.Types.NuGetTestMode.InvokeTestFunctionAgainstTestMode<T>(System.Func<T> function, bool testModeEnabled) -> T
+static NuGet.Protocol.Core.Types.NuGetTestMode.InvokeTestFunctionAgainstTestMode<T>(System.Func<T>! function, bool testModeEnabled) -> T
 ~static NuGet.Protocol.Core.Types.NullSourceCacheContext.Instance.get -> NuGet.Protocol.Core.Types.SourceCacheContext
 ~static NuGet.Protocol.Core.Types.OfflineFeedUtility.AddPackageToSource(NuGet.Protocol.Core.Types.OfflineFeedAddContext offlineFeedAddContext, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
 ~static NuGet.Protocol.Core.Types.OfflineFeedUtility.GetPackageDirectory(NuGet.Packaging.Core.PackageIdentity packageIdentity, string offlineFeed) -> string
@@ -2056,31 +2056,31 @@ static readonly NuGet.Protocol.Plugins.ProtocolConstants.MaxTimeout -> System.Ti
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.MinTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.RequestTimeout -> System.TimeSpan
 ~static readonly NuGet.Protocol.Plugins.ProtocolConstants.Version100 -> NuGet.Versioning.SemanticVersion
-~static readonly NuGet.Protocol.ProtocolConstants.ApiKeyHeader -> string
-~static readonly NuGet.Protocol.ProtocolConstants.ServerWarningHeader -> string
-~static readonly NuGet.Protocol.ProtocolConstants.SessionId -> string
+static readonly NuGet.Protocol.ProtocolConstants.ApiKeyHeader -> string!
+static readonly NuGet.Protocol.ProtocolConstants.ServerWarningHeader -> string!
+static readonly NuGet.Protocol.ProtocolConstants.SessionId -> string!
 static readonly NuGet.Protocol.ProxyAuthenticationHandler.MaxAuthRetries -> int
-~static readonly NuGet.Protocol.ServiceTypes.LegacyGallery -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.PackageBaseAddress -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.PackageDetailsUriTemplate -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.PackagePublish -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.RegistrationsBaseUrl -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.ReportAbuse -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.RepositorySignatures -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.SearchAutocompleteService -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.SearchQueryService -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.SymbolPackagePublish -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.Version200 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version300 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version300beta -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version300rc -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version340 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version360 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version470 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version490 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version500 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version510 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Versioned -> string
+static readonly NuGet.Protocol.ServiceTypes.LegacyGallery -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.PackageBaseAddress -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.PackageDetailsUriTemplate -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.PackagePublish -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.RegistrationsBaseUrl -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.ReportAbuse -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.RepositorySignatures -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.SearchAutocompleteService -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.SearchQueryService -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.SymbolPackagePublish -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.Version200 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version300 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version300beta -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version300rc -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version340 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version360 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version470 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version490 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version500 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version510 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Versioned -> string!
 static readonly NuGet.Protocol.StreamExtensions.BufferSize -> int
 ~virtual NuGet.Protocol.Core.Types.DependencyInfoResource.ResolvePackages(string packageId, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo>>
 ~virtual NuGet.Protocol.Core.Types.Repository.ProviderFactory.GetCoreV3() -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,8 +1,8 @@
 #nullable enable
 NuGet.Protocol.AlternatePackageMetadata
 NuGet.Protocol.AlternatePackageMetadata.AlternatePackageMetadata() -> void
-~NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string
-~NuGet.Protocol.AlternatePackageMetadata.Range.get -> NuGet.Versioning.VersionRange
+NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string!
+NuGet.Protocol.AlternatePackageMetadata.Range.get -> NuGet.Versioning.VersionRange?
 NuGet.Protocol.AmbientAuthenticationState
 NuGet.Protocol.AmbientAuthenticationState.AmbientAuthenticationState() -> void
 NuGet.Protocol.AmbientAuthenticationState.AuthenticationRetriesCount.get -> int
@@ -269,12 +269,12 @@ NuGet.Protocol.Core.Types.SearchFilter.IncludeDelisted.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.IncludePrerelease.get -> bool
 NuGet.Protocol.Core.Types.SearchFilter.OrderBy.get -> NuGet.Protocol.Core.Types.SearchOrderBy?
 NuGet.Protocol.Core.Types.SearchFilter.OrderBy.set -> void
-~NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.SearchFilter(bool includePrerelease) -> void
 NuGet.Protocol.Core.Types.SearchFilter.SearchFilter(bool includePrerelease, NuGet.Protocol.Core.Types.SearchFilterType? filter) -> void
-~NuGet.Protocol.Core.Types.SearchFilter.SupportedFrameworks.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Core.Types.SearchFilter.SupportedFrameworks.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.SupportedFrameworks.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Protocol.Core.Types.SearchFilter.SupportedFrameworks.set -> void
 NuGet.Protocol.Core.Types.SearchFilterType
 NuGet.Protocol.Core.Types.SearchFilterType.IsAbsoluteLatestVersion = 1 -> NuGet.Protocol.Core.Types.SearchFilterType
 NuGet.Protocol.Core.Types.SearchFilterType.IsLatestVersion = 0 -> NuGet.Protocol.Core.Types.SearchFilterType
@@ -329,12 +329,12 @@ NuGet.Protocol.Core.Types.UserAgentStringBuilder.UserAgentStringBuilder() -> voi
 ~NuGet.Protocol.Core.Types.UserAgentStringBuilder.WithVisualStudioSKU(string vsInfo) -> NuGet.Protocol.Core.Types.UserAgentStringBuilder
 NuGet.Protocol.Core.Types.VersionInfo
 NuGet.Protocol.Core.Types.VersionInfo.DownloadCount.get -> long?
-~NuGet.Protocol.Core.Types.VersionInfo.PackageSearchMetadata.get -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
-~NuGet.Protocol.Core.Types.VersionInfo.PackageSearchMetadata.set -> void
-~NuGet.Protocol.Core.Types.VersionInfo.Version.get -> NuGet.Versioning.NuGetVersion
-~NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion version) -> void
-~NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion version, long? downloadCount) -> void
-~NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion version, string downloadCount) -> void
+NuGet.Protocol.Core.Types.VersionInfo.PackageSearchMetadata.get -> NuGet.Protocol.Core.Types.IPackageSearchMetadata?
+NuGet.Protocol.Core.Types.VersionInfo.PackageSearchMetadata.set -> void
+NuGet.Protocol.Core.Types.VersionInfo.Version.get -> NuGet.Versioning.NuGetVersion!
+NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion! version) -> void
+NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion! version, long? downloadCount) -> void
+NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion! version, string? downloadCount) -> void
 NuGet.Protocol.DependencyInfoResourceV2Feed
 ~NuGet.Protocol.DependencyInfoResourceV2Feed.DependencyInfoResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser, NuGet.Protocol.Core.Types.SourceRepository source) -> void
 NuGet.Protocol.DependencyInfoResourceV2FeedProvider
@@ -728,10 +728,10 @@ NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheI
 ~NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ServiceDocument.set -> void
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentResourceV2Provider() -> void
 NuGet.Protocol.PackageDeprecationMetadata
-~NuGet.Protocol.PackageDeprecationMetadata.AlternatePackage.get -> NuGet.Protocol.AlternatePackageMetadata
-~NuGet.Protocol.PackageDeprecationMetadata.Message.get -> string
+NuGet.Protocol.PackageDeprecationMetadata.AlternatePackage.get -> NuGet.Protocol.AlternatePackageMetadata?
+NuGet.Protocol.PackageDeprecationMetadata.Message.get -> string?
 NuGet.Protocol.PackageDeprecationMetadata.PackageDeprecationMetadata() -> void
-~NuGet.Protocol.PackageDeprecationMetadata.Reasons.get -> System.Collections.Generic.IEnumerable<string>
+NuGet.Protocol.PackageDeprecationMetadata.Reasons.get -> System.Collections.Generic.IEnumerable<string!>!
 NuGet.Protocol.PackageDetailsUriResourceV3
 ~NuGet.Protocol.PackageDetailsUriResourceV3.GetUri(string id, NuGet.Versioning.NuGetVersion version) -> System.Uri
 NuGet.Protocol.PackageDetailsUriResourceV3Provider
@@ -1383,13 +1383,13 @@ NuGet.Protocol.ReportAbuseResourceV3
 NuGet.Protocol.ReportAbuseResourceV3Provider
 NuGet.Protocol.ReportAbuseResourceV3Provider.ReportAbuseResourceV3Provider() -> void
 NuGet.Protocol.RepositoryCertificateInfo
-~NuGet.Protocol.RepositoryCertificateInfo.ContentUrl.get -> string
-~NuGet.Protocol.RepositoryCertificateInfo.Fingerprints.get -> NuGet.Packaging.Core.Fingerprints
-~NuGet.Protocol.RepositoryCertificateInfo.Issuer.get -> string
+NuGet.Protocol.RepositoryCertificateInfo.ContentUrl.get -> string!
+NuGet.Protocol.RepositoryCertificateInfo.Fingerprints.get -> NuGet.Packaging.Core.Fingerprints!
+NuGet.Protocol.RepositoryCertificateInfo.Issuer.get -> string!
 NuGet.Protocol.RepositoryCertificateInfo.NotAfter.get -> System.DateTimeOffset
 NuGet.Protocol.RepositoryCertificateInfo.NotBefore.get -> System.DateTimeOffset
 NuGet.Protocol.RepositoryCertificateInfo.RepositoryCertificateInfo() -> void
-~NuGet.Protocol.RepositoryCertificateInfo.Subject.get -> string
+NuGet.Protocol.RepositoryCertificateInfo.Subject.get -> string!
 NuGet.Protocol.RepositorySignatureResource
 NuGet.Protocol.RepositorySignatureResource.AllRepositorySigned.get -> bool
 ~NuGet.Protocol.RepositorySignatureResource.RepositoryCertificateInfos.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.IRepositoryCertificateInfo>
@@ -1861,16 +1861,16 @@ override NuGet.Protocol.Providers.VulnerabilityInfoResourceV3Provider.TryCreate(
 ~override NuGet.Protocol.RemoteV3FindPackageByIdResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository sourceRepository, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.ReportAbuseResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.RepositorySignatureResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.SafeBoolConverter.CanConvert(System.Type objectType) -> bool
+override NuGet.Protocol.SafeBoolConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.SafeBoolConverter.CanRead.get -> bool
 override NuGet.Protocol.SafeBoolConverter.CanWrite.get -> bool
-~override NuGet.Protocol.SafeBoolConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.SafeBoolConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~override NuGet.Protocol.SafeUriConverter.CanConvert(System.Type objectType) -> bool
+override NuGet.Protocol.SafeBoolConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object!
+override NuGet.Protocol.SafeBoolConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
+override NuGet.Protocol.SafeUriConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.SafeUriConverter.CanRead.get -> bool
 override NuGet.Protocol.SafeUriConverter.CanWrite.get -> bool
-~override NuGet.Protocol.SafeUriConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.SafeUriConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.SafeUriConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
+override NuGet.Protocol.SafeUriConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 ~override NuGet.Protocol.SemanticVersionConverter.CanConvert(System.Type objectType) -> bool
 ~override NuGet.Protocol.SemanticVersionConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
 ~override NuGet.Protocol.SemanticVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
@@ -1886,9 +1886,9 @@ override NuGet.Protocol.SafeUriConverter.CanWrite.get -> bool
 override NuGet.Protocol.VersionInfoConverter.CanWrite.get -> bool
 ~override NuGet.Protocol.VersionInfoConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
 ~override NuGet.Protocol.VersionInfoConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~override NuGet.Protocol.VersionRangeConverter.CanConvert(System.Type objectType) -> bool
-~override NuGet.Protocol.VersionRangeConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.VersionRangeConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.VersionRangeConverter.CanConvert(System.Type! objectType) -> bool
+override NuGet.Protocol.VersionRangeConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
+override NuGet.Protocol.VersionRangeConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 ~override NuGet.Repositories.LocalPackageInfo.ToString() -> string
 ~static NuGet.Protocol.CachingUtility.ComputeHash(string value, bool addIdentifiableCharacters = true) -> string
 ~static NuGet.Protocol.CachingUtility.IsFileAlreadyOpen(string filePath) -> bool

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,8 +1,8 @@
 #nullable enable
 NuGet.Protocol.AlternatePackageMetadata
 NuGet.Protocol.AlternatePackageMetadata.AlternatePackageMetadata() -> void
-~NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string
-~NuGet.Protocol.AlternatePackageMetadata.Range.get -> NuGet.Versioning.VersionRange
+NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string!
+NuGet.Protocol.AlternatePackageMetadata.Range.get -> NuGet.Versioning.VersionRange?
 NuGet.Protocol.AmbientAuthenticationState
 NuGet.Protocol.AmbientAuthenticationState.AmbientAuthenticationState() -> void
 NuGet.Protocol.AmbientAuthenticationState.AuthenticationRetriesCount.get -> int
@@ -269,12 +269,12 @@ NuGet.Protocol.Core.Types.SearchFilter.IncludeDelisted.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.IncludePrerelease.get -> bool
 NuGet.Protocol.Core.Types.SearchFilter.OrderBy.get -> NuGet.Protocol.Core.Types.SearchOrderBy?
 NuGet.Protocol.Core.Types.SearchFilter.OrderBy.set -> void
-~NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Protocol.Core.Types.SearchFilter.PackageTypes.set -> void
 NuGet.Protocol.Core.Types.SearchFilter.SearchFilter(bool includePrerelease) -> void
 NuGet.Protocol.Core.Types.SearchFilter.SearchFilter(bool includePrerelease, NuGet.Protocol.Core.Types.SearchFilterType? filter) -> void
-~NuGet.Protocol.Core.Types.SearchFilter.SupportedFrameworks.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Core.Types.SearchFilter.SupportedFrameworks.set -> void
+NuGet.Protocol.Core.Types.SearchFilter.SupportedFrameworks.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Protocol.Core.Types.SearchFilter.SupportedFrameworks.set -> void
 NuGet.Protocol.Core.Types.SearchFilterType
 NuGet.Protocol.Core.Types.SearchFilterType.IsAbsoluteLatestVersion = 1 -> NuGet.Protocol.Core.Types.SearchFilterType
 NuGet.Protocol.Core.Types.SearchFilterType.IsLatestVersion = 0 -> NuGet.Protocol.Core.Types.SearchFilterType
@@ -329,12 +329,12 @@ NuGet.Protocol.Core.Types.UserAgentStringBuilder.UserAgentStringBuilder() -> voi
 ~NuGet.Protocol.Core.Types.UserAgentStringBuilder.WithVisualStudioSKU(string vsInfo) -> NuGet.Protocol.Core.Types.UserAgentStringBuilder
 NuGet.Protocol.Core.Types.VersionInfo
 NuGet.Protocol.Core.Types.VersionInfo.DownloadCount.get -> long?
-~NuGet.Protocol.Core.Types.VersionInfo.PackageSearchMetadata.get -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
-~NuGet.Protocol.Core.Types.VersionInfo.PackageSearchMetadata.set -> void
-~NuGet.Protocol.Core.Types.VersionInfo.Version.get -> NuGet.Versioning.NuGetVersion
-~NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion version) -> void
-~NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion version, long? downloadCount) -> void
-~NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion version, string downloadCount) -> void
+NuGet.Protocol.Core.Types.VersionInfo.PackageSearchMetadata.get -> NuGet.Protocol.Core.Types.IPackageSearchMetadata?
+NuGet.Protocol.Core.Types.VersionInfo.PackageSearchMetadata.set -> void
+NuGet.Protocol.Core.Types.VersionInfo.Version.get -> NuGet.Versioning.NuGetVersion!
+NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion! version) -> void
+NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion! version, long? downloadCount) -> void
+NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion! version, string? downloadCount) -> void
 NuGet.Protocol.DependencyInfoResourceV2Feed
 ~NuGet.Protocol.DependencyInfoResourceV2Feed.DependencyInfoResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser, NuGet.Protocol.Core.Types.SourceRepository source) -> void
 NuGet.Protocol.DependencyInfoResourceV2FeedProvider
@@ -728,10 +728,10 @@ NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheI
 ~NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ServiceDocument.set -> void
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentResourceV2Provider() -> void
 NuGet.Protocol.PackageDeprecationMetadata
-~NuGet.Protocol.PackageDeprecationMetadata.AlternatePackage.get -> NuGet.Protocol.AlternatePackageMetadata
-~NuGet.Protocol.PackageDeprecationMetadata.Message.get -> string
+NuGet.Protocol.PackageDeprecationMetadata.AlternatePackage.get -> NuGet.Protocol.AlternatePackageMetadata?
+NuGet.Protocol.PackageDeprecationMetadata.Message.get -> string?
 NuGet.Protocol.PackageDeprecationMetadata.PackageDeprecationMetadata() -> void
-~NuGet.Protocol.PackageDeprecationMetadata.Reasons.get -> System.Collections.Generic.IEnumerable<string>
+NuGet.Protocol.PackageDeprecationMetadata.Reasons.get -> System.Collections.Generic.IEnumerable<string!>!
 NuGet.Protocol.PackageDetailsUriResourceV3
 ~NuGet.Protocol.PackageDetailsUriResourceV3.GetUri(string id, NuGet.Versioning.NuGetVersion version) -> System.Uri
 NuGet.Protocol.PackageDetailsUriResourceV3Provider
@@ -1383,13 +1383,13 @@ NuGet.Protocol.ReportAbuseResourceV3
 NuGet.Protocol.ReportAbuseResourceV3Provider
 NuGet.Protocol.ReportAbuseResourceV3Provider.ReportAbuseResourceV3Provider() -> void
 NuGet.Protocol.RepositoryCertificateInfo
-~NuGet.Protocol.RepositoryCertificateInfo.ContentUrl.get -> string
-~NuGet.Protocol.RepositoryCertificateInfo.Fingerprints.get -> NuGet.Packaging.Core.Fingerprints
-~NuGet.Protocol.RepositoryCertificateInfo.Issuer.get -> string
+NuGet.Protocol.RepositoryCertificateInfo.ContentUrl.get -> string!
+NuGet.Protocol.RepositoryCertificateInfo.Fingerprints.get -> NuGet.Packaging.Core.Fingerprints!
+NuGet.Protocol.RepositoryCertificateInfo.Issuer.get -> string!
 NuGet.Protocol.RepositoryCertificateInfo.NotAfter.get -> System.DateTimeOffset
 NuGet.Protocol.RepositoryCertificateInfo.NotBefore.get -> System.DateTimeOffset
 NuGet.Protocol.RepositoryCertificateInfo.RepositoryCertificateInfo() -> void
-~NuGet.Protocol.RepositoryCertificateInfo.Subject.get -> string
+NuGet.Protocol.RepositoryCertificateInfo.Subject.get -> string!
 NuGet.Protocol.RepositorySignatureResource
 NuGet.Protocol.RepositorySignatureResource.AllRepositorySigned.get -> bool
 ~NuGet.Protocol.RepositorySignatureResource.RepositoryCertificateInfos.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.IRepositoryCertificateInfo>
@@ -1852,16 +1852,16 @@ override NuGet.Protocol.Providers.VulnerabilityInfoResourceV3Provider.TryCreate(
 ~override NuGet.Protocol.RemoteV3FindPackageByIdResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository sourceRepository, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.ReportAbuseResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.RepositorySignatureResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.SafeBoolConverter.CanConvert(System.Type objectType) -> bool
+override NuGet.Protocol.SafeBoolConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.SafeBoolConverter.CanRead.get -> bool
 override NuGet.Protocol.SafeBoolConverter.CanWrite.get -> bool
-~override NuGet.Protocol.SafeBoolConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.SafeBoolConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~override NuGet.Protocol.SafeUriConverter.CanConvert(System.Type objectType) -> bool
+override NuGet.Protocol.SafeBoolConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object!
+override NuGet.Protocol.SafeBoolConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
+override NuGet.Protocol.SafeUriConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.SafeUriConverter.CanRead.get -> bool
 override NuGet.Protocol.SafeUriConverter.CanWrite.get -> bool
-~override NuGet.Protocol.SafeUriConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.SafeUriConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.SafeUriConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
+override NuGet.Protocol.SafeUriConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 ~override NuGet.Protocol.SemanticVersionConverter.CanConvert(System.Type objectType) -> bool
 ~override NuGet.Protocol.SemanticVersionConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
 ~override NuGet.Protocol.SemanticVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
@@ -1876,9 +1876,9 @@ override NuGet.Protocol.SafeUriConverter.CanWrite.get -> bool
 override NuGet.Protocol.VersionInfoConverter.CanWrite.get -> bool
 ~override NuGet.Protocol.VersionInfoConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
 ~override NuGet.Protocol.VersionInfoConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~override NuGet.Protocol.VersionRangeConverter.CanConvert(System.Type objectType) -> bool
-~override NuGet.Protocol.VersionRangeConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.VersionRangeConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.VersionRangeConverter.CanConvert(System.Type! objectType) -> bool
+override NuGet.Protocol.VersionRangeConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
+override NuGet.Protocol.VersionRangeConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 ~override NuGet.Repositories.LocalPackageInfo.ToString() -> string
 ~static NuGet.Protocol.CachingUtility.ComputeHash(string value, bool addIdentifiableCharacters = true) -> string
 ~static NuGet.Protocol.CachingUtility.IsFileAlreadyOpen(string filePath) -> bool

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
 NuGet.Protocol.AlternatePackageMetadata
 NuGet.Protocol.AlternatePackageMetadata.AlternatePackageMetadata() -> void
-NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string!
+NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string?
 NuGet.Protocol.AlternatePackageMetadata.Range.get -> NuGet.Versioning.VersionRange?
 NuGet.Protocol.AmbientAuthenticationState
 NuGet.Protocol.AmbientAuthenticationState.AmbientAuthenticationState() -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -50,14 +50,14 @@ NuGet.Protocol.Core.Types.DownloadResourceResultStatus.AvailableWithoutStream = 
 NuGet.Protocol.Core.Types.DownloadResourceResultStatus.Cancelled = 3 -> NuGet.Protocol.Core.Types.DownloadResourceResultStatus
 NuGet.Protocol.Core.Types.DownloadResourceResultStatus.NotFound = 2 -> NuGet.Protocol.Core.Types.DownloadResourceResultStatus
 NuGet.Protocol.Core.Types.FatalProtocolException
-~NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string message) -> void
-~NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string message, System.Exception innerException) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string! message) -> void
+NuGet.Protocol.Core.Types.FatalProtocolException.FatalProtocolException(string! message, System.Exception! innerException) -> void
 NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo
-~NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.DependencyGroups.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.FindPackageByIdDependencyInfo(NuGet.Packaging.Core.PackageIdentity packageIdentity, System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup> dependencyGroups, System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup> frameworkReferenceGroups) -> void
-~NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.FrameworkReferenceGroups.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.FrameworkSpecificGroup>
-~NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.DependencyGroups.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.FindPackageByIdDependencyInfo(NuGet.Packaging.Core.PackageIdentity! packageIdentity, System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>! dependencyGroups, System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>! frameworkReferenceGroups) -> void
+NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.FrameworkReferenceGroups.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.FrameworkSpecificGroup!>!
+NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity!
 NuGet.Protocol.Core.Types.FindPackageByIdResource
 NuGet.Protocol.Core.Types.FindPackageByIdResource.FindPackageByIdResource() -> void
 NuGet.Protocol.Core.Types.HttpHandlerResource
@@ -68,8 +68,8 @@ NuGet.Protocol.Core.Types.HttpSourceCacheContext.MaxAge.get -> System.TimeSpan
 ~NuGet.Protocol.Core.Types.HttpSourceCacheContext.RootTempFolder.get -> string
 ~NuGet.Protocol.Core.Types.HttpSourceCacheContext.SourceCacheContext.get -> NuGet.Protocol.Core.Types.SourceCacheContext
 NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource
-~NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource.SupportsIsAbsoluteLatestVersionAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource.SupportsSearchAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
+NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource.SupportsIsAbsoluteLatestVersionAsync(NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource.SupportsSearchAsync(NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
 NuGet.Protocol.Core.Types.INuGetResource
 NuGet.Protocol.Core.Types.INuGetResourceProvider
 NuGet.Protocol.Core.Types.INuGetResourceProvider.After.get -> System.Collections.Generic.IEnumerable<string!>!
@@ -119,9 +119,9 @@ NuGet.Protocol.Core.Types.MetadataResource
 ~NuGet.Protocol.Core.Types.MetadataResource.GetVersions(string packageId, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
 NuGet.Protocol.Core.Types.MetadataResource.MetadataResource() -> void
 NuGet.Protocol.Core.Types.NuGetProtocolException
-~NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(string message) -> void
-~NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(string message, System.Exception innerException) -> void
+NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(string! message) -> void
+NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(string! message, System.Exception! innerException) -> void
 NuGet.Protocol.Core.Types.NuGetResourceProviderPositions
 NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.NuGetResourceProviderPositions() -> void
 NuGet.Protocol.Core.Types.NuGetTestMode
@@ -155,9 +155,9 @@ NuGet.Protocol.Core.Types.PackageProgressEventArgs
 NuGet.Protocol.Core.Types.PackageProgressEventArgs.Complete.get -> double
 NuGet.Protocol.Core.Types.PackageProgressEventArgs.HasPackageSource.get -> bool
 NuGet.Protocol.Core.Types.PackageProgressEventArgs.IsComplete.get -> bool
-~NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity
-~NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageProgressEventArgs(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Configuration.PackageSource source, double complete) -> void
-~NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageSource.get -> NuGet.Configuration.PackageSource
+NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity!
+NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageProgressEventArgs(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Configuration.PackageSource? source, double complete) -> void
+NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageSource.get -> NuGet.Configuration.PackageSource?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
 ~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.Build() -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata
@@ -259,9 +259,9 @@ NuGet.Protocol.Core.Types.ResourceProvider.ResourceProvider(System.Type! resourc
 NuGet.Protocol.Core.Types.ResourceProvider.ResourceProvider(System.Type! resourceType, string! name, System.Collections.Generic.IEnumerable<string!>! before, System.Collections.Generic.IEnumerable<string!>! after) -> void
 NuGet.Protocol.Core.Types.ResourceProvider.ResourceProvider(System.Type! resourceType, string! name, string? before) -> void
 NuGet.Protocol.Core.Types.RetriableProtocolException
-~NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(string message) -> void
-~NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(string message, System.Exception innerException) -> void
+NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(string! message) -> void
+NuGet.Protocol.Core.Types.RetriableProtocolException.RetriableProtocolException(string! message, System.Exception! innerException) -> void
 NuGet.Protocol.Core.Types.SearchFilter
 NuGet.Protocol.Core.Types.SearchFilter.Filter.get -> NuGet.Protocol.Core.Types.SearchFilterType?
 NuGet.Protocol.Core.Types.SearchFilter.IncludeDelisted.get -> bool
@@ -378,19 +378,19 @@ NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.IsRetry.get -> bool
 ~NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.Url.get -> System.Uri
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.FileSize.get -> long
-~NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.ProtocolDiagnosticNupkgCopiedEvent(string source, long fileSize) -> void
-~NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.Source.get -> string
+NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.ProtocolDiagnosticNupkgCopiedEvent(string! source, long fileSize) -> void
+NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.Source.get -> string!
 NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent
 NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Duration.get -> System.TimeSpan
-~NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Method.get -> string
-~NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.ProtocolDiagnosticResourceEvent(string source, string resourceType, string type, string method, System.TimeSpan duration) -> void
-~NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.ResourceType.get -> string
-~NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Source.get -> string
-~NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Type.get -> string
+NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Method.get -> string!
+NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.ProtocolDiagnosticResourceEvent(string! source, string! resourceType, string! type, string! method, System.TimeSpan duration) -> void
+NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.ResourceType.get -> string!
+NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Source.get -> string!
+NuGet.Protocol.Events.ProtocolDiagnosticResourceEvent.Type.get -> string!
 NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent
 NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent.HttpsSourceHasHttpResource.get -> bool
-~NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent.ProtocolDiagnosticServiceIndexEntryEvent(string source, bool httpsSourceHasHttpResource) -> void
-~NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent.Source.get -> string
+NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent.ProtocolDiagnosticServiceIndexEntryEvent(string! source, bool httpsSourceHasHttpResource) -> void
+NuGet.Protocol.Events.ProtocolDiagnosticServiceIndexEntryEvent.Source.get -> string!
 NuGet.Protocol.Events.ProtocolDiagnostics
 NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticHttpEventHandler
 NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticResourceEventHandler
@@ -581,9 +581,9 @@ NuGet.Protocol.IV2FeedParser
 NuGet.Protocol.IVulnerabilityInfoResource
 NuGet.Protocol.IVulnerabilityInfoResource.GetVulnerabilityInfoAsync(NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Model.GetVulnerabilityInfoResult!>!
 NuGet.Protocol.InvalidCacheProtocolException
-~NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(string message) -> void
-~NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(string message, System.Exception innerException) -> void
+NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(string! message) -> void
+NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(string! message, System.Exception! innerException) -> void
 NuGet.Protocol.JsonExtensions
 NuGet.Protocol.JsonProperties
 NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed
@@ -745,9 +745,9 @@ NuGet.Protocol.PackageMetadataResourceV3
 NuGet.Protocol.PackageMetadataResourceV3Provider
 NuGet.Protocol.PackageMetadataResourceV3Provider.PackageMetadataResourceV3Provider() -> void
 NuGet.Protocol.PackageNotFoundProtocolException
-~NuGet.Protocol.PackageNotFoundProtocolException.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity
-~NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity package) -> void
-~NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity package, System.Exception innerException) -> void
+NuGet.Protocol.PackageNotFoundProtocolException.PackageIdentity.get -> NuGet.Packaging.Core.PackageIdentity!
+NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity! package) -> void
+NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity! package, System.Exception! innerException) -> void
 NuGet.Protocol.PackageSearchMetadata
 ~NuGet.Protocol.PackageSearchMetadata.Authors.get -> string
 ~NuGet.Protocol.PackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
@@ -1419,10 +1419,10 @@ NuGet.Protocol.SemaphoreSlimThrottle.Release() -> void
 NuGet.Protocol.ServerWarningLogHandler
 ~NuGet.Protocol.ServerWarningLogHandler.ServerWarningLogHandler(System.Net.Http.HttpClientHandler clientHandler) -> void
 NuGet.Protocol.ServiceIndexEntry
-~NuGet.Protocol.ServiceIndexEntry.ClientVersion.get -> NuGet.Versioning.SemanticVersion
-~NuGet.Protocol.ServiceIndexEntry.ServiceIndexEntry(System.Uri serviceUri, string serviceType, NuGet.Versioning.SemanticVersion clientVersion) -> void
-~NuGet.Protocol.ServiceIndexEntry.Type.get -> string
-~NuGet.Protocol.ServiceIndexEntry.Uri.get -> System.Uri
+NuGet.Protocol.ServiceIndexEntry.ClientVersion.get -> NuGet.Versioning.SemanticVersion!
+NuGet.Protocol.ServiceIndexEntry.ServiceIndexEntry(System.Uri! serviceUri, string! serviceType, NuGet.Versioning.SemanticVersion! clientVersion) -> void
+NuGet.Protocol.ServiceIndexEntry.Type.get -> string!
+NuGet.Protocol.ServiceIndexEntry.Uri.get -> System.Uri!
 NuGet.Protocol.ServiceIndexResourceV3
 ~NuGet.Protocol.ServiceIndexResourceV3.ServiceIndexResourceV3(Newtonsoft.Json.Linq.JObject index, System.DateTime requestTime) -> void
 NuGet.Protocol.ServiceIndexResourceV3Provider
@@ -1570,9 +1570,9 @@ abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleCancelResponse() ->
 abstract NuGet.Protocol.Plugins.Receiver.Connect() -> void
 abstract NuGet.Protocol.Plugins.Receiver.Dispose(bool disposing) -> void
 const NuGet.Protocol.CachingUtility.BufferSize = 8192 -> int
-~const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.First = "First" -> string
-~const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.Last = "Last" -> string
-~const NuGet.Protocol.Core.Types.NuGetTestMode.NuGetTestClientName = "NuGet Test Client" -> string
+const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.First = "First" -> string!
+const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.Last = "Last" -> string!
+const NuGet.Protocol.Core.Types.NuGetTestMode.NuGetTestClientName = "NuGet Test Client" -> string!
 const NuGet.Protocol.JsonExtensions.JsonSerializationMaxDepth = 512 -> int
 ~const NuGet.Protocol.JsonProperties.AdvisoryUrl = "advisoryUrl" -> string
 ~const NuGet.Protocol.JsonProperties.AllRepositorySigned = "allRepositorySigned" -> string
@@ -1888,7 +1888,7 @@ override NuGet.Protocol.VersionInfoConverter.CanWrite.get -> bool
 ~static NuGet.Protocol.Core.Types.HttpSourceCacheContext.Create(NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, bool isFirstAttempt) -> NuGet.Protocol.Core.Types.HttpSourceCacheContext
 ~static NuGet.Protocol.Core.Types.HttpSourceCacheContext.Create(NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, int retryCount) -> NuGet.Protocol.Core.Types.HttpSourceCacheContext
 static NuGet.Protocol.Core.Types.NuGetTestMode.Enabled.get -> bool
-~static NuGet.Protocol.Core.Types.NuGetTestMode.InvokeTestFunctionAgainstTestMode<T>(System.Func<T> function, bool testModeEnabled) -> T
+static NuGet.Protocol.Core.Types.NuGetTestMode.InvokeTestFunctionAgainstTestMode<T>(System.Func<T>! function, bool testModeEnabled) -> T
 ~static NuGet.Protocol.Core.Types.NullSourceCacheContext.Instance.get -> NuGet.Protocol.Core.Types.SourceCacheContext
 ~static NuGet.Protocol.Core.Types.OfflineFeedUtility.AddPackageToSource(NuGet.Protocol.Core.Types.OfflineFeedAddContext offlineFeedAddContext, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
 ~static NuGet.Protocol.Core.Types.OfflineFeedUtility.GetPackageDirectory(NuGet.Packaging.Core.PackageIdentity packageIdentity, string offlineFeed) -> string
@@ -2044,31 +2044,31 @@ static readonly NuGet.Protocol.Plugins.ProtocolConstants.MaxTimeout -> System.Ti
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.MinTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.RequestTimeout -> System.TimeSpan
 ~static readonly NuGet.Protocol.Plugins.ProtocolConstants.Version100 -> NuGet.Versioning.SemanticVersion
-~static readonly NuGet.Protocol.ProtocolConstants.ApiKeyHeader -> string
-~static readonly NuGet.Protocol.ProtocolConstants.ServerWarningHeader -> string
-~static readonly NuGet.Protocol.ProtocolConstants.SessionId -> string
+static readonly NuGet.Protocol.ProtocolConstants.ApiKeyHeader -> string!
+static readonly NuGet.Protocol.ProtocolConstants.ServerWarningHeader -> string!
+static readonly NuGet.Protocol.ProtocolConstants.SessionId -> string!
 static readonly NuGet.Protocol.ProxyAuthenticationHandler.MaxAuthRetries -> int
-~static readonly NuGet.Protocol.ServiceTypes.LegacyGallery -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.PackageBaseAddress -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.PackageDetailsUriTemplate -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.PackagePublish -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.RegistrationsBaseUrl -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.ReportAbuse -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.RepositorySignatures -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.SearchAutocompleteService -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.SearchQueryService -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.SymbolPackagePublish -> string[]
-~static readonly NuGet.Protocol.ServiceTypes.Version200 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version300 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version300beta -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version300rc -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version340 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version360 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version470 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version490 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version500 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Version510 -> string
-~static readonly NuGet.Protocol.ServiceTypes.Versioned -> string
+static readonly NuGet.Protocol.ServiceTypes.LegacyGallery -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.PackageBaseAddress -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.PackageDetailsUriTemplate -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.PackagePublish -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.RegistrationsBaseUrl -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.ReportAbuse -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.RepositorySignatures -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.SearchAutocompleteService -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.SearchQueryService -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.SymbolPackagePublish -> string![]!
+static readonly NuGet.Protocol.ServiceTypes.Version200 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version300 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version300beta -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version300rc -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version340 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version360 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version470 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version490 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version500 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Version510 -> string!
+static readonly NuGet.Protocol.ServiceTypes.Versioned -> string!
 static readonly NuGet.Protocol.StreamExtensions.BufferSize -> int
 ~virtual NuGet.Protocol.Core.Types.DependencyInfoResource.ResolvePackages(string packageId, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo>>
 ~virtual NuGet.Protocol.Core.Types.Repository.ProviderFactory.GetCoreV3() -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResource.cs
@@ -28,7 +28,5 @@ namespace NuGet.Protocol.Core.Types
             string globalPackagesFolder,
             ILogger logger,
             CancellationToken token);
-
-        // public event EventHandler<PackageProgressEventArgs> Progress;
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/SearchFilter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SearchFilter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 namespace NuGet.Protocol
 {
     public static class ServiceTypes


### PR DESCRIPTION
Progress on: https://github.com/NuGet/Home/issues/14851

## Description

Remove `#nullable disable` from 24 leaf-type files in `NuGet.Protocol`. Most changes are mechanical — the interesting decisions are below.

### Significant decisions

**JSON model nullability driven by [NuGet V3 protocol spec](https://learn.microsoft.com/en-us/nuget/api/registration-base-url-resource):**

| Type | Property | Spec | Annotation | Rationale |
|---|---|---|---|---|
| `AlternatePackageMetadata` | `PackageId` | required | `string?` | 3rd party servers may omit it |
| `AlternatePackageMetadata` | `Range` | optional | `VersionRange?` | |
| `PackageDeprecationMetadata` | `Reasons` | required | `Array.Empty<string>()` default | Safer for 3rd party servers that may omit it |
| `PackageDeprecationMetadata` | `Message` | optional | `string?` | |
| `PackageDeprecationMetadata` | `AlternatePackage` | optional | `AlternatePackageMetadata?` | |

**`RepositoryCertificateInfo` — all fields `Required.Always` per [repo signatures spec](https://learn.microsoft.com/en-us/nuget/api/repository-signatures-resource).** Risk is minimal since this is package signing infrastructure declared in one place on nuget.org, and `IRepositoryCertificateInfo` is already declared in NuGet.Packaging.

**`PackageProgressEventArgs.PackageSource` → `PackageSource?`** — constructor accepts null, `HasPackageSource` checks for it. Also marked `[Obsolete]` since it has zero usages in the codebase.

**`VersionInfo.PackageSearchMetadata` → `IPackageSearchMetadata?`** — XML doc explicitly states it's null for V3 sources.

**`VersionRangeConverter.WriteJson`** — explicit `ArgumentNullException` guard instead of `!`-suppression on the nullable `value` parameter.

### Downstream fix

`PackageSearchResultTableRenderer.cs` — `PackageDeprecationMetadata.Message` is now `string?`, added `?? "N/A"` fallback.

### Mechanical changes

Everything else is removal of `#nullable disable` from types where all members are provably non-null: constants, exception hierarchies, event types with constructor-set properties, and models with constructor validation. 65 oblivious (`~`) entries updated in `PublicAPI.Shipped.txt` for both TFMs.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.