### PR TITLE
Add AOT publish test job

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -17,6 +17,7 @@
     <clear />
     <packageSource key="dotnet-public">
       <package pattern="AwesomeAssertions" />
+      <package pattern="Microsoft.DotNet.ILCompiler" />
       <package pattern="Azure.Core " />
       <package pattern="ben.demystifier" />
       <package pattern="castle.core" />

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -284,3 +284,20 @@ stages:
           displayName: Log Environment Variables
         - script: dotnet format whitespace --verify-no-changes NuGet.sln
           displayName: Run dotnet format whitespace
+
+- stage:
+  displayName: AOT Compatibility
+  dependsOn: []
+  jobs:
+  - job:
+    displayName: AOT Publish Smoke Test (win-x64)
+    timeoutInMinutes: 20
+    pool:
+      vmImage: windows-latest
+    steps:
+    - task: PowerShell@2
+      displayName: Run configure.ps1
+      inputs:
+        filePath: configure.ps1
+    - script: dotnet publish test/NuGet.AotCompatibility.Test/NuGet.AotCompatibility.Test.csproj -r win-x64 -c Release
+      displayName: AOT publish NuGet libraries

--- a/test/NuGet.AotCompatibility.Test/NuGet.AotCompatibility.Test.csproj
+++ b/test/NuGet.AotCompatibility.Test/NuGet.AotCompatibility.Test.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>$(LatestNETCoreTargetFramework)</TargetFramework>
     <PublishAot>true</PublishAot>
     <IlcTreatWarningsAsErrors>true</IlcTreatWarningsAsErrors>

--- a/test/NuGet.AotCompatibility.Test/NuGet.AotCompatibility.Test.csproj
+++ b/test/NuGet.AotCompatibility.Test/NuGet.AotCompatibility.Test.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(LatestNETCoreTargetFramework)</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <IlcTreatWarningsAsErrors>true</IlcTreatWarningsAsErrors>
+    <PackProject>false</PackProject>
+    <UsePublicApiAnalyzer>false</UsePublicApiAnalyzer>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj" />
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.Common\NuGet.Common.csproj" />
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.Configuration\NuGet.Configuration.csproj" />
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.Credentials\NuGet.Credentials.csproj" />
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.DependencyResolver.Core\NuGet.DependencyResolver.Core.csproj" />
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.Frameworks\NuGet.Frameworks.csproj" />
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.LibraryModel\NuGet.LibraryModel.csproj" />
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.Packaging\NuGet.Packaging.csproj" />
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.ProjectModel\NuGet.ProjectModel.csproj" />
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.Protocol\NuGet.Protocol.csproj" />
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.Resolver\NuGet.Resolver.csproj" />
+    <ProjectReference Include="..\..\src\NuGet.Core\NuGet.Versioning\NuGet.Versioning.csproj" />
+  </ItemGroup>
+
+  <!--
+    Root all public types in each NuGet assembly so the ILC compiler analyzes
+    the full public surface of every library, not just what Program.cs reaches.
+  -->
+  <ItemGroup>
+    <TrimmerRootAssembly Include="NuGet.Commands" />
+    <TrimmerRootAssembly Include="NuGet.Common" />
+    <TrimmerRootAssembly Include="NuGet.Configuration" />
+    <TrimmerRootAssembly Include="NuGet.Credentials" />
+    <TrimmerRootAssembly Include="NuGet.DependencyResolver.Core" />
+    <TrimmerRootAssembly Include="NuGet.Frameworks" />
+    <TrimmerRootAssembly Include="NuGet.LibraryModel" />
+    <TrimmerRootAssembly Include="NuGet.Packaging" />
+    <TrimmerRootAssembly Include="NuGet.ProjectModel" />
+    <TrimmerRootAssembly Include="NuGet.Protocol" />
+    <TrimmerRootAssembly Include="NuGet.Resolver" />
+    <TrimmerRootAssembly Include="NuGet.Versioning" />
+  </ItemGroup>
+</Project>

--- a/test/NuGet.AotCompatibility.Test/NuGet.AotCompatibility.Test.csproj
+++ b/test/NuGet.AotCompatibility.Test/NuGet.AotCompatibility.Test.csproj
@@ -22,10 +22,7 @@
     <ProjectReference Include="..\..\src\NuGet.Core\NuGet.Versioning\NuGet.Versioning.csproj" />
   </ItemGroup>
 
-  <!--
-    Root all public types in each NuGet assembly so the ILC compiler analyzes
-    the full public surface of every library, not just what Program.cs reaches.
-  -->
+  <!-- Root all public types so ILC analyzes the full public API surface of each library. -->
   <ItemGroup>
     <TrimmerRootAssembly Include="NuGet.Commands" />
     <TrimmerRootAssembly Include="NuGet.Common" />

--- a/test/NuGet.AotCompatibility.Test/Program.cs
+++ b/test/NuGet.AotCompatibility.Test/Program.cs
@@ -1,0 +1,8 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// AOT compatibility smoke test entry point.
+// All NuGet assemblies with IsAotCompatible=true are referenced via ProjectReference
+// and rooted via TrimmerRootAssembly so the ILC compiler analyzes their full public
+// surface. A successful publish with IlcTreatWarningsAsErrors=true confirms AOT
+// compatibility. No application logic is needed here.

--- a/test/NuGet.AotCompatibility.Test/Program.cs
+++ b/test/NuGet.AotCompatibility.Test/Program.cs
@@ -1,8 +1,0 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-// AOT compatibility smoke test entry point.
-// All NuGet assemblies with IsAotCompatible=true are referenced via ProjectReference
-// and rooted via TrimmerRootAssembly so the ILC compiler analyzes their full public
-// surface. A successful publish with IlcTreatWarningsAsErrors=true confirms AOT
-// compatibility. No application logic is needed here.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14847

## Description

 Adds a CI check that catches Native AOT regressions in NuGet.Core libraries on every PR.

   - test/NuGet.AotCompatibility.Test/ - minimal app referencing all 12 AOT-eligible NuGet.Core libraries via
   TrimmerRootAssembly, with IlcTreatWarningsAsErrors=true. Not added to the solution.
   - New AOT Compatibility stage in pr.yml runs dotnet publish -r win-x64 on Windows.

**Note:** This new job is expected to fail until the migration is complete.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
