### PR TITLE
Add E2E & Apex tests to ensure CpsPackageReferenceProject InitializesDteProject without throwing

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -12,8 +12,8 @@
   <PropertyGroup>
     <!-- **  Change for each new version -->
     <!-- when changing any of the NuGetVersion props below, run tools-local\ship-public-apis -->
-    <MajorNuGetVersion Condition="'$(MajorNuGetVersion)' == ''">7</MajorNuGetVersion>
-    <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">7</MinorNuGetVersion>
+    <MajorNuGetVersion Condition="'$(MajorNuGetVersion)' == ''">6</MajorNuGetVersion>
+    <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">6</MinorNuGetVersion>
     <PatchNuGetVersion Condition="'$(PatchNuGetVersion)' == ''">0</PatchNuGetVersion>
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
 

--- a/build/config.props
+++ b/build/config.props
@@ -12,8 +12,8 @@
   <PropertyGroup>
     <!-- **  Change for each new version -->
     <!-- when changing any of the NuGetVersion props below, run tools-local\ship-public-apis -->
-    <MajorNuGetVersion Condition="'$(MajorNuGetVersion)' == ''">6</MajorNuGetVersion>
-    <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">6</MinorNuGetVersion>
+    <MajorNuGetVersion Condition="'$(MajorNuGetVersion)' == ''">7</MajorNuGetVersion>
+    <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">7</MinorNuGetVersion>
     <PatchNuGetVersion Condition="'$(PatchNuGetVersion)' == ''">0</PatchNuGetVersion>
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -80,6 +80,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 return null;
             }
 
+            // Ensure the EnvDTE.Project is initialized on the UI thread before PMC accesses it later.
+            //_ = vsProject.Project;
+
             var fullProjectPath = vsProject.FullProjectPath;
 
             var projectServices = new CpsProjectSystemServices(vsProject, _scriptExecutor);

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Projects/CpsPackageReferenceProjectProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Projects/CpsPackageReferenceProjectProviderTests.cs
@@ -53,5 +53,56 @@ namespace NuGet.PackageManagement.VisualStudio.Test.Projects
             projectAdapter.Verify(a => a.IsCapabilityMatch(NuGet.VisualStudio.IDE.ProjectCapabilities.Cps), Times.Once);
             projectAdapter.Verify(a => a.IsCapabilityMatch(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences), Times.Once);
         }
+
+        [Fact]
+        public async Task TryCreateNuGetProject_CpsPackageReferenceProject_InitializesDteProject()
+        {
+            // Arrange
+            var hierarchy = new Mock<IVsHierarchy>();
+            var dteProject = new Mock<EnvDTE.Project>();
+            var buildProperties = new Mock<IVsProjectBuildProperties>();
+            string? restoreProjectStyle = null;
+#pragma warning disable CS0618 // Type or member is obsolete
+            buildProperties.Setup(x => x.GetPropertyValueWithDteFallback(ProjectBuildProperties.RestoreProjectStyle))
+                .Returns(restoreProjectStyle);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            var projectAdapter = new Mock<IVsProjectAdapter>();
+            projectAdapter.SetupGet(a => a.VsHierarchy)
+                .Returns(hierarchy.Object);
+            projectAdapter.SetupGet(a => a.BuildProperties)
+                .Returns(buildProperties.Object);
+            projectAdapter.SetupGet(a => a.Project)
+                .Returns(dteProject.Object);
+            projectAdapter.SetupGet(a => a.FullProjectPath)
+                .Returns(@"c:\test\project.csproj");
+            projectAdapter.SetupGet(a => a.ProjectName)
+                .Returns("TestProject");
+            projectAdapter.SetupGet(a => a.CustomUniqueName)
+                .Returns("TestProject");
+            projectAdapter.SetupGet(a => a.ProjectId)
+                .Returns(Guid.NewGuid().ToString());
+            projectAdapter.Setup(a => a.IsCapabilityMatch(NuGet.VisualStudio.IDE.ProjectCapabilities.Cps))
+                .Returns(true);
+            projectAdapter.Setup(a => a.IsCapabilityMatch(NuGet.VisualStudio.IDE.ProjectCapabilities.PackageReferences))
+                .Returns(true);
+
+            var nugetProjectContext = new Mock<INuGetProjectContext>();
+
+            var ppc = new ProjectProviderContext(nugetProjectContext.Object, packagesPathFactory: () => throw new NotImplementedException());
+
+            var projectSystemCache = new Mock<IProjectSystemCache>();
+            var scriptExecutor = new Mock<Lazy<IScriptExecutor>>();
+            var target = new CpsPackageReferenceProjectProvider(projectSystemCache.Object, scriptExecutor.Object);
+
+            // Act
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            NuGetProject actual = target.TryCreateNuGetProject(projectAdapter.Object, ppc, forceProjectType: false);
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.IsType<CpsPackageReferenceProject>(actual);
+            projectAdapter.VerifyGet(a => a.Project, Times.Once);
+        }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexTestContext.cs
@@ -51,7 +51,10 @@ namespace NuGet.Tests.Apex
 
             Project = CommonUtility.CreateAndInitProject(projectTemplate, _pathContext, SolutionService, logger);
 
-            NuGetApexTestService.WaitForAutoRestore();
+            if (!noAutoRestore)
+            {
+                NuGetApexTestService.WaitForAutoRestore();
+            }
         }
 
         public void Dispose()

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
@@ -48,7 +48,7 @@ namespace NuGet.Tests.Apex
             VisualStudio.Stop();
         }
 
-        protected NuGetConsoleTestExtension GetConsole(ProjectTestExtension project)
+        protected NuGetConsoleTestExtension GetConsole(ProjectTestExtension project, bool waitForAutoRestore = true)
         {
             Logger.WriteMessage("GetConsole");
             VisualStudio.ClearWindows();
@@ -65,7 +65,10 @@ namespace NuGet.Tests.Apex
             // but not so large as to create memory problems.
             _console.SetConsoleWidth(consoleWidth: 1024);
 
-            nugetTestService.WaitForAutoRestore();
+            if (waitForAutoRestore)
+            {
+                nugetTestService.WaitForAutoRestore();
+            }
 
             Logger.WriteMessage("GetConsole complete");
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -865,6 +865,22 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, testContext.Project, packageName, Logger);
         }
 
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        public void GetProjectFromPMCAccessingProjectNameForPackageReferenceProject_DoesNotThrow()
+        {
+            using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger, noAutoRestore: true);
+
+            var nugetConsole = GetConsole(testContext.Project, waitForAutoRestore: false);
+            nugetConsole.Clear();
+
+            nugetConsole.Execute("$proj = Get-Project; $proj.Name");
+
+            string pmcText = nugetConsole.GetText();
+            pmcText.Should().Contain(testContext.Project.Name, because: pmcText);
+            pmcText.Should().NotContain("FullyQualifiedErrorId", because: pmcText);
+        }
+
         public static IEnumerable<object[]> GetNetCoreTemplates()
         {
             yield return new object[] { ProjectTemplate.NetCoreConsoleApp };


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
