### PR TITLE
Update TFM version compatibility behavior to correctly handle CsWinRT 3.0 .1 TFMs

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
@@ -203,10 +203,13 @@ namespace NuGet.Frameworks
 
                 if (target.IsNet5Era && candidate.HasPlatform)
                 {
-                    // If targeting a TFM with .1 revision for the Windows Platform version, then that means
-                    // it is targeting CsWinRT 3.0 and we need to make sure the candidate is also doing
-                    // the same. Similarly, if it is not targeting .1, then we need to make sure the candidate
-                    // is also not targeting it for it to be compatible. The .1 revision was added in .NET 10.
+                    // net*.0-windows, where the windows version is 10 or higher, will make WinRT APIs available.
+                    // Under the covers it uses CsWinRT to convert WinRT ABIs to .NET API/ABIs.
+                    // Different major versions of CsWinRT are incompatible with each other, so we're special
+                    // casing windows to encode CsWinRT as the platform revision.
+                    // Therefore, net10.0-windows10.0.2610.0 should not be compatible with
+                    // net10.0-windows10.0.22000.1, even though the platform version is higher
+                    // because the revision number is different, signaling an incompatible CsWinRT version.
                     if (result
                          // Scope to .NET 10 and later for the Windows 10 TFM
                          && target.Version.Major >= 10

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
@@ -203,6 +203,22 @@ namespace NuGet.Frameworks
 
                 if (target.IsNet5Era && candidate.HasPlatform)
                 {
+                    // If targeting a TFM with .1 revision for the Platform version, then that means
+                    // it is targeting CsWinRT 3.0 and we need to make sure the candidate is also doing
+                    // the same. Similarly, if it is not targeting .1, then we need to make sure the candidate
+                    // is also not targeting it for it to be compatible. The .1 revision was added in .NET 10.
+                    if (result
+                         // Scope to .NET 10 and later for the Windows 10 TFM
+                         && target.Version.Major >= 10
+                         && StringComparer.OrdinalIgnoreCase.Equals(target.Platform, "windows")
+                         && target.PlatformVersion.Major >= 10
+                         && candidate.PlatformVersion.Major >= 10
+                         // Check if both are targeting the same version of CsWinRT support
+                         && (target.PlatformVersion.Revision == 1) != (candidate.PlatformVersion.Revision == 1))
+                    {
+                        result = false;
+                    }
+
                     result = result
                         && StringComparer.OrdinalIgnoreCase.Equals(target.Platform, candidate.Platform)
                         && IsVersionCompatible(target.PlatformVersion, candidate.PlatformVersion);

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
@@ -203,7 +203,7 @@ namespace NuGet.Frameworks
 
                 if (target.IsNet5Era && candidate.HasPlatform)
                 {
-                    // If targeting a TFM with .1 revision for the Platform version, then that means
+                    // If targeting a TFM with .1 revision for the Windows Platform version, then that means
                     // it is targeting CsWinRT 3.0 and we need to make sure the candidate is also doing
                     // the same. Similarly, if it is not targeting .1, then we need to make sure the candidate
                     // is also not targeting it for it to be compatible. The .1 revision was added in .NET 10.

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
@@ -214,7 +214,7 @@ namespace NuGet.Frameworks
                          && target.PlatformVersion.Major >= 10
                          && candidate.PlatformVersion.Major >= 10
                          // Check if both are targeting the same version of CsWinRT support
-                         && (target.PlatformVersion.Revision == 1) != (candidate.PlatformVersion.Revision == 1))
+                         && target.PlatformVersion.Revision != candidate.PlatformVersion.Revision)
                     {
                         result = false;
                     }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -106,6 +106,33 @@ namespace NuGet.Frameworks.Test
         [InlineData("net5.0-madeupname1.1.3.4.5.6", "net5.0", false)]
         [InlineData("net5.0", "net5.0-madeupname", false)]
 
+        // Compatibility based on Windows platform revision (CsWinRT 2.x vs 3.0 TFM)
+        // .0 project (CsWinRT 2.x) is incompatible with .1 candidate (CsWinRT 3.0)
+        [InlineData("net10.0-windows10.0.26100.0", "net10.0-windows10.0.17763.1", false)]
+        [InlineData("net10.0-windows10.0.26100.0", "net10.0-windows10.0.26100.1", false)]
+        [InlineData("net10.0-windows10.0.17763.0", "net10.0-windows10.0.17763.1", false)]
+        // .1 project (CsWinRT 3.0) is incompatible with .0 candidate (CsWinRT 2.x)
+        [InlineData("net10.0-windows10.0.26100.1", "net10.0-windows10.0.17763.0", false)]
+        [InlineData("net10.0-windows10.0.26100.1", "net10.0-windows10.0.26100.0", false)]
+        [InlineData("net10.0-windows10.0.17763.1", "net10.0-windows10.0.17763.0", false)]
+        // Same revision: compatible (standard version rules apply)
+        [InlineData("net10.0-windows10.0.26100.0", "net10.0-windows10.0.17763.0", true)]
+        [InlineData("net10.0-windows10.0.26100.1", "net10.0-windows10.0.17763.1", true)]
+        [InlineData("net10.0-windows10.0.17763.1", "net10.0-windows10.0.17763.1", true)]
+        [InlineData("net10.0-windows10.0.17763.0", "net10.0-windows10.0.17763.0", true)]
+        // Higher platform build still incompatible when candidate version > target
+        [InlineData("net10.0-windows10.0.17763.0", "net10.0-windows10.0.26100.0", false)]
+        [InlineData("net10.0-windows10.0.17763.1", "net10.0-windows10.0.26100.1", false)]
+        // Cross .NET version with matching revision is compatible
+        [InlineData("net10.0-windows10.0.26100.0", "net6.0-windows10.0.17763.0", true)]
+        // Rule does NOT apply to non-Windows platforms
+        [InlineData("net10.0-android10.0.26100.0", "net10.0-android10.0.17763.1", true)]
+        // Candidate without platform OS version is handled normally
+        [InlineData("net10.0-windows10.0.26100.0", "net10.0", true)]
+        [InlineData("net10.0-windows10.0.26100.1", "net10.0", true)]
+        [InlineData("net10.0-windows10.0.26100.0", "net10.0-windows", true)]
+        [InlineData("net10.0-windows10.0.26100.1", "net10.0-windows", true)]
+
         // dotnet
         [InlineData("dotnet", "dotnet", true)]
         [InlineData("dotnet5.1", "dotnet", true)]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
@@ -140,6 +140,17 @@ namespace NuGet.Frameworks.Test
         [InlineData("net7.0-android", "xamarin.mac,net6.0,net6.0-tizen,monoandroid,net5.0,netcoreapp3.1", "net6.0")]
         [InlineData("net7.0-android", "xamarin.mac,net7.0,net6.0-android,monoandroid,net5.0,netcoreapp3.1", "net7.0")]
         [InlineData("net7.0-android", "xamarin.mac,net7.0-tizen,net6.0-macos,", null)]
+        // Compatibility based on Windows platform revision (CsWinRT 2.x vs 3.0 TFM)
+        // .0 project skips .1 candidate, falls back to net6.0
+        [InlineData("net10.0-windows10.0.26100.0", "net10.0-windows10.0.17763.1,net6.0-windows10.0.17763.0", "net6.0-windows10.0.17763.0")]
+        // .1 project skips .0 candidate, falls back to net6.0 (no .1 available in net6.0 era)
+        [InlineData("net10.0-windows10.0.26100.1", "net10.0-windows10.0.17763.0,net6.0-windows10.0.17763.0", null)]
+        // .1 project picks .1 candidate
+        [InlineData("net10.0-windows10.0.26100.1", "net10.0-windows10.0.17763.1,net6.0-windows10.0.17763.0", "net10.0-windows10.0.17763.1")]
+        // Same revision, picks higher .NET version
+        [InlineData("net10.0-windows10.0.26100.0", "net10.0-windows10.0.17763.0,net6.0-windows10.0.17763.0", "net10.0-windows10.0.17763.0")]
+        // .1 project picks version with no platform version
+        [InlineData("net10.0-windows10.0.26100.1", "net10.0-windows", "net10.0-windows")]
         // Additional tests
         [InlineData("dotnet5.5", "dotnet6.0,dotnet5.4,portable-net45+win8", "dotnet5.4")]
         [InlineData("dotnet7", "dotnet6.0,dotnet5.4,portable-net45+win8", "dotnet6.0")]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14859

## Description
Updating the TFM version compatibility checker to correctly handle the new .1 Windows OS version TFMs that were added in .NET 10.  In .NET 10, `net10.0-windows10.0.17763.1` and similar TFMs for the other Windows OS versions were added to allow multi-targeting between `CsWinRT 3.0` and `CsWinRT 2.x` WinRT projections and not be a breaking change allowing for consumers to adopt at their own pace.  But this means the version compatibility checker needs to treat the .1 revision as not compatible with .0 revision and vice-versa.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
