### PR TITLE
Add NuGetFeatureFlags feature switch

### DIFF
--- a/build/Shared/AotCompatibilityAttributes.cs
+++ b/build/Shared/AotCompatibilityAttributes.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if !NET9_0_OR_GREATER
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Property, Inherited = false)]
+    internal sealed class FeatureSwitchDefinitionAttribute : Attribute
+    {
+        public FeatureSwitchDefinitionAttribute(string switchName) => SwitchName = switchName;
+        public string SwitchName { get; }
+    }
+}
+#endif

--- a/build/Shared/NuGetFeatureFlags.cs
+++ b/build/Shared/NuGetFeatureFlags.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using NuGet.Common;
+
+namespace NuGet.Shared
+{
+    internal static class NuGetFeatureFlags
+    {
+        internal const string UsesNSJDeserializationSwitchName = "NuGet.UsesNSJDeserialization";
+        internal const string UsesNSJDeserializationEnvVar = "NUGET_USES_NSJ_DESERIALIZATION";
+
+        private static readonly Lazy<bool> _isNSJDeserializationEnabledByEnvironment =
+            new Lazy<bool>(() => IsNSJDeserializationEnabledByEnvironment(EnvironmentVariableWrapper.Instance));
+
+        /// <summary>Feature switch for NSJ deserialization. Defaults to <see langword="true"/>.</summary>
+        [FeatureSwitchDefinition(UsesNSJDeserializationSwitchName)]
+        internal static bool NSJDeserializationFeatureSwitch { get; } =
+            !AppContext.TryGetSwitch(UsesNSJDeserializationSwitchName, out bool value) || value;
+
+        /// <summary>Returns <see langword="false"/> when env var <c>NUGET_USES_NSJ_DESERIALIZATION</c> is <c>false</c>.</summary>
+        internal static bool IsNSJDeserializationEnabledByEnvironment(IEnvironmentVariableReader? env = null)
+        {
+            if (env is null)
+            {
+                return _isNSJDeserializationEnabledByEnvironment.Value;
+            }
+
+            string? envValue = env.GetEnvironmentVariable(UsesNSJDeserializationEnvVar);
+            return !string.Equals(envValue, "false", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -39,6 +39,8 @@
     <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs" />
     <Compile Include="$(SharedDirectory)\NoAllocEnumerateExtensions.cs" />
     <Compile Include="$(SharedDirectory)\NullableAttributes.cs" />
+    <Compile Include="$(SharedDirectory)\NuGetFeatureFlags.cs" />
+    <Compile Include="$(SharedDirectory)\AotCompatibilityAttributes.cs" />
     <Compile Include="$(SharedDirectory)\SimplePool.cs" />
     <Compile Include="$(SharedDirectory)\StringBuilderPool.cs" />
     <Compile Include="$(SharedDirectory)\TaskResult.cs" />

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetFeatureFlagsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/NuGetFeatureFlagsTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Shared;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class NuGetFeatureFlagsTests
+    {
+        [Fact]
+        public void NSJDeserializationFeatureSwitch_Default_ReturnsTrue()
+        {
+            Assert.True(NuGetFeatureFlags.NSJDeserializationFeatureSwitch);
+        }
+
+        [Fact]
+        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarNotSet_ReturnsTrue()
+        {
+            Assert.True(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(TestEnvironmentVariableReader.EmptyInstance));
+        }
+
+        [Theory]
+        [InlineData("false")]
+        [InlineData("False")]
+        [InlineData("FALSE")]
+        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarSetToFalse_ReturnsFalse(string value)
+        {
+            var env = new TestEnvironmentVariableReader(
+                new Dictionary<string, string> { [NuGetFeatureFlags.UsesNSJDeserializationEnvVar] = value });
+
+            Assert.False(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(env));
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("True")]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("anything")]
+        public void IsNSJDeserializationEnabledByEnvironment_WhenEnvVarSetToTrueOrUnrecognized_ReturnsTrue(string value)
+        {
+            var env = new TestEnvironmentVariableReader(
+                new Dictionary<string, string> { [NuGetFeatureFlags.UsesNSJDeserializationEnvVar] = value });
+
+            Assert.True(NuGetFeatureFlags.IsNSJDeserializationEnabledByEnvironment(env));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Shared.Tests/NuGet.Shared.Tests.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Shared.Tests/NuGet.Shared.Tests.csproj
@@ -9,6 +9,8 @@
     <Compile Include="$(SharedDirectory)\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <Compile Remove="$(SharedDirectory)\IsExternalInit.cs" />
     <Compile Remove="$(SharedDirectory)\RequiredModifierAttributes.cs" />
+    <Compile Remove="$(SharedDirectory)\AotCompatibilityAttributes.cs" />
+    <Compile Remove="$(SharedDirectory)\NuGetFeatureFlags.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 
Related: https://github.com/NuGet/Home/issues/14846

## Description

 This is the foundational PR for migrating NuGet.Core from `Newtonsoft.Json` to `System.Text.Json` . It introduces no behavioral changes - it only adds the switches that follow-up migration PRs will build on. T

Switch: NuGet.UsesNSJDeserialization

 - Default: true (NSJ - no behavioral change)
 - Set to false to opt into STJ deserialization
 - Controllable via AppContext switch (runtimeconfig.json) or env var NUGET_USES_NSJ_DESERIALIZATION=false
 - Annotated with [FeatureSwitchDefinition] so the .NET 9+ linker can dead-code-eliminate NSJ branches when publishing with Trim="true"

Feature switch design: https://github.com/dotnet/designs/blob/main/accepted/2020/feature-switch.md

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
