### PR TITLE
Support `#:ref` directives of file-based apps

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -73,16 +73,12 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
 
             DependencyGraphSpec result = DependencyGraphSpec.Load(tempFile);
 
-            // Fixup virtual project paths.
-            if (_msbuildUtility.VirtualProjectBuilder?.GetVirtualProjectPath(project) is { } virtualProjectPath)
+            // When a file-based app references other file-based apps via #:ref directives,
+            // the DGSpec contains virtual .csproj paths for all of them.
+            // We need to map all virtual paths back to entry point file paths.
+            if (_msbuildUtility.VirtualProjectBuilder is { } builder)
             {
-                foreach (var packageSpec in result.Projects)
-                {
-                    if (packageSpec.FilePath == virtualProjectPath)
-                    {
-                        packageSpec.FilePath = project;
-                    }
-                }
+                result = FixupVirtualProjectPaths(result, project, builder);
             }
 
             return result;
@@ -124,6 +120,90 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
             process.WaitForExit();
 
             return process.ExitCode == 0;
+        }
+    }
+
+    /// <summary>
+    /// Maps virtual project paths (e.g., <c>app.csproj</c>) in the DGSpec back to the actual
+    /// entry point file paths (e.g., <c>app.cs</c>) for all file-based apps in the project graph.
+    /// This is needed because file-based apps don't have real <c>.csproj</c> files;
+    /// the SDK generates virtual project XML in memory.
+    /// </summary>
+    private static DependencyGraphSpec FixupVirtualProjectPaths(DependencyGraphSpec dgSpec, string rootEntryPoint, IVirtualProjectBuilder builder)
+    {
+        // Build mapping from virtual project paths to entry point file paths.
+        var virtualToEntryPoint = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        // Root project: we know the entry point from the user-provided path.
+        string rootVirtualPath = builder.GetVirtualProjectPath(rootEntryPoint);
+        virtualToEntryPoint[rootVirtualPath] = rootEntryPoint;
+
+        // Referenced file-based apps: reverse-map virtual paths to entry points.
+        foreach (PackageSpec packageSpec in dgSpec.Projects)
+        {
+            string filePath = packageSpec.FilePath;
+            if (!virtualToEntryPoint.ContainsKey(filePath) &&
+                builder.TryGetEntryPointPath(filePath) is { } entryPoint)
+            {
+                virtualToEntryPoint[filePath] = entryPoint;
+            }
+        }
+
+        // Create a new DGSpec with all virtual paths replaced by entry point paths.
+        var fixedDgSpec = new DependencyGraphSpec();
+
+        foreach (PackageSpec packageSpec in dgSpec.Projects)
+        {
+            FixupPackageSpecPaths(packageSpec, virtualToEntryPoint);
+            fixedDgSpec.AddProject(packageSpec);
+        }
+
+        foreach (string restorePath in dgSpec.Restore)
+        {
+            fixedDgSpec.AddRestore(virtualToEntryPoint.TryGetValue(restorePath, out string? entryPoint) ? entryPoint : restorePath);
+        }
+
+        return fixedDgSpec;
+    }
+
+    /// <summary>
+    /// Replaces virtual project paths with entry point paths in a single <see cref="PackageSpec"/>.
+    /// </summary>
+    private static void FixupPackageSpecPaths(PackageSpec packageSpec, Dictionary<string, string> virtualToEntryPoint)
+    {
+        if (virtualToEntryPoint.TryGetValue(packageSpec.FilePath, out string? entryPoint))
+        {
+            packageSpec.FilePath = entryPoint;
+        }
+
+        if (packageSpec.RestoreMetadata is { } metadata)
+        {
+            if (virtualToEntryPoint.TryGetValue(metadata.ProjectUniqueName, out entryPoint))
+            {
+                metadata.ProjectUniqueName = entryPoint;
+            }
+
+            if (virtualToEntryPoint.TryGetValue(metadata.ProjectPath, out entryPoint))
+            {
+                metadata.ProjectPath = entryPoint;
+            }
+
+            // Fix up project references that point to virtual projects.
+            foreach (ProjectRestoreMetadataFrameworkInfo tfm in metadata.TargetFrameworks)
+            {
+                foreach (ProjectRestoreReference projRef in tfm.ProjectReferences)
+                {
+                    if (virtualToEntryPoint.TryGetValue(projRef.ProjectUniqueName, out entryPoint))
+                    {
+                        projRef.ProjectUniqueName = entryPoint;
+                    }
+
+                    if (virtualToEntryPoint.TryGetValue(projRef.ProjectPath, out entryPoint))
+                    {
+                        projRef.ProjectPath = entryPoint;
+                    }
+                }
+            }
         }
     }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/IVirtualProjectBuilder.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/IVirtualProjectBuilder.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.IO;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 
@@ -28,6 +29,21 @@ public interface IVirtualProjectBuilder
     /// (e.g., <c>app.cs</c>). The returned path is used by MSBuild for DG specs and property evaluation.
     /// </summary>
     string GetVirtualProjectPath(string entryPointFilePath);
+
+    /// <summary>
+    /// Given a virtual project path (e.g., <c>app.csproj</c>), attempts to find the corresponding
+    /// entry point file path (e.g., <c>app.cs</c>). Returns <c>null</c> if no valid entry point exists.
+    /// </summary>
+    /// <remarks>
+    /// This is the reverse of <see cref="GetVirtualProjectPath"/>.
+    /// </remarks>
+    string? TryGetEntryPointPath(string virtualProjectPath)
+    {
+        // Default implementation for backward compatibility with SDK versions
+        // that don't yet implement this method.
+        string potentialEntryPoint = Path.ChangeExtension(virtualProjectPath, ".cs");
+        return IsValidEntryPointPath(potentialEntryPoint) ? potentialEntryPoint : null;
+    }
 
     ProjectRootElement CreateProjectRootElement(string entryPointFilePath, ProjectCollection projectCollection);
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+NuGet.CommandLine.XPlat.IVirtualProjectBuilder.TryGetEntryPointPath(string! virtualProjectPath) -> string?

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -7,9 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
-using NuGet.CommandLine.XPlat;
 using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -79,7 +77,6 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/14823: This should use `dotnet package add` when it supports file-based apps.
         [Fact]
         public async Task AddPkg_FileBasedApp()
         {
@@ -95,56 +92,23 @@ namespace Dotnet.Integration.Test
                 Console.WriteLine();
                 """);
 
-            var tempDir = Path.Join(pathContext.WorkingDirectory, "temp");
-            Directory.CreateDirectory(tempDir);
-
-            // Generate DG file.
-            var dgFile = Path.Join(tempDir, "dg.json");
-            _fixture.RunDotnetExpectSuccess(fbaDir, $"build app.cs -t:GenerateRestoreGraphFile -p:RestoreGraphOutputPath={ArgumentEscaper.EscapeAndConcatenate([dgFile])}", testOutputHelper: _testOutputHelper);
-
-            // Get project content.
-            var virtualProject = _fixture.GetFileBasedAppVirtualProject(appFile, _testOutputHelper);
-            _testOutputHelper.WriteLine("before:\n" + virtualProject.Content);
-            Assert.DoesNotContain("PackageReference", virtualProject.Content);
-            using var builder = new TestVirtualProjectBuilder(virtualProject);
-
             // Create a package.
             var packageX = XPlatTestUtils.CreatePackage();
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, PackageSaveMode.Defaultv3, packageX);
 
             // Add the package.
-            using var outWriter = new StringWriter();
-            using var errorWriter = new StringWriter();
-            var testApp = new CommandLineApplication
-            {
-                Out = outWriter,
-                Error = errorWriter,
-            };
-            AddPackageReferenceCommand.Register(
-                testApp,
-                () => new TestLogger(_testOutputHelper),
-                () => new AddPackageReferenceCommandRunner(),
-                () => builder);
-            int result = testApp.Execute([
-                "add",
-                "--project", appFile,
-                "--package", "packageX",
-                "--dg-file", dgFile,
-            ]);
+            _fixture.RunDotnetExpectSuccess(fbaDir, "package add packageX --file app.cs --version 1.0.0", testOutputHelper: _testOutputHelper);
 
-            var output = outWriter.ToString();
-            var error = errorWriter.ToString();
-
-            _testOutputHelper.WriteLine(output);
-            _testOutputHelper.WriteLine(error);
-
-            Assert.Equal(0, result);
-
-            Assert.Empty(error);
-
-            var modifiedProjectContent = builder.ModifiedContent;
-            _testOutputHelper.WriteLine("after:\n" + modifiedProjectContent);
-            Assert.Contains("""<PackageReference Include="packageX" Version="1.0.0" />""", modifiedProjectContent);
+            // Verify the full content of the modified .cs file.
+            var modifiedContent = File.ReadAllText(appFile);
+            _testOutputHelper.WriteLine("after:\n" + modifiedContent);
+            Assert.Equal(
+                """
+                #:package packageX@1.0.0
+                #:property PublishAot=false
+                Console.WriteLine();
+                """,
+                modifiedContent);
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetAddPackageTests.cs
@@ -112,6 +112,59 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
+        public async Task AddPkg_FileBasedApp_WithRef()
+        {
+            using var pathContext = _fixture.CreateSimpleTestPathContext();
+
+            // Create a referenced file-based app.
+            var libDir = Path.Join(pathContext.SolutionRoot, "lib");
+            Directory.CreateDirectory(libDir);
+
+            var libFile = Path.Join(libDir, "lib.cs");
+            var libContent = """
+                #:property PublishAot=false
+                public class Lib { }
+                """;
+            File.WriteAllText(libFile, libContent);
+
+            // Create the root file-based app referencing the lib.
+            var fbaDir = Path.Join(pathContext.SolutionRoot, "fba");
+            Directory.CreateDirectory(fbaDir);
+
+            var refPath = Path.GetRelativePath(fbaDir, libFile);
+            var appFile = Path.Join(fbaDir, "app.cs");
+            var appContent = $"""
+                #:property PublishAot=false
+                #:property ExperimentalFileBasedProgramEnableRefDirective=true
+                #:ref {refPath}
+                Console.WriteLine();
+                """;
+            File.WriteAllText(appFile, appContent);
+
+            // Create a package.
+            var packageX = XPlatTestUtils.CreatePackage();
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, PackageSaveMode.Defaultv3, packageX);
+
+            // Add a package to the root app (which has a #:ref to lib).
+            _fixture.RunDotnetExpectSuccess(fbaDir, "package add packageX --file app.cs --version 1.0.0", testOutputHelper: _testOutputHelper);
+
+            // Verify the package was added to the root app.
+            var modifiedAppContent = File.ReadAllText(appFile);
+            _testOutputHelper.WriteLine("app after:\n" + modifiedAppContent);
+            Assert.Equal(
+                $"""
+                #:package packageX@1.0.0
+                {appContent}
+                """,
+                modifiedAppContent);
+
+            // Verify the lib was not modified.
+            var modifiedLibContent = File.ReadAllText(libFile);
+            _testOutputHelper.WriteLine("lib after:\n" + modifiedLibContent);
+            Assert.Equal(libContent, modifiedLibContent);
+        }
+
+        [Fact]
         public async Task AddPkg_V3LocalSourceFeed_WithRelativePath_NoVersionSpecified_Fail()
         {
             using (SimpleTestPathContext pathContext = _fixture.CreateSimpleTestPathContext())

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -11,11 +11,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Threading;
 using FluentAssertions;
-using Microsoft.Build.Locator;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 using NuGet.Commands;
 using NuGet.Common;
@@ -56,9 +53,6 @@ namespace Dotnet.Integration.Test
 
             SdkDirectory = new DirectoryInfo(sdkPath);
             MsBuildSdksPath = Path.Combine(sdkPath, "Sdks");
-
-            // https://github.com/NuGet/Home/issues/14823: This can be removed when we migrate to `dotnet.exe`-only integration tests for file-based apps.
-            MSBuildLocator.RegisterMSBuildPath(sdkPath);
 
             _templateDirectory = new SimpleTestPathContext();
             TestDotnetCLiUtility.WriteGlobalJson(_templateDirectory.WorkingDirectory);
@@ -359,18 +353,6 @@ namespace Dotnet.Integration.Test
             }
 
             return RunDotnet(workingDirectory, $"msbuild {file} {args}", expectSuccess, testOutputHelper: testOutputHelper);
-        }
-
-        internal (string Content, string ProjectPath, string FilePath) GetFileBasedAppVirtualProject(string entryPointFileFullPath, ITestOutputHelper testOutputHelper)
-        {
-            var runApi = RunDotnetExpectSuccess(Path.GetDirectoryName(entryPointFileFullPath), "run-api", testOutputHelper: testOutputHelper, inputAction: writer =>
-            {
-                writer.Write($$"""{ "$type": "GetProject", "EntryPointFileFullPath": {{JsonSerializer.Serialize(entryPointFileFullPath)}} }""");
-            });
-            var node = JsonNode.Parse(runApi.AllOutput);
-            return (Content: node["Content"].GetValue<string>(),
-                ProjectPath: node["ProjectPath"].GetValue<string>(),
-                FilePath: entryPointFileFullPath);
         }
 
         internal TestDirectory CreateTestDirectory()

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -12,10 +12,8 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;
-using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 using Newtonsoft.Json.Linq;
-using NuGet.CommandLine.XPlat;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -79,7 +77,6 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // https://github.com/NuGet/Home/issues/14823: This should use `dotnet package list` when it supports file-based apps.
         [Fact]
         public async Task DotnetListPackage_FileBasedApp()
         {
@@ -102,45 +99,11 @@ namespace Dotnet.Integration.Test
             // Restore.
             _fixture.RunDotnetExpectSuccess(fbaDir, "restore app.cs", testOutputHelper: _testOutputHelper);
 
-            // Get project content.
-            var virtualProject = _fixture.GetFileBasedAppVirtualProject(appFile, _testOutputHelper);
-            using var builder = new TestVirtualProjectBuilder(virtualProject);
-
             // List packages.
-            using var outWriter = new StringWriter();
-            using var errorWriter = new StringWriter();
-            var testApp = new CommandLineApplication
-            {
-                Out = outWriter,
-                Error = errorWriter,
-            };
-            var logger = new TestLogger(_testOutputHelper);
-            var msbuild = new MSBuildAPIUtility(logger, builder);
-            ListPackageCommand.Register(
-                testApp,
-                () => logger,
-                (_) => { },
-                () => new ListPackageCommandRunner(msbuild));
-            int result = testApp.Execute([
-                "list", appFile,
-                "--source", pathContext.PackageSource,
-                "--format", "json",
-            ]);
+            var result = _fixture.RunDotnetExpectSuccess(fbaDir, "package list --file app.cs --format json", testOutputHelper: _testOutputHelper);
 
-            var output = outWriter.ToString();
-            var error = errorWriter.ToString();
-
-            _testOutputHelper.WriteLine(output);
-            _testOutputHelper.WriteLine(error);
-
-            Assert.Equal(0, result);
-
-            Assert.Empty(error);
-
-            Assert.Contains("packageX", output);
-            Assert.Contains("1.0.0", output);
-
-            Assert.Null(builder.ModifiedContent);
+            Assert.Contains("packageX", result.AllOutput);
+            Assert.Contains("1.0.0", result.AllOutput);
         }
 
         [PlatformFact(Platform.Windows)]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -87,11 +87,12 @@ namespace Dotnet.Integration.Test
             Directory.CreateDirectory(fbaDir);
 
             var appFile = Path.Join(fbaDir, "app.cs");
-            File.WriteAllText(appFile, """
+            var appContent = """
                 #:property PublishAot=false
                 #:package packageX@1.0.0
                 Console.WriteLine();
-                """);
+                """;
+            File.WriteAllText(appFile, appContent);
 
             var packageX = XPlatTestUtils.CreatePackage();
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, PackageSaveMode.Defaultv3, packageX);
@@ -104,6 +105,61 @@ namespace Dotnet.Integration.Test
 
             Assert.Contains("packageX", result.AllOutput);
             Assert.Contains("1.0.0", result.AllOutput);
+
+            // Verify the file was not modified (list is read-only).
+            Assert.Equal(appContent, File.ReadAllText(appFile));
+        }
+
+        [Fact]
+        public async Task DotnetListPackage_FileBasedApp_WithRef()
+        {
+            using var pathContext = _fixture.CreateSimpleTestPathContext();
+
+            // Create a referenced file-based app with a package.
+            var libDir = Path.Join(pathContext.SolutionRoot, "lib");
+            Directory.CreateDirectory(libDir);
+
+            var libFile = Path.Join(libDir, "lib.cs");
+            var libContent = """
+                #:property PublishAot=false
+                #:package packageY@1.0.0
+                public class Lib { }
+                """;
+            File.WriteAllText(libFile, libContent);
+
+            // Create the root file-based app referencing the lib.
+            var fbaDir = Path.Join(pathContext.SolutionRoot, "fba");
+            Directory.CreateDirectory(fbaDir);
+
+            var packageX = XPlatTestUtils.CreatePackage();
+            var packageY = XPlatTestUtils.CreatePackage("packageY");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, PackageSaveMode.Defaultv3, packageX, packageY);
+
+            var refPath = Path.GetRelativePath(fbaDir, libFile);
+            var appFile = Path.Join(fbaDir, "app.cs");
+            var appContent = $"""
+                #:property PublishAot=false
+                #:property ExperimentalFileBasedProgramEnableRefDirective=true
+                #:ref {refPath}
+                #:package packageX@1.0.0
+                Console.WriteLine();
+                """;
+            File.WriteAllText(appFile, appContent);
+
+            // Restore.
+            _fixture.RunDotnetExpectSuccess(fbaDir, "restore app.cs", testOutputHelper: _testOutputHelper);
+
+            // List packages.
+            var result = _fixture.RunDotnetExpectSuccess(fbaDir, "package list --file app.cs --format json", testOutputHelper: _testOutputHelper);
+
+            // The root app's packages should be listed, but not the referenced lib's packages.
+            Assert.Contains("packageX", result.AllOutput);
+            Assert.DoesNotContain("packageY", result.AllOutput);
+            Assert.Contains("1.0.0", result.AllOutput);
+
+            // Verify neither file was modified (list is read-only).
+            Assert.Equal(appContent, File.ReadAllText(appFile));
+            Assert.Equal(libContent, File.ReadAllText(libFile));
         }
 
         [PlatformFact(Platform.Windows)]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -13,14 +12,10 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using FluentAssertions;
 using NuGet.CommandLine.Xplat.Tests;
-using NuGet.CommandLine.XPlat;
-using NuGet.CommandLine.XPlat.Commands.Package.Update;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
-using NuGet.XPlat.FuncTest;
-using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -100,7 +95,6 @@ namespace Dotnet.Integration.Test
             version.Should().Be("2.0.0");
         }
 
-        // https://github.com/NuGet/Home/issues/14823: This should use `dotnet package update` when it supports file-based apps.
         [Fact]
         public async Task FileBasedApp()
         {
@@ -124,43 +118,19 @@ namespace Dotnet.Integration.Test
                 Console.WriteLine();
                 """);
 
-            // Get project content.
-            var virtualProject = _testFixture.GetFileBasedAppVirtualProject(appFile, _testOutputHelper);
-            _testOutputHelper.WriteLine("before:\n" + virtualProject.Content);
-            Assert.Contains("""<PackageReference Include="NuGet.Internal.Test.a" Version="1.0.0" />""", virtualProject.Content);
-            using var builder = new TestVirtualProjectBuilder(virtualProject);
-
             // Update the package.
-            using var outWriter = new StringWriter();
-            using var errorWriter = new StringWriter();
-            var rootCommand = new RootCommand();
-            PackageUpdateCommand.Register(
-                rootCommand,
-                new Option<bool>("--interactive"),
-                (args, ct) =>
-                {
-                    var msbuildUtility = new MSBuildAPIUtility(new TestLogger(_testOutputHelper), builder);
-                    var packageUpdateIO = new PackageUpdateIO(args.Project, msbuildUtility, new TestEnvironmentVariableReader(_envVars));
-                    return PackageUpdateCommandRunner.Run(args, new TestCommandOutputLogger(_testOutputHelper), packageUpdateIO, ct);
-                });
-            int result = rootCommand.Parse([
-                "update",
-                "--project", appFile,
-            ]).Invoke(new() { Output = outWriter, Error = errorWriter });
+            _testFixture.RunDotnetExpectSuccess(fbaDir, "package update --file app.cs", testOutputHelper: _testOutputHelper, environmentVariables: _envVars);
 
-            var output = outWriter.ToString();
-            var error = errorWriter.ToString();
-
-            _testOutputHelper.WriteLine(output);
-            _testOutputHelper.WriteLine(error);
-
-            Assert.Equal(0, result);
-
-            Assert.Empty(error);
-
-            var modifiedProjectContent = builder.ModifiedContent;
-            _testOutputHelper.WriteLine("after:\n" + modifiedProjectContent);
-            Assert.Contains("""<PackageReference Include="NuGet.Internal.Test.a" Version="2.0.0" />""", modifiedProjectContent);
+            // Verify the full content of the modified .cs file.
+            var modifiedContent = File.ReadAllText(appFile);
+            _testOutputHelper.WriteLine("after:\n" + modifiedContent);
+            Assert.Equal(
+                """
+                #:property PublishAot=false
+                #:package NuGet.Internal.Test.a@2.0.0
+                Console.WriteLine();
+                """,
+                modifiedContent);
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
@@ -134,6 +134,63 @@ namespace Dotnet.Integration.Test
         }
 
         [Fact]
+        public async Task FileBasedApp_WithRef()
+        {
+            using var pathContext = _testFixture.CreateSimpleTestPathContext();
+
+            // Create packages.
+            var a1 = new SimpleTestPackageContext("NuGet.Internal.Test.a", "1.0.0");
+            var a2 = new SimpleTestPackageContext("NuGet.Internal.Test.a", "2.0.0");
+            var b1 = new SimpleTestPackageContext("NuGet.Internal.Test.b", "1.0.0");
+            var b2 = new SimpleTestPackageContext("NuGet.Internal.Test.b", "2.0.0");
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, [a1, a2, b1, b2]);
+
+            // Create a referenced file-based app.
+            var libDir = Path.Join(pathContext.SolutionRoot, "lib");
+            Directory.CreateDirectory(libDir);
+
+            var libFile = Path.Join(libDir, "lib.cs");
+            var libContent = """
+                #:property PublishAot=false
+                #:package NuGet.Internal.Test.b@1.0.0
+                public class Lib { }
+                """;
+            File.WriteAllText(libFile, libContent);
+
+            // Create the root file-based app referencing the lib.
+            var fbaDir = Path.Join(pathContext.SolutionRoot, "fba");
+            Directory.CreateDirectory(fbaDir);
+
+            var refPath = Path.GetRelativePath(fbaDir, libFile);
+            var appFile = Path.Join(fbaDir, "app.cs");
+            var appContent = $"""
+                #:property PublishAot=false
+                #:property ExperimentalFileBasedProgramEnableRefDirective=true
+                #:ref {refPath}
+                #:package NuGet.Internal.Test.a@1.0.0
+                Console.WriteLine();
+                """;
+            File.WriteAllText(appFile, appContent);
+
+            // Update all packages.
+            _testFixture.RunDotnetExpectSuccess(fbaDir, "package update --file app.cs", testOutputHelper: _testOutputHelper, environmentVariables: _envVars);
+
+            // Verify the root app's package was updated.
+            var modifiedAppContent = File.ReadAllText(appFile);
+            _testOutputHelper.WriteLine("app after:\n" + modifiedAppContent);
+            Assert.Equal(
+                appContent.Replace("NuGet.Internal.Test.a@1.0.0", "NuGet.Internal.Test.a@2.0.0"),
+                modifiedAppContent);
+
+            // Verify the referenced lib's package was NOT updated
+            // (matching project-based behavior: only the specified project is updated).
+            var modifiedLibContent = File.ReadAllText(libFile);
+            _testOutputHelper.WriteLine("lib after:\n" + modifiedLibContent);
+            Assert.Equal(libContent, modifiedLibContent);
+        }
+
+        [Fact]
         public async Task SingleTfmCpmProject_PackageVersionUpdated()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRemovePackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRemovePackageTests.cs
@@ -2,11 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
-using System.Threading.Tasks;
-using Microsoft.Extensions.CommandLineUtils;
-using NuGet.CommandLine.XPlat;
-using NuGet.Test.Utility;
-using NuGet.XPlat.FuncTest;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,9 +13,8 @@ public sealed class DotnetRemovePackageTests(DotnetIntegrationTestFixture fixtur
     private readonly DotnetIntegrationTestFixture _fixture = fixture;
     private readonly ITestOutputHelper _testOutputHelper = testOutputHelper;
 
-    // https://github.com/NuGet/Home/issues/14823: This should use `dotnet package remove` when it supports file-based apps.
     [Fact]
-    public async Task RemovePkg_FileBasedApp()
+    public void RemovePkg_FileBasedApp()
     {
         using var pathContext = _fixture.CreateSimpleTestPathContext();
 
@@ -34,43 +28,16 @@ public sealed class DotnetRemovePackageTests(DotnetIntegrationTestFixture fixtur
             Console.WriteLine();
             """);
 
-        // Get project content.
-        var virtualProject = _fixture.GetFileBasedAppVirtualProject(appFile, _testOutputHelper);
-        _testOutputHelper.WriteLine("before:\n" + virtualProject.Content);
-        Assert.Contains("""<PackageReference Include="packageX" Version="1.0.0" />""", virtualProject.Content);
-        using var builder = new TestVirtualProjectBuilder(virtualProject);
-
         // Remove the package.
-        using var outWriter = new StringWriter();
-        using var errorWriter = new StringWriter();
-        var testApp = new CommandLineApplication
-        {
-            Out = outWriter,
-            Error = errorWriter,
-        };
-        RemovePackageReferenceCommand.Register(
-            testApp,
-            () => new TestLogger(_testOutputHelper),
-            () => new RemovePackageReferenceCommandRunner(),
-            () => builder);
-        int result = testApp.Execute([
-            "remove",
-            "--project", appFile,
-            "--package", "packageX",
-        ]);
+        _fixture.RunDotnetExpectSuccess(fbaDir, "package remove packageX --file app.cs", testOutputHelper: _testOutputHelper);
 
-        var output = outWriter.ToString();
-        var error = errorWriter.ToString();
-
-        _testOutputHelper.WriteLine(output);
-        _testOutputHelper.WriteLine(error);
-
-        Assert.Equal(0, result);
-
-        Assert.Empty(error);
-
-        var modifiedProjectContent = builder.ModifiedContent;
-        _testOutputHelper.WriteLine("after:\n" + modifiedProjectContent);
-        Assert.DoesNotContain("PackageReference", modifiedProjectContent);
+        // Verify the full content of the modified .cs file.
+        var modifiedContent = File.ReadAllText(appFile);
+        _testOutputHelper.WriteLine("after:\n" + modifiedContent);
+        Assert.Equal(
+            """
+            Console.WriteLine();
+            """,
+            modifiedContent);
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRemovePackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRemovePackageTests.cs
@@ -40,4 +40,60 @@ public sealed class DotnetRemovePackageTests(DotnetIntegrationTestFixture fixtur
             """,
             modifiedContent);
     }
+
+    [Fact]
+    public void RemovePkg_FileBasedApp_WithRef()
+    {
+        using var pathContext = _fixture.CreateSimpleTestPathContext();
+
+        // Create a referenced file-based app.
+        var libDir = Path.Join(pathContext.SolutionRoot, "lib");
+        Directory.CreateDirectory(libDir);
+
+        var libFile = Path.Join(libDir, "lib.cs");
+        var libContent = """
+            #:property PublishAot=false
+            #:package packageY@1.0.0
+            public class Lib { }
+            """;
+        File.WriteAllText(libFile, libContent);
+
+        // Create the root file-based app referencing the lib.
+        var fbaDir = Path.Join(pathContext.SolutionRoot, "fba");
+        Directory.CreateDirectory(fbaDir);
+
+        var refPath = Path.GetRelativePath(fbaDir, libFile);
+        var appFile = Path.Join(fbaDir, "app.cs");
+        var appContentPre = $"""
+            #:property PublishAot=false
+            #:property ExperimentalFileBasedProgramEnableRefDirective=true
+            #:ref {refPath}
+            """;
+        var appContentPost = """
+            Console.WriteLine();
+            """;
+        File.WriteAllText(appFile, $"""
+            {appContentPre}
+            #:package packageX@1.0.0
+            {appContentPost}
+            """);
+
+        // Remove the package from the root app.
+        _fixture.RunDotnetExpectSuccess(fbaDir, "package remove packageX --file app.cs", testOutputHelper: _testOutputHelper);
+
+        // Verify the package was removed from the root app.
+        var modifiedAppContent = File.ReadAllText(appFile);
+        _testOutputHelper.WriteLine("app after:\n" + modifiedAppContent);
+        Assert.Equal(
+            $"""
+            {appContentPre}
+            {appContentPost}
+            """,
+            modifiedAppContent);
+
+        // Verify the lib was not modified.
+        var modifiedLibContent = File.ReadAllText(libFile);
+        _testOutputHelper.WriteLine("lib after:\n" + modifiedLibContent);
+        Assert.Equal(libContent, modifiedLibContent);
+    }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -3,20 +3,14 @@
 
 #nullable disable
 
-using System;
-using System.CommandLine;
 using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 using NuGet.CommandLine.XPlat;
-using NuGet.CommandLine.XPlat.Commands.Why;
-using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
 using NuGet.XPlat.FuncTest;
-using Spectre.Console;
-using Spectre.Console.Testing;
 using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
@@ -69,7 +63,6 @@ namespace Dotnet.Integration.Test
             Assert.Contains($"Project '{ProjectName}' has the following dependency graph(s) for '{packageY.Id}'", result.AllOutput.Replace("\n", "").Replace("\r", ""));
         }
 
-        // https://github.com/NuGet/Home/issues/14823: This should use `dotnet nuget why` when it supports file-based apps.
         [Fact]
         public async Task WhyCommand_FileBasedApp()
         {
@@ -95,37 +88,11 @@ namespace Dotnet.Integration.Test
             // Restore.
             _testFixture.RunDotnetExpectSuccess(fbaDir, "restore app.cs", testOutputHelper: _testOutputHelper);
 
-            // Get project content.
-            var virtualProject = _testFixture.GetFileBasedAppVirtualProject(appFile, _testOutputHelper);
-            using var builder = new TestVirtualProjectBuilder(virtualProject);
-
             // Run "why" command.
-            var console = new TestConsole();
-            using var outWriter = new StringWriter();
-            using var errorWriter = new StringWriter();
-            var rootCommand = new RootCommand();
-            WhyCommand.Register(
-                rootCommand,
-                new Lazy<IAnsiConsole>(console),
-                () => new WhyCommandRunner(new MSBuildAPIUtility(NullLogger.Instance, builder)));
-            int result = rootCommand.Parse([
-                "why", appFile, "PackageB",
-            ]).Invoke(new() { Output = outWriter, Error = errorWriter });
+            var result = _testFixture.RunDotnetExpectSuccess(fbaDir, "nuget why app.cs PackageB", testOutputHelper: _testOutputHelper);
 
-            var output = outWriter.ToString() + console.Output;
-            var error = errorWriter.ToString();
-
-            _testOutputHelper.WriteLine(output);
-            _testOutputHelper.WriteLine(error);
-
-            Assert.Equal(0, result);
-
-            Assert.Empty(error);
-
-            Assert.Contains("PackageA (v1.0.0)", output);
-            Assert.Contains("packageB (v1.0.1)", output);
-
-            Assert.Null(builder.ModifiedContent);
+            Assert.Contains("PackageA (v1.0.0)", result.AllOutput);
+            Assert.Contains("packageB (v1.0.1)", result.AllOutput);
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -79,11 +79,12 @@ namespace Dotnet.Integration.Test
             Directory.CreateDirectory(fbaDir);
 
             var appFile = Path.Join(fbaDir, "app.cs");
-            File.WriteAllText(appFile, """
+            var appContent = """
                 #:property PublishAot=false
                 #:package PackageA@1.0.0
                 Console.WriteLine();
-                """);
+                """;
+            File.WriteAllText(appFile, appContent);
 
             // Restore.
             _testFixture.RunDotnetExpectSuccess(fbaDir, "restore app.cs", testOutputHelper: _testOutputHelper);
@@ -93,6 +94,73 @@ namespace Dotnet.Integration.Test
 
             Assert.Contains("PackageA (v1.0.0)", result.AllOutput);
             Assert.Contains("packageB (v1.0.1)", result.AllOutput);
+
+            // Verify the file was not modified (why is read-only).
+            Assert.Equal(appContent, File.ReadAllText(appFile));
+        }
+
+        [Fact]
+        public async Task WhyCommand_FileBasedApp_WithRef()
+        {
+            using var pathContext = _testFixture.CreateSimpleTestPathContext();
+
+            // Create packages: PackageA depends on PackageB; PackageC is standalone.
+            var packageB = XPlatTestUtils.CreatePackage("Fba.PackageB", "1.0.1", TestConstants.ProjectTargetFramework);
+            var packageA = XPlatTestUtils.CreatePackage("Fba.PackageA", "1.0.0", TestConstants.ProjectTargetFramework);
+            packageA.Dependencies.Add(packageB);
+            var packageC = XPlatTestUtils.CreatePackage("Fba.PackageC", "2.0.0", TestConstants.ProjectTargetFramework);
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                packageA,
+                packageB,
+                packageC);
+
+            // Create a referenced file-based app with PackageC.
+            var libDir = Path.Join(pathContext.SolutionRoot, "lib");
+            Directory.CreateDirectory(libDir);
+
+            var libFile = Path.Join(libDir, "lib.cs");
+            var libContent = """
+                #:property PublishAot=false
+                #:package Fba.PackageC@2.0.0
+                public class Lib { }
+                """;
+            File.WriteAllText(libFile, libContent);
+
+            // Create the root file-based app referencing the lib, with PackageA.
+            var fbaDir = Path.Join(pathContext.SolutionRoot, "fba");
+            Directory.CreateDirectory(fbaDir);
+
+            var refPath = Path.GetRelativePath(fbaDir, libFile);
+            var appFile = Path.Join(fbaDir, "app.cs");
+            var appContent = $"""
+                #:property PublishAot=false
+                #:property ExperimentalFileBasedProgramEnableRefDirective=true
+                #:ref {refPath}
+                #:package Fba.PackageA@1.0.0
+                Console.WriteLine();
+                """;
+            File.WriteAllText(appFile, appContent);
+
+            // Restore.
+            _testFixture.RunDotnetExpectSuccess(fbaDir, "restore app.cs", testOutputHelper: _testOutputHelper);
+
+            // Run "why" command for PackageB (transitive dependency of root's PackageA).
+            var result = _testFixture.RunDotnetExpectSuccess(fbaDir, "nuget why app.cs Fba.PackageB", testOutputHelper: _testOutputHelper);
+
+            Assert.Contains("Fba.PackageA (v1.0.0)", result.AllOutput);
+            Assert.Contains("Fba.PackageB (v1.0.1)", result.AllOutput);
+
+            // Run "why" command for PackageC (direct dependency of referenced lib).
+            // The why command should find it since it's a transitive dependency through the project reference.
+            var resultC = _testFixture.RunDotnetExpectSuccess(fbaDir, "nuget why app.cs Fba.PackageC", testOutputHelper: _testOutputHelper);
+
+            Assert.Contains("Fba.PackageC (v2.0.0)", resultC.AllOutput);
+
+            // Verify neither file was modified (why is read-only).
+            Assert.Equal(appContent, File.ReadAllText(appFile));
+            Assert.Equal(libContent, File.ReadAllText(libFile));
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/TestVirtualProjectBuilder.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/TestVirtualProjectBuilder.cs
@@ -49,6 +49,16 @@ internal sealed class TestVirtualProjectBuilder : IVirtualProjectBuilder, IDispo
         return _virtualProject.ProjectPath;
     }
 
+    public string? TryGetEntryPointPath(string virtualProjectPath)
+    {
+        if (string.Equals(_virtualProject.ProjectPath, virtualProjectPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return _virtualProject.FilePath;
+        }
+
+        return null;
+    }
+
     public ProjectRootElement CreateProjectRootElement(string entryPointFilePath, ProjectCollection projectCollection)
     {
         using var stringReader = new StringReader(_virtualProject.Content);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes https://github.com/NuGet/Home/issues/14808

## Description

`#:ref` directives are basically virtual `<ProjectReference />`s between file-based apps. This PR updates the `package update` command implementation to handle that and adds tests verifying all the relevant NuGet commands work as expected with these directives. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
