### PR TITLE
[NSJ -> STJ]Migrate RepositorySignature

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/FingerprintsStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/FingerprintsStjConverter.cs
@@ -21,9 +21,10 @@ namespace NuGet.Protocol.Converters
             var dict = new Dictionary<string, string>();
             while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
             {
-                // Non-null: GetString() returns null only for JsonTokenType.Null.
+                // Key token: the loop condition guarantees JsonTokenType.PropertyName, so GetString() is never null.
                 string key = reader.GetString()!;
                 reader.Read();
+                // Value token: may be null (e.g. "key": null), default to empty string.
                 dict[key] = reader.GetString() ?? string.Empty;
             }
 

--- a/src/NuGet.Core/NuGet.Protocol/Converters/FingerprintsStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/FingerprintsStjConverter.cs
@@ -21,6 +21,7 @@ namespace NuGet.Protocol.Converters
             var dict = new Dictionary<string, string>();
             while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
             {
+                // Non-null: GetString() returns null only for JsonTokenType.Null.
                 string key = reader.GetString()!;
                 reader.Read();
                 dict[key] = reader.GetString() ?? string.Empty;

--- a/src/NuGet.Core/NuGet.Protocol/Converters/FingerprintsStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/FingerprintsStjConverter.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NuGet.Packaging.Core;
+
+namespace NuGet.Protocol.Converters
+{
+    internal sealed class FingerprintsStjConverter : JsonConverter<Fingerprints>
+    {
+        public override Fingerprints Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException();
+            }
+
+            var dict = new Dictionary<string, string>();
+            while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+            {
+                string key = reader.GetString()!;
+                reader.Read();
+                dict[key] = reader.GetString() ?? string.Empty;
+            }
+
+            return new Fingerprints(dict);
+        }
+
+        public override void Write(Utf8JsonWriter writer, Fingerprints value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            foreach (KeyValuePair<string, string> kvp in value)
+            {
+                writer.WriteString(kvp.Key, kvp.Value);
+            }
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Model/RepositoryCertificateInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/RepositoryCertificateInfo.cs
@@ -12,26 +12,45 @@ namespace NuGet.Protocol
     {
         [JsonProperty(PropertyName = JsonProperties.Fingerprints, Required = Required.Always)]
         [JsonPropertyName(JsonProperties.Fingerprints)]
-        public Fingerprints Fingerprints { get; internal init; } = null!;
+        public Fingerprints Fingerprints { get; private set; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.Subject, Required = Required.Always)]
         [JsonPropertyName(JsonProperties.Subject)]
-        public string Subject { get; internal init; } = null!;
+        public string Subject { get; private set; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.Issuer, Required = Required.Always)]
         [JsonPropertyName(JsonProperties.Issuer)]
-        public string Issuer { get; internal init; } = null!;
+        public string Issuer { get; private set; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.NotBefore, Required = Required.Always)]
         [JsonPropertyName(JsonProperties.NotBefore)]
-        public DateTimeOffset NotBefore { get; internal init; }
+        public DateTimeOffset NotBefore { get; private set; }
 
         [JsonProperty(PropertyName = JsonProperties.NotAfter, Required = Required.Always)]
         [JsonPropertyName(JsonProperties.NotAfter)]
-        public DateTimeOffset NotAfter { get; internal init; }
+        public DateTimeOffset NotAfter { get; private set; }
 
         [JsonProperty(PropertyName = JsonProperties.ContentUrl, Required = Required.Always)]
         [JsonPropertyName(JsonProperties.ContentUrl)]
-        public string ContentUrl { get; internal init; } = null!;
+        public string ContentUrl { get; private set; } = null!;
+
+        public RepositoryCertificateInfo() { }
+
+        [System.Text.Json.Serialization.JsonConstructor]
+        internal RepositoryCertificateInfo(
+            Fingerprints fingerprints,
+            string subject,
+            string issuer,
+            DateTimeOffset notBefore,
+            DateTimeOffset notAfter,
+            string contentUrl)
+        {
+            Fingerprints = fingerprints;
+            Subject = subject;
+            Issuer = issuer;
+            NotBefore = notBefore;
+            NotAfter = notAfter;
+            ContentUrl = contentUrl;
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/RepositoryCertificateInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/RepositoryCertificateInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using Newtonsoft.Json;
 using NuGet.Packaging.Core;
 using System.Text.Json.Serialization;
@@ -24,11 +25,13 @@ namespace NuGet.Protocol
 
         [JsonProperty(PropertyName = JsonProperties.NotBefore, Required = Required.Always)]
         [JsonPropertyName(JsonProperties.NotBefore)]
-        public DateTimeOffset NotBefore { get; private set; }
+        [System.Text.Json.Serialization.JsonRequired]
+        public DateTimeOffset NotBefore { get; init; }
 
         [JsonProperty(PropertyName = JsonProperties.NotAfter, Required = Required.Always)]
         [JsonPropertyName(JsonProperties.NotAfter)]
-        public DateTimeOffset NotAfter { get; private set; }
+        [System.Text.Json.Serialization.JsonRequired]
+        public DateTimeOffset NotAfter { get; init; }
 
         [JsonProperty(PropertyName = JsonProperties.ContentUrl, Required = Required.Always)]
         [JsonPropertyName(JsonProperties.ContentUrl)]
@@ -45,12 +48,12 @@ namespace NuGet.Protocol
             DateTimeOffset notAfter,
             string contentUrl)
         {
-            Fingerprints = fingerprints;
-            Subject = subject;
-            Issuer = issuer;
+            Fingerprints = fingerprints ?? throw new System.Text.Json.JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_RequiredJsonPropertyMissing, JsonProperties.Fingerprints));
+            Subject = subject ?? throw new System.Text.Json.JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_RequiredJsonPropertyMissing, JsonProperties.Subject));
+            Issuer = issuer ?? throw new System.Text.Json.JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_RequiredJsonPropertyMissing, JsonProperties.Issuer));
             NotBefore = notBefore;
             NotAfter = notAfter;
-            ContentUrl = contentUrl;
+            ContentUrl = contentUrl ?? throw new System.Text.Json.JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_RequiredJsonPropertyMissing, JsonProperties.ContentUrl));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/RepositoryCertificateInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/RepositoryCertificateInfo.cs
@@ -4,27 +4,34 @@
 using System;
 using Newtonsoft.Json;
 using NuGet.Packaging.Core;
+using System.Text.Json.Serialization;
 
 namespace NuGet.Protocol
 {
     public class RepositoryCertificateInfo : IRepositoryCertificateInfo
     {
         [JsonProperty(PropertyName = JsonProperties.Fingerprints, Required = Required.Always)]
-        public Fingerprints Fingerprints { get; private set; } = null!;
+        [JsonPropertyName(JsonProperties.Fingerprints)]
+        public Fingerprints Fingerprints { get; internal init; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.Subject, Required = Required.Always)]
-        public string Subject { get; private set; } = null!;
+        [JsonPropertyName(JsonProperties.Subject)]
+        public string Subject { get; internal init; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.Issuer, Required = Required.Always)]
-        public string Issuer { get; private set; } = null!;
+        [JsonPropertyName(JsonProperties.Issuer)]
+        public string Issuer { get; internal init; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.NotBefore, Required = Required.Always)]
-        public DateTimeOffset NotBefore { get; private set; }
+        [JsonPropertyName(JsonProperties.NotBefore)]
+        public DateTimeOffset NotBefore { get; internal init; }
 
         [JsonProperty(PropertyName = JsonProperties.NotAfter, Required = Required.Always)]
-        public DateTimeOffset NotAfter { get; private set; }
+        [JsonPropertyName(JsonProperties.NotAfter)]
+        public DateTimeOffset NotAfter { get; internal init; }
 
         [JsonProperty(PropertyName = JsonProperties.ContentUrl, Required = Required.Always)]
-        public string ContentUrl { get; private set; } = null!;
+        [JsonPropertyName(JsonProperties.ContentUrl)]
+        public string ContentUrl { get; internal init; } = null!;
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/RepositorySignatureModel.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/RepositorySignatureModel.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace NuGet.Protocol.Model
+{
+    internal sealed class RepositorySignatureModel
+    {
+        [JsonPropertyName(JsonProperties.AllRepositorySigned)]
+        public bool? AllRepositorySigned { get; set; }
+
+        [JsonPropertyName(JsonProperties.SigningCertificates)]
+        public RepositoryCertificateInfo[]? SigningCertificates { get; set; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Label="NuGet Shared">
+    <Compile Include="$(SharedDirectory)\IsExternalInit.cs" />
     <Compile Include="$(SharedDirectory)\EncodingUtility.cs" />
     <Compile Include="$(SharedDirectory)\EqualityUtility.cs" />
     <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs" />

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -37,6 +37,7 @@
     <Compile Include="$(SharedDirectory)\EncodingUtility.cs" />
     <Compile Include="$(SharedDirectory)\EqualityUtility.cs" />
     <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs" />
+    <Compile Include="$(SharedDirectory)\IsExternalInit.cs" />
     <Compile Include="$(SharedDirectory)\NoAllocEnumerateExtensions.cs" />
     <Compile Include="$(SharedDirectory)\NullableAttributes.cs" />
     <Compile Include="$(SharedDirectory)\NuGetFeatureFlags.cs" />

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -37,7 +37,6 @@
     <Compile Include="$(SharedDirectory)\EncodingUtility.cs" />
     <Compile Include="$(SharedDirectory)\EqualityUtility.cs" />
     <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs" />
-    <Compile Include="$(SharedDirectory)\IsExternalInit.cs" />
     <Compile Include="$(SharedDirectory)\NoAllocEnumerateExtensions.cs" />
     <Compile Include="$(SharedDirectory)\NullableAttributes.cs" />
     <Compile Include="$(SharedDirectory)\NuGetFeatureFlags.cs" />

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
@@ -6,10 +6,13 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
+using NuGet.Protocol.Utility;
 
 namespace NuGet.Protocol
 {
@@ -80,9 +83,12 @@ namespace NuGet.Protocol
                             },
                             async httpSourceResult =>
                             {
-                                var json = await httpSourceResult.Stream.AsJObjectAsync(token);
+                                RepositorySignatureModel model = await JsonSerializer.DeserializeAsync(
+                                    httpSourceResult.Stream,
+                                    JsonContext.Default.RepositorySignatureModel,
+                                    token);
 
-                                return new RepositorySignatureResource(json, source);
+                                return new RepositorySignatureResource(model, source);
                             },
                             log,
                             token);

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
@@ -93,7 +93,7 @@ namespace NuGet.Protocol
                                 {
                                     var model = await JsonSerializer.DeserializeAsync(
                                         httpSourceResult.Stream,
-                                        JsonContext.Default.RepositorySignatureModel,
+                                        RepositorySignatureJsonContext.Default.RepositorySignatureModel,
                                         token);
                                     return new RepositorySignatureResource(model, source);
                                 }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
-using NuGet.Protocol.Model;
 using NuGet.Protocol.Utility;
 using NuGet.Shared;
 
@@ -48,21 +47,7 @@ namespace NuGet.Protocol
             return new Tuple<bool, INuGetResource>(resource != null, resource);
         }
 
-        private Task<RepositorySignatureResource> GetRepositorySignatureResourceAsync(
-            SourceRepository source,
-            ServiceIndexEntry serviceEntry,
-            ILogger log,
-            CancellationToken token)
-        {
-            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
-            {
-                return GetRepositorySignatureResourceStjAsync(source, serviceEntry, log, token);
-            }
-            return GetRepositorySignatureResourceNsjAsync(source, serviceEntry, log, token);
-        }
-
-        private static async Task<RepositorySignatureResource> GetRepositorySignatureResourceStjAsync(
+        private async Task<RepositorySignatureResource> GetRepositorySignatureResourceAsync(
             SourceRepository source,
             ServiceIndexEntry serviceEntry,
             ILogger log,
@@ -103,78 +88,20 @@ namespace NuGet.Protocol
                             },
                             async httpSourceResult =>
                             {
-                                RepositorySignatureModel model = await JsonSerializer.DeserializeAsync(
-                                    httpSourceResult.Stream,
-                                    JsonContext.Default.RepositorySignatureModel,
-                                    token);
-
-                                return new RepositorySignatureResource(model, source);
-                            },
-                            log,
-                            token);
-                    }
-                    catch (Exception ex) when (retry < maxRetries)
-                    {
-                        var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_RetryingRepositorySignature, repositorySignaturesResourceUri.AbsoluteUri)
-                            + Environment.NewLine
-                            + ExceptionUtilities.DisplayMessage(ex);
-                        log.LogMinimal(message);
-                    }
-                    catch (Exception ex) when (retry == maxRetries)
-                    {
-                        var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToReadRepositorySignature, repositorySignaturesResourceUri.AbsoluteUri);
-
-                        throw new FatalProtocolException(message, ex);
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        private static async Task<RepositorySignatureResource> GetRepositorySignatureResourceNsjAsync(
-            SourceRepository source,
-            ServiceIndexEntry serviceEntry,
-            ILogger log,
-            CancellationToken token)
-        {
-            var repositorySignaturesResourceUri = serviceEntry.Uri;
-
-            if (repositorySignaturesResourceUri == null
-                || !string.Equals(repositorySignaturesResourceUri.Scheme, "https", StringComparison.OrdinalIgnoreCase)
-                && !string.Equals(repositorySignaturesResourceUri.Scheme, "http", StringComparison.OrdinalIgnoreCase))
-            {
-                throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.RepositorySignaturesResourceMustBeHttps, source.PackageSource.Source));
-            }
-
-            var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
-            var client = httpSourceResource.HttpSource;
-            var cacheKey = GenerateCacheKey(serviceEntry);
-
-            const int maxRetries = 3;
-            for (var retry = 1; retry <= maxRetries; retry++)
-            {
-                using (var sourceCacheContext = new SourceCacheContext())
-                {
-                    var cacheContext = HttpSourceCacheContext.Create(sourceCacheContext, isFirstAttempt: retry == 1);
-
-                    try
-                    {
-                        return await client.GetAsync(
-                            new HttpSourceCachedRequest(
-                                serviceEntry.Uri.AbsoluteUri,
-                                cacheKey,
-                                cacheContext)
-                            {
-                                EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(repositorySignaturesResourceUri.AbsoluteUri, stream),
-                                MaxTries = 1,
-                                IsRetry = retry > 1,
-                                IsLastAttempt = retry == maxRetries
-                            },
-                            async httpSourceResult =>
-                            {
-                                var json = await httpSourceResult.Stream.AsJObjectAsync(token);
-                                return new RepositorySignatureResource(json, source);
+                                if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
+                                    || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+                                {
+                                    var model = await JsonSerializer.DeserializeAsync(
+                                        httpSourceResult.Stream,
+                                        JsonContext.Default.RepositorySignatureModel,
+                                        token);
+                                    return new RepositorySignatureResource(model, source);
+                                }
+                                else
+                                {
+                                    var json = await httpSourceResult.Stream.AsJObjectAsync(token);
+                                    return new RepositorySignatureResource(json, source);
+                                }
                             },
                             log,
                             token);

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
@@ -13,16 +13,22 @@ using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
 using NuGet.Protocol.Utility;
+using NuGet.Shared;
 
 namespace NuGet.Protocol
 {
     public class RepositorySignatureResourceProvider : ResourceProvider
     {
-        public RepositorySignatureResourceProvider()
+        private readonly IEnvironmentVariableReader _environmentVariableReader;
+
+        public RepositorySignatureResourceProvider() : this(null) { }
+
+        internal RepositorySignatureResourceProvider(IEnvironmentVariableReader environmentVariableReader)
            : base(typeof(RepositorySignatureResource),
                  nameof(RepositorySignatureResource),
                  NuGetResourceProviderPositions.Last)
         {
+            _environmentVariableReader = environmentVariableReader;
         }
 
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
@@ -42,7 +48,21 @@ namespace NuGet.Protocol
             return new Tuple<bool, INuGetResource>(resource != null, resource);
         }
 
-        private async Task<RepositorySignatureResource> GetRepositorySignatureResourceAsync(
+        private Task<RepositorySignatureResource> GetRepositorySignatureResourceAsync(
+            SourceRepository source,
+            ServiceIndexEntry serviceEntry,
+            ILogger log,
+            CancellationToken token)
+        {
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
+                || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+            {
+                return GetRepositorySignatureResourceStjAsync(source, serviceEntry, log, token);
+            }
+            return GetRepositorySignatureResourceNsjAsync(source, serviceEntry, log, token);
+        }
+
+        private static async Task<RepositorySignatureResource> GetRepositorySignatureResourceStjAsync(
             SourceRepository source,
             ServiceIndexEntry serviceEntry,
             ILogger log,
@@ -89,6 +109,72 @@ namespace NuGet.Protocol
                                     token);
 
                                 return new RepositorySignatureResource(model, source);
+                            },
+                            log,
+                            token);
+                    }
+                    catch (Exception ex) when (retry < maxRetries)
+                    {
+                        var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_RetryingRepositorySignature, repositorySignaturesResourceUri.AbsoluteUri)
+                            + Environment.NewLine
+                            + ExceptionUtilities.DisplayMessage(ex);
+                        log.LogMinimal(message);
+                    }
+                    catch (Exception ex) when (retry == maxRetries)
+                    {
+                        var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToReadRepositorySignature, repositorySignaturesResourceUri.AbsoluteUri);
+
+                        throw new FatalProtocolException(message, ex);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static async Task<RepositorySignatureResource> GetRepositorySignatureResourceNsjAsync(
+            SourceRepository source,
+            ServiceIndexEntry serviceEntry,
+            ILogger log,
+            CancellationToken token)
+        {
+            var repositorySignaturesResourceUri = serviceEntry.Uri;
+
+            if (repositorySignaturesResourceUri == null
+                || !string.Equals(repositorySignaturesResourceUri.Scheme, "https", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(repositorySignaturesResourceUri.Scheme, "http", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.RepositorySignaturesResourceMustBeHttps, source.PackageSource.Source));
+            }
+
+            var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
+            var client = httpSourceResource.HttpSource;
+            var cacheKey = GenerateCacheKey(serviceEntry);
+
+            const int maxRetries = 3;
+            for (var retry = 1; retry <= maxRetries; retry++)
+            {
+                using (var sourceCacheContext = new SourceCacheContext())
+                {
+                    var cacheContext = HttpSourceCacheContext.Create(sourceCacheContext, isFirstAttempt: retry == 1);
+
+                    try
+                    {
+                        return await client.GetAsync(
+                            new HttpSourceCachedRequest(
+                                serviceEntry.Uri.AbsoluteUri,
+                                cacheKey,
+                                cacheContext)
+                            {
+                                EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(repositorySignaturesResourceUri.AbsoluteUri, stream),
+                                MaxTries = 1,
+                                IsRetry = retry > 1,
+                                IsLastAttempt = retry == maxRetries
+                            },
+                            async httpSourceResult =>
+                            {
+                                var json = await httpSourceResult.Stream.AsJObjectAsync(token);
+                                return new RepositorySignatureResource(json, source);
                             },
                             log,
                             token);

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.PackageId.get -> string!
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.ProtocolDiagnosticNupkgCopiedEvent(string! source, long fileSize, string! packageId) -> void
+NuGet.Protocol.RepositoryCertificateInfo.NotAfter.init -> void
+NuGet.Protocol.RepositoryCertificateInfo.NotBefore.init -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.PackageId.get -> string!
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.ProtocolDiagnosticNupkgCopiedEvent(string! source, long fileSize, string! packageId) -> void
+NuGet.Protocol.RepositoryCertificateInfo.NotAfter.init -> void
+NuGet.Protocol.RepositoryCertificateInfo.NotBefore.init -> void

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
 
 namespace NuGet.Protocol
 {
@@ -41,6 +42,27 @@ namespace NuGet.Protocol
                 }
             }
 
+            Source = source.PackageSource.Source;
+        }
+
+        internal RepositorySignatureResource(RepositorySignatureModel model, SourceRepository source)
+        {
+            AllRepositorySigned = model.AllRepositorySigned ??
+                throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToParseRepoSignInfor, JsonProperties.AllRepositorySigned, source.PackageSource.Source));
+
+            RepositoryCertificateInfo[] certs = model.SigningCertificates ??
+                throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToParseRepoSignInfor, JsonProperties.SigningCertificates, source.PackageSource.Source));
+
+            foreach (RepositoryCertificateInfo cert in certs)
+            {
+                if (!Uri.TryCreate(cert.ContentUrl, UriKind.Absolute, out Uri contentUrl)
+                    || !string.Equals(contentUrl.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new FatalProtocolException(Strings.RepositoryContentUrlMustBeHttps);
+                }
+            }
+
+            RepositoryCertificateInfos = certs;
             Source = source.PackageSource.Source;
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -205,6 +205,15 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Required property &apos;{0}&apos; not found in JSON..
+        /// </summary>
+        internal static string Error_RequiredJsonPropertyMissing {
+            get {
+                return ResourceManager.GetString("Error_RequiredJsonPropertyMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The server responded with HTTP &apos;403 Forbidden&apos; when accessing the source &apos;{0}&apos;. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource..
         /// </summary>
         internal static string Http_CredentialsForForbidden {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -543,4 +543,7 @@ The "s" should be localized to the abbreviation for seconds.</comment>
     <value>Expected package {0} {1}, but got package {2} {3}</value>
     <comment>0 and 2 are package names, and 1 and 3 are version numbers</comment>
   </data>
+  <data name="Error_RequiredJsonPropertyMissing" xml:space="preserve">
+    <value>Required property '{0}' not found in JSON.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Utility/JsonContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/JsonContext.cs
@@ -12,12 +12,13 @@ namespace NuGet.Protocol.Utility
     [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true,
         PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
         GenerationMode = JsonSourceGenerationMode.Metadata,
-        Converters = [typeof(VersionRangeStjConverter)])]
+        Converters = [typeof(VersionRangeStjConverter), typeof(FingerprintsStjConverter)])]
 #pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
     [JsonSerializable(typeof(HttpFileSystemBasedFindPackageByIdResource.FlatContainerVersionList))]
     [JsonSerializable(typeof(IReadOnlyList<V3VulnerabilityIndexEntry>), TypeInfoPropertyName = "VulnerabilityIndex")]
     [JsonSerializable(typeof(CaseInsensitiveDictionary<IReadOnlyList<PackageVulnerabilityInfo>>), TypeInfoPropertyName = "VulnerabilityPage")]
     [JsonSerializable(typeof(AutoCompleteModel))]
+    [JsonSerializable(typeof(RepositorySignatureModel))]
     internal partial class JsonContext : JsonSerializerContext
     {
     }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/RepositorySignatureJsonContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/RepositorySignatureJsonContext.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using NuGet.Protocol.Converters;
 using NuGet.Protocol.Model;
@@ -12,13 +11,10 @@ namespace NuGet.Protocol.Utility
     [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true,
         PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
         GenerationMode = JsonSourceGenerationMode.Metadata,
-        Converters = [typeof(VersionRangeStjConverter)])]
+        Converters = [typeof(FingerprintsStjConverter)])]
 #pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
-    [JsonSerializable(typeof(HttpFileSystemBasedFindPackageByIdResource.FlatContainerVersionList))]
-    [JsonSerializable(typeof(IReadOnlyList<V3VulnerabilityIndexEntry>), TypeInfoPropertyName = "VulnerabilityIndex")]
-    [JsonSerializable(typeof(CaseInsensitiveDictionary<IReadOnlyList<PackageVulnerabilityInfo>>), TypeInfoPropertyName = "VulnerabilityPage")]
-    [JsonSerializable(typeof(AutoCompleteModel))]
-    internal partial class JsonContext : JsonSerializerContext
+    [JsonSerializable(typeof(RepositorySignatureModel))]
+    internal partial class RepositorySignatureJsonContext : JsonSerializerContext
     {
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.cs.xlf
@@ -84,6 +84,11 @@
         <target state="translated">Očekával se balíček {0} {1}, ale byl získán balíček {2} {3}</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">Při přístupu ke zdroji {0} server odpověděl zprávou HTTP 403 Zakázáno. To naznačuje, že server ověřil vaši identitu, ale nepovolil vám přístup k požadovanému prostředku. Poskytněte přihlašovací údaje, které mají oprávnění zobrazit tento prostředek.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.de.xlf
@@ -84,6 +84,11 @@
         <target state="translated">Paket {0} {1} erwartet, aber Paket {2} {3} erhalten</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">Der Server hat beim Zugriff auf die Quelle "{0}" mit dem HTTP-Fehler "403 – Verboten" geantwortet. Dies weist darauf hin, dass der Server Ihre Identität authentifiziert hat, Ihnen aber keinen Zugriff auf die angeforderte Ressource gewährt. Geben Sie Anmeldeinformationen mit Berechtigungen zum Anzeigen dieser Ressource an.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.es.xlf
@@ -84,6 +84,11 @@
         <target state="translated">Se esperaba el paquete {0}{1}, pero se obtuvo el paquete {2}{3}</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">El servidor respondió con HTTP "403 Prohibido" al acceder al origen "{0}". Este hecho hace pensar que el servidor ha autenticado la identidad pero no le ha permitido acceder al recurso solicitado. Proporcione credenciales que tengan permiso para ver este recurso.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.fr.xlf
@@ -84,6 +84,11 @@
         <target state="translated">Paquet attendu {0} {1}, mais paquet reçu {2} {3}</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">Le serveur a répondu avec HTTP '403 Interdit' lors de l'accès à la source '{0}'. Le serveur vous a identifié, mais ne vous a pas autorisé à accéder à la ressource demandée. Fournissez des informations d'identification autorisées à afficher cette ressource.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.it.xlf
@@ -84,6 +84,11 @@
         <target state="translated">Era previsto il pacchetto {0} {1}, ma è stato ricevuto il pacchetto {2} {3}</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">Il server ha restituito un errore HTTP '403: accesso non consentito' durante l'accesso all'origine '{0}'. Questo suggerisce che il server ha autenticato l'identità dell'utente ma non ha consentito l'accesso alla risorsa richiesta. Specificare credenziali autorizzate a visualizzare questa risorsa.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ja.xlf
@@ -84,6 +84,11 @@
         <target state="translated">パッケージ {0} {1} が必要でしたが、パッケージ {2} {3} が見つかりました</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">ソース '{0}' にアクセスするときに、サーバーが HTTP「403 アクセス不可」で応答しました。サーバーが身元を認証したものの、要求されたリソースにアクセスするためのアクセス許可がないことを示します。このリソースを表示するためのアクセス許可を持つ資格情報を提供してください。</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ko.xlf
@@ -84,6 +84,11 @@
         <target state="translated">패키지 이름은  {0} {1}이어야 하는데, {2} {3} 버전의 패키지가 왔습니다.</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">'{0}' 원본에 액세스할 때 서버에서 HTTP '403 사용 권한 없음'으로 응답했습니다. 서버에서 ID를 인증했지만 요청된 리소스에 대한 액세스를 허용하지 않았습니다. 이 리소스를 볼 수 있는 권한이 있는 자격 증명을 제공하세요.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pl.xlf
@@ -84,6 +84,11 @@
         <target state="translated">Oczekiwano pakietu {0} {1}, ale uzyskano pakiet {2} {3}</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">Serwer wysłał odpowiedź HTTP 403 „Zabronione” podczas uzyskiwania dostępu do źródła „{0}”. Może to oznaczać, że serwer uwierzytelnił Twoją tożsamość, ale nie zezwolił Ci na dostęp do żądanego źródła. Podaj poświadczenia z uprawnieniami do wyświetlania tego zasobu.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pt-BR.xlf
@@ -84,6 +84,11 @@
         <target state="translated">Pacote esperado {0} {1}, mas o pacote recebido foi {2} {3}</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">O servidor respondeu com HTTP '403 Proibido' ao acessar a origem '{0}'. Isso sugere que o servidor autenticou sua identidade, mas não permitiu que você acessasse o recurso solicitado. Forneça credenciais que tenham permissões para exibir esse recurso.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ru.xlf
@@ -84,6 +84,11 @@
         <target state="translated">Ожидался пакет {0} {1}, но получен пакет {2} {3}</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">При попытке обратиться к источнику "{0}" сервер вернул сообщение "HTTP 403 — запрещено". Это значит, что сервер проверил подлинность вашего удостоверения, но запретил доступ к запрошенному ресурсу. Укажите учетные данные, которым разрешено просматривать этот ресурс.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.tr.xlf
@@ -84,6 +84,11 @@
         <target state="translated">Paket {0} {1} bekleniyordu, ancak paket {2} {3} alındı</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">'{0}' kaynağına erişilirken sunucu HTTP '403 Yasak' yanıtı döndürdü. Bu, sunucunun kimliğinizi doğruladığı, ancak size istenen kaynağa erişim izni vermediği anlamına gelir. Bu kaynağı görüntüleme iznine sahip kimlik bilgilerini sağlayın.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hans.xlf
@@ -84,6 +84,11 @@
         <target state="translated">预期获得包 {0} {1}，但实际获得包 {2} {3}</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">访问源“{0}”时，服务器响应为 HTTP“403 禁止访问”。这表明服务器已验证你的身份，但不允许访问你请求的资源。请提供有权查看此资源的凭据。</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hant.xlf
@@ -84,6 +84,11 @@
         <target state="translated">預期套件 {0} {1} 版本，但收到套件 {2} {3}</target>
         <note>0 and 2 are package names, and 1 and 3 are version numbers</note>
       </trans-unit>
+      <trans-unit id="Error_RequiredJsonPropertyMissing">
+        <source>Required property '{0}' not found in JSON.</source>
+        <target state="new">Required property '{0}' not found in JSON.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">存取來源 '{0}' 時，伺服器回應了 HTTP '403 禁止'。這表示伺服器已驗證您的身分識別，但未允許您存取要求的資源。請提供有權檢視此資源的認證。</target>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/RepositorySignatureResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/RepositorySignatureResourceProviderTests.cs
@@ -9,11 +9,14 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Moq;
 using Newtonsoft.Json.Linq;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Tests;
 using NuGet.Protocol.Tests.Providers;
+using NuGet.Shared;
 using Test.Utility;
 using Xunit;
 
@@ -34,36 +37,53 @@ namespace NuGet.Protocol.Providers.Tests
         private static readonly SemanticVersion DefaultVersion = new SemanticVersion(0, 0, 0);
 
         private readonly PackageSource _packageSource;
-        private readonly RepositorySignatureResourceProvider _repositorySignatureResourceProvider;
 
         public RepositorySignatureResourceProviderTests()
         {
             _packageSource = new PackageSource("https://unit.test");
-            _repositorySignatureResourceProvider = new RepositorySignatureResourceProvider();
         }
 
-        [Fact]
-        public async Task TryCreate_WhenResourceDoesNotExist_ReturnsNoResource()
+        private static IEnvironmentVariableReader CreateStjEnabledEnvReader()
         {
+            var mockEnvReader = new Mock<IEnvironmentVariableReader>();
+            mockEnvReader.Setup(r => r.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar))
+                .Returns("true");
+            return mockEnvReader.Object;
+        }
+
+        private RepositorySignatureResourceProvider CreateProvider(bool useStj)
+            => useStj
+                ? new RepositorySignatureResourceProvider(CreateStjEnabledEnvReader())
+                : new RepositorySignatureResourceProvider();
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TryCreate_WhenResourceDoesNotExist_ReturnsNoResource(bool useStj)
+        {
+            var provider = CreateProvider(useStj);
             var resourceProviders = new ResourceProvider[]
             {
                 MockServiceIndexResourceV3Provider.Create(),
-                _repositorySignatureResourceProvider
+                provider
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
 
-            var result = await _repositorySignatureResourceProvider.TryCreate(sourceRepository, CancellationToken.None);
+            var result = await provider.TryCreate(sourceRepository, CancellationToken.None);
 
             Assert.False(result.Item1);
             Assert.Null(result.Item2);
         }
 
-        [Fact]
-        public async Task TryCreate_WhenUrlIsHttp_Throws()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TryCreate_WhenUrlIsHttp_Throws(bool useStj)
         {
             string resourceUrl = "http://unit.test/4.9.0";
             string resourceType = ResourceType490;
             var serviceEntry = new ServiceIndexEntry(new Uri(resourceUrl), resourceType, DefaultVersion);
+            var provider = CreateProvider(useStj);
             var resourceProviders = new ResourceProvider[]
             {
                 MockServiceIndexResourceV3Provider.Create(serviceEntry),
@@ -72,22 +92,25 @@ namespace NuGet.Protocol.Providers.Tests
                     {
                         { serviceEntry.Uri.AbsoluteUri, GetRepositorySignaturesResourceJson(resourceUrl) }
                     }),
-                _repositorySignatureResourceProvider
+                provider
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
 
             var exception = await Assert.ThrowsAsync<FatalProtocolException>(
-                () => _repositorySignatureResourceProvider.TryCreate(sourceRepository, CancellationToken.None));
+                () => provider.TryCreate(sourceRepository, CancellationToken.None));
 
             exception.InnerException.Message.Should().Contain(string.Format(NuGet.Protocol.Strings.Error_Insecure_HTTP, _packageSource.SourceUri, resourceUrl));
         }
 
-        [Fact]
-        public async Task TryCreate_WhenUrlIsInvalid_Throws()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TryCreate_WhenUrlIsInvalid_Throws(bool useStj)
         {
             string resourceUrl = @"\\localhost\unit\test\4.9.0";
             string resourceType = ResourceType490;
             var serviceEntry = new ServiceIndexEntry(new Uri(resourceUrl), resourceType, DefaultVersion);
+            var provider = CreateProvider(useStj);
             var resourceProviders = new ResourceProvider[]
             {
                 MockServiceIndexResourceV3Provider.Create(serviceEntry),
@@ -96,23 +119,27 @@ namespace NuGet.Protocol.Providers.Tests
                     {
                         { serviceEntry.Uri.AbsoluteUri, GetRepositorySignaturesResourceJson(resourceUrl) }
                     }),
-                _repositorySignatureResourceProvider
+                provider
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
 
             var exception = await Assert.ThrowsAsync<FatalProtocolException>(
-                () => _repositorySignatureResourceProvider.TryCreate(sourceRepository, CancellationToken.None));
+                () => provider.TryCreate(sourceRepository, CancellationToken.None));
 
             Assert.Equal($"Repository Signatures resouce must be served over HTTPS. Source: {_packageSource.Source}", exception.Message);
         }
 
         [Theory]
-        [InlineData(ResourceUri500, ResourceType500)]
-        [InlineData(ResourceUri490, ResourceType490)]
-        [InlineData(ResourceUri470, ResourceType470)]
-        public async Task TryCreate_WhenOnlyOneResourceIsPresent_ReturnsThatResource(string resourceUrl, string resourceType)
+        [InlineData(ResourceUri500, ResourceType500, false)]
+        [InlineData(ResourceUri500, ResourceType500, true)]
+        [InlineData(ResourceUri490, ResourceType490, false)]
+        [InlineData(ResourceUri490, ResourceType490, true)]
+        [InlineData(ResourceUri470, ResourceType470, false)]
+        [InlineData(ResourceUri470, ResourceType470, true)]
+        public async Task TryCreate_WhenOnlyOneResourceIsPresent_ReturnsThatResource(string resourceUrl, string resourceType, bool useStj)
         {
             var serviceEntry = new ServiceIndexEntry(new Uri(resourceUrl), resourceType, DefaultVersion);
+            var provider = CreateProvider(useStj);
             var resourceProviders = new ResourceProvider[]
             {
                 MockServiceIndexResourceV3Provider.Create(serviceEntry),
@@ -121,11 +148,11 @@ namespace NuGet.Protocol.Providers.Tests
                     {
                         { serviceEntry.Uri.AbsoluteUri, GetRepositorySignaturesResourceJson(resourceUrl) }
                     }),
-                _repositorySignatureResourceProvider
+                provider
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
 
-            var result = await _repositorySignatureResourceProvider.TryCreate(sourceRepository, CancellationToken.None);
+            var result = await provider.TryCreate(sourceRepository, CancellationToken.None);
 
             Assert.True(result.Item1);
 
@@ -136,12 +163,15 @@ namespace NuGet.Protocol.Providers.Tests
             Assert.Single(resource.RepositoryCertificateInfos);
         }
 
-        [Fact]
-        public async Task TryCreate_WhenMultipleResourcesArePresent_Returns500Resource()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TryCreate_WhenMultipleResourcesArePresent_Returns500Resource(bool useStj)
         {
             var serviceEntry470 = new ServiceIndexEntry(new Uri(ResourceUri470), ResourceType470, DefaultVersion);
             var serviceEntry490 = new ServiceIndexEntry(new Uri(ResourceUri490), ResourceType490, DefaultVersion);
             var serviceEntry500 = new ServiceIndexEntry(new Uri(ResourceUri500), ResourceType500, DefaultVersion);
+            var provider = CreateProvider(useStj);
             var resourceProviders = new ResourceProvider[]
             {
                 MockServiceIndexResourceV3Provider.Create(serviceEntry470, serviceEntry490, serviceEntry500),
@@ -152,11 +182,11 @@ namespace NuGet.Protocol.Providers.Tests
                         { serviceEntry490.Uri.AbsoluteUri, GetRepositorySignaturesResourceJson(serviceEntry490.Uri.AbsoluteUri) },
                         { serviceEntry500.Uri.AbsoluteUri, GetRepositorySignaturesResourceJson(serviceEntry500.Uri.AbsoluteUri) }
                     }),
-                _repositorySignatureResourceProvider
+                provider
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
 
-            var result = await _repositorySignatureResourceProvider.TryCreate(sourceRepository, CancellationToken.None);
+            var result = await provider.TryCreate(sourceRepository, CancellationToken.None);
 
             Assert.True(result.Item1);
 
@@ -169,10 +199,13 @@ namespace NuGet.Protocol.Providers.Tests
         }
 
         [Theory]
-        [InlineData(ResourceUri500, ResourceType500, "repository_signatures_5.0.0")]
-        [InlineData(ResourceUri490, ResourceType490, "repository_signatures_4.9.0")]
-        [InlineData(ResourceUri470, ResourceType470, "repository_signatures_4.7.0")]
-        public async Task TryCreate_WhenResourceIsPresent_CreatesVersionedHttpCacheEntry(string resourceUrl, string resourceType, string expectedCacheKey)
+        [InlineData(ResourceUri500, ResourceType500, "repository_signatures_5.0.0", false)]
+        [InlineData(ResourceUri500, ResourceType500, "repository_signatures_5.0.0", true)]
+        [InlineData(ResourceUri490, ResourceType490, "repository_signatures_4.9.0", false)]
+        [InlineData(ResourceUri490, ResourceType490, "repository_signatures_4.9.0", true)]
+        [InlineData(ResourceUri470, ResourceType470, "repository_signatures_4.7.0", false)]
+        [InlineData(ResourceUri470, ResourceType470, "repository_signatures_4.7.0", true)]
+        public async Task TryCreate_WhenResourceIsPresent_CreatesVersionedHttpCacheEntry(string resourceUrl, string resourceType, string expectedCacheKey, bool useStj)
         {
             var serviceEntry = new ServiceIndexEntry(new Uri(resourceUrl), resourceType, DefaultVersion);
             var responses = new Dictionary<string, string>()
@@ -181,11 +214,12 @@ namespace NuGet.Protocol.Providers.Tests
             };
 
             var httpSource = new TestHttpSource(_packageSource, responses);
+            var provider = CreateProvider(useStj);
             var resourceProviders = new ResourceProvider[]
             {
                 MockServiceIndexResourceV3Provider.Create(serviceEntry),
                 StaticHttpSource.CreateHttpSource(responses, httpSource: httpSource),
-                _repositorySignatureResourceProvider
+                provider
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
             string actualCacheKey = null;
@@ -195,7 +229,7 @@ namespace NuGet.Protocol.Providers.Tests
                 actualCacheKey = request.CacheKey;
             };
 
-            var result = await _repositorySignatureResourceProvider.TryCreate(sourceRepository, CancellationToken.None);
+            var result = await provider.TryCreate(sourceRepository, CancellationToken.None);
 
             Assert.True(result.Item1);
             Assert.Equal(expectedCacheKey, actualCacheKey);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14887
Related: https://github.com/NuGet/Home/issues/14846

## Description

 Migrates `RepositorySignatureResourceProvider` from NSJ to STJ behind the `NuGetFeatureFlags` feature switch.
 Add `RepositorySignatureModel` POCO,  `FingerprintsStjConverter` for the Fingerprints type, and a dedicated `RepositorySignatureJsonContext` to avoid merge conflicts with other STJ migration PRs. This can be removed later.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
