### PR TITLE
Switch file-based app integration tests to use dotnet.exe only

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -7,9 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
-using NuGet.CommandLine.XPlat;
 using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -79,7 +77,6 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/14823: This should use `dotnet package add` when it supports file-based apps.
         [Fact]
         public async Task AddPkg_FileBasedApp()
         {
@@ -95,56 +92,23 @@ namespace Dotnet.Integration.Test
                 Console.WriteLine();
                 """);
 
-            var tempDir = Path.Join(pathContext.WorkingDirectory, "temp");
-            Directory.CreateDirectory(tempDir);
-
-            // Generate DG file.
-            var dgFile = Path.Join(tempDir, "dg.json");
-            _fixture.RunDotnetExpectSuccess(fbaDir, $"build app.cs -t:GenerateRestoreGraphFile -p:RestoreGraphOutputPath={ArgumentEscaper.EscapeAndConcatenate([dgFile])}", testOutputHelper: _testOutputHelper);
-
-            // Get project content.
-            var virtualProject = _fixture.GetFileBasedAppVirtualProject(appFile, _testOutputHelper);
-            _testOutputHelper.WriteLine("before:\n" + virtualProject.Content);
-            Assert.DoesNotContain("PackageReference", virtualProject.Content);
-            using var builder = new TestVirtualProjectBuilder(virtualProject);
-
             // Create a package.
             var packageX = XPlatTestUtils.CreatePackage();
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, PackageSaveMode.Defaultv3, packageX);
 
             // Add the package.
-            using var outWriter = new StringWriter();
-            using var errorWriter = new StringWriter();
-            var testApp = new CommandLineApplication
-            {
-                Out = outWriter,
-                Error = errorWriter,
-            };
-            AddPackageReferenceCommand.Register(
-                testApp,
-                () => new TestLogger(_testOutputHelper),
-                () => new AddPackageReferenceCommandRunner(),
-                () => builder);
-            int result = testApp.Execute([
-                "add",
-                "--project", appFile,
-                "--package", "packageX",
-                "--dg-file", dgFile,
-            ]);
+            _fixture.RunDotnetExpectSuccess(fbaDir, "package add packageX --file app.cs --version 1.0.0", testOutputHelper: _testOutputHelper);
 
-            var output = outWriter.ToString();
-            var error = errorWriter.ToString();
-
-            _testOutputHelper.WriteLine(output);
-            _testOutputHelper.WriteLine(error);
-
-            Assert.Equal(0, result);
-
-            Assert.Empty(error);
-
-            var modifiedProjectContent = builder.ModifiedContent;
-            _testOutputHelper.WriteLine("after:\n" + modifiedProjectContent);
-            Assert.Contains("""<PackageReference Include="packageX" Version="1.0.0" />""", modifiedProjectContent);
+            // Verify the full content of the modified .cs file.
+            var modifiedContent = File.ReadAllText(appFile);
+            _testOutputHelper.WriteLine("after:\n" + modifiedContent);
+            Assert.Equal(
+                """
+                #:package packageX@1.0.0
+                #:property PublishAot=false
+                Console.WriteLine();
+                """,
+                modifiedContent);
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -11,11 +11,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Threading;
 using FluentAssertions;
-using Microsoft.Build.Locator;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 using NuGet.Commands;
 using NuGet.Common;
@@ -56,9 +53,6 @@ namespace Dotnet.Integration.Test
 
             SdkDirectory = new DirectoryInfo(sdkPath);
             MsBuildSdksPath = Path.Combine(sdkPath, "Sdks");
-
-            // https://github.com/NuGet/Home/issues/14823: This can be removed when we migrate to `dotnet.exe`-only integration tests for file-based apps.
-            MSBuildLocator.RegisterMSBuildPath(sdkPath);
 
             _templateDirectory = new SimpleTestPathContext();
             TestDotnetCLiUtility.WriteGlobalJson(_templateDirectory.WorkingDirectory);
@@ -359,18 +353,6 @@ namespace Dotnet.Integration.Test
             }
 
             return RunDotnet(workingDirectory, $"msbuild {file} {args}", expectSuccess, testOutputHelper: testOutputHelper);
-        }
-
-        internal (string Content, string ProjectPath, string FilePath) GetFileBasedAppVirtualProject(string entryPointFileFullPath, ITestOutputHelper testOutputHelper)
-        {
-            var runApi = RunDotnetExpectSuccess(Path.GetDirectoryName(entryPointFileFullPath), "run-api", testOutputHelper: testOutputHelper, inputAction: writer =>
-            {
-                writer.Write($$"""{ "$type": "GetProject", "EntryPointFileFullPath": {{JsonSerializer.Serialize(entryPointFileFullPath)}} }""");
-            });
-            var node = JsonNode.Parse(runApi.AllOutput);
-            return (Content: node["Content"].GetValue<string>(),
-                ProjectPath: node["ProjectPath"].GetValue<string>(),
-                FilePath: entryPointFileFullPath);
         }
 
         internal TestDirectory CreateTestDirectory()

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -12,10 +12,8 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;
-using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 using Newtonsoft.Json.Linq;
-using NuGet.CommandLine.XPlat;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -79,7 +77,6 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/14823: This should use `dotnet package list` when it supports file-based apps.
         [Fact]
         public async Task DotnetListPackage_FileBasedApp()
         {
@@ -102,45 +99,11 @@ namespace Dotnet.Integration.Test
             // Restore.
             _fixture.RunDotnetExpectSuccess(fbaDir, "restore app.cs", testOutputHelper: _testOutputHelper);
 
-            // Get project content.
-            var virtualProject = _fixture.GetFileBasedAppVirtualProject(appFile, _testOutputHelper);
-            using var builder = new TestVirtualProjectBuilder(virtualProject);
-
             // List packages.
-            using var outWriter = new StringWriter();
-            using var errorWriter = new StringWriter();
-            var testApp = new CommandLineApplication
-            {
-                Out = outWriter,
-                Error = errorWriter,
-            };
-            var logger = new TestLogger(_testOutputHelper);
-            var msbuild = new MSBuildAPIUtility(logger, builder);
-            ListPackageCommand.Register(
-                testApp,
-                () => logger,
-                (_) => { },
-                () => new ListPackageCommandRunner(msbuild));
-            int result = testApp.Execute([
-                "list", appFile,
-                "--source", pathContext.PackageSource,
-                "--format", "json",
-            ]);
+            var result = _fixture.RunDotnetExpectSuccess(fbaDir, "package list --file app.cs --format json", testOutputHelper: _testOutputHelper);
 
-            var output = outWriter.ToString();
-            var error = errorWriter.ToString();
-
-            _testOutputHelper.WriteLine(output);
-            _testOutputHelper.WriteLine(error);
-
-            Assert.Equal(0, result);
-
-            Assert.Empty(error);
-
-            Assert.Contains("packageX", output);
-            Assert.Contains("1.0.0", output);
-
-            Assert.Null(builder.ModifiedContent);
+            Assert.Contains("packageX", result.AllOutput);
+            Assert.Contains("1.0.0", result.AllOutput);
         }
 
         [PlatformFact(Platform.Windows)]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -13,14 +12,10 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using FluentAssertions;
 using NuGet.CommandLine.Xplat.Tests;
-using NuGet.CommandLine.XPlat;
-using NuGet.CommandLine.XPlat.Commands.Package.Update;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
-using NuGet.XPlat.FuncTest;
-using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -100,7 +95,6 @@ namespace Dotnet.Integration.Test
             version.Should().Be("2.0.0");
         }
 
-        // https://github.com/NuGet/Home/issues/14823: This should use `dotnet package update` when it supports file-based apps.
         [Fact]
         public async Task FileBasedApp()
         {
@@ -124,43 +118,19 @@ namespace Dotnet.Integration.Test
                 Console.WriteLine();
                 """);
 
-            // Get project content.
-            var virtualProject = _testFixture.GetFileBasedAppVirtualProject(appFile, _testOutputHelper);
-            _testOutputHelper.WriteLine("before:\n" + virtualProject.Content);
-            Assert.Contains("""<PackageReference Include="NuGet.Internal.Test.a" Version="1.0.0" />""", virtualProject.Content);
-            using var builder = new TestVirtualProjectBuilder(virtualProject);
-
             // Update the package.
-            using var outWriter = new StringWriter();
-            using var errorWriter = new StringWriter();
-            var rootCommand = new RootCommand();
-            PackageUpdateCommand.Register(
-                rootCommand,
-                new Option<bool>("--interactive"),
-                (args, ct) =>
-                {
-                    var msbuildUtility = new MSBuildAPIUtility(new TestLogger(_testOutputHelper), builder);
-                    var packageUpdateIO = new PackageUpdateIO(args.Project, msbuildUtility, new TestEnvironmentVariableReader(_envVars));
-                    return PackageUpdateCommandRunner.Run(args, new TestCommandOutputLogger(_testOutputHelper), packageUpdateIO, ct);
-                });
-            int result = rootCommand.Parse([
-                "update",
-                "--project", appFile,
-            ]).Invoke(new() { Output = outWriter, Error = errorWriter });
+            _testFixture.RunDotnetExpectSuccess(fbaDir, "package update --file app.cs", testOutputHelper: _testOutputHelper, environmentVariables: _envVars);
 
-            var output = outWriter.ToString();
-            var error = errorWriter.ToString();
-
-            _testOutputHelper.WriteLine(output);
-            _testOutputHelper.WriteLine(error);
-
-            Assert.Equal(0, result);
-
-            Assert.Empty(error);
-
-            var modifiedProjectContent = builder.ModifiedContent;
-            _testOutputHelper.WriteLine("after:\n" + modifiedProjectContent);
-            Assert.Contains("""<PackageReference Include="NuGet.Internal.Test.a" Version="2.0.0" />""", modifiedProjectContent);
+            // Verify the full content of the modified .cs file.
+            var modifiedContent = File.ReadAllText(appFile);
+            _testOutputHelper.WriteLine("after:\n" + modifiedContent);
+            Assert.Equal(
+                """
+                #:property PublishAot=false
+                #:package NuGet.Internal.Test.a@2.0.0
+                Console.WriteLine();
+                """,
+                modifiedContent);
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRemovePackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRemovePackageTests.cs
@@ -2,11 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
-using System.Threading.Tasks;
-using Microsoft.Extensions.CommandLineUtils;
-using NuGet.CommandLine.XPlat;
-using NuGet.Test.Utility;
-using NuGet.XPlat.FuncTest;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,9 +13,8 @@ public sealed class DotnetRemovePackageTests(DotnetIntegrationTestFixture fixtur
     private readonly DotnetIntegrationTestFixture _fixture = fixture;
     private readonly ITestOutputHelper _testOutputHelper = testOutputHelper;
 
-    // https://github.com/NuGet/Home/issues/14823: This should use `dotnet package remove` when it supports file-based apps.
     [Fact]
-    public async Task RemovePkg_FileBasedApp()
+    public void RemovePkg_FileBasedApp()
     {
         using var pathContext = _fixture.CreateSimpleTestPathContext();
 
@@ -34,43 +28,16 @@ public sealed class DotnetRemovePackageTests(DotnetIntegrationTestFixture fixtur
             Console.WriteLine();
             """);
 
-        // Get project content.
-        var virtualProject = _fixture.GetFileBasedAppVirtualProject(appFile, _testOutputHelper);
-        _testOutputHelper.WriteLine("before:\n" + virtualProject.Content);
-        Assert.Contains("""<PackageReference Include="packageX" Version="1.0.0" />""", virtualProject.Content);
-        using var builder = new TestVirtualProjectBuilder(virtualProject);
-
         // Remove the package.
-        using var outWriter = new StringWriter();
-        using var errorWriter = new StringWriter();
-        var testApp = new CommandLineApplication
-        {
-            Out = outWriter,
-            Error = errorWriter,
-        };
-        RemovePackageReferenceCommand.Register(
-            testApp,
-            () => new TestLogger(_testOutputHelper),
-            () => new RemovePackageReferenceCommandRunner(),
-            () => builder);
-        int result = testApp.Execute([
-            "remove",
-            "--project", appFile,
-            "--package", "packageX",
-        ]);
+        _fixture.RunDotnetExpectSuccess(fbaDir, "package remove packageX --file app.cs", testOutputHelper: _testOutputHelper);
 
-        var output = outWriter.ToString();
-        var error = errorWriter.ToString();
-
-        _testOutputHelper.WriteLine(output);
-        _testOutputHelper.WriteLine(error);
-
-        Assert.Equal(0, result);
-
-        Assert.Empty(error);
-
-        var modifiedProjectContent = builder.ModifiedContent;
-        _testOutputHelper.WriteLine("after:\n" + modifiedProjectContent);
-        Assert.DoesNotContain("PackageReference", modifiedProjectContent);
+        // Verify the full content of the modified .cs file.
+        var modifiedContent = File.ReadAllText(appFile);
+        _testOutputHelper.WriteLine("after:\n" + modifiedContent);
+        Assert.Equal(
+            """
+            Console.WriteLine();
+            """,
+            modifiedContent);
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -3,20 +3,14 @@
 
 #nullable disable
 
-using System;
-using System.CommandLine;
 using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 using NuGet.CommandLine.XPlat;
-using NuGet.CommandLine.XPlat.Commands.Why;
-using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
 using NuGet.XPlat.FuncTest;
-using Spectre.Console;
-using Spectre.Console.Testing;
 using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
@@ -69,7 +63,6 @@ namespace Dotnet.Integration.Test
             Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", result.AllOutput.Replace("\n", "").Replace("\r", ""));
         }
 
-        // https://github.com/NuGet/Home/issues/14823: This should use `dotnet nuget why` when it supports file-based apps.
         [Fact]
         public async Task WhyCommand_FileBasedApp()
         {
@@ -95,37 +88,11 @@ namespace Dotnet.Integration.Test
             // Restore.
             _testFixture.RunDotnetExpectSuccess(fbaDir, "restore app.cs", testOutputHelper: _testOutputHelper);
 
-            // Get project content.
-            var virtualProject = _testFixture.GetFileBasedAppVirtualProject(appFile, _testOutputHelper);
-            using var builder = new TestVirtualProjectBuilder(virtualProject);
-
             // Run "why" command.
-            var console = new TestConsole();
-            using var outWriter = new StringWriter();
-            using var errorWriter = new StringWriter();
-            var rootCommand = new RootCommand();
-            WhyCommand.Register(
-                rootCommand,
-                new Lazy<IAnsiConsole>(console),
-                () => new WhyCommandRunner(new MSBuildAPIUtility(NullLogger.Instance, builder)));
-            int result = rootCommand.Parse([
-                "why", appFile, "PackageB",
-            ]).Invoke(new() { Output = outWriter, Error = errorWriter });
+            var result = _testFixture.RunDotnetExpectSuccess(fbaDir, "nuget why app.cs PackageB", testOutputHelper: _testOutputHelper);
 
-            var output = outWriter.ToString() + console.Output;
-            var error = errorWriter.ToString();
-
-            _testOutputHelper.WriteLine(output);
-            _testOutputHelper.WriteLine(error);
-
-            Assert.Equal(0, result);
-
-            Assert.Empty(error);
-
-            Assert.Contains("PackageA (v1.0.0)", output);
-            Assert.Contains("packageB (v1.0.1)", output);
-
-            Assert.Null(builder.ModifiedContent);
+            Assert.Contains("PackageA (v1.0.0)", result.AllOutput);
+            Assert.Contains("packageB (v1.0.1)", result.AllOutput);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

Closes https://github.com/NuGet/Home/issues/14823

## Description

Migrate all 5 file-based app tests in Dotnet.Integration.Test to invoke dotnet CLI commands directly instead of calling internal NuGet APIs:

- dotnet package add --file
- dotnet package remove --file
- dotnet package list --file
- dotnet package update --file
- dotnet nuget why <file>

This is possible because the test SDK (10.0.300-preview from .test/dotnet) includes the companion SDK-side support (dotnet/sdk#53535).

Also removes:
- MSBuildLocator.RegisterMSBuildPath from the fixture (no longer needed)
- GetFileBasedAppVirtualProject helper (no longer used)
- TestVirtualProjectBuilder usage from integration tests
- Unnecessary using directives

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
