### PR TITLE
Add `dotnet nuget apikey` commands

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ApiKeyCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ApiKeyCommand.cs
@@ -1,0 +1,219 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Globalization;
+using System.IO;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration;
+
+namespace NuGet.CommandLine.XPlat
+{
+    internal static class ApiKeyCommand
+    {
+        public static void Register(CommandLineApplication app, Func<ILogger> getLogger)
+        {
+            app.Command("apikey", apiKey =>
+            {
+                apiKey.Description = Strings.ApiKeyCommand_Description;
+                apiKey.HelpOption(XPlatUtility.HelpOption);
+
+                RegisterSetCommand(apiKey, getLogger);
+                RegisterUnsetCommand(apiKey, getLogger);
+
+                apiKey.OnExecute(() =>
+                {
+                    apiKey.ShowHelp();
+                    return ExitCodes.InvalidArguments;
+                });
+            });
+        }
+
+        private static void RegisterSetCommand(CommandLineApplication apiKey, Func<ILogger> getLogger)
+        {
+            apiKey.Command("set", set =>
+            {
+                set.Description = Strings.ApiKeySetCommand_Description;
+                set.HelpOption(XPlatUtility.HelpOption);
+
+                CommandOption source = set.Option(
+                    "-s|--source <source>",
+                    Strings.ApiKeyCommand_SourceDescription,
+                    CommandOptionType.SingleValue);
+
+                CommandOption configurationFile = set.Option(
+                    "--configfile",
+                    Strings.Option_ConfigFile,
+                    CommandOptionType.SingleValue);
+
+                CommandArgument apiKeyArgument = set.Argument(
+                    "[apiKey]",
+                    Strings.ApiKeySetCommand_ApiKeyDescription);
+
+                set.OnExecute(() =>
+                {
+                    var args = new ApiKeySetArgs
+                    {
+                        ApiKey = apiKeyArgument.Value,
+                        Source = source.Value(),
+                        ConfigFile = configurationFile.Value()
+                    };
+
+                    return ApiKeySetRunner.Run(args, getLogger);
+                });
+            });
+        }
+
+        private static void RegisterUnsetCommand(CommandLineApplication apiKey, Func<ILogger> getLogger)
+        {
+            apiKey.Command("unset", unset =>
+            {
+                unset.Description = Strings.ApiKeyUnsetCommand_Description;
+                unset.HelpOption(XPlatUtility.HelpOption);
+
+                CommandOption source = unset.Option(
+                    "-s|--source <source>",
+                    Strings.ApiKeyCommand_SourceDescription,
+                    CommandOptionType.SingleValue);
+
+                CommandOption configurationFile = unset.Option(
+                    "--configfile",
+                    Strings.Option_ConfigFile,
+                    CommandOptionType.SingleValue);
+
+                unset.OnExecute(() =>
+                {
+                    var args = new ApiKeyUnsetArgs
+                    {
+                        Source = source.Value(),
+                        ConfigFile = configurationFile.Value()
+                    };
+
+                    return ApiKeyUnsetRunner.Run(args, getLogger);
+                });
+            });
+        }
+    }
+
+    internal sealed class ApiKeySetArgs
+    {
+        public string? ApiKey { get; set; }
+
+        public string? Source { get; set; }
+
+        public string? ConfigFile { get; set; }
+    }
+
+    internal sealed class ApiKeyUnsetArgs
+    {
+        public string? Source { get; set; }
+
+        public string? ConfigFile { get; set; }
+    }
+
+    internal static class ApiKeySetRunner
+    {
+        public static int Run(ApiKeySetArgs args, Func<ILogger> getLogger)
+        {
+            RunnerHelper.EnsureArgumentsNotNull(args, getLogger);
+
+            if (string.IsNullOrEmpty(args.ApiKey))
+            {
+                getLogger().LogError(Strings.ApiKeySetCommand_MissingApiKey);
+                return ExitCodes.InvalidArguments;
+            }
+
+            PackageSourceProvider sourceProvider = ApiKeyRunnerUtility.GetPackageSourceProvider(args.ConfigFile);
+            string source = ApiKeyRunnerUtility.ResolveSource(sourceProvider, args.Source);
+            ISettings settings = ApiKeyRunnerUtility.GetSettingsForWriting(args.ConfigFile);
+
+            SettingsUtility.SetEncryptedValueForAddItem(settings, ConfigurationConstants.ApiKeys, source, args.ApiKey);
+
+            getLogger().LogMinimal(string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.ApiKeySetCommand_ApiKeySaved,
+                source));
+
+            return ExitCodes.Success;
+        }
+    }
+
+    internal static class ApiKeyUnsetRunner
+    {
+        public static int Run(ApiKeyUnsetArgs args, Func<ILogger> getLogger)
+        {
+            RunnerHelper.EnsureArgumentsNotNull(args, getLogger);
+
+            PackageSourceProvider sourceProvider = ApiKeyRunnerUtility.GetPackageSourceProvider(args.ConfigFile);
+            string source = ApiKeyRunnerUtility.ResolveSource(sourceProvider, args.Source);
+            ISettings settings = ApiKeyRunnerUtility.GetSettingsForWriting(args.ConfigFile);
+
+            if (SettingsUtility.DeleteValue(settings, ConfigurationConstants.ApiKeys, ConfigurationConstants.KeyAttribute, source))
+            {
+                getLogger().LogMinimal(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.ApiKeyUnsetCommand_ApiKeyRemoved,
+                    source));
+            }
+            else
+            {
+                getLogger().LogMinimal(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.ApiKeyUnsetCommand_ApiKeyNotFound,
+                    source));
+            }
+
+            return ExitCodes.Success;
+        }
+    }
+
+    internal static class ApiKeyRunnerUtility
+    {
+        public static PackageSourceProvider GetPackageSourceProvider(string? configFile)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            return new PackageSourceProvider(GetSettingsForReading(configFile), enablePackageSourcesChangedEvent: false);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        public static ISettings GetSettingsForWriting(string? configFile)
+        {
+            if (!string.IsNullOrEmpty(configFile))
+            {
+                return XPlatUtility.ProcessConfigFile(configFile);
+            }
+
+            return Settings.LoadDefaultSettings(
+                root: null,
+                configFileName: null,
+                machineWideSettings: null);
+        }
+
+        public static string ResolveSource(PackageSourceProvider sourceProvider, string? source)
+        {
+            if (string.IsNullOrEmpty(source))
+            {
+                return NuGetConstants.DefaultGalleryServerUrl;
+            }
+
+            return sourceProvider.ResolveAndValidateSource(source);
+        }
+
+        private static ISettings GetSettingsForReading(string? configFile)
+        {
+            if (!string.IsNullOrEmpty(configFile))
+            {
+                return XPlatUtility.ProcessConfigFile(configFile);
+            }
+
+            return Settings.LoadDefaultSettings(
+                Directory.GetCurrentDirectory(),
+                configFileName: null,
+                machineWideSettings: new XPlatMachineWideSetting());
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -329,6 +329,7 @@ namespace NuGet.CommandLine.XPlat
                 // "dotnet nuget *" commands
                 app.Name = DotnetNuGetAppName;
                 CommandParsers.Register(app, getHidePrefixLogger);
+                ApiKeyCommand.Register(app, getHidePrefixLogger);
                 DeleteCommand.Register(app, getHidePrefixLogger);
                 PushCommand.Register(app, getHidePrefixLogger);
                 LocalsCommand.Register(app, getHidePrefixLogger);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -214,6 +214,87 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Manages NuGet API keys..
+        /// </summary>
+        internal static string ApiKeyCommand_Description {
+            get {
+                return ResourceManager.GetString("ApiKeyCommand_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery..
+        /// </summary>
+        internal static string ApiKeyCommand_SourceDescription {
+            get {
+                return ResourceManager.GetString("ApiKeyCommand_SourceDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The API key to save..
+        /// </summary>
+        internal static string ApiKeySetCommand_ApiKeyDescription {
+            get {
+                return ResourceManager.GetString("ApiKeySetCommand_ApiKeyDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The API key was saved for &apos;{0}&apos;..
+        /// </summary>
+        internal static string ApiKeySetCommand_ApiKeySaved {
+            get {
+                return ResourceManager.GetString("ApiKeySetCommand_ApiKeySaved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Saves an API key for a package source..
+        /// </summary>
+        internal static string ApiKeySetCommand_Description {
+            get {
+                return ResourceManager.GetString("ApiKeySetCommand_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please provide an API key..
+        /// </summary>
+        internal static string ApiKeySetCommand_MissingApiKey {
+            get {
+                return ResourceManager.GetString("ApiKeySetCommand_MissingApiKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No API key was found for &apos;{0}&apos;..
+        /// </summary>
+        internal static string ApiKeyUnsetCommand_ApiKeyNotFound {
+            get {
+                return ResourceManager.GetString("ApiKeyUnsetCommand_ApiKeyNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The API key was removed for &apos;{0}&apos;..
+        /// </summary>
+        internal static string ApiKeyUnsetCommand_ApiKeyRemoved {
+            get {
+                return ResourceManager.GetString("ApiKeyUnsetCommand_ApiKeyRemoved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removes a saved API key for a package source..
+        /// </summary>
+        internal static string ApiKeyUnsetCommand_Description {
+            get {
+                return ResourceManager.GetString("ApiKeyUnsetCommand_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to NuGet Command Line.
         /// </summary>
         internal static string App_FullName {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -120,6 +120,36 @@
   <data name="ApiKey_Description" xml:space="preserve">
     <value>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</value>
   </data>
+  <data name="ApiKeyCommand_Description" xml:space="preserve">
+    <value>Manages NuGet API keys.</value>
+  </data>
+  <data name="ApiKeyCommand_SourceDescription" xml:space="preserve">
+    <value>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</value>
+  </data>
+  <data name="ApiKeySetCommand_ApiKeyDescription" xml:space="preserve">
+    <value>The API key to save.</value>
+  </data>
+  <data name="ApiKeySetCommand_ApiKeySaved" xml:space="preserve">
+    <value>The API key was saved for '{0}'.</value>
+    <comment>{0} - The package source the API key was saved for.</comment>
+  </data>
+  <data name="ApiKeySetCommand_Description" xml:space="preserve">
+    <value>Saves an API key for a package source.</value>
+  </data>
+  <data name="ApiKeySetCommand_MissingApiKey" xml:space="preserve">
+    <value>Please provide an API key.</value>
+  </data>
+  <data name="ApiKeyUnsetCommand_ApiKeyNotFound" xml:space="preserve">
+    <value>No API key was found for '{0}'.</value>
+    <comment>{0} - The package source the API key was not found for.</comment>
+  </data>
+  <data name="ApiKeyUnsetCommand_ApiKeyRemoved" xml:space="preserve">
+    <value>The API key was removed for '{0}'.</value>
+    <comment>{0} - The package source the API key was removed for.</comment>
+  </data>
+  <data name="ApiKeyUnsetCommand_Description" xml:space="preserve">
+    <value>Removes a saved API key for a package source.</value>
+  </data>
   <data name="App_FullName" xml:space="preserve">
     <value>NuGet Command Line</value>
   </data>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.cs.xlf
@@ -82,6 +82,51 @@
         <target state="translated">Umožňuje vkládání do HTTP zdrojů (nezabezpečené).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">Klíč rozhraní API pro server Pokud není nastaven, načte se proměnná prostředí NUGET_API_KEY.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.de.xlf
@@ -82,6 +82,51 @@
         <target state="translated">Ermöglicht pushen an HTTP-Quellen (unsicher).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">Der API-Schlüssel für den Server. Wenn er nicht festgelegt ist, wird die Umgebungsvariable NUGET_API_KEY ausgelesen.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.es.xlf
@@ -82,6 +82,51 @@
         <target state="translated">Permite insertar en orígenes HTTP (no seguro).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">La clave de API del servidor. Si no se establece, se lee la variable de entorno NUGET_API_KEY.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.fr.xlf
@@ -82,6 +82,51 @@
         <target state="translated">Autorise l’envoi (push) vers des sources HTTP (non sécurisé).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">La clé API pour le serveur. Si elle n'est pas définie, la variable d'environnement NUGET_API_KEY est lue.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.it.xlf
@@ -82,6 +82,51 @@
         <target state="translated">Consente di eseguire il push in origini HTTP (non sicuro).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">Chiave API per il server. Se non impostata, viene letta la variabile di ambiente NUGET_API_KEY.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ja.xlf
@@ -82,6 +82,51 @@
         <target state="translated">HTTP ソースへのプッシュを許可します (安全ではありません)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">サーバーの API キー。設定されていない場合は、NUGET_API_KEY 環境変数が読み取られます。</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ko.xlf
@@ -82,6 +82,51 @@
         <target state="translated">HTTP 원본으로 푸시할 수 있습니다(안전하지 않음).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">서버의 API 키입니다. 설정하지 않으면 NUGET_API_KEY 환경 변수를 사용합니다.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pl.xlf
@@ -82,6 +82,51 @@
         <target state="translated">Umożliwia wypychanie do źródeł HTTP (niezabezpieczone).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">Klucz interfejsu API dla serwera. Jeśli nie zostanie ustawiony, odczytywana jest zmienna środowiskowa NUGET_API_KEY.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.pt-BR.xlf
@@ -82,6 +82,51 @@
         <target state="translated">Permite enviar por push para fontes HTTP (não seguras).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">A chave de API do servidor. Se não estiver definida, a variável de ambiente NUGET_API_KEY será usada.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.ru.xlf
@@ -82,6 +82,51 @@
         <target state="translated">Разрешает отправку в HTTP-источники (небезопасные).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">Ключ API сервера. Если не настроено, читается переменная среды NUGET_API_KEY.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.tr.xlf
@@ -82,6 +82,51 @@
         <target state="translated">HTTP kaynaklarına (güvenli olmayan) aktarım yapılmasına izin verir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">Sunucunun API anahtarı. Ayarlı değilse, NUGET_API_KEY ortam değişkeni okunur.</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hans.xlf
@@ -82,6 +82,51 @@
         <target state="translated">允许推送到 HTTP 源(不安全)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">服务器的 API 密钥。如果未设置，则读取 NUGET_API_KEY 环境变量。</target>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/xlf/Strings.zh-Hant.xlf
@@ -82,6 +82,51 @@
         <target state="translated">允許推送至 HTTP 來源 (不安全)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApiKeyCommand_Description">
+        <source>Manages NuGet API keys.</source>
+        <target state="new">Manages NuGet API keys.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyCommand_SourceDescription">
+        <source>Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</source>
+        <target state="new">Package source (URL or package source name) the API key is for. Defaults to the NuGet gallery.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeyDescription">
+        <source>The API key to save.</source>
+        <target state="new">The API key to save.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_ApiKeySaved">
+        <source>The API key was saved for '{0}'.</source>
+        <target state="new">The API key was saved for '{0}'.</target>
+        <note>{0} - The package source the API key was saved for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_Description">
+        <source>Saves an API key for a package source.</source>
+        <target state="new">Saves an API key for a package source.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeySetCommand_MissingApiKey">
+        <source>Please provide an API key.</source>
+        <target state="new">Please provide an API key.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyNotFound">
+        <source>No API key was found for '{0}'.</source>
+        <target state="new">No API key was found for '{0}'.</target>
+        <note>{0} - The package source the API key was not found for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_ApiKeyRemoved">
+        <source>The API key was removed for '{0}'.</source>
+        <target state="new">The API key was removed for '{0}'.</target>
+        <note>{0} - The package source the API key was removed for.</note>
+      </trans-unit>
+      <trans-unit id="ApiKeyUnsetCommand_Description">
+        <source>Removes a saved API key for a package source.</source>
+        <target state="new">Removes a saved API key for a package source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ApiKey_Description">
         <source>The API key for the server. If not set, the NUGET_API_KEY environment variable is read.</source>
         <target state="translated">伺服器的 API 金鑰。若未設定，系統會讀取 NUGET_API_KEY 環境變數。</target>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatHelpOutputTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatHelpOutputTests.cs
@@ -48,6 +48,7 @@ namespace NuGet.XPlat.FuncTest
         public static IEnumerable<string> HelpCommands => new List<string>
         {
             "add",
+            "apikey",
             "config",
             "delete",
             "disable",

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/ApiKeyCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/ApiKeyCommandTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using NuGet.CommandLine.XPlat;
+using NuGet.Configuration;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Xplat.Tests
+{
+    public class ApiKeyCommandTests
+    {
+        private const string SourceName = "contoso";
+        private const string SourceUrl = "https://nuget.contoso.org/v3/index.json";
+
+        [PlatformFact(Platform.Windows)]
+        public void SetApiKey_WithDefaultSource_SavesApiKey()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                string configFile = CreateEmptyConfig(testDirectory);
+                string apiKey = Guid.NewGuid().ToString();
+                var logger = new TestLogger();
+                var args = new ApiKeySetArgs
+                {
+                    ApiKey = apiKey,
+                    ConfigFile = configFile
+                };
+
+                int exitCode = ApiKeySetRunner.Run(args, () => logger);
+
+                Assert.Equal(ExitCodes.Success, exitCode);
+                Assert.Contains(logger.MinimalMessages, message => message.Contains(NuGetConstants.DefaultGalleryServerUrl));
+                ISettings settings = LoadSettings(configFile);
+                string? actualApiKey = SettingsUtility.GetDecryptedValueForAddItem(
+                    settings,
+                    ConfigurationConstants.ApiKeys,
+                    NuGetConstants.DefaultGalleryServerUrl);
+                Assert.Equal(apiKey, actualApiKey);
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData(SourceName)]
+        [InlineData(SourceUrl)]
+        public void SetApiKey_WithSpecifiedSource_SavesApiKeyForResolvedSource(string source)
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                string configFile = CreateConfigWithSource(testDirectory);
+                string apiKey = Guid.NewGuid().ToString();
+                var logger = new TestLogger();
+                var args = new ApiKeySetArgs
+                {
+                    ApiKey = apiKey,
+                    Source = source,
+                    ConfigFile = configFile
+                };
+
+                int exitCode = ApiKeySetRunner.Run(args, () => logger);
+
+                Assert.Equal(ExitCodes.Success, exitCode);
+                Assert.Contains(logger.MinimalMessages, message => message.Contains(SourceUrl));
+                ISettings settings = LoadSettings(configFile);
+                string? actualApiKey = SettingsUtility.GetDecryptedValueForAddItem(
+                    settings,
+                    ConfigurationConstants.ApiKeys,
+                    SourceUrl);
+                Assert.Equal(apiKey, actualApiKey);
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void UnsetApiKey_WithSpecifiedSource_RemovesApiKey()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                string configFile = CreateConfigWithSource(testDirectory);
+                string apiKey = Guid.NewGuid().ToString();
+                var logger = new TestLogger();
+                var setArgs = new ApiKeySetArgs
+                {
+                    ApiKey = apiKey,
+                    Source = SourceName,
+                    ConfigFile = configFile
+                };
+                var unsetArgs = new ApiKeyUnsetArgs
+                {
+                    Source = SourceName,
+                    ConfigFile = configFile
+                };
+
+                ApiKeySetRunner.Run(setArgs, () => logger);
+                int exitCode = ApiKeyUnsetRunner.Run(unsetArgs, () => logger);
+
+                Assert.Equal(ExitCodes.Success, exitCode);
+                Assert.Contains(logger.MinimalMessages, message => message.Contains(SourceUrl));
+                ISettings settings = LoadSettings(configFile);
+                string? actualApiKey = SettingsUtility.GetDecryptedValueForAddItem(
+                    settings,
+                    ConfigurationConstants.ApiKeys,
+                    SourceUrl);
+                Assert.Null(actualApiKey);
+            }
+        }
+
+        [Fact]
+        public void UnsetApiKey_WhenApiKeyDoesNotExist_ReportsMissingApiKey()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                string configFile = CreateConfigWithSource(testDirectory);
+                var logger = new TestLogger();
+                var args = new ApiKeyUnsetArgs
+                {
+                    Source = SourceName,
+                    ConfigFile = configFile
+                };
+
+                int exitCode = ApiKeyUnsetRunner.Run(args, () => logger);
+
+                Assert.Equal(ExitCodes.Success, exitCode);
+                Assert.Contains(logger.MinimalMessages, message => message.Contains("No API key was found"));
+                Assert.Contains(logger.MinimalMessages, message => message.Contains(SourceUrl));
+            }
+        }
+
+        [Fact]
+        public void SetApiKey_WithMissingApiKey_ReturnsInvalidArguments()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                string configFile = CreateEmptyConfig(testDirectory);
+                var logger = new TestLogger();
+                var args = new ApiKeySetArgs
+                {
+                    ConfigFile = configFile
+                };
+
+                int exitCode = ApiKeySetRunner.Run(args, () => logger);
+
+                Assert.Equal(ExitCodes.InvalidArguments, exitCode);
+                Assert.Contains(logger.ErrorMessages, message => message.Contains("Please provide an API key"));
+            }
+        }
+
+        private static string CreateEmptyConfig(TestDirectory testDirectory)
+        {
+            string configFile = Path.Combine(testDirectory, "nuget.config");
+            File.WriteAllText(configFile, "<configuration />");
+            return configFile;
+        }
+
+        private static string CreateConfigWithSource(TestDirectory testDirectory)
+        {
+            string configFile = Path.Combine(testDirectory, "nuget.config");
+            File.WriteAllText(
+                configFile,
+                $@"<configuration>
+  <packageSources>
+    <add key=""{SourceName}"" value=""{SourceUrl}"" />
+  </packageSources>
+</configuration>");
+            return configFile;
+        }
+
+        private static ISettings LoadSettings(string configFile)
+        {
+            return Settings.LoadDefaultSettings(
+                Path.GetDirectoryName(configFile),
+                Path.GetFileName(configFile),
+                machineWideSettings: null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `dotnet nuget apikey set` and `dotnet nuget apikey unset` to persist and remove API keys for package sources.
- Reuse existing NuGet config source resolution and encrypted API key storage, with `--configfile` support.
- Add XPlat resources/localization placeholders and focused tests for set/unset behavior.

Fixes NuGet/Home#6437
Spec: NuGet/Home#12321

## Test plan
- `dotnet test test\NuGet.Core.Tests\NuGet.CommandLine.Xplat.Tests\NuGet.CommandLine.Xplat.Tests.csproj --filter ApiKey`
- `dotnet format whitespace --verify-no-changes NuGet.sln --include "src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/ApiKeyCommand.cs" "src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs" "test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/ApiKeyCommandTests.cs"`
- `dotnet test test\NuGet.Core.Tests\NuGet.Commands.Test\NuGet.Commands.Test.csproj --filter Push` partially passed: `net10.0` push tests passed; `net472` host failed before matching tests due to strong-name validation of `Microsoft.Internal.NuGet.Testing.SignedPackages`.

## Notes
- Full solution whitespace verification is currently blocked by pre-existing formatting findings outside this change, including source-package files under the local NuGet package cache and `DependencyGraphResolver.cs`.