### PR TITLE
Fix flakey MockServer test

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -342,7 +342,15 @@ namespace NuGet.CommandLine.Test
                 new Action<HttpListenerResponse>(response =>
                 {
                     response.ContentType = "application/atom+xml;type=feed;charset=utf-8";
-                    string feed = server.ToODataFeed(packages, "FindPackagesById");
+                    var requestedId = r.QueryString["id"]?.Trim('\'');
+                    var filteredPackages = string.IsNullOrEmpty(requestedId)
+                        ? packages
+                        : packages.Where(p =>
+                        {
+                            using var reader = new PackageArchiveReader(p.OpenRead());
+                            return string.Equals(reader.NuspecReader.GetId(), requestedId, StringComparison.OrdinalIgnoreCase);
+                        }).ToList();
+                    string feed = server.ToODataFeed(filteredPackages, "FindPackagesById");
                     MockServer.SetResponseContent(response, feed);
                 }));
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: flakey test

## Description

The MockServer used by the test `NuGetMockServerTests.MockServer_VerifySessionId` sets up the MockServer with two packages, but the MockServer would not filter V2 OData results based on the incoming request and would therefore return info about both packages when asked for just one.

Copilot says the flakiness is related to the cache in FindPackagesByIdNupkgDownloader. Since the two packages are downloaded in parllel, it just depends on thread timing which one gets added to the cache first, and that determines if the test will pass or fail. The failure was caused by the mock server returning the wrong nupkg to restore, and the recently added package id validation on download is failing the test which previously did not fail. 

Running the test 10 times locally it previously failed 5 times and now passes all 10 times.


## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
