### PR TITLE
[7.3.x] Use 1ES task to generate SBOM

### DIFF
--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -156,8 +156,15 @@ steps:
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
 
   - ${{ if not(parameters.BuildRTM)}}:
+      - task: PowerShell@1
+        displayName: "Prepare for SBOM generation"
+        inputs:
+          scriptType: "inlineScript"
+          inlineScript: |
+            mkdir $(Build.ArtifactStagingDirectory)/sbom
+
       - task: ManifestGeneratorTask@0
-        displayName: 'Generation Task'
+        displayName: 'Generate SBOM'
         inputs:
           BuildDropPath: '$(System.DefaultWorkingDirectory)/artifacts'
           ManifestDirPath: '$(Build.ArtifactStagingDirectory)/sbom'

--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -154,12 +154,15 @@ steps:
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/restore:false /target:BuildVSIX /property:BuildRTM=$(BuildRTM) /property:ExcludeTestProjects=$(BuildRTM) /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\13.PackVSIX.binlog"
     condition: "and(succeeded(),eq(variables['BuildRTM'], 'false'))"
+
   - ${{ if not(parameters.BuildRTM)}}:
-      - template: /eng/common/templates-official/steps/generate-sbom.yml@self
-        parameters:
+      - task: ManifestGeneratorTask@0
+        displayName: 'Generation Task'
+        inputs:
+          BuildDropPath: '$(System.DefaultWorkingDirectory)/artifacts'
+          ManifestDirPath: '$(Build.ArtifactStagingDirectory)/sbom'
           PackageName: "NuGet.Client"
           PackageVersion: "$(SemanticVersion)"
-          publishArtifacts: false
 
   - task: MSBuild@1
     displayName: "Generate Build Tools package"

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -113,8 +113,18 @@ steps:
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/restore:false /target:BuildVSIX /property:ExcludeTestProjects=false /property:IsCIBuild=true /binarylogger:$(Build.StagingDirectory)\\binlog\\07.PackVSIX.binlog"
 
-  - template: /eng/common/templates/steps/generate-sbom.yml@self
-    parameters:
+  - task: PowerShell@1
+    displayName: "Prepare for SBOM generation"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        mkdir $(Build.ArtifactStagingDirectory)/sbom
+
+  - task: ManifestGeneratorTask@0
+    displayName: 'Generate SBOM'
+    inputs:
+      BuildDropPath: '$(System.DefaultWorkingDirectory)/artifacts'
+      ManifestDirPath: '$(Build.ArtifactStagingDirectory)/sbom'
       PackageName: "NuGet.Client"
       PackageVersion: "$(NuGetVersion)"
 

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools/Microsoft.VisualStudio.NuGet.BuildTools.vsmanproj
@@ -9,7 +9,7 @@
     <TargetName>$(MSBuildProjectName)</TargetName>
     <OutputPath>$(VsixPublishDestination)</OutputPath>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <SBOMFileLocation>$(ManifestDirPath)\$(ARTIFACT_NAME)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
+    <SBOMFileLocation>$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">

--- a/setup/Microsoft.VisualStudio.NuGet.Core/Microsoft.VisualStudio.NuGet.Core.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.Core/Microsoft.VisualStudio.NuGet.Core.vsmanproj
@@ -9,7 +9,7 @@
     <TargetName>$(MSBuildProjectName)</TargetName>
     <OutputPath>$(VsixPublishDestination)</OutputPath>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <SBOMFileLocation>$(ManifestDirPath)\$(ARTIFACT_NAME)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
+    <SBOMFileLocation>$(ManifestDirPath)\_manifest\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

Someone changed Arcade to [break generating sboms via common arcade yaml](https://github.com/NuGet/NuGet.Client/pull/7272/files#diff-e110358d423f1959840c70d3932213483b24d2a92e40c5bd3fa26d4564aa05c1). It originally came from [this PR in the arcade repo](https://github.com/dotnet/arcade/pull/16317).

This PR changes our pipeline to use the 1ES task directly

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
