### PR TITLE
[NSJ -> STJ]Migrate AutoComplete

### DIFF
--- a/build/Shared/AotCompatibilityAttributes.cs
+++ b/build/Shared/AotCompatibilityAttributes.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if !NET9_0_OR_GREATER
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Property, Inherited = false)]
+    internal sealed class FeatureSwitchDefinitionAttribute : Attribute
+    {
+        public FeatureSwitchDefinitionAttribute(string switchName) => SwitchName = switchName;
+        public string SwitchName { get; }
+    }
+}
+#endif

--- a/build/Shared/NuGetFeatureFlags.cs
+++ b/build/Shared/NuGetFeatureFlags.cs
@@ -9,26 +9,31 @@ namespace NuGet.Shared
 {
     internal static class NuGetFeatureFlags
     {
-        internal const string UseNSJDeserializationSwitchName = "NuGet.UseNSJDeserialization";
-        internal const string UseNSJDeserializationEnvVar = "NUGET_USE_NSJ_DESERIALIZATION";
+        internal const string UseLegacyJsonDeserializationSwitchName = "NuGet.UseLegacyJsonDeserialization";
+        internal const string UseLegacyJsonDeserializationEnvVar = "NUGET_USE_LEGACY_JSON_DESERIALIZATION";
 
-        private static readonly Lazy<bool> _isNSJDeserializationEnabledByEnvironment =
-            new Lazy<bool>(() => IsNSJDeserializationEnabledByEnvironment(EnvironmentVariableWrapper.Instance));
+        private static readonly Lazy<bool> _isLegacyJsonDeserializationEnabledByEnvironment =
+            new Lazy<bool>(() => IsLegacyJsonDeserializationEnabledByEnvironment(EnvironmentVariableWrapper.Instance));
 
-        /// <summary>Feature switch for NSJ deserialization. Defaults to <see langword="false"/> (STJ is the default).</summary>
-        [FeatureSwitchDefinition(UseNSJDeserializationSwitchName)]
-        internal static bool UseNSJDeserializationFeatureSwitch { get; } =
-            AppContext.TryGetSwitch(UseNSJDeserializationSwitchName, out bool value) && value;
+        /// <summary>Feature switch for legacy (Newtonsoft) JSON deserialization. Defaults to <see langword="false"/> (STJ is the default).</summary>
+        [FeatureSwitchDefinition(UseLegacyJsonDeserializationSwitchName)]
+        internal static bool UseLegacyJsonDeserializationFeatureSwitch { get; } =
+            AppContext.TryGetSwitch(UseLegacyJsonDeserializationSwitchName, out bool value) && value;
 
-        /// <summary>Returns <see langword="true"/> when env var <c>NUGET_USE_NSJ_DESERIALIZATION</c> is <c>true</c>.</summary>
-        internal static bool IsNSJDeserializationEnabledByEnvironment(IEnvironmentVariableReader? env = null)
+        /// <summary>Returns <see langword="true"/> when env var <c>NUGET_USE_LEGACY_JSON_DESERIALIZATION</c> is <c>true</c>.</summary>
+        /// <param name="env">
+        /// Pass <see langword="null"/> (or omit) in production code to use the cached <see cref="Lazy{T}"/> value,
+        /// avoiding repeated allocations on .NET Framework. Pass an explicit <see cref="IEnvironmentVariableReader"/>
+        /// only in tests to override the value.
+        /// </param>
+        internal static bool IsLegacyJsonDeserializationEnabledByEnvironment(IEnvironmentVariableReader? env = null)
         {
             if (env is null)
             {
-                return _isNSJDeserializationEnabledByEnvironment.Value;
+                return _isLegacyJsonDeserializationEnabledByEnvironment.Value;
             }
 
-            string? envValue = env.GetEnvironmentVariable(UseNSJDeserializationEnvVar);
+            string? envValue = env.GetEnvironmentVariable(UseLegacyJsonDeserializationEnvVar);
             return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
         }
     }

--- a/build/Shared/NuGetFeatureFlags.cs
+++ b/build/Shared/NuGetFeatureFlags.cs
@@ -9,31 +9,31 @@ namespace NuGet.Shared
 {
     internal static class NuGetFeatureFlags
     {
-        internal const string UseLegacyJsonDeserializationSwitchName = "NuGet.UseLegacyJsonDeserialization";
-        internal const string UseLegacyJsonDeserializationEnvVar = "NUGET_USE_LEGACY_JSON_DESERIALIZATION";
+        internal const string UseSystemTextJsonDeserializationSwitchName = "NuGet.UseSystemTextJsonDeserialization";
+        internal const string UseSystemTextJsonDeserializationEnvVar = "NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION";
 
-        private static readonly Lazy<bool> _isLegacyJsonDeserializationEnabledByEnvironment =
-            new Lazy<bool>(() => IsLegacyJsonDeserializationEnabledByEnvironment(EnvironmentVariableWrapper.Instance));
+        private static readonly Lazy<bool> _isSystemTextJsonDeserializationEnabledByEnvironment =
+            new Lazy<bool>(() => IsSystemTextJsonDeserializationEnabledByEnvironment(EnvironmentVariableWrapper.Instance));
 
-        /// <summary>Feature switch for legacy (Newtonsoft) JSON deserialization. Defaults to <see langword="false"/> (STJ is the default).</summary>
-        [FeatureSwitchDefinition(UseLegacyJsonDeserializationSwitchName)]
-        internal static bool UseLegacyJsonDeserializationFeatureSwitch { get; } =
-            AppContext.TryGetSwitch(UseLegacyJsonDeserializationSwitchName, out bool value) && value;
+        /// <summary>Feature switch for System.Text.Json deserialization. Defaults to <see langword="false"/> (Newtonsoft is the default).</summary>
+        [FeatureSwitchDefinition(UseSystemTextJsonDeserializationSwitchName)]
+        internal static bool UseSystemTextJsonDeserializationFeatureSwitch { get; } =
+            AppContext.TryGetSwitch(UseSystemTextJsonDeserializationSwitchName, out bool value) && value;
 
-        /// <summary>Returns <see langword="true"/> when env var <c>NUGET_USE_LEGACY_JSON_DESERIALIZATION</c> is <c>true</c>.</summary>
+        /// <summary>Returns <see langword="true"/> when env var <c>NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION</c> is <c>true</c>.</summary>
         /// <param name="env">
         /// Pass <see langword="null"/> (or omit) in production code to use the cached <see cref="Lazy{T}"/> value,
         /// avoiding repeated allocations on .NET Framework. Pass an explicit <see cref="IEnvironmentVariableReader"/>
         /// only in tests to override the value.
         /// </param>
-        internal static bool IsLegacyJsonDeserializationEnabledByEnvironment(IEnvironmentVariableReader? env = null)
+        internal static bool IsSystemTextJsonDeserializationEnabledByEnvironment(IEnvironmentVariableReader? env = null)
         {
             if (env is null)
             {
-                return _isLegacyJsonDeserializationEnabledByEnvironment.Value;
+                return _isSystemTextJsonDeserializationEnabledByEnvironment.Value;
             }
 
-            string? envValue = env.GetEnvironmentVariable(UseLegacyJsonDeserializationEnvVar);
+            string? envValue = env.GetEnvironmentVariable(UseSystemTextJsonDeserializationEnvVar);
             return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
         }
     }

--- a/build/Shared/NuGetFeatureFlags.cs
+++ b/build/Shared/NuGetFeatureFlags.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using NuGet.Common;
+
+namespace NuGet.Shared
+{
+    internal static class NuGetFeatureFlags
+    {
+        internal const string UsesNSJDeserializationSwitchName = "NuGet.UsesNSJDeserialization";
+        internal const string UsesNSJDeserializationEnvVar = "NUGET_USES_NSJ_DESERIALIZATION";
+
+        private static readonly Lazy<bool> _isNSJDeserializationEnabledByEnvironment =
+            new Lazy<bool>(() => IsNSJDeserializationEnabledByEnvironment(EnvironmentVariableWrapper.Instance));
+
+        /// <summary>Feature switch for NSJ deserialization. Defaults to <see langword="true"/>.</summary>
+        [FeatureSwitchDefinition(UsesNSJDeserializationSwitchName)]
+        internal static bool NSJDeserializationFeatureSwitch { get; } =
+            !AppContext.TryGetSwitch(UsesNSJDeserializationSwitchName, out bool value) || value;
+
+        /// <summary>Returns <see langword="false"/> when env var <c>NUGET_USES_NSJ_DESERIALIZATION</c> is <c>false</c>.</summary>
+        internal static bool IsNSJDeserializationEnabledByEnvironment(IEnvironmentVariableReader? env = null)
+        {
+            if (env is null)
+            {
+                return _isNSJDeserializationEnabledByEnvironment.Value;
+            }
+
+            string? envValue = env.GetEnvironmentVariable(UsesNSJDeserializationEnvVar);
+            return !string.Equals(envValue, "false", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/build/Shared/NuGetFeatureFlags.cs
+++ b/build/Shared/NuGetFeatureFlags.cs
@@ -9,18 +9,18 @@ namespace NuGet.Shared
 {
     internal static class NuGetFeatureFlags
     {
-        internal const string UsesNSJDeserializationSwitchName = "NuGet.UsesNSJDeserialization";
-        internal const string UsesNSJDeserializationEnvVar = "NUGET_USES_NSJ_DESERIALIZATION";
+        internal const string UseNSJDeserializationSwitchName = "NuGet.UseNSJDeserialization";
+        internal const string UseNSJDeserializationEnvVar = "NUGET_USE_NSJ_DESERIALIZATION";
 
         private static readonly Lazy<bool> _isNSJDeserializationEnabledByEnvironment =
             new Lazy<bool>(() => IsNSJDeserializationEnabledByEnvironment(EnvironmentVariableWrapper.Instance));
 
-        /// <summary>Feature switch for NSJ deserialization. Defaults to <see langword="true"/>.</summary>
-        [FeatureSwitchDefinition(UsesNSJDeserializationSwitchName)]
-        internal static bool NSJDeserializationFeatureSwitch { get; } =
-            !AppContext.TryGetSwitch(UsesNSJDeserializationSwitchName, out bool value) || value;
+        /// <summary>Feature switch for NSJ deserialization. Defaults to <see langword="false"/> (STJ is the default).</summary>
+        [FeatureSwitchDefinition(UseNSJDeserializationSwitchName)]
+        internal static bool UseNSJDeserializationFeatureSwitch { get; } =
+            AppContext.TryGetSwitch(UseNSJDeserializationSwitchName, out bool value) && value;
 
-        /// <summary>Returns <see langword="false"/> when env var <c>NUGET_USES_NSJ_DESERIALIZATION</c> is <c>false</c>.</summary>
+        /// <summary>Returns <see langword="true"/> when env var <c>NUGET_USE_NSJ_DESERIALIZATION</c> is <c>true</c>.</summary>
         internal static bool IsNSJDeserializationEnabledByEnvironment(IEnvironmentVariableReader? env = null)
         {
             if (env is null)
@@ -28,8 +28,8 @@ namespace NuGet.Shared
                 return _isNSJDeserializationEnabledByEnvironment.Value;
             }
 
-            string? envValue = env.GetEnvironmentVariable(UsesNSJDeserializationEnvVar);
-            return !string.Equals(envValue, "false", StringComparison.OrdinalIgnoreCase);
+            string? envValue = env.GetEnvironmentVariable(UseNSJDeserializationEnvVar);
+            return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/AutoCompleteModel.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/AutoCompleteModel.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace NuGet.Protocol.Model
+{
+    internal sealed class AutoCompleteModel
+    {
+        [JsonPropertyName("data")]
+        public string[]? Data { get; set; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -39,6 +39,8 @@
     <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs" />
     <Compile Include="$(SharedDirectory)\NoAllocEnumerateExtensions.cs" />
     <Compile Include="$(SharedDirectory)\NullableAttributes.cs" />
+    <Compile Include="$(SharedDirectory)\NuGetFeatureFlags.cs" />
+    <Compile Include="$(SharedDirectory)\AotCompatibilityAttributes.cs" />
     <Compile Include="$(SharedDirectory)\SimplePool.cs" />
     <Compile Include="$(SharedDirectory)\StringBuilderPool.cs" />
     <Compile Include="$(SharedDirectory)\TaskResult.cs" />

--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
@@ -8,10 +8,12 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
+using NuGet.Protocol.Utility;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol
@@ -55,32 +57,29 @@ namespace NuGet.Protocol
             Common.ILogger logger = log ?? Common.NullLogger.Instance;
 
             var queryUri = queryUrl.Uri;
-            var results = await _client.GetJObjectAsync(
+            AutoCompleteModel results = await _client.ProcessStreamAsync(
                 new HttpSourceRequest(queryUri, logger),
+                async stream =>
+                {
+                    if (stream == null)
+                    {
+                        return null;
+                    }
+
+                    return await JsonSerializer.DeserializeAsync(stream, JsonContext.Default.AutoCompleteModel, token);
+                },
                 logger,
                 token);
+
             token.ThrowIfCancellationRequested();
-            if (results == null)
-            {
-                return Enumerable.Empty<string>();
-            }
-            var data = results.Value<JArray>("data");
-            if (data == null)
+
+            if (results?.Data == null)
             {
                 return Enumerable.Empty<string>();
             }
 
-            // Resolve all the objects
-            var outputs = new List<string>();
-            foreach (var result in data)
-            {
-                if (result != null)
-                {
-                    outputs.Add(result.ToString());
-                }
-            }
-
-            return outputs.Where(item => item.StartsWith(packageIdPrefix, StringComparison.OrdinalIgnoreCase));
+            return results.Data
+                .Where(item => item != null && item.StartsWith(packageIdPrefix, StringComparison.OrdinalIgnoreCase));
         }
 
         public override async Task<IEnumerable<NuGetVersion>> VersionStartsWith(

--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
@@ -29,11 +29,8 @@ namespace NuGet.Protocol
         private readonly IEnvironmentVariableReader _environmentVariableReader;
 
         public AutoCompleteResourceV3(HttpSource client, ServiceIndexResourceV3 serviceIndex, RegistrationResourceV3 regResource)
-            : base()
+            : this(client, serviceIndex, regResource, null)
         {
-            _regResource = regResource;
-            _serviceIndex = serviceIndex;
-            _client = client;
         }
 
         internal AutoCompleteResourceV3(HttpSource client, ServiceIndexResourceV3 serviceIndex, RegistrationResourceV3 regResource, IEnvironmentVariableReader environmentVariableReader)
@@ -51,13 +48,13 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            if (NuGetFeatureFlags.UseLegacyJsonDeserializationFeatureSwitch || NuGetFeatureFlags.IsLegacyJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
             {
-                return await IdStartsWithNsjAsync(packageIdPrefix, includePrerelease, log, token);
+                return await IdStartsWithStjAsync(packageIdPrefix, includePrerelease, log, token);
             }
             else
             {
-                return await IdStartsWithStjAsync(packageIdPrefix, includePrerelease, log, token);
+                return await IdStartsWithNsjAsync(packageIdPrefix, includePrerelease, log, token);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
@@ -11,18 +11,22 @@ using System.Net;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
 using NuGet.Protocol.Utility;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol
 {
     public class AutoCompleteResourceV3 : AutoCompleteResource
     {
-        private readonly RegistrationResourceV3 _regResource;
-        private readonly ServiceIndexResourceV3 _serviceIndex;
-        private readonly HttpSource _client;
+        internal readonly RegistrationResourceV3 _regResource;
+        internal readonly ServiceIndexResourceV3 _serviceIndex;
+        internal readonly HttpSource _client;
+        private readonly IEnvironmentVariableReader _environmentVariableReader;
 
         public AutoCompleteResourceV3(HttpSource client, ServiceIndexResourceV3 serviceIndex, RegistrationResourceV3 regResource)
             : base()
@@ -30,6 +34,16 @@ namespace NuGet.Protocol
             _regResource = regResource;
             _serviceIndex = serviceIndex;
             _client = client;
+            _environmentVariableReader = EnvironmentVariableWrapper.Instance;
+        }
+
+        internal AutoCompleteResourceV3(HttpSource client, ServiceIndexResourceV3 serviceIndex, RegistrationResourceV3 regResource, IEnvironmentVariableReader environmentVariableReader)
+            : base()
+        {
+            _regResource = regResource;
+            _serviceIndex = serviceIndex;
+            _client = client;
+            _environmentVariableReader = environmentVariableReader;
         }
 
         public override async Task<IEnumerable<string>> IdStartsWith(
@@ -55,8 +69,13 @@ namespace NuGet.Protocol
             queryUrl.Query = queryString;
 
             Common.ILogger logger = log ?? Common.NullLogger.Instance;
-
             var queryUri = queryUrl.Uri;
+
+            if (NuGetFeatureFlags.UseNSJDeserializationFeatureSwitch || NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(_environmentVariableReader))
+            {
+                return await IdStartsWithNsjAsync(packageIdPrefix, logger, queryUri, token);
+            }
+
             AutoCompleteModel results = await _client.ProcessStreamAsync(
                 new HttpSourceRequest(queryUri, logger),
                 async stream =>
@@ -73,13 +92,45 @@ namespace NuGet.Protocol
 
             token.ThrowIfCancellationRequested();
 
-            if (results?.Data == null)
+            return results?.Data?.Where(item => item != null && item.StartsWith(packageIdPrefix, StringComparison.OrdinalIgnoreCase))
+                ?? [];
+        }
+
+        private async Task<IEnumerable<string>> IdStartsWithNsjAsync(
+            string packageIdPrefix,
+            Common.ILogger logger,
+            Uri queryUri,
+            CancellationToken token)
+        {
+            var results = await _client.GetJObjectAsync(
+                new HttpSourceRequest(queryUri, logger),
+                logger,
+                token);
+
+            token.ThrowIfCancellationRequested();
+
+            if (results == null)
             {
                 return Enumerable.Empty<string>();
             }
 
-            return results.Data
-                .Where(item => item != null && item.StartsWith(packageIdPrefix, StringComparison.OrdinalIgnoreCase));
+            var data = results.Value<JArray>("data");
+            if (data == null)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            // Resolve all the objects
+            var outputs = new List<string>();
+            foreach (var result in data)
+            {
+                if (result != null)
+                {
+                    outputs.Add(result.ToString());
+                }
+            }
+
+            return outputs.Where(item => item.StartsWith(packageIdPrefix, StringComparison.OrdinalIgnoreCase));
         }
 
         public override async Task<IEnumerable<NuGetVersion>> VersionStartsWith(

--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
@@ -34,7 +34,6 @@ namespace NuGet.Protocol
             _regResource = regResource;
             _serviceIndex = serviceIndex;
             _client = client;
-            _environmentVariableReader = EnvironmentVariableWrapper.Instance;
         }
 
         internal AutoCompleteResourceV3(HttpSource client, ServiceIndexResourceV3 serviceIndex, RegistrationResourceV3 regResource, IEnvironmentVariableReader environmentVariableReader)
@@ -52,29 +51,24 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            var searchUrl = _serviceIndex.GetServiceEntryUri(ServiceTypes.SearchAutocompleteService);
-
-            if (searchUrl == null)
+            if (NuGetFeatureFlags.UseLegacyJsonDeserializationFeatureSwitch || NuGetFeatureFlags.IsLegacyJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
             {
-                throw new FatalProtocolException(Strings.Protocol_MissingSearchService);
+                return await IdStartsWithNsjAsync(packageIdPrefix, includePrerelease, log, token);
             }
+            else
+            {
+                return await IdStartsWithStjAsync(packageIdPrefix, includePrerelease, log, token);
+            }
+        }
 
-            // Construct the query
-            var queryUrl = new UriBuilder(searchUrl.AbsoluteUri);
-            var queryString =
-                "q=" + WebUtility.UrlEncode(packageIdPrefix) +
-                "&prerelease=" + includePrerelease.ToString(CultureInfo.CurrentCulture).ToLowerInvariant() +
-                "&semVerLevel=2.0.0";
-
-            queryUrl.Query = queryString;
-
+        private async Task<IEnumerable<string>> IdStartsWithStjAsync(
+            string packageIdPrefix,
+            bool includePrerelease,
+            Common.ILogger log,
+            CancellationToken token)
+        {
+            var queryUri = BuildQueryUri(packageIdPrefix, includePrerelease);
             Common.ILogger logger = log ?? Common.NullLogger.Instance;
-            var queryUri = queryUrl.Uri;
-
-            if (NuGetFeatureFlags.UseNSJDeserializationFeatureSwitch || NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(_environmentVariableReader))
-            {
-                return await IdStartsWithNsjAsync(packageIdPrefix, logger, queryUri, token);
-            }
 
             AutoCompleteModel results = await _client.ProcessStreamAsync(
                 new HttpSourceRequest(queryUri, logger),
@@ -98,22 +92,22 @@ namespace NuGet.Protocol
 
         private async Task<IEnumerable<string>> IdStartsWithNsjAsync(
             string packageIdPrefix,
-            Common.ILogger logger,
-            Uri queryUri,
+            bool includePrerelease,
+            Common.ILogger log,
             CancellationToken token)
         {
+            var queryUri = BuildQueryUri(packageIdPrefix, includePrerelease);
+            Common.ILogger logger = log ?? Common.NullLogger.Instance;
+
             var results = await _client.GetJObjectAsync(
                 new HttpSourceRequest(queryUri, logger),
                 logger,
                 token);
-
             token.ThrowIfCancellationRequested();
-
             if (results == null)
             {
                 return Enumerable.Empty<string>();
             }
-
             var data = results.Value<JArray>("data");
             if (data == null)
             {
@@ -131,6 +125,25 @@ namespace NuGet.Protocol
             }
 
             return outputs.Where(item => item.StartsWith(packageIdPrefix, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private Uri BuildQueryUri(string packageIdPrefix, bool includePrerelease)
+        {
+            var searchUrl = _serviceIndex.GetServiceEntryUri(ServiceTypes.SearchAutocompleteService);
+
+            if (searchUrl == null)
+            {
+                throw new FatalProtocolException(Strings.Protocol_MissingSearchService);
+            }
+
+            // Construct the query
+            var queryUrl = new UriBuilder(searchUrl.AbsoluteUri);
+            queryUrl.Query =
+                "q=" + WebUtility.UrlEncode(packageIdPrefix) +
+                "&prerelease=" + includePrerelease.ToString(CultureInfo.CurrentCulture).ToLowerInvariant() +
+                "&semVerLevel=2.0.0";
+
+            return queryUrl.Uri;
         }
 
         public override async Task<IEnumerable<NuGetVersion>> VersionStartsWith(

--- a/src/NuGet.Core/NuGet.Protocol/Utility/JsonContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/JsonContext.cs
@@ -17,6 +17,11 @@ namespace NuGet.Protocol.Utility
     [JsonSerializable(typeof(HttpFileSystemBasedFindPackageByIdResource.FlatContainerVersionList))]
     [JsonSerializable(typeof(IReadOnlyList<V3VulnerabilityIndexEntry>), TypeInfoPropertyName = "VulnerabilityIndex")]
     [JsonSerializable(typeof(CaseInsensitiveDictionary<IReadOnlyList<PackageVulnerabilityInfo>>), TypeInfoPropertyName = "VulnerabilityPage")]
+<<<<<<< Updated upstream
+=======
+    [JsonSerializable(typeof(AutoCompleteModel))]
+    [JsonSerializable(typeof(ServiceIndexModel))]
+>>>>>>> Stashed changes
     internal partial class JsonContext : JsonSerializerContext
     {
     }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/JsonContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/JsonContext.cs
@@ -17,11 +17,7 @@ namespace NuGet.Protocol.Utility
     [JsonSerializable(typeof(HttpFileSystemBasedFindPackageByIdResource.FlatContainerVersionList))]
     [JsonSerializable(typeof(IReadOnlyList<V3VulnerabilityIndexEntry>), TypeInfoPropertyName = "VulnerabilityIndex")]
     [JsonSerializable(typeof(CaseInsensitiveDictionary<IReadOnlyList<PackageVulnerabilityInfo>>), TypeInfoPropertyName = "VulnerabilityPage")]
-<<<<<<< Updated upstream
-=======
     [JsonSerializable(typeof(AutoCompleteModel))]
-    [JsonSerializable(typeof(ServiceIndexModel))]
->>>>>>> Stashed changes
     internal partial class JsonContext : JsonSerializerContext
     {
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
@@ -22,21 +22,24 @@ namespace NuGet.Protocol.Tests
         [InlineData("false")] // STJ path
         public async Task IdStartsWith_BothPaths_ReturnsResultsAsync(string useNsj)
         {
+            // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
+            responses.Add("http://testsource.test/v3/index.json", JsonData.IndexWithoutFlatContainer);
             responses.Add("https://api-v3search-0.nuget.org/autocomplete?q=newt&prerelease=true&semVerLevel=2.0.0",
                 JsonData.AutoCompleteEndpointNewtResult);
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+            var repo = StaticHttpHandler.CreateSource("http://testsource.test/v3/index.json", Repository.Provider.GetCoreV3(), responses);
             var resource = (AutoCompleteResourceV3)await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
 
             var envReader = new Mock<IEnvironmentVariableReader>();
-            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseNSJDeserializationEnvVar)).Returns(useNsj);
+            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseLegacyJsonDeserializationEnvVar)).Returns(useNsj);
             var testResource = new AutoCompleteResourceV3(resource._client, resource._serviceIndex, resource._regResource, envReader.Object);
-
             var logger = new TestLogger();
+
+            // Act
             var result = await testResource.IdStartsWith("newt", true, logger, CancellationToken.None);
 
+            // Assert
             Assert.Equal(10, result.Count());
             Assert.NotEmpty(logger.Messages);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
@@ -18,9 +18,9 @@ namespace NuGet.Protocol.Tests
     public class AutoCompleteResourceV3Tests
     {
         [Theory]
-        [InlineData("true")]  // NSJ path
-        [InlineData("false")] // STJ path
-        public async Task IdStartsWith_BothPaths_ReturnsResultsAsync(string useNsj)
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task IdStartsWith_BothPaths_ReturnsResultsAsync(string useStj)
         {
             // Arrange
             var responses = new Dictionary<string, string>();
@@ -32,7 +32,7 @@ namespace NuGet.Protocol.Tests
             var resource = (AutoCompleteResourceV3)await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
 
             var envReader = new Mock<IEnvironmentVariableReader>();
-            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseLegacyJsonDeserializationEnvVar)).Returns(useNsj);
+            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar)).Returns(useStj);
             var testResource = new AutoCompleteResourceV3(resource._client, resource._serviceIndex, resource._regResource, envReader.Object);
             var logger = new TestLogger();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
@@ -5,7 +5,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
+using NuGet.Common;
 using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
 using NuGet.Test.Utility;
 using Test.Utility;
 using Xunit;
@@ -14,25 +17,26 @@ namespace NuGet.Protocol.Tests
 {
     public class AutoCompleteResourceV3Tests
     {
-        [Fact]
-        public async Task AutoCompleteResourceV3_IdStartsWithAsync()
+        [Theory]
+        [InlineData("true")]  // NSJ path
+        [InlineData("false")] // STJ path
+        public async Task IdStartsWith_BothPaths_ReturnsResultsAsync(string useNsj)
         {
-            // Arrange
             var responses = new Dictionary<string, string>();
-            const string sourceName = "http://testsource.com/v3/index.json";
-            responses.Add(sourceName, JsonData.IndexWithoutFlatContainer);
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
             responses.Add("https://api-v3search-0.nuget.org/autocomplete?q=newt&prerelease=true&semVerLevel=2.0.0",
                 JsonData.AutoCompleteEndpointNewtResult);
 
-            var repo = StaticHttpHandler.CreateSource(sourceName, Repository.Provider.GetCoreV3(), responses);
-            var resource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
+            var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+            var resource = (AutoCompleteResourceV3)await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
+
+            var envReader = new Mock<IEnvironmentVariableReader>();
+            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseNSJDeserializationEnvVar)).Returns(useNsj);
+            var testResource = new AutoCompleteResourceV3(resource._client, resource._serviceIndex, resource._regResource, envReader.Object);
 
             var logger = new TestLogger();
+            var result = await testResource.IdStartsWith("newt", true, logger, CancellationToken.None);
 
-            // Act
-            var result = await resource.IdStartsWith("newt", true, logger, CancellationToken.None);
-
-            // Assert
             Assert.Equal(10, result.Count());
             Assert.NotEmpty(logger.Messages);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetFeatureFlagsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetFeatureFlagsTests.cs
@@ -11,27 +11,27 @@ namespace NuGet.Protocol.Tests
     public class NuGetFeatureFlagsTests
     {
         [Fact]
-        public void UseLegacyJsonDeserializationFeatureSwitch_Default_ReturnsFalse()
+        public void UseSystemTextJsonDeserializationFeatureSwitch_Default_ReturnsFalse()
         {
-            Assert.False(NuGetFeatureFlags.UseLegacyJsonDeserializationFeatureSwitch);
+            Assert.False(NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch);
         }
 
         [Fact]
-        public void IsLegacyJsonDeserializationEnabledByEnvironment_WhenEnvVarNotSet_ReturnsFalse()
+        public void IsSystemTextJsonDeserializationEnabledByEnvironment_WhenEnvVarNotSet_ReturnsFalse()
         {
-            Assert.False(NuGetFeatureFlags.IsLegacyJsonDeserializationEnabledByEnvironment(TestEnvironmentVariableReader.EmptyInstance));
+            Assert.False(NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(TestEnvironmentVariableReader.EmptyInstance));
         }
 
         [Theory]
         [InlineData("true")]
         [InlineData("True")]
         [InlineData("TRUE")]
-        public void IsLegacyJsonDeserializationEnabledByEnvironment_WhenEnvVarSetToTrue_ReturnsTrue(string value)
+        public void IsSystemTextJsonDeserializationEnabledByEnvironment_WhenEnvVarSetToTrue_ReturnsTrue(string value)
         {
             var env = new TestEnvironmentVariableReader(
-                new Dictionary<string, string> { [NuGetFeatureFlags.UseLegacyJsonDeserializationEnvVar] = value });
+                new Dictionary<string, string> { [NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar] = value });
 
-            Assert.True(NuGetFeatureFlags.IsLegacyJsonDeserializationEnabledByEnvironment(env));
+            Assert.True(NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(env));
         }
 
         [Theory]
@@ -39,12 +39,12 @@ namespace NuGet.Protocol.Tests
         [InlineData("0")]
         [InlineData("1")]
         [InlineData("anything")]
-        public void IsLegacyJsonDeserializationEnabledByEnvironment_WhenEnvVarSetToFalseOrUnrecognized_ReturnsFalse(string value)
+        public void IsSystemTextJsonDeserializationEnabledByEnvironment_WhenEnvVarSetToFalseOrUnrecognized_ReturnsFalse(string value)
         {
             var env = new TestEnvironmentVariableReader(
-                new Dictionary<string, string> { [NuGetFeatureFlags.UseLegacyJsonDeserializationEnvVar] = value });
+                new Dictionary<string, string> { [NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar] = value });
 
-            Assert.False(NuGetFeatureFlags.IsLegacyJsonDeserializationEnabledByEnvironment(env));
+            Assert.False(NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(env));
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetFeatureFlagsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetFeatureFlagsTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Shared;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class NuGetFeatureFlagsTests
+    {
+        [Fact]
+        public void NSJDeserializationFeatureSwitch_Default_ReturnsTrue()
+        {
+            Assert.True(NuGetFeatureFlags.NSJDeserializationFeatureSwitch);
+        }
+
+        [Fact]
+        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarNotSet_ReturnsTrue()
+        {
+            Assert.True(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(TestEnvironmentVariableReader.EmptyInstance));
+        }
+
+        [Theory]
+        [InlineData("false")]
+        [InlineData("False")]
+        [InlineData("FALSE")]
+        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarSetToFalse_ReturnsFalse(string value)
+        {
+            var env = new TestEnvironmentVariableReader(
+                new Dictionary<string, string> { [NuGetFeatureFlags.UsesNSJDeserializationEnvVar] = value });
+
+            Assert.False(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(env));
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("True")]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("anything")]
+        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarSetToTrueOrUnrecognized_ReturnsTrue(string value)
+        {
+            var env = new TestEnvironmentVariableReader(
+                new Dictionary<string, string> { [NuGetFeatureFlags.UsesNSJDeserializationEnvVar] = value });
+
+            Assert.True(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(env));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetFeatureFlagsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetFeatureFlagsTests.cs
@@ -11,41 +11,40 @@ namespace NuGet.Protocol.Tests
     public class NuGetFeatureFlagsTests
     {
         [Fact]
-        public void NSJDeserializationFeatureSwitch_Default_ReturnsTrue()
+        public void UseNSJDeserializationFeatureSwitch_Default_ReturnsFalse()
         {
-            Assert.True(NuGetFeatureFlags.NSJDeserializationFeatureSwitch);
+            Assert.False(NuGetFeatureFlags.UseNSJDeserializationFeatureSwitch);
         }
 
         [Fact]
-        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarNotSet_ReturnsTrue()
+        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarNotSet_ReturnsFalse()
         {
-            Assert.True(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(TestEnvironmentVariableReader.EmptyInstance));
-        }
-
-        [Theory]
-        [InlineData("false")]
-        [InlineData("False")]
-        [InlineData("FALSE")]
-        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarSetToFalse_ReturnsFalse(string value)
-        {
-            var env = new TestEnvironmentVariableReader(
-                new Dictionary<string, string> { [NuGetFeatureFlags.UsesNSJDeserializationEnvVar] = value });
-
-            Assert.False(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(env));
+            Assert.False(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(TestEnvironmentVariableReader.EmptyInstance));
         }
 
         [Theory]
         [InlineData("true")]
         [InlineData("True")]
+        [InlineData("TRUE")]
+        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarSetToTrue_ReturnsTrue(string value)
+        {
+            var env = new TestEnvironmentVariableReader(
+                new Dictionary<string, string> { [NuGetFeatureFlags.UseNSJDeserializationEnvVar] = value });
+
+            Assert.True(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(env));
+        }
+
+        [Theory]
+        [InlineData("false")]
         [InlineData("0")]
         [InlineData("1")]
         [InlineData("anything")]
-        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarSetToTrueOrUnrecognized_ReturnsTrue(string value)
+        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarSetToFalseOrUnrecognized_ReturnsFalse(string value)
         {
             var env = new TestEnvironmentVariableReader(
-                new Dictionary<string, string> { [NuGetFeatureFlags.UsesNSJDeserializationEnvVar] = value });
+                new Dictionary<string, string> { [NuGetFeatureFlags.UseNSJDeserializationEnvVar] = value });
 
-            Assert.True(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(env));
+            Assert.False(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(env));
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetFeatureFlagsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetFeatureFlagsTests.cs
@@ -11,27 +11,27 @@ namespace NuGet.Protocol.Tests
     public class NuGetFeatureFlagsTests
     {
         [Fact]
-        public void UseNSJDeserializationFeatureSwitch_Default_ReturnsFalse()
+        public void UseLegacyJsonDeserializationFeatureSwitch_Default_ReturnsFalse()
         {
-            Assert.False(NuGetFeatureFlags.UseNSJDeserializationFeatureSwitch);
+            Assert.False(NuGetFeatureFlags.UseLegacyJsonDeserializationFeatureSwitch);
         }
 
         [Fact]
-        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarNotSet_ReturnsFalse()
+        public void IsLegacyJsonDeserializationEnabledByEnvironment_WhenEnvVarNotSet_ReturnsFalse()
         {
-            Assert.False(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(TestEnvironmentVariableReader.EmptyInstance));
+            Assert.False(NuGetFeatureFlags.IsLegacyJsonDeserializationEnabledByEnvironment(TestEnvironmentVariableReader.EmptyInstance));
         }
 
         [Theory]
         [InlineData("true")]
         [InlineData("True")]
         [InlineData("TRUE")]
-        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarSetToTrue_ReturnsTrue(string value)
+        public void IsLegacyJsonDeserializationEnabledByEnvironment_WhenEnvVarSetToTrue_ReturnsTrue(string value)
         {
             var env = new TestEnvironmentVariableReader(
-                new Dictionary<string, string> { [NuGetFeatureFlags.UseNSJDeserializationEnvVar] = value });
+                new Dictionary<string, string> { [NuGetFeatureFlags.UseLegacyJsonDeserializationEnvVar] = value });
 
-            Assert.True(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(env));
+            Assert.True(NuGetFeatureFlags.IsLegacyJsonDeserializationEnabledByEnvironment(env));
         }
 
         [Theory]
@@ -39,12 +39,12 @@ namespace NuGet.Protocol.Tests
         [InlineData("0")]
         [InlineData("1")]
         [InlineData("anything")]
-        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarSetToFalseOrUnrecognized_ReturnsFalse(string value)
+        public void IsLegacyJsonDeserializationEnabledByEnvironment_WhenEnvVarSetToFalseOrUnrecognized_ReturnsFalse(string value)
         {
             var env = new TestEnvironmentVariableReader(
-                new Dictionary<string, string> { [NuGetFeatureFlags.UseNSJDeserializationEnvVar] = value });
+                new Dictionary<string, string> { [NuGetFeatureFlags.UseLegacyJsonDeserializationEnvVar] = value });
 
-            Assert.False(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(env));
+            Assert.False(NuGetFeatureFlags.IsLegacyJsonDeserializationEnabledByEnvironment(env));
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Shared.Tests/NuGet.Shared.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Shared.Tests/NuGet.Shared.Tests.csproj
@@ -9,6 +9,8 @@
     <Compile Include="$(SharedDirectory)\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <Compile Remove="$(SharedDirectory)\IsExternalInit.cs" />
     <Compile Remove="$(SharedDirectory)\RequiredModifierAttributes.cs" />
+    <Compile Remove="$(SharedDirectory)\AotCompatibilityAttributes.cs" />
+    <Compile Remove="$(SharedDirectory)\NuGetFeatureFlags.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14889
Related: https://github.com/NuGet/Home/issues/14846

## Description

Makes use of features introduced in https://github.com/NuGet/NuGet.Client/pull/7313.

 Replaces NSJ deserialization with (stj)JsonSerializer.DeserializeAsync into a new AutoCompleteModel POCO. STJ is now the default path. Users can opt back into NSJ by setting NUGET_USE_NSJ_DESERIALIZATION=true or via the NuGet.UseNSJDeserialization AppContext switch.

   - AutoCompleteModel - new internal POCO for STJ deserialization
   - NuGetFeatureFlags - new shared class with AppContext switch + env var opt-in for NSJ
   - AutoCompleteResourceV3 - dispatches to NSJ or STJ based on the flag; NSJ fallback is identical to the previous implementation
   - Tests cover both paths via a [Theory]

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
