### PR TITLE
Respect package update version ranges

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/IPackageUpdateIO.cs
@@ -82,6 +82,24 @@ internal interface IPackageUpdateIO
         ILogger logger,
         CancellationToken cancellationToken);
 
+    /// <summary>Gets the highest package version matching the allowed update range.</summary>
+    /// <param name="packageId">The package name to check.</param>
+    /// <param name="includePrerelease">Whether prerelease packages should be considered.</param>
+    /// <param name="allowedSources">Package source mapping sources configured for this package name.
+    /// <see langword="null"/> if package source mapping is not configured.</param>
+    /// <param name="allowedVersions">The version range allowed by the project reference.</param>
+    /// <param name="logger">Output logger</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The <see cref="NuGetVersion"/> of the highest version of the package available in the allowed range.
+    /// <see langword="null"/> if no versions of the package are found.</returns>
+    Task<NuGetVersion?> GetLatestVersionAsync(
+        string packageId,
+        bool includePrerelease,
+        IReadOnlyList<string>? allowedSources,
+        VersionRange? allowedVersions,
+        ILogger logger,
+        CancellationToken cancellationToken);
+
     /// <summary>Gets the vulnerability database from the source(s) vulnerability info resource. Uses
     /// audit sources if the settings have any configured, otherwise uses package sources, just like restore.</summary>
     /// <param name="logger">The output logger.</param>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -430,6 +430,14 @@ internal static class PackageUpdateCommandRunner
             VersionRange upgradeVersion;
             if (package.VersionRange is not null)
             {
+                if (!IsVersionRangeAllowed(package.VersionRange, existingVersion))
+                {
+                    var message = $"Package '{package.Id}' version '{package.VersionRange}' is outside the allowed update range '{existingVersion}'.";
+                    logger.LogMinimal(message, ConsoleColor.Red);
+                    hasErrors = true;
+                    continue;
+                }
+
                 upgradeVersion = package.VersionRange;
                 if (upgradeVersion == existingVersion)
                 {
@@ -440,7 +448,11 @@ internal static class PackageUpdateCommandRunner
             else
             {
                 bool usePrerelease = existingVersion.HasLowerBound && existingVersion.MinVersion.IsPrerelease;
-                var latestVersion = await packageUpdateIO.GetLatestVersionAsync(package.Id, usePrerelease, mappedSources, NullLogger.Instance, cancellationToken);
+                var allowedUpdateRange = GetAllowedUpdateRange(existingVersion);
+                var latestVersion = allowedUpdateRange == null
+                    ? await packageUpdateIO.GetLatestVersionAsync(package.Id, usePrerelease, mappedSources, NullLogger.Instance, cancellationToken)
+                    : await packageUpdateIO.GetLatestVersionAsync(package.Id, usePrerelease, mappedSources, allowedUpdateRange, NullLogger.Instance, cancellationToken);
+
                 if (latestVersion is null)
                 {
                     logger.LogMinimal(Messages.Error_NoVersionsAvailable(package.Id), ConsoleColor.Red);
@@ -448,7 +460,7 @@ internal static class PackageUpdateCommandRunner
                     continue;
                 }
 
-                upgradeVersion = VersionRange.Parse(latestVersion.OriginalVersion!);
+                upgradeVersion = GetVersionRangeForUpdate(existingVersion, latestVersion);
                 if (upgradeVersion == existingVersion)
                 {
                     logger.LogMinimal(Messages.Warning_AlreadyHighestVersion(package.Id, latestVersion.OriginalVersion!, project.FilePath), ConsoleColor.Yellow);
@@ -508,17 +520,10 @@ internal static class PackageUpdateCommandRunner
                     }
 
                     VersionRange tfmVersionRange;
-                    if (project.RestoreMetadata.CentralPackageFloatingVersionsEnabled)
+                    if (tfm.CentralPackageVersions.TryGetValue(
+                        packageId,
+                        out CentralPackageVersion? centralVersion))
                     {
-                        if (!tfm.CentralPackageVersions.TryGetValue(
-                            packageId,
-                            out CentralPackageVersion? centralVersion))
-                        {
-                            logger.LogMinimal(
-                                Messages.Error_CouldNotFindPackageVersionForCpmPackage(packageId),
-                                ConsoleColor.Red);
-                            return (null, []);
-                        }
                         tfmVersionRange = centralVersion.VersionRange;
                     }
                     else
@@ -545,6 +550,42 @@ internal static class PackageUpdateCommandRunner
         }
 
         return (existingVersion, frameworks);
+    }
+
+    private static VersionRange? GetAllowedUpdateRange(VersionRange currentVersionRange)
+    {
+        return currentVersionRange.HasUpperBound || currentVersionRange.IsFloating
+            ? currentVersionRange
+            : null;
+    }
+
+    private static VersionRange GetVersionRangeForUpdate(VersionRange currentVersionRange, NuGetVersion selectedVersion)
+    {
+        if (currentVersionRange.IsFloating)
+        {
+            return currentVersionRange;
+        }
+
+        if (currentVersionRange.HasUpperBound)
+        {
+            return new VersionRange(
+                minVersion: selectedVersion,
+                includeMinVersion: true,
+                maxVersion: currentVersionRange.MaxVersion,
+                includeMaxVersion: currentVersionRange.IsMaxInclusive);
+        }
+
+        return VersionRange.Parse(selectedVersion.OriginalVersion!);
+    }
+
+    private static bool IsVersionRangeAllowed(VersionRange requestedVersionRange, VersionRange currentVersionRange)
+    {
+        if (!currentVersionRange.HasUpperBound && !currentVersionRange.IsFloating)
+        {
+            return true;
+        }
+
+        return requestedVersionRange.IsSubSetOrEqualTo(currentVersionRange);
     }
 
     internal static async Task<(List<PackageUpdateResult>? packagesToUpdate, HashSet<string> scannedPackages)> SelectAllPackagesWithUpdatesAsync(
@@ -577,7 +618,10 @@ internal static class PackageUpdateCommandRunner
             // package.identity.VersionRange is the project's referenced version.
             Debug.Assert(package.identity.VersionRange != null);
             bool usePrerelease = package.identity.VersionRange.HasLowerBound && package.identity.VersionRange.MinVersion.IsPrerelease;
-            var latestVersion = await packageUpdateIO.GetLatestVersionAsync(package.identity.Id, usePrerelease, mappedSources, NullLogger.Instance, cancellationToken);
+            var allowedUpdateRange = GetAllowedUpdateRange(package.identity.VersionRange);
+            var latestVersion = allowedUpdateRange == null
+                ? await packageUpdateIO.GetLatestVersionAsync(package.identity.Id, usePrerelease, mappedSources, NullLogger.Instance, cancellationToken)
+                : await packageUpdateIO.GetLatestVersionAsync(package.identity.Id, usePrerelease, mappedSources, allowedUpdateRange, NullLogger.Instance, cancellationToken);
 
             if (latestVersion is null)
             {
@@ -586,7 +630,7 @@ internal static class PackageUpdateCommandRunner
                 continue;
             }
 
-            var upgradeVersion = VersionRange.Parse(latestVersion.OriginalVersion!);
+            var upgradeVersion = GetVersionRangeForUpdate(package.identity.VersionRange, latestVersion);
             if (upgradeVersion.ToString() == package.identity.VersionRange.ToString())
             {
                 // Already using the highest version.
@@ -627,7 +671,9 @@ internal static class PackageUpdateCommandRunner
                             continue;
                         }
 
-                        if (existing.Item1 != dependency.LibraryRange.VersionRange)
+                        VersionRange versionRange = GetDependencyVersionRange(tfm, dependency);
+
+                        if (existing.Item1 != versionRange)
                         {
                             logger.LogMinimal(
                                 Messages.Unsupported_UpdatePackageWithDifferentPerTfmVersions(dependency.Name, project.FilePath),
@@ -640,7 +686,7 @@ internal static class PackageUpdateCommandRunner
                     }
                     else
                     {
-                        VersionRange version = dependency.LibraryRange.VersionRange ?? VersionRange.All;
+                        VersionRange version = GetDependencyVersionRange(tfm, dependency);
                         List<string> tfms = [tfm.TargetAlias];
                         allPackages[dependency.Name] = (version, tfms, hasError: false);
                     }
@@ -661,6 +707,16 @@ internal static class PackageUpdateCommandRunner
         }
 
         return result;
+    }
+
+    private static VersionRange GetDependencyVersionRange(TargetFrameworkInformation tfm, LibraryDependency dependency)
+    {
+        if (tfm.CentralPackageVersions.TryGetValue(dependency.Name, out CentralPackageVersion? centralVersion))
+        {
+            return centralVersion.VersionRange;
+        }
+
+        return dependency.LibraryRange.VersionRange ?? VersionRange.All;
     }
 
     private static DependencyGraphSpec GetUpdatedDependencyGraphSpec(DependencyGraphSpec currentDgSpec, Dictionary<string, List<PackageUpdateResult>> projectPackageUpdates)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -228,13 +228,31 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
         ILogger logger,
         CancellationToken cancellationToken)
     {
+        return await GetLatestVersionAsync(
+            packageId,
+            includePrerelease,
+            allowedSources,
+            allowedVersions: null,
+            logger,
+            cancellationToken);
+    }
+
+    /// <inheritdoc cref="IPackageUpdateIO.GetLatestVersionAsync(string, bool, IReadOnlyList{string}?, VersionRange?, ILogger, CancellationToken)"/>
+    public async Task<NuGetVersion?> GetLatestVersionAsync(
+        string packageId,
+        bool includePrerelease,
+        IReadOnlyList<string>? allowedSources,
+        VersionRange? allowedVersions,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
         var sources = GetSourcesForPackage(packageId, allowedSources);
         var lookups = new Task<NuGetVersion?>[sources.Count];
         for (int source = 0; source < sources.Count; source++)
         {
             SourceRepository sourceRepository = sources[source];
             // If package source is a local folder feed, it might not actually be async
-            lookups[source] = Task.Run(() => FindHighestPackageVersionAsync(sourceRepository, packageId, includePrerelease, logger, cancellationToken));
+            lookups[source] = Task.Run(() => FindHighestPackageVersionAsync(sourceRepository, packageId, includePrerelease, allowedVersions, logger, cancellationToken));
         }
 
         await Task.WhenAll(lookups);
@@ -424,6 +442,7 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
         SourceRepository source,
         string packageId,
         bool includePrerelease,
+        VersionRange? allowedVersions,
         ILogger logger,
         CancellationToken cancellationToken)
     {
@@ -442,7 +461,11 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
             return null;
         }
 
-        NuGetVersion highestVersion = packageDetails.Max(p => p.Identity.Version)!;
+        NuGetVersion? highestVersion = packageDetails
+            .Select(p => p.Identity.Version)
+            .Where(version => allowedVersions == null || allowedVersions.Satisfies(version))
+            .Max();
+
         return highestVersion;
     }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -863,10 +863,14 @@ namespace NuGet.PackageManagement
 
                         if (resolvedPackage != null && resolvedPackage.LatestVersion != null && resolvedPackage.LatestVersion > installedPackage.PackageIdentity.Version)
                         {
+                            var packageIdentity = new PackageIdentity(installedPackage.PackageIdentity.Id, resolvedPackage.LatestVersion);
+                            TryGetVersionRangeForUpdate(installedPackage, packageIdentity, out VersionRange versionRange);
+
                             lowLevelActions.Add(NuGetProjectAction.CreateInstallProjectAction(
-                                new PackageIdentity(installedPackage.PackageIdentity.Id, resolvedPackage.LatestVersion),
+                                packageIdentity,
                                 primarySources.FirstOrDefault(),
-                                nuGetProject));
+                                nuGetProject,
+                                versionRange));
                         }
                     }
                 }
@@ -949,8 +953,11 @@ namespace NuGet.PackageManagement
                     //  if the package is not currently installed, or the installed one is auto referenced ignore it
                     if (installed != null && !autoReferenced)
                     {
-                        lowLevelActions.Add(NuGetProjectAction.CreateInstallProjectAction(packageIdentity,
-                            primarySources.FirstOrDefault(), nuGetProject));
+                        if (TryGetVersionRangeForUpdate(installed, packageIdentity, out VersionRange versionRange))
+                        {
+                            lowLevelActions.Add(NuGetProjectAction.CreateInstallProjectAction(packageIdentity,
+                                primarySources.FirstOrDefault(), nuGetProject, versionRange));
+                        }
                     }
                 }
 
@@ -990,6 +997,38 @@ namespace NuGet.PackageManagement
         {
             var buildPackageReference = package as BuildIntegratedPackageReference;
             return buildPackageReference?.Dependency?.AutoReferenced == true;
+        }
+
+        private static bool TryGetVersionRangeForUpdate(PackageReference installedPackage, PackageIdentity packageIdentity, out VersionRange versionRange)
+        {
+            versionRange = null;
+
+            if (installedPackage?.AllowedVersions == null)
+            {
+                return true;
+            }
+
+            var allowedVersions = installedPackage.AllowedVersions;
+
+            if (!allowedVersions.Satisfies(packageIdentity.Version))
+            {
+                return false;
+            }
+
+            if (allowedVersions.IsFloating)
+            {
+                versionRange = allowedVersions;
+            }
+            else if (allowedVersions.HasUpperBound)
+            {
+                versionRange = new VersionRange(
+                    minVersion: packageIdentity.Version,
+                    includeMinVersion: true,
+                    maxVersion: allowedVersions.MaxVersion,
+                    includeMaxVersion: allowedVersions.IsMaxInclusive);
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1010,17 +1010,22 @@ namespace NuGet.PackageManagement
 
             var allowedVersions = installedPackage.AllowedVersions;
 
-            if (!allowedVersions.Satisfies(packageIdentity.Version))
-            {
-                return false;
-            }
-
             if (allowedVersions.IsFloating)
             {
+                if (!allowedVersions.Satisfies(packageIdentity.Version))
+                {
+                    return false;
+                }
+
                 versionRange = allowedVersions;
             }
             else if (allowedVersions.HasUpperBound)
             {
+                if (!allowedVersions.Satisfies(packageIdentity.Version))
+                {
+                    return false;
+                }
+
                 versionRange = new VersionRange(
                     minVersion: packageIdentity.Version,
                     includeMinVersion: true,

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetLatestVersionAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetLatestVersionAsyncTests.cs
@@ -56,6 +56,32 @@ public class GetLatestVersionAsyncTests
     }
 
     [Fact]
+    public async Task GetLatestVersionAsync_WithAllowedVersions_ReturnsHighestVersionInRange()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+        var packageId = "TestPackage.Range";
+
+        var packages = new[]
+        {
+            new SimpleTestPackageContext(packageId, "1.0.0"),
+            new SimpleTestPackageContext(packageId, "1.5.0"),
+            new SimpleTestPackageContext(packageId, "2.0.0"),
+        };
+
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packages);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = await packageUpdateIO.GetLatestVersionAsync(packageId, includePrerelease: false, allowedSources: null, allowedVersions: VersionRange.Parse("[1.0.0,2.0.0)"), NullLogger.Instance, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(new NuGetVersion("1.5.0"));
+    }
+
+    [Fact]
     public async Task GetLatestVersionAsync_WithPrereleaseVersions_WhenIncludePrereleaseTrue_ReturnsPrereleaseVersion()
     {
         // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetLatestVersionAsyncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/GetLatestVersionAsyncTests.cs
@@ -82,6 +82,60 @@ public class GetLatestVersionAsyncTests
     }
 
     [Fact]
+    public async Task GetLatestVersionAsync_WithAllowedVersions_FiltersOutVersionsAboveUpperBound()
+    {
+        // Arrange
+        // Strengthened version of the in-range test: feed contains a version in the next major
+        // (2.5.0) above the upper bound. The allowedVersions filter must drop both 2.0.0 and 2.5.0.
+        using var testContext = new SimpleTestPathContext();
+        var packageId = "TestPackage.RangeFilter";
+
+        var packages = new[]
+        {
+            new SimpleTestPackageContext(packageId, "1.0.0"),
+            new SimpleTestPackageContext(packageId, "1.5.0"),
+            new SimpleTestPackageContext(packageId, "2.0.0"),
+            new SimpleTestPackageContext(packageId, "2.5.0"),
+        };
+
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packages);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = await packageUpdateIO.GetLatestVersionAsync(packageId, includePrerelease: false, allowedSources: null, allowedVersions: VersionRange.Parse("[1.0.0,2.0.0)"), NullLogger.Instance, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(new NuGetVersion("1.5.0"));
+    }
+
+    [Fact]
+    public async Task GetLatestVersionAsync_WithAllowedVersions_WhenAllVersionsOutOfRange_ReturnsNull()
+    {
+        // Arrange
+        // Cross-major filter at the IO layer: only a 9.0.0 package is published,
+        // but the allowed range is [1.0.0, 2.0.0). The auto-update path must surface no candidate.
+        using var testContext = new SimpleTestPathContext();
+        var packageId = "TestPackage.RangeMiss";
+
+        var packages = new[]
+        {
+            new SimpleTestPackageContext(packageId, "9.0.0"),
+        };
+
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packages);
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        // Act
+        var result = await packageUpdateIO.GetLatestVersionAsync(packageId, includePrerelease: false, allowedSources: null, allowedVersions: VersionRange.Parse("[1.0.0,2.0.0)"), NullLogger.Instance, CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetLatestVersionAsync_WithPrereleaseVersions_WhenIncludePrereleaseTrue_ReturnsPrereleaseVersion()
     {
         // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/UpdatePackageReferenceTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Commands/Package/Update/PackageUpdateIOTests/UpdatePackageReferenceTests.cs
@@ -138,6 +138,69 @@ public class UpdatePackageReferenceTests
     }
 
     [Fact]
+    public async Task UpdatePackageReference_WithUpperBound_PreservesUpperBound()
+    {
+        // Arrange
+        using var testContext = new SimpleTestPathContext();
+
+        var packageA_v1 = new SimpleTestPackageContext("PackageA", "1.0.0");
+        var packageA_v15 = new SimpleTestPackageContext("PackageA", "1.5.0");
+        await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, packageA_v1, packageA_v15);
+
+        var project = SimpleTestProjectContext.CreateNETCore("TestProject", testContext.SolutionRoot, "net9.0");
+
+        project.AddPackageToAllFrameworks(packageA_v1);
+        project.Properties.Add("RestorePackagesPath", testContext.UserPackagesFolder);
+        project.Sources = new List<PackageSource> { new PackageSource(testContext.PackageSource) };
+        project.FallbackFolders = new List<string> { testContext.FallbackFolder };
+        project.GlobalPackagesFolder = testContext.UserPackagesFolder;
+        project.Save();
+
+        using var packageUpdateIO = CreatePackageUpdateIO(testContext.SolutionRoot);
+
+        var updatedDgSpec = new ProjectModel.DependencyGraphSpec();
+        var projectSpec = project.PackageSpec.Clone();
+        projectSpec.RestoreMetadata.Sources = new List<PackageSource> { new PackageSource(testContext.PackageSource) };
+        projectSpec.RestoreMetadata.FallbackFolders = new List<string> { testContext.FallbackFolder };
+        projectSpec.RestoreMetadata.PackagesPath = testContext.UserPackagesFolder;
+        var framework = projectSpec.TargetFrameworks.First();
+        framework.Dependencies.Clear();
+        framework.Dependencies.Add(new LibraryModel.LibraryDependency
+        {
+            LibraryRange = new LibraryModel.LibraryRange(
+                "PackageA", VersionRange.Parse("[1.5.0,2.0.0)"), NuGet.LibraryModel.LibraryDependencyTarget.Package)
+        });
+        updatedDgSpec.AddProject(projectSpec);
+        updatedDgSpec.AddRestore(projectSpec.RestoreMetadata.ProjectUniqueName);
+
+        var previewResult = await packageUpdateIO.PreviewUpdatePackageReferenceAsync(updatedDgSpec, NullLogger.Instance, CancellationToken.None);
+        previewResult.Success.Should().BeTrue();
+
+        var packageToUpdate = new PackageToUpdate
+        {
+            Id = "PackageA",
+            CurrentVersion = VersionRange.Parse("[1.0.0,2.0.0)"),
+            NewVersion = VersionRange.Parse("[1.5.0,2.0.0)")
+        };
+
+        var tfmAliases = projectSpec.TargetFrameworks.Select(tf => tf.TargetAlias).ToList();
+
+        // Act
+        packageUpdateIO.UpdatePackageReference(projectSpec, previewResult, tfmAliases, packageToUpdate, NullLogger.Instance);
+
+        // Assert
+        var projectXml = XDocument.Load(project.ProjectPath);
+        var ns = projectXml.Root!.GetDefaultNamespace();
+        var packageReferences = projectXml.Descendants(ns + "PackageReference")
+            .Where(e => e.Attribute("Include")?.Value == "PackageA")
+            .ToList();
+
+        packageReferences.Should().ContainSingle();
+        var packageReference = packageReferences.First();
+        packageReference.Attribute("Version")?.Value.Should().Be("[1.5.0, 2.0.0)");
+    }
+
+    [Fact]
     public async Task UpdatePackageReference_FileBasedApp()
     {
         // Arrange

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
@@ -192,6 +192,110 @@ public class GetPackageToUpdateTests
     }
 
     [Fact]
+    public async Task RequestPackage_WithVersionRangeOutsideUpperBound_ReturnsError()
+    {
+        // Arrange
+        // Cross-major range request: installed [8.0.0, 9.0.0), explicit request [9.0.0, 10.0.0).
+        // The request is rejected because the requested range is not a subset of the installed range,
+        // and IPackageUpdateIO.GetLatestVersionAsync must never be called for an explicit-range request.
+        Pkg package = new()
+        {
+            Id = "Contoso.Utils",
+            VersionRange = VersionRange.Parse("[9.0.0,10.0.0)")
+        };
+
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Contoso.Utils", [new("Version", "[8.0.0,9.0.0)")]);
+        })
+            .Build();
+
+        var packageUpdateIO = new Mock<IPackageUpdateIO>(MockBehavior.Strict);
+        packageUpdateIO.Setup(v => v.GetPackageSourceMapping()).Returns(DisabledPackageSourceMapping);
+
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectSpecificPackagesToUpdateAsync([package], packageSpec, logger.Object, packageUpdateIO.Object, CancellationToken.None);
+
+        // Assert
+        packagesToUpdate.Should().BeNull();
+        scannedPackages.Should().ContainSingle().Which.Should().Be("Contoso.Utils");
+        logger.Invocations.Count.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task RequestPackage_WithFloatingRangeOutsideInstalledFloatingRange_ReturnsError()
+    {
+        // Arrange
+        // Floating-to-floating cross-major bump: installed [8.*, 9.0.0), requested [9.*, 10.0.0).
+        // The requested floating range is outside the installed upper bound and must be rejected.
+        Pkg package = new()
+        {
+            Id = "Contoso.Utils",
+            VersionRange = VersionRange.Parse("[9.*,10.0.0)")
+        };
+
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Contoso.Utils", [new("Version", "[8.*,9.0.0)")]);
+        })
+            .Build();
+
+        var packageUpdateIO = new Mock<IPackageUpdateIO>(MockBehavior.Strict);
+        packageUpdateIO.Setup(v => v.GetPackageSourceMapping()).Returns(DisabledPackageSourceMapping);
+
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectSpecificPackagesToUpdateAsync([package], packageSpec, logger.Object, packageUpdateIO.Object, CancellationToken.None);
+
+        // Assert
+        packagesToUpdate.Should().BeNull();
+        scannedPackages.Should().ContainSingle().Which.Should().Be("Contoso.Utils");
+        logger.Invocations.Count.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task RequestPackage_WithSubsetRangeWithinUpperBound_IsAccepted()
+    {
+        // Arrange
+        // Positive guardrail: installed [1.0.0, 2.0.0), requested [1.5.0, 2.0.0) is a subset
+        // and must be accepted as the new version range without invoking latest-version lookup.
+        Pkg package = new()
+        {
+            Id = "Contoso.Utils",
+            VersionRange = VersionRange.Parse("[1.5.0,2.0.0)")
+        };
+
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Contoso.Utils", [new("Version", "[1.0.0,2.0.0)")]);
+        })
+            .Build();
+
+        var packageUpdateIO = new Mock<IPackageUpdateIO>(MockBehavior.Strict);
+        packageUpdateIO.Setup(v => v.GetPackageSourceMapping()).Returns(DisabledPackageSourceMapping);
+
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectSpecificPackagesToUpdateAsync([package], packageSpec, logger.Object, packageUpdateIO.Object, CancellationToken.None);
+
+        // Assert
+        packagesToUpdate.Should().HaveCount(1);
+        scannedPackages.Should().ContainSingle().Which.Should().Be("Contoso.Utils");
+        var packageToUpdate = packagesToUpdate.First().Package;
+        packageToUpdate.Id.Should().Be("Contoso.Utils");
+        packageToUpdate.CurrentVersion.ToString().Should().Be("[1.0.0, 2.0.0)");
+        packageToUpdate.NewVersion.ToString().Should().Be("[1.5.0, 2.0.0)");
+        logger.Invocations.Count.Should().Be(0);
+    }
+
+    [Fact]
     public async Task RequestSinglePackageWithRangeSyntax_GetsRequestedVersion()
     {
         // Arrange

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/GetPackageToUpdateTests.cs
@@ -11,6 +11,7 @@ using NuGet.CommandLine.XPlat;
 using NuGet.CommandLine.XPlat.Commands.Package.Update;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.LibraryModel;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -118,6 +119,76 @@ public class GetPackageToUpdateTests
         packageToUpdate.CurrentVersion.ToString().Should().Be("[1.0.0, )");
         packageToUpdate.NewVersion.ToString().Should().Be("[3.4.5, )");
         logger.Invocations.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RequestPackageWithoutVersion_WithUpperBound_GetsLatestVersionWithinRange()
+    {
+        // Arrange
+        Pkg package = new()
+        {
+            Id = "Contoso.Utils",
+            VersionRange = null
+        };
+
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Contoso.Utils", [new("Version", "[1.0.0,2.0.0)")]);
+        })
+            .Build();
+
+        var packageUpdateIO = new Mock<IPackageUpdateIO>(MockBehavior.Strict);
+        packageUpdateIO
+            .Setup(v => v.GetLatestVersionAsync("Contoso.Utils", false, _anyPackageSourceMapping, It.Is<VersionRange>(r => r.ToString() == "[1.0.0, 2.0.0)"), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("1.5.0"));
+        packageUpdateIO.Setup(v => v.GetPackageSourceMapping()).Returns(DisabledPackageSourceMapping);
+
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectSpecificPackagesToUpdateAsync([package], packageSpec, logger.Object, packageUpdateIO.Object, CancellationToken.None);
+
+        // Assert
+        packagesToUpdate.Should().HaveCount(1);
+        scannedPackages.Should().ContainSingle().Which.Should().Be("Contoso.Utils");
+        var packageToUpdate = packagesToUpdate.First().Package;
+        packageToUpdate.Should().NotBeNull();
+        packageToUpdate.Id.Should().Be("Contoso.Utils");
+        packageToUpdate.CurrentVersion.ToString().Should().Be("[1.0.0, 2.0.0)");
+        packageToUpdate.NewVersion.ToString().Should().Be("[1.5.0, 2.0.0)");
+        logger.Invocations.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RequestPackage_WithVersionOutsideUpperBound_ReturnsError()
+    {
+        // Arrange
+        Pkg package = new()
+        {
+            Id = "Contoso.Utils",
+            VersionRange = VersionRange.Parse("2.0.0")
+        };
+
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Contoso.Utils", [new("Version", "[1.0.0,2.0.0)")]);
+        })
+            .Build();
+
+        var packageUpdateIO = new Mock<IPackageUpdateIO>(MockBehavior.Strict);
+        packageUpdateIO.Setup(v => v.GetPackageSourceMapping()).Returns(DisabledPackageSourceMapping);
+
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectSpecificPackagesToUpdateAsync([package], packageSpec, logger.Object, packageUpdateIO.Object, CancellationToken.None);
+
+        // Assert
+        packagesToUpdate.Should().BeNull();
+        scannedPackages.Should().ContainSingle().Which.Should().Be("Contoso.Utils");
+        logger.Invocations.Count.Should().BeGreaterThan(0);
     }
 
     [Fact]
@@ -331,6 +402,82 @@ public class GetPackageToUpdateTests
         var package2Update = packagesToUpdate.First(p => p.Package.Id == "Test.Package2");
         package2Update.Package.CurrentVersion.ToString().Should().Be("[2.0.0, )");
         package2Update.Package.NewVersion.ToString().Should().Be("[2.1.0, )");
+
+        logger.Invocations.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NoPackagesProvided_WithUpperBound_UpdatesWithinRange()
+    {
+        // Arrange
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithItem("PackageReference", "Test.Package", [new("Version", "[1.0.0,2.0.0)")]);
+        })
+            .Build();
+
+        var packageUpdateIO = new Mock<IPackageUpdateIO>(MockBehavior.Strict);
+        packageUpdateIO
+            .Setup(v => v.GetLatestVersionAsync("Test.Package", false, _anyPackageSourceMapping, It.Is<VersionRange>(r => r.ToString() == "[1.0.0, 2.0.0)"), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("1.3.0"));
+        packageUpdateIO.Setup(v => v.GetPackageSourceMapping()).Returns(DisabledPackageSourceMapping);
+
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectAllPackagesWithUpdatesAsync(packageSpec, logger.Object, packageUpdateIO.Object, CancellationToken.None);
+
+        // Assert
+        scannedPackages.Should().ContainSingle().Which.Should().Be("Test.Package");
+        packagesToUpdate.Should().ContainSingle();
+
+        var packageUpdate = packagesToUpdate.First();
+        packageUpdate.Package.CurrentVersion.ToString().Should().Be("[1.0.0, 2.0.0)");
+        packageUpdate.Package.NewVersion.ToString().Should().Be("[1.3.0, 2.0.0)");
+
+        logger.Invocations.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NoPackagesProvided_WithCentralPackageVersionUpperBound_UpdatesWithinRange()
+    {
+        // Arrange
+        PackageSpec packageSpec = new TestPackageSpecFactory(builder =>
+        {
+            builder.WithProperty("TargetFramework", "net9.0")
+                   .WithProperty("ManagePackageVersionsCentrally", "true")
+                   .WithProperty("CentralPackageFloatingVersionsEnabled", "true")
+                   .WithItem("PackageReference", "Test.Package", null);
+        })
+            .Build();
+        packageSpec.RestoreMetadata.CentralPackageVersionsEnabled = true;
+        packageSpec.TargetFrameworks[0] = new TargetFrameworkInformation(packageSpec.TargetFrameworks[0])
+        {
+            CentralPackageVersions = new Dictionary<string, CentralPackageVersion>
+            {
+                ["Test.Package"] = new CentralPackageVersion("Test.Package", VersionRange.Parse("[1.0.0,2.0.0)"))
+            }
+        };
+
+        var packageUpdateIO = new Mock<IPackageUpdateIO>(MockBehavior.Strict);
+        packageUpdateIO
+            .Setup(v => v.GetLatestVersionAsync("Test.Package", false, _anyPackageSourceMapping, It.Is<VersionRange>(r => r.ToString() == "[1.0.0, 2.0.0)"), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NuGetVersion("1.4.0"));
+        packageUpdateIO.Setup(v => v.GetPackageSourceMapping()).Returns(DisabledPackageSourceMapping);
+
+        var logger = new Mock<ILoggerWithColor>();
+
+        // Act
+        var (packagesToUpdate, scannedPackages) = await PackageUpdateCommandRunner.SelectAllPackagesWithUpdatesAsync(packageSpec, logger.Object, packageUpdateIO.Object, CancellationToken.None);
+
+        // Assert
+        scannedPackages.Should().ContainSingle().Which.Should().Be("Test.Package");
+        packagesToUpdate.Should().ContainSingle();
+
+        var packageUpdate = packagesToUpdate.First();
+        packageUpdate.Package.CurrentVersion.ToString().Should().Be("[1.0.0, 2.0.0)");
+        packageUpdate.Package.NewVersion.ToString().Should().Be("[1.4.0, 2.0.0)");
 
         logger.Invocations.Count.Should().Be(0);
     }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -773,6 +773,38 @@ namespace NuGet.Test
         }
 
         [Fact]
+        public async Task UpdatePackage_WithExplicitVersionOutsideAllowedRange_DoesNotCreateAction()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            using var testSolutionManager = new TestSolutionManager(pathContext);
+
+            var projectName = "TestProjectName";
+            var packageId = "NuGet.Versioning";
+            var originalPackage = new PackageIdentity(packageId, NuGetVersion.Parse("1.0.0"));
+            var outOfRangePackage = new PackageIdentity(packageId, NuGetVersion.Parse("2.0.0"));
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, originalPackage, outOfRangePackage);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var nuGetPackageManager = new NuGetPackageManager(sourceRepositoryProvider, testSettings, testSolutionManager, new TestDeleteOnRestartManager());
+
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(testSettings, projectName, pathContext.SolutionRoot, framework: "net472");
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency(packageId, VersionRange.Parse("[1.0.0,2.0.0)")));
+
+            var projectTargetFramework = NuGetFramework.Parse("net472");
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, projectFullPath: Path.GetDirectoryName(packageSpec.FilePath), projectName);
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
+            var sourceRepositories = sourceRepositoryProvider.GetRepositories();
+
+            // Act
+            var actions = (await nuGetPackageManager.PreviewUpdatePackagesAsync(new List<PackageIdentity> { outOfRangePackage }, new List<NuGetProject> { buildIntegratedProject }, new ResolutionContext(), new TestNuGetProjectContext(), primarySources: sourceRepositories, secondarySources: sourceRepositories, CancellationToken.None)).ToList();
+
+            // Assert
+            actions.Should().BeEmpty();
+        }
+
+        [Fact]
         public async Task UpdateMultipleAndRollback()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -805,6 +805,123 @@ namespace NuGet.Test
         }
 
         [Fact]
+        public async Task UpdatePackage_WithExplicitVersionInsideAllowedRange_PreservesUpperBound()
+        {
+            // Arrange
+            // Positive guardrail to the existing OutsideAllowedRange test: when the requested
+            // PackageIdentity falls inside the authored range, an action is emitted whose
+            // VersionRange keeps the original upper bound and slides the lower bound up.
+            using var pathContext = new SimpleTestPathContext();
+            using var testSolutionManager = new TestSolutionManager(pathContext);
+
+            var projectName = "TestProjectName";
+            var packageId = "NuGet.Versioning";
+            var originalPackage = new PackageIdentity(packageId, NuGetVersion.Parse("1.0.0"));
+            var inRangePackage = new PackageIdentity(packageId, NuGetVersion.Parse("1.5.0"));
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, originalPackage, inRangePackage);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var nuGetPackageManager = new NuGetPackageManager(sourceRepositoryProvider, testSettings, testSolutionManager, new TestDeleteOnRestartManager());
+
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(testSettings, projectName, pathContext.SolutionRoot, framework: "net472");
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency(packageId, VersionRange.Parse("[1.0.0,2.0.0)")));
+
+            var projectTargetFramework = NuGetFramework.Parse("net472");
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, projectFullPath: Path.GetDirectoryName(packageSpec.FilePath), projectName);
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
+            var sourceRepositories = sourceRepositoryProvider.GetRepositories();
+
+            // Act
+            var actions = (await nuGetPackageManager.PreviewUpdatePackagesAsync(new List<PackageIdentity> { inRangePackage }, new List<NuGetProject> { buildIntegratedProject }, new ResolutionContext(), new TestNuGetProjectContext(), primarySources: sourceRepositories, secondarySources: sourceRepositories, CancellationToken.None)).ToList();
+
+            // Assert
+            actions.Should().ContainSingle().Which.Should().BeOfType<BuildIntegratedProjectAction>();
+            var buildIntegratedAction = (BuildIntegratedProjectAction)actions[0];
+            var lowLevelActions = buildIntegratedAction.ActionAndContextList.Select(t => t.Item1).ToList();
+            lowLevelActions.Should().ContainSingle();
+            lowLevelActions[0].PackageIdentity.Should().Be(inRangePackage);
+            lowLevelActions[0].VersionRange.Should().NotBeNull();
+            lowLevelActions[0].VersionRange.ToString().Should().Be("[1.5.0, 2.0.0)");
+        }
+
+        [Fact]
+        public async Task UpdatePackage_WithExplicitVersionAcrossMajorBoundary_DoesNotCreateAction()
+        {
+            // Arrange
+            // Cross-major boundary: installed [8.0.0, 9.0.0), explicit request 9.0.0.
+            // The PM UI / PMC path must not silently widen the authored upper bound to admit a new major.
+            using var pathContext = new SimpleTestPathContext();
+            using var testSolutionManager = new TestSolutionManager(pathContext);
+
+            var projectName = "TestProjectName";
+            var packageId = "NuGet.Versioning";
+            var originalPackage = new PackageIdentity(packageId, NuGetVersion.Parse("8.0.0"));
+            var nextMajorPackage = new PackageIdentity(packageId, NuGetVersion.Parse("9.0.0"));
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, originalPackage, nextMajorPackage);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var nuGetPackageManager = new NuGetPackageManager(sourceRepositoryProvider, testSettings, testSolutionManager, new TestDeleteOnRestartManager());
+
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(testSettings, projectName, pathContext.SolutionRoot, framework: "net472");
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency(packageId, VersionRange.Parse("[8.0.0,9.0.0)")));
+
+            var projectTargetFramework = NuGetFramework.Parse("net472");
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, projectFullPath: Path.GetDirectoryName(packageSpec.FilePath), projectName);
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
+            var sourceRepositories = sourceRepositoryProvider.GetRepositories();
+
+            // Act
+            var actions = (await nuGetPackageManager.PreviewUpdatePackagesAsync(new List<PackageIdentity> { nextMajorPackage }, new List<NuGetProject> { buildIntegratedProject }, new ResolutionContext(), new TestNuGetProjectContext(), primarySources: sourceRepositories, secondarySources: sourceRepositories, CancellationToken.None)).ToList();
+
+            // Assert
+            actions.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task UpdatePackage_WithFloatingAllowedRange_PreservesFloatingIntent()
+        {
+            // Arrange
+            // Floating-range branch of TryGetVersionRangeForUpdate: the authored floating
+            // range must be preserved verbatim on the resulting action.
+            using var pathContext = new SimpleTestPathContext();
+            using var testSolutionManager = new TestSolutionManager(pathContext);
+
+            var projectName = "TestProjectName";
+            var packageId = "NuGet.Versioning";
+            var originalPackage = new PackageIdentity(packageId, NuGetVersion.Parse("8.0.0"));
+            var inRangePackage = new PackageIdentity(packageId, NuGetVersion.Parse("8.5.0"));
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, originalPackage, inRangePackage);
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(new PackageSource(pathContext.PackageSource));
+            var testSettings = TestSourceRepositoryUtility.PopulateSettingsWithSources(sourceRepositoryProvider, pathContext.WorkingDirectory);
+            var nuGetPackageManager = new NuGetPackageManager(sourceRepositoryProvider, testSettings, testSolutionManager, new TestDeleteOnRestartManager());
+
+            var packageSpec = ProjectTestHelpers.GetPackageSpec(testSettings, projectName, pathContext.SolutionRoot, framework: "net472");
+            var floatingRange = VersionRange.Parse("[8.*,9.0.0)");
+            PackageSpecOperations.AddOrUpdateDependency(packageSpec, new PackageDependency(packageId, floatingRange));
+
+            var projectTargetFramework = NuGetFramework.Parse("net472");
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, projectFullPath: Path.GetDirectoryName(packageSpec.FilePath), projectName);
+            var buildIntegratedProject = new TestPackageReferenceNuGetProject(packageSpec, msBuildNuGetProjectSystem);
+            var sourceRepositories = sourceRepositoryProvider.GetRepositories();
+
+            // Act
+            var actions = (await nuGetPackageManager.PreviewUpdatePackagesAsync(new List<PackageIdentity> { inRangePackage }, new List<NuGetProject> { buildIntegratedProject }, new ResolutionContext(), new TestNuGetProjectContext(), primarySources: sourceRepositories, secondarySources: sourceRepositories, CancellationToken.None)).ToList();
+
+            // Assert
+            actions.Should().ContainSingle().Which.Should().BeOfType<BuildIntegratedProjectAction>();
+            var buildIntegratedAction = (BuildIntegratedProjectAction)actions[0];
+            var lowLevelActions = buildIntegratedAction.ActionAndContextList.Select(t => t.Item1).ToList();
+            lowLevelActions.Should().ContainSingle();
+            lowLevelActions[0].PackageIdentity.Should().Be(inRangePackage);
+            lowLevelActions[0].VersionRange.Should().NotBeNull();
+            lowLevelActions[0].VersionRange.ToString().Should().Be(floatingRange.ToString());
+            lowLevelActions[0].VersionRange.IsFloating.Should().BeTrue();
+        }
+
+        [Fact]
         public async Task UpdateMultipleAndRollback()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/TestPackageReferenceNuGetProject.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/TestPackageReferenceNuGetProject.cs
@@ -165,7 +165,11 @@ namespace NuGet.Test
                 e => e.Dependencies.Select(p =>
                 new PackageReference(
                     new PackageIdentity(p.Name, p.LibraryRange.VersionRange.MinVersion),
-                    e.FrameworkName)))]);
+                    e.FrameworkName,
+                    userInstalled: true,
+                    developmentDependency: false,
+                    requireReinstallation: false,
+                    allowedVersions: p.LibraryRange.VersionRange)))]);
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the version-range update behavior tracked in NuGet/Home#6566. When package update tooling evaluates an installed `PackageReference` or central `PackageVersion` with an authored version range, NuGet now respects that range while selecting update candidates and preserves the authored constraint when writing the update back.

Previously, update flows could select versions outside an existing upper bound, or replace a bounded range such as `[1.0.0, 2.0.0)` with a fixed version after a successful in-range update. This made update behavior inconsistent across PM UI, Package Manager Console, and `dotnet package update`, and could silently discard constraints that users intentionally authored.

Fixes: NuGet/Home#6566

### Behavior

Updates now preserve version-range intent when **all** are true:

* The installed package has an authored allowed version range.
* The requested or discovered update version satisfies that range.
* The update operation writes a new `PackageReference` or central `PackageVersion` value.

For upper-bounded ranges, NuGet updates the lower bound to the selected package version while keeping the original upper bound. Floating ranges are preserved as authored. Explicit update requests outside an authored floating or upper-bounded range are rejected or skipped instead of producing an out-of-range install action. Fixed PackageReference versions are treated as normal installed versions, not authored update constraints, so explicit downgrade operations continue to work.

### Implementation

The change carries the installed `VersionRange` through package update action creation in `NuGetPackageManager` so PM UI and Package Manager Console flows can reject out-of-range explicit updates and preserve allowed ranges for in-range updates.

For `dotnet package update`, latest-version resolution now accepts an optional allowed range and filters package source results before selecting the highest candidate. The command runner also reads central package version ranges when Central Package Management is enabled, so CPM updates follow the same range-preserving behavior as project-local `PackageReference` updates.

### Test plan

* `dotnet test test\NuGet.Core.Tests\NuGet.CommandLine.Xplat.Tests\NuGet.CommandLine.Xplat.Tests.csproj --filter FullyQualifiedName~GetPackageToUpdateTests --no-restore`
* `dotnet test test\NuGet.Core.Tests\NuGet.PackageManagement.Test\NuGet.PackageManagement.Test.csproj --filter FullyQualifiedName~BuildIntegratedTests --no-restore`
* `dotnet test test\NuGet.Core.FuncTests\NuGet.XPlat.FuncTest\NuGet.XPlat.FuncTest.csproj --filter FullyQualifiedName~GetLatestVersionAsyncTests --no-build`
* `dotnet format whitespace --verify-no-changes NuGet.sln`

### Notes / follow-ups

* The functional test path that writes project files depends on local .NET SDK discovery in this environment; the targeted source-filtering functional tests were validated separately.
* The range-preserving write path intentionally keeps the existing upper bound instead of widening user-authored constraints during update.
