### PR TITLE
Local tests don't run netfx signing tests needing admin access

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/AllowListVerificationProviderTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedRepoTestCert = fixture.TrustedRepositoryCertificate;
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_AuthorSignedPackage_WithCertificateInAllowList_SuccessAsync()
         {
             // Arrange
@@ -77,7 +77,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [MemberData(nameof(EmptyNullAndRequiredListCombinations))]
         public async Task GetTrustResultAsync_AuthorSignedPackage_RequirementsAsync(
             SignedPackageVerifierSettings verifierSettings,
@@ -125,7 +125,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_AuthorSignedPackage_VerifyWithoutCertificateInAllowList_AllowUntrusted_WarnAsync()
         {
             // Arrange
@@ -171,7 +171,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_AuthorSignedPackage_VerifyWithoutCertificateInAllowList_NotAllowUntrusted_ErrorAsync()
         {
             // Arrange
@@ -217,7 +217,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositorySignedPackage_AllowListWithAuthorTarget_AndPrimaryPlacement_ErrorAsync()
         {
             // Arrange
@@ -265,7 +265,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositorySignedPackage_AllowListWithRepositoryTarget_AndCounterPlacementOnly_ErrorAsync()
         {
             // Arrange
@@ -313,7 +313,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositorySignedPackage_AllowListWithRepositoryTarget_AndPrimaryPlacement_SuccessAsync()
         {
             // Arrange
@@ -359,7 +359,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_AllowListWithAuthorTarget_AndPrimaryPlacement_ErrorAsync()
         {
             // Arrange
@@ -409,7 +409,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_AllowListWithRepositoryTarget_AndPrimaryPlacementOnly_ErrorAsync()
         {
             // Arrange
@@ -459,7 +459,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_AllowListWithRepositoryTarget_AndCounterPlacement_SuccessAsync()
         {
             // Arrange
@@ -507,7 +507,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -551,7 +551,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertNotFromAllowList_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -602,7 +602,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithOwnerInOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -652,7 +652,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithOwnerNotInOwnersList_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -703,7 +703,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithNoOwnersInPackage_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -752,7 +752,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithOwnerInOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -804,7 +804,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithOwnerNotInOwnersList_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -857,7 +857,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithOwnerNotInOwnersList_AuthorInList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -911,7 +911,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignedPackage_PackageSignedWithCertFromAllowList_WithNoOwnersInPackage_RequireMode_ErrorAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -963,7 +963,7 @@ namespace NuGet.Packaging.FuncTest
         }
 
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList_WithEmptyOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -1013,7 +1013,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryPrimarySignedPackage_PackageSignedWithCertFromAllowList__WithNullOwnersList_RequireMode_SuccessAsync()
         {
             var nupkg = new SimpleTestPackageContext();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/ClientPolicyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/ClientPolicyTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedRepoTestCert.Dispose();
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData(SigningTestType.Author, "accept", true, 0)]
         [InlineData(SigningTestType.Author, "require", false, 1)]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0)]
@@ -91,7 +91,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData(SigningTestType.Author, "accept", true, 0, 1)]
         [InlineData(SigningTestType.Author, "require", false, 1, 0)]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0, 1)]
@@ -152,7 +152,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData(SigningTestType.Author, SignaturePlacement.PrimarySignature, "accept")]
         [InlineData(SigningTestType.Author, SignaturePlacement.PrimarySignature, "require")]
         [InlineData(SigningTestType.RepositoryPrimary, SignaturePlacement.PrimarySignature, "accept")]
@@ -223,7 +223,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData(SigningTestType.RepositoryPrimary, "accept")]
         [InlineData(SigningTestType.RepositoryPrimary, "require")]
         [InlineData(SigningTestType.RepositoryCountersigned, "accept")]
@@ -283,7 +283,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0, 1)]
         [InlineData(SigningTestType.RepositoryPrimary, "require", false, 1, 0)]
         [InlineData(SigningTestType.RepositoryCountersigned, "accept", true, 0, 1)]
@@ -343,7 +343,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData(SigningTestType.RepositoryPrimary, "accept", true, 0, 1)]
         [InlineData(SigningTestType.RepositoryPrimary, "require", false, 1, 0)]
         [InlineData(SigningTestType.RepositoryCountersigned, "accept", true, 0, 1)]

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/IntegrityVerificationProviderTests.cs
@@ -61,7 +61,7 @@ namespace NuGet.Packaging.FuncTest
             return SignedPackageVerifierSettings.GetDefault(TestEnvironmentVariableReader.EmptyInstance);
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnSignedPackageAsync(string policyString)
@@ -87,7 +87,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileDeletedAsync(string policyString)
@@ -121,7 +121,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileAddedAsync(string policyString)
@@ -166,7 +166,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileAppendedAsync(string policyString)
@@ -210,7 +210,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileTruncatedAsync(string policyString)
@@ -251,7 +251,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData("command")]
         [InlineData("vs")]
         public async Task Signer_VerifyOnTamperedPackage_FileMetadataModifiedAsync(string policyString)
@@ -295,7 +295,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData("command", false)]
         [InlineData("vs", true)]
         public async Task Signer_VerifyOnTamperedPackage_SignatureRemovedAsync(string policyString, bool expectedValidity)
@@ -339,7 +339,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData("command", false)]
         [InlineData("vs", true)]
         public async Task Signer_VerifyOnTamperedPackage_SignatureTamperedAsync(string policyString, bool expectedValidity)

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PackageSignatureVerifierTests.cs
@@ -25,7 +25,7 @@ namespace NuGet.Packaging.FuncTest
     [Collection(SigningTestCollection.Name)]
     public class PackageSignatureVerifierTests
     {
-        [Fact]
+        [NetFxCIOnlyFact]
         public void Constructor_WhenArgumentIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
@@ -55,7 +55,7 @@ namespace NuGet.Packaging.FuncTest
                 };
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_ValidCertificate_SuccessAsync()
             {
                 // Arrange
@@ -80,7 +80,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_ValidCertificateAndTimestamp_SuccessAsync()
             {
                 // Arrange
@@ -110,7 +110,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_ValidCertificateAndTimestampWithDifferentHashAlgorithms_SuccessAsync()
             {
                 var packageContext = new SimpleTestPackageContext();
@@ -241,7 +241,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Verify a package meeting minimum signature requirements.
             // This signature is neither an author nor repository signature.
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_WithBasicSignedCms_SucceedsAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -290,7 +290,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_SettingsRequireTimestamp_NoTimestamp_FailsAsync()
             {
                 // Arrange
@@ -331,7 +331,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_SettingsNotRequireCheckCountersignature_WithValidPrimarySignatureAndInvalidCountersignature_SucceedsAsync()
             {
                 // Arrange
@@ -381,7 +381,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_SettingsRequireCheckCountersignature_WithValidPrimarySignatureAndInvalidCountersignature_FailsAsync()
             {
                 // Arrange
@@ -431,7 +431,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_SettingsRequireCheckCountersignature_WithValidPrimarySignatureAndValidCountersignature_SucceedsAsync()
             {
                 // Arrange
@@ -481,7 +481,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_WithExpiredPrimarySignature_ValidCountersignature_AndPrimarySignatureValidAtCountersignTime_SucceedsAsync()
             {
                 // Arrange
@@ -534,7 +534,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_WithExpiredAndUntrustedPrimarySignature_ValidCountersignature_AndPrimarySignatureValidAtCountersignTime_SucceedsAsync()
             {
                 var nupkg = new SimpleTestPackageContext();
@@ -582,7 +582,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_WithExpiredPrimarySignature_ValidCountersignature_AndPrimarySignatureExpiredAtCountersignTime_FailsAsync()
             {
                 // Arrange
@@ -637,7 +637,7 @@ namespace NuGet.Packaging.FuncTest
             }
 
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_WithSignedAndCountersignedPackage_SucceedsAsync()
             {
                 // Arrange
@@ -676,7 +676,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_WithSignedTimestampedCountersignedAndCountersignatureTimestampedPackage_SucceedsAsync()
             {
                 // Arrange
@@ -718,7 +718,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_WithExpiredTimestamp_NotAllowIgnoreTimestamp_ShouldNotBeAnErrorAsync()
             {
                 using (var nupkgStream = new MemoryStream(GetResource("UntrustedTimestampPackage.nupkg")))
@@ -739,7 +739,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task VerifySignaturesAsync_WithTimestampChainingToUntrustedRoot_NotAllowIgnoreTimestamp_FailAsync()
             {
                 using (var nupkgStream = new MemoryStream(GetResource("UntrustedTimestampPackage.nupkg")))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PrimarySignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/PrimarySignatureTests.cs
@@ -33,7 +33,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedTestCert = _testFixture.TrustedTestCertificate;
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task Signature_HasTimestampAsync()
         {
             // Arrange
@@ -62,7 +62,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task Signature_HasNoTimestampAsync()
         {
             // Arrange
@@ -86,7 +86,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task Load_WithPrimarySignatureWithNoCertificates_ThrowsAsync()
         {
             var packageContext = new SimpleTestPackageContext();
@@ -116,7 +116,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task Load_WithReissuedSigningCertificate_ThrowsAsync()
         {
             var certificates = _testFixture.TrustedTestCertificateWithReissuedCertificate;

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/RepositoryCountersignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/RepositoryCountersignatureTests.cs
@@ -43,7 +43,7 @@ namespace NuGet.Packaging.FuncTest
             Assert.Equal("primarySignature", exception.ParamName);
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetRepositoryCountersignature_WithNoCountersignatures_ReturnsNull()
         {
             using (var test = await Test.CreateWithoutRepositoryCountersignatureAsync(_fixture.TrustedTestCertificate.Source.Cert))
@@ -54,7 +54,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetRepositoryCountersignature_WithRepositoryCountersignature_ReturnsInstance()
         {
             using (var test = await Test.CreateAsync(_fixture.TrustedTestCertificate.Source.Cert))
@@ -72,7 +72,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetSignatureValue_WithSha256_ReturnsValue()
         {
             using (var test = await Test.CreateAsync(_fixture.TrustedTestCertificate.Source.Cert))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Packaging.FuncTest
             _untrustedTestCertificate = _testFixture.UntrustedTestCertificate;
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task Verify_WithUntrustedSelfSignedCertificateAndNotAllowUntrusted_FailsAsync()
         {
             var settings = new SignatureVerifySettings(
@@ -57,7 +57,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task Verify_WithUntrustedSelfSignedCertificateAndAllowUntrusted_SucceedsAndWarnsAsync()
         {
             var settings = new SignatureVerifySettings(
@@ -82,7 +82,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task Verify_WithUntrustedSelfSignedCertificateAndAllowUntrustedAndNotReportUntrustedRoot_SucceedsAsync()
         {
             var settings = new SignatureVerifySettings(
@@ -107,7 +107,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetSigningCertificateFingerprint_WithUnsupportedHashAlgorithm_Throws()
         {
             using (var test = await VerifyTest.CreateAsync(_untrustedTestCertificate.Cert))
@@ -116,7 +116,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetSigningCertificateFingerprint_SuccessfullyHashesMultipleAlgorithms()
         {
             using (var test = await VerifyTest.CreateAsync(_untrustedTestCertificate.Cert))
@@ -135,7 +135,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task Timestamps_WitMultipleTimestamps_ReturnsMultipleTimestamps()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureTrustAndValidityVerificationProviderTests.cs
@@ -42,7 +42,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedTestCert = _testFixture.TrustedTestCertificate;
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_WithInvalidSignature_ThrowsAsync()
         {
             var package = new SimpleTestPackageContext();
@@ -77,7 +77,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_SettingsRequireExactlyOneTimestamp_MultipleTimestamps_FailsAsync()
         {
             // Arrange
@@ -132,7 +132,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_PrimarySignatureWithUntrustedRoot_EmptyAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -167,7 +167,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignatureWithUntrustedRoot_EmptyAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -204,7 +204,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_PrimarySignatureWithUntrustedRoot_NotInAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -240,7 +240,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignatureWithUntrustedRoot_NotInAllowedUntrustedRootList_AllowUntrustedFalse_ErrorAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -278,7 +278,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_PrimarySignatureWithUntrustedRoot_InAllowedUntrustedRootList_AllowUntrustedFalse_SucceedsAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -316,7 +316,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_RepositoryCountersignatureWithUntrustedRoot_InAllowedUntrustedRootList_AllowUntrustedFalse_SucceedsAsync()
         {
             var settings = new SignedPackageVerifierSettings(
@@ -356,7 +356,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [PlatformFact(Platform.Windows, Platform.Linux, NetFxCIOnly = true)]
         public async Task GetTrustResultAsync_WithUnavailableRevocationInformationInAcceptMode_DoesNotWarnAsync()
         {
             // Arrange
@@ -372,7 +372,7 @@ namespace NuGet.Packaging.FuncTest
             Assert.Empty(matchingIssues);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [PlatformFact(Platform.Windows, Platform.Linux, NetFxCIOnly = true)]
         public async Task GetTrustResultAsync_WithUnavailableRevocationInformationInRequireMode_WarnsAsync()
         {
             // Arrange
@@ -398,7 +398,7 @@ namespace NuGet.Packaging.FuncTest
             SigningTestUtility.AssertRevocationStatusUnknown(matchingIssues, LogLevel.Warning, NuGetLogCode.NU3018);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [PlatformFact(Platform.Windows, Platform.Linux, NetFxCIOnly = true)]
         public async Task GetTrustResultAsync_WithUnavailableRevocationInformationInVerify_WarnsAsync()
         {
             // Act & Assert
@@ -421,7 +421,7 @@ namespace NuGet.Packaging.FuncTest
             SigningTestUtility.AssertRevocationStatusUnknown(matchingIssues, LogLevel.Warning, NuGetLogCode.NU3018);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [PlatformFact(Platform.Windows, Platform.Linux, NetFxCIOnly = true)]
         public async Task GetTrustResultAsync_WithUnavailableRevocationInformationAndAllowIllegal_WarnsAsync()
         {
             // Arrange
@@ -449,7 +449,7 @@ namespace NuGet.Packaging.FuncTest
             Assert.Empty(matchingIssues);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [PlatformFact(Platform.Windows, Platform.Linux, NetFxCIOnly = true)]
         public async Task GetTrustResultAsync_WithUnavailableRevocationInformationAndAllowUnknownRevocation_WithOnlineRevocationMode_WarnsAsync()
         {
             // Arrange
@@ -487,7 +487,7 @@ namespace NuGet.Packaging.FuncTest
             SigningTestUtility.AssertRevocationStatusUnknown(matchingIssues, LogLevel.Warning, NuGetLogCode.NU3018);
         }
 
-        [PlatformFact(Platform.Windows, Platform.Linux)]
+        [PlatformFact(Platform.Windows, Platform.Linux, NetFxCIOnly = true)]
         public async Task GetTrustResultAsync_WithUnavailableRevocationInformationAndAllowUnknownRevocation_WithOfflineRevocationMode_WarnsAsync()
         {
             // Arrange
@@ -520,7 +520,7 @@ namespace NuGet.Packaging.FuncTest
             SigningTestUtility.AssertRevocationStatusUnknown(matchingIssues, LogLevel.Information, NuGetLogCode.Undefined);
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_WithTrustedButExpiredPrimaryAndTimestampCertificates_WithUnavailableRevocationInformationAndAllowUnknownRevocation_WarnsAsync()
         {
             List<SignatureLog> matchingIssues = await VerifyUnavailableRevocationInfoAsync(
@@ -543,7 +543,7 @@ namespace NuGet.Packaging.FuncTest
             SigningTestUtility.AssertRevocationStatusUnknown(matchingIssues, LogLevel.Warning, NuGetLogCode.NU3018);
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTrustResultAsync_WithNoIgnoringTimestamp_TimestampWithGeneralizedTimeOutsideCertificateValidity_FailAsync()
         {
             var verificationProvider = new SignatureTrustAndValidityVerificationProvider();
@@ -588,7 +588,7 @@ namespace NuGet.Packaging.FuncTest
                 _provider = new SignatureTrustAndValidityVerificationProvider();
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithRepositorySignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -616,7 +616,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithValidSignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -646,7 +646,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Theory]
+            [NetFxCIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithValidSignatureButNoTimestamp_ReturnsStatusAsync(
@@ -677,7 +677,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Theory]
+            [NetFxCIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithUntrustedSignature_ReturnsStatusAsync(
@@ -711,7 +711,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
+            [PlatformTheory(Platform.Windows, Platform.Linux, NetFxCIOnly = true)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true)]
             [InlineData(false)]
             public async Task GetTrustResultAsync_WithRevokedPrimaryCertificate_ReturnsSuspectAsync(bool allowEverything)
@@ -753,7 +753,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
+            [PlatformTheory(Platform.Windows, Platform.Linux, NetFxCIOnly = true)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithRevokedTimestampCertificate_ReturnsStatusAsync(
@@ -797,7 +797,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithTamperedRepositoryPrimarySignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -855,7 +855,7 @@ namespace NuGet.Packaging.FuncTest
                 _provider = new SignatureTrustAndValidityVerificationProvider();
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithAuthorSignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -883,7 +883,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithValidSignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -913,7 +913,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Theory]
+            [NetFxCIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithValidSignatureButNoTimestamp_ReturnsStatusAsync(
@@ -945,7 +945,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Theory]
+            [NetFxCIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithUntrustedSignature_ReturnsStatusAsync(
@@ -979,7 +979,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
+            [PlatformTheory(Platform.Windows, Platform.Linux, NetFxCIOnly = true)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true)]
             [InlineData(false)]
             public async Task GetTrustResultAsync_WithRevokedPrimaryCertificate_ReturnsSuspectAsync(bool allowEverything)
@@ -1021,7 +1021,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
+            [PlatformTheory(Platform.Windows, Platform.Linux, NetFxCIOnly = true)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithRevokedTimestampCertificate_ReturnsStatusAsync(
@@ -1065,7 +1065,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithTamperedRepositoryPrimarySignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1104,7 +1104,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithAlwaysVerifyCountersignatureBehavior_ReturnsDisallowedAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1143,7 +1143,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredSignature_ReturnsValidAsync()
             {
                 using (X509Certificate2 certificate = await GetExpiringCertificateAsync(_fixture))
@@ -1183,7 +1183,7 @@ namespace NuGet.Packaging.FuncTest
                 _provider = new SignatureTrustAndValidityVerificationProvider();
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithAuthorSignedPackage_ReturnsUnknownAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1211,7 +1211,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithValidCountersignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1243,7 +1243,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithValidCountersignatureAndUntrustedPrimarySignature_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1275,7 +1275,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Theory]
+            [NetFxCIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithValidCountersignatureButNoTimestamp_ReturnsStatusAsync(
@@ -1310,7 +1310,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Theory]
+            [NetFxCIOnlyTheory]
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithUntrustedCountersignature_ReturnsStatusAsync(
@@ -1346,7 +1346,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
+            [PlatformTheory(Platform.Windows, Platform.Linux, NetFxCIOnly = true)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true)]
             [InlineData(false)]
             public async Task GetTrustResultAsync_WithRevokedCountersignatureCertificate_ReturnsSuspectAsync(bool allowEverything)
@@ -1390,7 +1390,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [PlatformTheory(Platform.Windows, Platform.Linux)] // https://github.com/NuGet/Home/issues/9501
+            [PlatformTheory(Platform.Windows, Platform.Linux, NetFxCIOnly = true)] // https://github.com/NuGet/Home/issues/9501
             [InlineData(true, SignatureVerificationStatus.Valid)]
             [InlineData(false, SignatureVerificationStatus.Disallowed)]
             public async Task GetTrustResultAsync_WithRevokedTimestampCertificate_ReturnsStatusAsync(
@@ -1437,7 +1437,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithTamperedRepositoryCountersignedPackage_ReturnsValidAsync()
             {
                 var settings = new SignedPackageVerifierSettings(
@@ -1478,7 +1478,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredPrimaryCertificateAndExpiredRepositoryCertificateAndValidTimestamps_ReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1504,7 +1504,7 @@ namespace NuGet.Packaging.FuncTest
                 }
             }
 
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredRepositoryCertificateAndNoTimestamp_ReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1561,7 +1561,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case1: primary signature (trusted + non-expired) doesn't fall back to countersignature (trusted + non-expired).
             // The verification result is the primary signature status(valid).
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithGoodPrimarySignatureAndGoodCountersignature_NoFallbackAndReturnsValidAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1582,7 +1582,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case2: primary signature (trusted + non-expired) doesn't fall back to countersignature untrusted + non-expired).
             // The verification result is the primary signature status(valid).
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithGoodPrimarySignatureAndUntrustedCountersignature_NoFallbackAndReturnsValidAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1603,7 +1603,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case3: primary signature (untrusted + non-expired) falls back to countersignature (trusted + non-expired).
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithUntrustedPrimarySignatureAndGoodCountersignature_FallbackAndReturnsValidAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1624,7 +1624,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case4: primary signature (untrusted + non-expired) falls back to countersignature (untrusted + non-expired).
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithUntrustedPrimarySignatureAndUntrustedCountersignature_FallbackAndReturnsDisallowedAsync()
             {
                 using (Test test = await Test.CreateAuthorSignedRepositoryCountersignedPackageAsync(
@@ -1646,7 +1646,7 @@ namespace NuGet.Packaging.FuncTest
             // Case5: primary signature (trusted + expired) falls back to countersignature (trusted + non-expired).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1673,7 +1673,7 @@ namespace NuGet.Packaging.FuncTest
 
             // Case6: primary signature (trusted + expired) falls back to countersignature (untrusted + non-expired).
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(disallowed), so it's disallowed.
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndUntrustedCountersignatureWithTimestamp_FallbackAndReturnsDisallowedAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1701,7 +1701,7 @@ namespace NuGet.Packaging.FuncTest
             // Case7: primary signature (trusted + expired) falls back to countersignature (trusted + non-expired).
             // But the timestamp on countersignature could NOT fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
             {
                 using (X509Certificate2 authorSigningCertificate = await GetExpiringCertificateAsync(_fixture))
@@ -1725,7 +1725,7 @@ namespace NuGet.Packaging.FuncTest
             // Case8: primary signature (trusted + expired) falls back to countersignature (trusted + expired but protected by a timestamp).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithExpiredPrimarySignatureAndExpiredCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();
@@ -1755,7 +1755,7 @@ namespace NuGet.Packaging.FuncTest
             // Case9: primary signature (untrusted + expired) falls back to countersignature (trusted + non-expired).
             // But the timestamp on countersignature could NOT fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(disallowed) and the countersignature status(valid), so it's disallowed.
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithUntrustedExpiredPrimarySignatureAndGoodCountersignatureWithNoTimestamp_FallbackAndReturnsDisallowedAsync()
             {
                 using (X509Certificate2 authorSigningCertificate = _fixture.CreateUntrustedTestCertificateThatWillExpireSoon().Cert)
@@ -1779,7 +1779,7 @@ namespace NuGet.Packaging.FuncTest
             // Case10: primary signature (untrusted + expired) falls back to countersignature (trusted + non-expired).
             // And the timestamp on countersignature could fullfill the role of a trust anchor for primary signature.
             // The verification result is the severe one of fallback status(valid) and the countersignature status(valid), so it's valid.
-            [Fact]
+            [NetFxCIOnlyFact]
             public async Task GetTrustResultAsync_WithUntrustedExpiredPrimarySignatureAndGoodCountersignatureWithTimestamp_FallbackAndReturnsValidAsync()
             {
                 TimestampService timestampService = await _fixture.GetDefaultTrustedTimestampServiceAsync();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignatureUtilityTests.cs
@@ -30,7 +30,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
         }
 
 #if IS_DESKTOP
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampCertificateChain_WithNoSigningCertificateUsage_Throws()
         {
             ISigningTestServer testServer = await _fixture.GetSigningTestServerAsync();
@@ -70,7 +70,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData(SigningCertificateUsage.V1)]
         public async Task GetTimestampCertificateChain_WithShortEssCertIdCertificateHash_Throws(
             SigningCertificateUsage signingCertificateUsage)
@@ -113,7 +113,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
             }
         }
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData(SigningCertificateUsage.V1)]
         public async Task GetTimestampCertificateChain_WithMismatchedEssCertIdCertificateHash_ReturnsChain(
             SigningCertificateUsage signingCertificateUsage)
@@ -169,7 +169,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
         }
 #endif
 
-        [Theory]
+        [NetFxCIOnlyTheory]
         [InlineData(SigningCertificateUsage.V1)]
         [InlineData(SigningCertificateUsage.V2)]
         [InlineData(SigningCertificateUsage.V1 | SigningCertificateUsage.V2)]

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageArchiveTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageArchiveTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Packaging.FuncTest
             _fixture = fixture;
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task RemoveSignatureAsync_RemovesPackageSignatureAsync()
         {
             using (var test = await Test.CreateAsync(_fixture))
@@ -44,7 +44,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task RemoveSignatureAsync_WithCancelledToken_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_fixture))
@@ -54,7 +54,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task RemoveSignatureAsync_WithUnsignedPackage_ThrowsAsync()
         {
             using (var test = await Test.CreateUnsignedAsync())

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SignedPackageIntegrityVerificationTests.cs
@@ -58,7 +58,7 @@ namespace NuGet.Packaging.FuncTest
                 revocationMode: RevocationMode.Online);
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsLastAndFileHeaderIsLastAsync()
         {
             // Arrange
@@ -92,7 +92,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsFirstAndFileHeaderIsFirstAsync()
         {
             // Arrange
@@ -119,7 +119,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsLastAndFileHeaderIsFirstAsync()
         {
             // Arrange
@@ -153,7 +153,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsFirstAndFileHeaderIsLastAsync()
         {
             // Arrange
@@ -187,7 +187,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnShiftedSignaturePackage_WhenCentralDirectoryIsMiddleAndFileHeaderIsMiddleAsync()
         {
             // Arrange
@@ -222,7 +222,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAsync()
         {
             // Arrange
@@ -261,7 +261,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAssertExceptionAsync()
         {
             // Arrange
@@ -288,7 +288,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAndCompressedAsync()
         {
             // Arrange
@@ -327,7 +327,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureIsCreatedUsingZipArchiveAndCompressedAssertExceptionAsync()
         {
             // Arrange
@@ -354,7 +354,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidExternalFileAttributesAsync()
         {
             var nupkg = new SimpleTestPackageContext();
@@ -383,7 +383,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidGeneralPurposeFlagBitsAsync()
         {
             // Arrange
@@ -427,7 +427,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidGeneralPurposeFlagBitsAssertExceptionAsync()
         {
             // Arrange
@@ -459,7 +459,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidCompressionMethodAsync()
         {
             // Arrange
@@ -491,7 +491,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidCompressedSizeAsync()
         {
             // Arrange
@@ -535,7 +535,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidCompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -567,7 +567,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidUncompressedSizeAsync()
         {
             // Arrange
@@ -611,7 +611,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureCentralDirectoryHeaderHasInvalidUncompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -643,7 +643,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidGeneralPurposeFlagBitsAsync()
         {
             // Arrange
@@ -687,7 +687,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidGeneralPurposeFlagBitsAssertExceptionAsync()
         {
             // Arrange
@@ -719,7 +719,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressionMethodAsync()
         {
             // Arrange
@@ -763,7 +763,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressionMethodAssertExceptionAsync()
         {
             // Arrange
@@ -795,7 +795,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressedSizeAsync()
         {
             // Arrange
@@ -839,7 +839,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidCompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -871,7 +871,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidUncompressedSizeAsync()
         {
             // Arrange
@@ -918,7 +918,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyOnInvalidSignatureFileEntry_SignatureLocalFileHeaderHasInvalidUncompressedSizeAssertExceptionAsync()
         {
             // Arrange
@@ -949,7 +949,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyPackageContentHash_SignedPackagesAsync()
         {
             // Arrange
@@ -983,7 +983,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task ReadSignedArchiveMetadata_InvalidSignatureFileEntry_IgnoreVerifySignatureEntry()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/SigningUtilityTests.cs
@@ -24,7 +24,7 @@ namespace NuGet.Packaging.FuncTest
             _testFixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public void Verify_WithValidInput_DoesNotThrow()
         {
 #if NET9_0_OR_GREATER
@@ -38,7 +38,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task SignAsync_AddsPackageAuthorSignatureAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -54,7 +54,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task SignAsync_AddsPackageRepositorySignatureAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -70,7 +70,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task SignAsync_WhenRepositoryCountersigningPrimarySignature_SucceedsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -99,7 +99,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task SignAsync_WithExpiredCertificate_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificateExpired.Source.Cert))
@@ -117,7 +117,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task SignAsync_WithNotYetValidCertificate_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificateNotYetValid.Source.Cert))
@@ -135,7 +135,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task SignAsync_WhenRepositoryCountersigningRepositorySignedPackage_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))
@@ -165,7 +165,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task SignAsync_WhenRepositoryCountersigningRepositoryCountersignedPackage_ThrowsAsync()
         {
             using (var test = await Test.CreateAsync(_testFixture.TrustedTestCertificate.Source.Cert))

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TimestampProviderTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.Packaging.FuncTest
             _trustedTestCert = _testFixture.TrustedTestCertificate;
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_WithValidInput_ReturnsTimestampAsync()
         {
             var logger = new TestLogger();
@@ -69,7 +69,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_AssertCompleteChain_SuccessAsync()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
@@ -128,7 +128,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_WhenRequestNull_ThrowsAsync()
         {
             var logger = new TestLogger();
@@ -166,7 +166,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_WhenLoggerNull_ThrowsAsync()
         {
             var timestampService = await _testFixture.GetDefaultTrustedTimestampServiceAsync();
@@ -197,7 +197,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_WhenCancelled_ThrowsAsync()
         {
             var logger = new TestLogger();
@@ -228,7 +228,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_WhenRevocationInformationUnavailable_SuccessAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -258,7 +258,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_WhenTimestampSigningCertificateRevoked_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -282,7 +282,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_WithFailureReponse_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -304,7 +304,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_WhenSigningCertificateNotReturned_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -324,7 +324,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_WhenSignatureHashAlgorithmIsSha1_ThrowsAsync()
         {
             var testServer = await _testFixture.GetSigningTestServerAsync();
@@ -346,7 +346,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_WhenCertificateSignatureAlgorithmIsSha1_ThrowsAsync()
         {
             Oid sha1 = new(Oids.Sha1);
@@ -372,7 +372,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetTimestampAsync_TimestampGeneralizedTimeOutsideCertificateValidityPeriod_FailAsync()
         {
             // Arrange
@@ -402,7 +402,7 @@ namespace NuGet.Packaging.FuncTest
                 });
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task TimestampSignatureAsync_TimestampingPrimarySignature_SuccedsAsync()
         {
             var logger = new TestLogger();
@@ -450,7 +450,7 @@ namespace NuGet.Packaging.FuncTest
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task TimestampSignatureAsync_TimestampingCountersignature_SucceedsAsync()
         {
             var logger = new TestLogger();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/DotNetDefaultTrustStoreX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/DotNetDefaultTrustStoreX509ChainFactoryTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Packaging.Signing;
 using Xunit;
+using NuGet.Test.Utility;
 
 namespace NuGet.Packaging.FuncTest.SigningTests
 {
@@ -20,7 +21,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
             _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsNull()
         {
             DotNetDefaultTrustStoreX509ChainFactory factory = new();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/FallbackCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/FallbackCertificateBundleX509ChainFactoryTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
         {
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsLogMessage()
         {
             using (TestDirectory directory = TestDirectory.Create())

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/NoCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/NoCertificateBundleX509ChainFactoryTests.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography.X509Certificates;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
 using Xunit;
+using NuGet.Test.Utility;
 
 namespace NuGet.Packaging.FuncTest.SigningTests
 {
@@ -19,7 +20,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
         {
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsLogMessage()
         {
             NoCertificateBundleX509ChainFactory factory = new();

--- a/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/SystemCertificateBundleX509ChainFactoryTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Packaging.FuncTest/SigningTests/TrustStore/SystemCertificateBundleX509ChainFactoryTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.Packaging.FuncTest.SigningTests
         {
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public void AdditionalContext_WhenRootCertificateIsUntrusted_ReturnsLogMessage()
         {
             using (TestDirectory directory = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TrustedSignerActionsProviderTests.cs
@@ -331,7 +331,7 @@ namespace NuGet.Commands.Test
             ex.Message.Should().Be(Strings.Error_PackageNotSigned);
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_TargetRepository_NonRepositorySignedPackage_ThrowsAsync()
         {
             // Arrange
@@ -363,7 +363,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_NameAlreadyExists_ThrowsAsync()
         {
             // Arrange
@@ -402,7 +402,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_ServiceIndexAlreadyExists_ThrowsAsync()
         {
             // Arrange
@@ -442,7 +442,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_WithUnknownPrimarySignature_ThrowsAsync()
         {
             // Arrange
@@ -490,7 +490,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositorySignedPackage_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -535,7 +535,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositorySignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -581,7 +581,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositorySignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -627,7 +627,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -674,7 +674,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_WithOwners_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -722,7 +722,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_RepositoryCountersignedPackage_WithAllowUntrustedRoot_AddsRepositoryCorrectlyAsync()
         {
             // Arrange
@@ -770,7 +770,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_AuthorSignedPackage_AddsAuthorCorrectlyAsync()
         {
             // Arrange
@@ -812,7 +812,7 @@ namespace NuGet.Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task AddTrustedSignerAsync_AuthorSignedPackage_WithAllowUntrustedRoot_AddsAuthorCorrectlyAsync()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
@@ -617,7 +617,7 @@ namespace Commands.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task Test_ExtractionHonorsFileTimestamp()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -1866,7 +1866,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task GetContentHash_IsSameForUnsignedAndSignedPackageAsync()
         {
             // this test will create an unsigned package, copy it, then sign it. then compare the contentHash

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -1208,7 +1208,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task ExtractPackageAsync_PreservesZipEntryTimeAsync()
         {
             // Arrange
@@ -1824,7 +1824,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task ExtractPackageAsync_UnsignedPackage_WhenRepositorySaysAllPackagesSigned_WithEnvVar_Error()
         {
             // Arrange
@@ -1999,7 +1999,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task ExtractPackageAsync_UnsignedPackage_RequireMode_WithEnvVar_Error()
         {
             // Arrange
@@ -2198,7 +2198,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task ExtractPackageAsync_RequireMode_NoMatchInClientAllowList_WithEnvVar_Error()
         {
             // Arrange
@@ -2404,7 +2404,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task ExtractPackageAsync_WithAllowUntrusted_SucceedsWithoutSigningWarningsOrErrors_WithEnvVar()
         {
             // Arrange
@@ -2618,7 +2618,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task ExtractPackageAsync_RequireMode_UnsignedPackage_PackageArchiveReader_WhenUnsignedPackagesDisallowed_WithEnvVar_Errors()
         {
             // Arrange
@@ -3726,7 +3726,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task ExtractPackageAsyncByStream_InvalidSignPackageWithUnzip_WithOptInEnvVar_Throws()
         {
             // Arrange
@@ -3969,7 +3969,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task ExtractPackageAsyncByPackageReader_InvalidSignPackageWithUnzip_WithEnvVar_Throws()
         {
             // Arrange
@@ -4165,7 +4165,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task ExtractPackageAsyncByPackageReaderAndStream_InvalidSignPackageWithUnzip_WithEnvVar_Throws()
         {
             // Arrange
@@ -4314,7 +4314,7 @@ namespace NuGet.Packaging.Test
             }
         }
 
-        [Fact]
+        [NetFxCIOnlyFact]
         public async Task VerifyPackageSignatureAsync_PassesCommonSettingsWhenNoRepoSignatureInfo_WithEnvVar_DoVerify()
         {
             // Arrange

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/NetFxCIOnlyFactAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/NetFxCIOnlyFactAttribute.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable disable
+
+using Xunit;
+
+namespace NuGet.Test.Utility
+{
+    /// <summary>
+    /// On .NET Framework, skip the test unless running in CI (where elevation is available).
+    /// On .NET 5+, always run (in-memory trust stores don't require elevation).
+    /// </summary>
+    public class NetFxCIOnlyFactAttribute
+        : FactAttribute
+    {
+        private string _skip;
+
+        public override string Skip
+        {
+            get
+            {
+                var skip = _skip;
+
+#if !NET5_0_OR_GREATER
+                if (string.IsNullOrEmpty(skip))
+                {
+                    if (!XunitAttributeUtility.IsCI)
+                    {
+                        skip = "This test requires elevation on .NET Framework. It only runs on CI for this TFM. To run it locally, use a .NET 5+ TFM or set the env var CI=true";
+                    }
+                }
+#endif
+
+                return skip;
+            }
+
+            set
+            {
+                _skip = value;
+            }
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/NetFxCIOnlyTheoryAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/NetFxCIOnlyTheoryAttribute.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable disable
+
+using Xunit;
+
+namespace NuGet.Test.Utility
+{
+    /// <summary>
+    /// On .NET Framework, skip the test unless running in CI (where elevation is available).
+    /// On .NET 5+, always run (in-memory trust stores don't require elevation).
+    /// </summary>
+    public class NetFxCIOnlyTheoryAttribute
+        : TheoryAttribute
+    {
+        private string _skip;
+
+        public override string Skip
+        {
+            get
+            {
+                var skip = _skip;
+
+#if !NET5_0_OR_GREATER
+                if (string.IsNullOrEmpty(skip))
+                {
+                    if (!XunitAttributeUtility.IsCI)
+                    {
+                        skip = "This test requires elevation on .NET Framework. It only runs on CI for this TFM. To run it locally, use a .NET 5+ TFM or set the env var CI=true";
+                    }
+                }
+#endif
+
+                return skip;
+            }
+
+            set
+            {
+                _skip = value;
+            }
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformFactAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformFactAttribute.cs
@@ -29,6 +29,16 @@ namespace NuGet.Test.Utility
                     }
                 }
 
+#if !NET5_0_OR_GREATER
+                if (string.IsNullOrEmpty(skip))
+                {
+                    if (NetFxCIOnly && !XunitAttributeUtility.IsCI)
+                    {
+                        skip = "This test requires elevation on .NET Framework. It only runs on CI for this TFM. To run it locally, use a .NET 5+ TFM or set the env var CI=true";
+                    }
+                }
+#endif
+
                 if (string.IsNullOrEmpty(skip))
                 {
                     skip = XunitAttributeUtility.GetPlatformSkipMessageOrNull(GetAllPlatforms());
@@ -62,6 +72,12 @@ namespace NuGet.Test.Utility
         public bool SkipMono { get; set; }
 
         public bool CIOnly { get; set; }
+
+        /// <summary>
+        /// If true, skip on .NET Framework unless CI=true.
+        /// On .NET 5+, does not skip (in-memory trust stores don't require elevation).
+        /// </summary>
+        public bool NetFxCIOnly { get; set; }
 
         /// <summary>
         /// Provide property values to use this attribute.

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformTheoryAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PlatformTheoryAttribute.cs
@@ -36,6 +36,16 @@ namespace NuGet.Test.Utility
                     }
                 }
 
+#if !NET5_0_OR_GREATER
+                if (string.IsNullOrEmpty(skip))
+                {
+                    if (NetFxCIOnly && !XunitAttributeUtility.IsCI)
+                    {
+                        skip = "This test requires elevation on .NET Framework. It only runs on CI for this TFM. To run it locally, use a .NET 5+ TFM or set the env var CI=true";
+                    }
+                }
+#endif
+
                 // If this is null the test will run.
                 return skip;
             }
@@ -59,6 +69,12 @@ namespace NuGet.Test.Utility
         public bool SkipMono { get; set; }
 
         public bool CIOnly { get; set; }
+
+        /// <summary>
+        /// If true, skip on .NET Framework unless CI=true.
+        /// On .NET 5+, does not skip (in-memory trust stores don't require elevation).
+        /// </summary>
+        public bool NetFxCIOnly { get; set; }
 
         /// <summary>
         /// Provide property values to use this attribute.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: running tests locally

## Description

The PR https://github.com/NuGet/NuGet.Client/pull/7241 made it possible to run .NET signing tests locally, but didn't take into account .NET Framework tests still need admin access. This PR makes it so on .NET Framework the tests will be skipped locally and run on CI, while the .NET tests will run both locally and on CI.

cc @dtivel 

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
