### PR TITLE
Force initialize EnvDTE.Project because EnvDTE.Project initialization does not specify its thread affinity (#7292)

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/CpsPackageReferenceProjectProvider.cs
@@ -84,6 +84,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var projectServices = new CpsProjectSystemServices(vsProject, _scriptExecutor);
 
+            // Ensure the EnvDTE.Project is initialized.
+            // Under the hood VSProjectAdapter actually has a Lazy<EnvDte.project>, which needs the UI thread to satisfy the cast.
+            // If PMC is actually the first one that wants the EnvDTE.Project, it would fail because it's being called from the pipeline thread.
+            // This is a workaround to make sure the EnvDTE.Project is initialized before any PMC code tries to use it.
+            _ = vsProject.Project;
             var lazyUnconfiguredProject = new AsyncLazy<UnconfiguredProject>(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -865,6 +865,22 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageNotInPackagesConfig(VisualStudio, testContext.Project, packageName, Logger);
         }
 
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        public void GetProject_CanAccessProjectName()
+        {
+            using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger);
+
+            var nugetConsole = GetConsole(testContext.Project);
+            nugetConsole.Clear();
+
+            nugetConsole.Execute("$proj = Get-Project; $proj.Name");
+
+            string pmcText = nugetConsole.GetText();
+            pmcText.Should().Contain(testContext.Project.Name, because: pmcText);
+            pmcText.Should().NotContain("FullyQualifiedErrorId", because: pmcText);
+        }
+
         public static IEnumerable<object[]> GetNetCoreTemplates()
         {
             yield return new object[] { ProjectTemplate.NetCoreConsoleApp };


### PR DESCRIPTION

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14862

## Description

Cherry picking https://github.com/NuGet/NuGet.Client/pull/7292.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
