### PR TITLE
LoadingStatus: fix 'occured' -> 'occurred' in inline comment

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/LoadingStatus.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/LoadingStatus.cs
@@ -7,7 +7,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
     {
         Unknown, // not initialized
         Cancelled, // loading cancelled
-        ErrorOccurred, // error occured
+        ErrorOccurred, // error occurred
         Loading, // loading is running in background
         NoItemsFound, // loading complete, no items found
         NoMoreItems, // loading complete, no more items discovered beyond current page


### PR DESCRIPTION
Inline comment in `src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/LoadingStatus.cs` line 10 reads `error occured`. Fixed to `occurred`. Comment-only change — the enum value `ErrorOccurred` is already spelled correctly.