### PR TITLE
Force initialize EnvDTE.Project because EnvDTE.Project initialization does not specify its thread affinity

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -85,8 +85,8 @@ namespace NuGet.PackageManagement.VisualStudio
             var projectServices = new CpsProjectSystemServices(vsProject, _scriptExecutor);
 
             // Ensure the EnvDTE.Project is initialized.
-            // Under the hood VSProjectAdapter actually has a Lazy<EnvDte.project>, which is really a bug, so if code like
-            // PMC is actually the first one that wants the EnvDTE.Project, it would fail because it's being called from the pipeline thread.
+            // Under the hood VSProjectAdapter actually has a Lazy<EnvDte.project>, which needs the UI thread to satisfy the cast.
+            // If PMC is actually the first one that wants the EnvDTE.Project, it would fail because it's being called from the pipeline thread.
             // This is a workaround to make sure the EnvDTE.Project is initialized before any PMC code tries to use it.
             _ = vsProject.Project;
             var lazyUnconfiguredProject = new AsyncLazy<UnconfiguredProject>(async () =>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -84,6 +84,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var projectServices = new CpsProjectSystemServices(vsProject, _scriptExecutor);
 
+            // Ensure the EnvDTE.Project is initialized.
+            // Under the hood VSProjectAdapter actually has a Lazy<EnvDte.project>, which is really a bug, so if code like
+            // PMC is actually the first one that wants the EnvDTE.Project, it would fail.
+            // This is a workaround to make sure the EnvDTE.Project is initialized before any PMC code tries to use it.
+            _ = vsProject.Project;
             var lazyUnconfiguredProject = new AsyncLazy<UnconfiguredProject>(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -86,7 +86,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // Ensure the EnvDTE.Project is initialized.
             // Under the hood VSProjectAdapter actually has a Lazy<EnvDte.project>, which is really a bug, so if code like
-            // PMC is actually the first one that wants the EnvDTE.Project, it would fail.
+            // PMC is actually the first one that wants the EnvDTE.Project, it would fail because it's being called from the pipeline thread.
             // This is a workaround to make sure the EnvDTE.Project is initialized before any PMC code tries to use it.
             _ = vsProject.Project;
             var lazyUnconfiguredProject = new AsyncLazy<UnconfiguredProject>(async () =>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -865,6 +865,22 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, testContext.Project, packageName, Logger);
         }
 
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        public void GetProject_CanAccessProjectName()
+        {
+            using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger);
+
+            var nugetConsole = GetConsole(testContext.Project);
+            nugetConsole.Clear();
+
+            nugetConsole.Execute("$proj = Get-Project; $proj.Name");
+
+            string pmcText = nugetConsole.GetText();
+            pmcText.Should().Contain(testContext.Project.Name, because: pmcText);
+            pmcText.Should().NotContain("FullyQualifiedErrorId", because: pmcText);
+        }
+
         public static IEnumerable<object[]> GetNetCoreTemplates()
         {
             yield return new object[] { ProjectTemplate.NetCoreConsoleApp };


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14862

## Description

Ensure the EnvDTE.Project is initialized.
Under the hood VSProjectAdapter actually has a Lazy<EnvDte.project>, which needs the UI thread to satisfy the cast.
If PMC is actually the first one that wants the EnvDTE.Project, it would fail because it's being called from the pipeline thread.
This is a workaround to make sure the EnvDTE.Project is initialized before any PMC code tries to use it.

The code change that regressed is https://github.com/NuGet/NuGet.Client/commit/bff510e1c53565f714dff7552e0220465f236deb. 

In that code change, UnconfiguredProject acquisition was lazified, but unfortunately that also meant we never actualized EnvDTE.Project and the PMC command call `Get-Project` ended up being the first one needing it.

Basically, that change, exposed a bug in the VSProjectAdapter implementation where an STA dependent callwas being performed in a lazy that simply cannot ensure we were on the correct thread. 
The code that does the conversion is here: https://github.com/NuGet/NuGet.Client/blob/1f130f612623d7922c8f59dfa1ca5ef52cef5c19/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsHierarchyUtility.cs#L135

This is the simplest fix, but probably not the ideal one.

For the test, note that we verified it failed without my fix and passed with it. cc @donnie-msft 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests (Thanks for writing the test @donnie-msft )
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
