### PR TITLE
Change audit source to data.nuget.org and fix vulnerable package warning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -96,6 +96,8 @@
     <PackageVersion Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="$(SystemSecurityCryptographyProtectedDataVersion)" />
+    <!-- S.S.C.Xml is a dependency of MSBuild. Once MSBuild no longer has a transitive dependency on a vulnerable version, this can be removed -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <!--
       The Microsoft.VisualStudio.SDK metapackage brings in System.Threading.Tasks.Dataflow 4.11.1 (assembly version 4.9.5.0).

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -11,7 +11,7 @@
   </packageSources>
   <auditSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget.org" value="https://data.nuget.org/v3/index.json" />
   </auditSources>
   <packageSourceMapping>
     <clear />

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -52,6 +52,8 @@
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <Nullable>enable</Nullable>
+    <!-- NuGetAuditMode only defaults to all when targeting net10.0 or higher, which many projects do not -->
+    <NuGetAuditMode>all</NuGetAuditMode>
   </PropertyGroup>
 
   <!-- Defaults -->

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -30,6 +30,8 @@ variables:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -27,6 +27,8 @@ variables:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -37,6 +37,8 @@
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
+    <!-- MSBuild has a dependency on a vulnerable version of System.Security.Cryptography.Xml. Once MSBuild no longer has a transitive dependency on a vulnerable version, this can be removed -->
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14865

## Description

* Migrate to data.nuget.org as the audit source
* Force NuGetAuditMode=all since that's only the default for projects targeting net10.0, which NuGet's VS projects will never target.
* Pin a transitive package with a known vulnerability to a higher version without a known vulnerability. We get the package via MSBuild, so once MSBuild publish a new version we can hopefully upgrade and remove the pinning.
* I'm already in contact with the network isolation team to unblock data.nuget.org from the CFSClean policy, but currently it's still blocking, so this PR also explicitly opts-in to the permissive policy. I'll follow up with another PR to move us to CFSClean as soon as configuration is complete on their end.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
