### PR TITLE
Pack opted-in project reference outputs

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VSNominationUtilities.cs
@@ -699,6 +699,8 @@ namespace NuGet.SolutionRestoreManager
                 includeAssets: GetPropertyValueOrNull(item, ProjectBuildProperties.IncludeAssets),
                 excludeAssets: GetPropertyValueOrNull(item, ProjectBuildProperties.ExcludeAssets),
                 privateAssets: GetPropertyValueOrNull(item, ProjectBuildProperties.PrivateAssets));
+            dependency.Pack = MSBuildStringUtility.IsTrue(GetPropertyValueOrNull(item, "Pack"));
+            dependency.PackagePath = GetPropertyValueOrNull(item, "PackagePath");
 
             return dependency;
         }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -473,6 +473,8 @@ namespace NuGet.Build.Tasks.Console
                 {
                     ExcludeAssets = GetLibraryIncludeFlags(projectReferenceItem.GetProperty("ExcludeAssets"), LibraryIncludeFlags.None),
                     IncludeAssets = GetLibraryIncludeFlags(projectReferenceItem.GetProperty("IncludeAssets"), LibraryIncludeFlags.All),
+                    Pack = projectReferenceItem.IsPropertyTrue("Pack", defaultValue: false),
+                    PackagePath = MSBuildStringUtility.TrimAndGetNullForEmpty(projectReferenceItem.GetProperty("PackagePath")),
                     PrivateAssets = GetLibraryIncludeFlags(projectReferenceItem.GetProperty("PrivateAssets"), LibraryIncludeFlagUtils.DefaultSuppressParent),
                     ProjectPath = fullPath,
                     ProjectUniqueName = fullPath

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetProjectReferencesFromAssetsFileTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetProjectReferencesFromAssetsFileTask.cs
@@ -4,12 +4,14 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Common;
+using NuGet.LibraryModel;
 using NuGet.ProjectModel;
 
 namespace NuGet.Build.Tasks.Pack
@@ -30,6 +32,12 @@ namespace NuGet.Build.Tasks.Pack
         /// </summary>
         [Output]
         public ITaskItem[] ProjectReferences { get; set; }
+
+        /// <summary>
+        /// Project references that should be packed into the parent package.
+        /// </summary>
+        [Output]
+        public ITaskItem[] PackedProjectReferences { get; set; }
 
         public override bool Execute()
         {
@@ -79,7 +87,120 @@ namespace NuGet.Build.Tasks.Pack
             {
                 ProjectReferences = Array.Empty<ITaskItem>();
             }
+
+            PackedProjectReferences = CreatePackedProjectReferenceItems(assetsFile, projectDirectory).ToArray();
+
             return true;
+        }
+
+        private static IEnumerable<ITaskItem> CreatePackedProjectReferenceItems(LockFile assetsFile, string projectDirectory)
+        {
+            var projectLibraryPaths = assetsFile
+                .Libraries
+                .Where(library => library.MSBuildProject != null)
+                .ToDictionary(
+                    library => $"{library.Name}/{library.Version}",
+                    library => Path.GetFullPath(Path.Combine(
+                        projectDirectory,
+                        PathUtility.GetPathWithDirectorySeparator(library.MSBuildProject))),
+                    StringComparer.OrdinalIgnoreCase);
+
+            var seen = new HashSet<string>(PathUtility.GetStringComparerBasedOnOS());
+
+            foreach (var framework in assetsFile.PackageSpec.RestoreMetadata.TargetFrameworks)
+            {
+                var target = assetsFile.GetTarget(framework.TargetAlias, runtimeIdentifier: null);
+                if (target == null)
+                {
+                    continue;
+                }
+
+                foreach (var projectReference in framework.ProjectReferences.Where(projectReference => projectReference.Pack))
+                {
+                    var projectLibrary = target.Libraries.FirstOrDefault(library =>
+                        string.Equals(library.Type, LibraryType.Project, StringComparison.OrdinalIgnoreCase)
+                        && projectLibraryPaths.TryGetValue($"{library.Name}/{library.Version}", out var projectPath)
+                        && PathUtility.GetStringComparerBasedOnOS().Equals(projectPath, projectReference.ProjectPath));
+
+                    foreach (var taskItem in CreatePackedProjectReferenceItems(
+                        framework,
+                        target.Libraries,
+                        projectLibraryPaths,
+                        projectReference.ProjectPath,
+                        projectReference.PackagePath,
+                        projectLibrary,
+                        seen))
+                    {
+                        yield return taskItem;
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<ITaskItem> CreatePackedProjectReferenceItems(
+            ProjectRestoreMetadataFrameworkInfo framework,
+            IEnumerable<LockFileTargetLibrary> targetLibraries,
+            IReadOnlyDictionary<string, string> projectLibraryPaths,
+            string projectPath,
+            string packagePath,
+            LockFileTargetLibrary projectLibrary,
+            ISet<string> seen)
+        {
+            var targetFramework = string.IsNullOrEmpty(framework.TargetAlias)
+                ? framework.FrameworkName.GetShortFolderName()
+                : framework.TargetAlias;
+
+            var key = $"{targetFramework}|{projectPath}";
+            if (seen.Add(key))
+            {
+                yield return CreatePackedProjectReferenceItem(projectPath, targetFramework, packagePath);
+            }
+
+            if (projectLibrary == null)
+            {
+                yield break;
+            }
+
+            foreach (var dependency in projectLibrary.Dependencies)
+            {
+                var childLibrary = targetLibraries.FirstOrDefault(library =>
+                    string.Equals(library.Type, LibraryType.Project, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(library.Name, dependency.Id, StringComparison.OrdinalIgnoreCase)
+                    && dependency.VersionRange.Satisfies(library.Version));
+
+                if (childLibrary == null
+                    || !projectLibraryPaths.TryGetValue($"{childLibrary.Name}/{childLibrary.Version}", out var childProjectPath))
+                {
+                    continue;
+                }
+
+                foreach (var taskItem in CreatePackedProjectReferenceItems(
+                    framework,
+                    targetLibraries,
+                    projectLibraryPaths,
+                    childProjectPath,
+                    packagePath,
+                    childLibrary,
+                    seen))
+                {
+                    yield return taskItem;
+                }
+            }
+        }
+
+        private static ITaskItem CreatePackedProjectReferenceItem(string projectPath, string targetFramework, string packagePath)
+        {
+            var taskItem = new TaskItem(projectPath);
+            taskItem.SetMetadata("TargetFramework", targetFramework);
+            taskItem.SetMetadata("AdditionalProperties", $"TargetFramework={targetFramework};BuildProjectReferences=false");
+
+            if (!string.IsNullOrEmpty(packagePath))
+            {
+                taskItem.SetMetadata("PackagePath", packagePath);
+                taskItem.SetMetadata("AdditionalProperties", $"TargetFramework={targetFramework};BuildProjectReferences=false;PackProjectReferencePackagePath={packagePath}");
+            }
+
+            return taskItem;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -526,6 +526,7 @@ namespace NuGet.Build.Tasks.Pack
 
                 var targetPath = assembly.GetProperty("TargetPath");
                 var targetFrameworkProperty = assembly.GetProperty("TargetFramework");
+                var packagePath = assembly.GetProperty("PackagePath");
 
                 if (!File.Exists(finalOutputPath))
                 {
@@ -564,7 +565,8 @@ namespace NuGet.Build.Tasks.Pack
                 {
                     FinalOutputPath = finalOutputPath,
                     TargetPath = targetPath,
-                    TargetFramework = targetFramework
+                    TargetFramework = targetFramework,
+                    PackagePath = packagePath
                 });
             }
 
@@ -963,6 +965,17 @@ namespace NuGet.Build.Tasks.Pack
                         continue;
                     }
 
+                    if (projectReference.Pack)
+                    {
+                        AddPackageDependenciesFromPackedProject(
+                            targetLibrary,
+                            target.Libraries,
+                            dependencies,
+                            new HashSet<PackageIdentity>());
+
+                        continue;
+                    }
+
                     var versionToUse = new VersionRange(targetLibrary.Version);
 
                     // Use the project reference version obtained at build time if it exists, otherwise fallback to the one in assets file.
@@ -987,6 +1000,63 @@ namespace NuGet.Build.Tasks.Pack
                     PackCommandRunner.AddLibraryDependency(projectDependency, dependencies);
                 }
             }
+        }
+
+        private static void AddPackageDependenciesFromPackedProject(
+            LockFileTargetLibrary projectLibrary,
+            IEnumerable<LockFileTargetLibrary> targetLibraries,
+            HashSet<LibraryDependency> dependencies,
+            HashSet<PackageIdentity> visitedProjects)
+        {
+            var projectIdentity = new PackageIdentity(projectLibrary.Name, projectLibrary.Version);
+            if (!visitedProjects.Add(projectIdentity))
+            {
+                return;
+            }
+
+            foreach (var dependency in projectLibrary.Dependencies)
+            {
+                var targetLibrary = targetLibraries.FirstOrDefault(library =>
+                    string.Equals(library.Name, dependency.Id, StringComparison.OrdinalIgnoreCase)
+                    && dependency.VersionRange.Satisfies(library.Version));
+
+                if (targetLibrary == null)
+                {
+                    continue;
+                }
+
+                if (string.Equals(targetLibrary.Type, LibraryType.Project, StringComparison.OrdinalIgnoreCase))
+                {
+                    AddPackageDependenciesFromPackedProject(targetLibrary, targetLibraries, dependencies, visitedProjects);
+                    continue;
+                }
+
+                if (string.Equals(targetLibrary.Type, LibraryType.Package, StringComparison.OrdinalIgnoreCase))
+                {
+                    var packageDependency = new LibraryDependency()
+                    {
+                        LibraryRange = new LibraryRange(
+                            targetLibrary.Name,
+                            dependency.VersionRange,
+                            LibraryDependencyTarget.Package),
+                        IncludeType = GetLibraryIncludeFlags(dependency.Include, LibraryIncludeFlags.All)
+                            & ~GetLibraryIncludeFlags(dependency.Exclude, LibraryIncludeFlags.None),
+                        SuppressParent = LibraryIncludeFlags.None
+                    };
+
+                    PackCommandRunner.AddLibraryDependency(packageDependency, dependencies);
+                }
+            }
+        }
+
+        private static LibraryIncludeFlags GetLibraryIncludeFlags(IReadOnlyList<string> flags, LibraryIncludeFlags defaultFlags)
+        {
+            if (flags == null || flags.Count == 0)
+            {
+                return defaultFlags;
+            }
+
+            return LibraryIncludeFlagUtils.GetFlags(string.Join(";", flags), defaultFlags);
         }
 
         private void InitializePackageDependencies(

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
@@ -82,6 +82,8 @@ namespace NuGet.Build.Tasks
                     BuildTasksUtility.CopyPropertyIfExists(project, properties, "IncludeAssets");
                     BuildTasksUtility.CopyPropertyIfExists(project, properties, "ExcludeAssets");
                     BuildTasksUtility.CopyPropertyIfExists(project, properties, "PrivateAssets");
+                    BuildTasksUtility.CopyPropertyIfExists(project, properties, "Pack");
+                    BuildTasksUtility.CopyPropertyIfExists(project, properties, "PackagePath");
 
                     entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));
                 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
@@ -326,6 +326,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
         TaskParameter="ProjectReferences"
         ItemName="_ProjectReferencesFromAssetsFile" />
+      <Output
+        TaskParameter="PackedProjectReferences"
+        ItemName="_PackedProjectReferencesFromAssetsFile" />
     </GetProjectReferencesFromAssetsFileTask>
 
     <MSBuild
@@ -368,6 +371,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     </MSBuild>
 
     <MSBuild
+      Condition="'$(IncludeBuildOutput)' == 'true' AND '@(_PackedProjectReferencesFromAssetsFile)' != ''"
+      Projects="@(_PackedProjectReferencesFromAssetsFile)"
+      Targets="_GetBuildOutputFilesWithTfm"
+      BuildInParallel="$(BuildInParallel)"
+      Properties="BuildProjectReferences=false">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_BuildOutputInPackage" />
+    </MSBuild>
+
+    <MSBuild
       Condition="'$(TargetsForTfmSpecificContentInPackage)' != ''"
       Projects="@(_ProjectsWithTFM)"
       Targets="_GetTfmSpecificContentForPackage"
@@ -383,6 +398,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       Projects="@(_ProjectsWithTFM)"
       Targets="_GetDebugSymbolsWithTfm"
       BuildInParallel="$(BuildInParallel)">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_TargetPathsToSymbols" />
+    </MSBuild>
+
+    <MSBuild
+      Condition="'$(IncludeBuildOutput)' == 'true' AND '@(_PackedProjectReferencesFromAssetsFile)' != ''"
+      Projects="@(_PackedProjectReferencesFromAssetsFile)"
+      Targets="_GetDebugSymbolsWithTfm"
+      BuildInParallel="$(BuildInParallel)"
+      Properties="BuildProjectReferences=false">
 
       <Output
           TaskParameter="TargetOutputs"
@@ -444,6 +471,9 @@ Copyright (c) .NET Foundation. All rights reserved.
                             @(BuiltProjectOutputGroupOutput);
                             @(DocumentationProjectOutputGroupOutput);
                             @(_PathToPriFile)"/>
+      <BuildOutputInPackage Condition="'$(PackProjectReferencePackagePath)' != ''" Update="@(BuildOutputInPackage)">
+        <PackagePath>$(PackProjectReferencePackagePath)</PackagePath>
+      </BuildOutputInPackage>
     </ItemGroup>
   </Target>
 
@@ -465,6 +495,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition="'$(IncludeBuildOutput)' == 'true'">
       <_TargetPathsToSymbolsWithTfm Include="@(DebugSymbolsProjectOutputGroupOutput)">
         <TargetFramework>$(TargetFramework)</TargetFramework>
+        <PackagePath Condition="'$(PackProjectReferencePackagePath)' != ''">$(PackProjectReferencePackagePath)</PackagePath>
       </_TargetPathsToSymbolsWithTfm>
     </ItemGroup>
     <ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
@@ -310,9 +310,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
   </Target>
 
-  <Target Name="_GetProjectReferenceVersions"
+  <Target Name="_GetProjectReferencesFromAssetsFile"
           Condition="'$(NuspecFile)' == ''"
-          DependsOnTargets="_GetAbsoluteOutputPathsForPack;$(GetPackageVersionDependsOn)">
+          DependsOnTargets="_GetAbsoluteOutputPathsForPack">
 
     <!-- 'RestoreOutputAbsolutePath' will be provided by '_GetAbsoluteOutputPathsForPack' target -->
 
@@ -330,7 +330,11 @@ Copyright (c) .NET Foundation. All rights reserved.
         TaskParameter="PackedProjectReferences"
         ItemName="_PackedProjectReferencesFromAssetsFile" />
     </GetProjectReferencesFromAssetsFileTask>
+  </Target>
 
+  <Target Name="_GetProjectReferenceVersions"
+          Condition="'$(NuspecFile)' == ''"
+          DependsOnTargets="_GetProjectReferencesFromAssetsFile;$(GetPackageVersionDependsOn)">
     <MSBuild
       Projects="@(_ProjectReferencesFromAssetsFile)"
       Targets="_GetProjectVersion"
@@ -353,7 +357,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target Name="_WalkEachTargetPerFramework">
+  <Target Name="_WalkEachTargetPerFramework"
+          DependsOnTargets="_GetProjectReferencesFromAssetsFile">
     <ItemGroup>
         <_ProjectsWithTFM Include="$(MSBuildProjectFullPath)" AdditionalProperties="TargetFramework=%(_TargetFrameworks.Identity)" />
         <_ProjectsWithTFMNoBuild Include="$(MSBuildProjectFullPath)" AdditionalProperties="TargetFramework=%(_TargetFrameworks.Identity);BuildProjectReferences=false" />

--- a/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
@@ -48,5 +48,10 @@ namespace NuGet.Commands
         /// This is the target framework for which this assembly was built.
         /// </summary>
         public string TargetFramework { get; set; }
+
+        /// <summary>
+        /// This is an optional package path override for the output file.
+        /// </summary>
+        public string PackagePath { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -140,17 +140,31 @@ namespace NuGet.Commands
                 }
                 var tfm = NuGetFramework.Parse(file.TargetFramework).GetShortFolderName();
                 var targetPath = file.TargetPath;
-                for (var i = 0; i < targetFolders.Length; i++)
+                var hasPackagePath = !string.IsNullOrEmpty(file.PackagePath);
+                var targetFolderCount = hasPackagePath ? 1 : targetFolders.Length;
+
+                for (var i = 0; i < targetFolderCount; i++)
                 {
+                    var target = hasPackagePath
+                        ? Path.Combine(file.PackagePath, targetPath)
+                        : GetBuildOutputPackagePath(targetFolders[i], tfm, targetPath);
+
                     var packageFile = new ManifestFile()
                     {
                         Source = file.FinalOutputPath,
-                        Target = IsTool ? Path.Combine(targetFolders[i], targetPath) : Path.Combine(targetFolders[i], tfm, targetPath)
+                        Target = target
                     };
 
                     AddFileToBuilder(packageFile);
                 }
             }
+        }
+
+        private string GetBuildOutputPackagePath(string targetFolder, string tfm, string targetPath)
+        {
+            return IsTool
+                ? Path.Combine(targetFolder, targetPath)
+                : Path.Combine(targetFolder, tfm, targetPath);
         }
 
         private bool AddFileToBuilder(ManifestFile packageFile)

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
 const NuGet.Commands.Restore.Utility.PackageSpecFactory.EnvironmentVariableName = "NUGET_USE_NEW_PACKAGESPEC_FACTORY" -> string!
+~NuGet.Commands.OutputLibFile.PackagePath.get -> string
+~NuGet.Commands.OutputLibFile.PackagePath.set -> void

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
 const NuGet.Commands.Restore.Utility.PackageSpecFactory.EnvironmentVariableName = "NUGET_USE_NEW_PACKAGESPEC_FACTORY" -> string!
+~NuGet.Commands.OutputLibFile.PackagePath.get -> string
+~NuGet.Commands.OutputLibFile.PackagePath.set -> void

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -152,6 +152,14 @@ namespace NuGet.Commands
             dependency.PrivateAssets = GetIncludeFlags(privateAssets, LibraryIncludeFlagUtils.DefaultSuppressParent);
         }
 
+        private static void ApplyProjectReferencePackMetadata(ProjectRestoreReference dependency, string pack, string packagePath)
+        {
+            if (dependency == null) throw new ArgumentNullException(nameof(dependency));
+
+            dependency.Pack = MSBuildStringUtility.IsTrue(pack);
+            dependency.PackagePath = MSBuildStringUtility.TrimAndGetNullForEmpty(packagePath);
+        }
+
         /// <summary>
         /// Convert MSBuild items to a PackageSpec.
         /// </summary>
@@ -595,6 +603,7 @@ namespace NuGet.Commands
             };
 
             ApplyIncludeFlags(reference, item.GetProperty("IncludeAssets"), item.GetProperty("ExcludeAssets"), item.GetProperty("PrivateAssets"));
+            ApplyProjectReferencePackMetadata(reference, item.GetProperty("Pack"), item.GetProperty("PackagePath"));
 
             return new Tuple<List<string>, ProjectRestoreReference>(frameworks, reference);
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -79,6 +79,8 @@ namespace NuGet.ProjectModel
         private static readonly byte[] WarnNotAsErrorPropertyName = Encoding.UTF8.GetBytes("warnNotAsError");
         private static readonly byte[] ExcludeAssetsPropertyName = Encoding.UTF8.GetBytes("excludeAssets");
         private static readonly byte[] IncludeAssetsPropertyName = Encoding.UTF8.GetBytes("includeAssets");
+        private static readonly byte[] PackPropertyName = Encoding.UTF8.GetBytes("pack");
+        private static readonly byte[] PackagePathPropertyName = Encoding.UTF8.GetBytes("packagePath");
         private static readonly byte[] TargetAliasPropertyName = Encoding.UTF8.GetBytes("targetAlias");
         private static readonly byte[] AssetTargetFallbackPropertyName = Encoding.UTF8.GetBytes("assetTargetFallback");
         private static readonly byte[] SecondaryFrameworkPropertyName = Encoding.UTF8.GetBytes("secondaryFramework");
@@ -1329,6 +1331,8 @@ namespace NuGet.ProjectModel
                                         var projectReferencePropertyName = jsonReader.GetString();
                                         string excludeAssets = null;
                                         string includeAssets = null;
+                                        bool pack = false;
+                                        string packagePath = null;
                                         string privateAssets = null;
                                         string projectReferenceProjectPath = null;
 
@@ -1347,6 +1351,14 @@ namespace NuGet.ProjectModel
                                                 else if (jsonReader.ValueTextEquals(PrivateAssetsPropertyName))
                                                 {
                                                     privateAssets = jsonReader.ReadNextTokenAsString();
+                                                }
+                                                else if (jsonReader.ValueTextEquals(PackPropertyName))
+                                                {
+                                                    pack = jsonReader.ReadNextTokenAsBoolOrFalse();
+                                                }
+                                                else if (jsonReader.ValueTextEquals(PackagePathPropertyName))
+                                                {
+                                                    packagePath = jsonReader.ReadNextTokenAsString();
                                                 }
                                                 else if (jsonReader.ValueTextEquals(ProjectPathPropertyName))
                                                 {
@@ -1376,6 +1388,9 @@ namespace NuGet.ProjectModel
                                             PrivateAssets = LibraryIncludeFlagUtils.GetFlags(
                                                 flags: privateAssets,
                                                 defaultFlags: LibraryIncludeFlagUtils.DefaultSuppressParent),
+
+                                            Pack = pack,
+                                            PackagePath = packagePath,
                                         });
                                     }
                                 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -262,6 +262,13 @@ namespace NuGet.ProjectModel
                                 writer.WriteNameValue("privateAssets", LibraryIncludeFlagUtils.GetFlagString(project.PrivateAssets));
                             }
 
+                            if (project.Pack)
+                            {
+                                writer.WriteNameValue("pack", project.Pack);
+                            }
+
+                            SetValueIfNotNull(writer, "packagePath", project.PackagePath);
+
                             writer.WriteObjectEnd();
                         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreReference.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreReference.cs
@@ -27,6 +27,10 @@ namespace NuGet.ProjectModel
 
         public LibraryIncludeFlags PrivateAssets { get; set; } = LibraryIncludeFlagUtils.DefaultSuppressParent;
 
+        public bool Pack { get; set; }
+
+        public string PackagePath { get; set; }
+
         public override int GetHashCode()
         {
             var combiner = new HashCodeCombiner();
@@ -36,6 +40,8 @@ namespace NuGet.ProjectModel
             combiner.AddStruct(IncludeAssets);
             combiner.AddStruct(ExcludeAssets);
             combiner.AddStruct(PrivateAssets);
+            combiner.AddStruct(Pack);
+            combiner.AddObject(PackagePath);
 
             return combiner.CombinedHash;
         }
@@ -66,7 +72,9 @@ namespace NuGet.ProjectModel
                 && StringComparer.OrdinalIgnoreCase.Equals(ProjectUniqueName, other.ProjectUniqueName)
                 && IncludeAssets == other.IncludeAssets
                 && ExcludeAssets == other.ExcludeAssets
-                && PrivateAssets == other.PrivateAssets;
+                && PrivateAssets == other.PrivateAssets
+                && Pack == other.Pack
+                && StringComparer.Ordinal.Equals(PackagePath, other.PackagePath);
         }
 
         public ProjectRestoreReference Clone()
@@ -77,6 +85,8 @@ namespace NuGet.ProjectModel
             clonedObject.ExcludeAssets = ExcludeAssets;
             clonedObject.IncludeAssets = IncludeAssets;
             clonedObject.PrivateAssets = PrivateAssets;
+            clonedObject.Pack = Pack;
+            clonedObject.PackagePath = PackagePath;
             return clonedObject;
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
 #nullable enable
 NuGet.ProjectModel.ProjectRestoreMetadata.RestoreDoNotWriteDependencyGraphSpec.get -> bool
 NuGet.ProjectModel.ProjectRestoreMetadata.RestoreDoNotWriteDependencyGraphSpec.set -> void
+~NuGet.ProjectModel.ProjectRestoreReference.PackagePath.get -> string
+~NuGet.ProjectModel.ProjectRestoreReference.PackagePath.set -> void
+NuGet.ProjectModel.ProjectRestoreReference.Pack.get -> bool
+NuGet.ProjectModel.ProjectRestoreReference.Pack.set -> void

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -980,6 +980,114 @@ namespace Dotnet.Integration.Test
             }
         }
 
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_PackProjectReferenceWithPackTrue_AddsProjectOutputToLib()
+        {
+            // Arrange
+            using (var testDirectory = _dotnetFixture.CreateTestDirectory())
+            {
+                var projectName = "ClassLibrary1";
+                var referencedProject = "ClassLibrary2";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                _dotnetFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "classlib", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.CreateDotnetNewProject(testDirectory.Path, referencedProject, "classlib", testOutputHelper: _testOutputHelper);
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "ProjectReference",
+                        @"..\ClassLibrary2\ClassLibrary2.csproj",
+                        string.Empty,
+                        new Dictionary<string, string>
+                        {
+                            { "Pack", "true" }
+                        },
+                        new Dictionary<string, string>());
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                _dotnetFixture.RestoreProjectExpectSuccess(workingDirectory, projectName, testOutputHelper: _testOutputHelper);
+
+                // Act
+                _dotnetFixture.PackProjectExpectSuccess(workingDirectory, projectName, $"-o {workingDirectory}", testOutputHelper: _testOutputHelper);
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+
+                // Assert
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var files = nupkgReader.GetFiles().ToList();
+                    files.Should().Contain(filePath => filePath.StartsWith("lib/") && filePath.EndsWith("/ClassLibrary1.dll"));
+                    files.Should().Contain(filePath => filePath.StartsWith("lib/") && filePath.EndsWith("/ClassLibrary2.dll"));
+
+                    var packages = nupkgReader.NuspecReader.GetDependencyGroups().SelectMany(group => group.Packages);
+                    packages.Should().NotContain(package => package.Id == referencedProject);
+                }
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void PackCommand_PackProjectReferenceWithPackagePath_AddsProjectOutputToPackagePath()
+        {
+            // Arrange
+            using (var testDirectory = _dotnetFixture.CreateTestDirectory())
+            {
+                var projectName = "ClassLibrary1";
+                var referencedProject = "ClassLibrary2";
+                var packagePath = "analyzers/dotnet/cs";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                _dotnetFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "classlib", testOutputHelper: _testOutputHelper);
+                _dotnetFixture.CreateDotnetNewProject(testDirectory.Path, referencedProject, "classlib", testOutputHelper: _testOutputHelper);
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "ProjectReference",
+                        @"..\ClassLibrary2\ClassLibrary2.csproj",
+                        string.Empty,
+                        new Dictionary<string, string>
+                        {
+                            { "Pack", "true" },
+                            { "PackagePath", packagePath }
+                        },
+                        new Dictionary<string, string>());
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                _dotnetFixture.RestoreProjectExpectSuccess(workingDirectory, projectName, testOutputHelper: _testOutputHelper);
+
+                // Act
+                _dotnetFixture.PackProjectExpectSuccess(workingDirectory, projectName, $"-o {workingDirectory}", testOutputHelper: _testOutputHelper);
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+
+                // Assert
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var files = nupkgReader.GetFiles().ToList();
+                    files.Should().Contain($"{packagePath}/ClassLibrary2.dll");
+                    files.Should().NotContain(filePath => filePath.StartsWith("lib/") && filePath.EndsWith("/ClassLibrary2.dll"));
+
+                    var packages = nupkgReader.NuspecReader.GetDependencyGroups().SelectMany(group => group.Packages);
+                    packages.Should().NotContain(package => package.Id == referencedProject);
+                }
+            }
+        }
+
         [PlatformTheory(Platform.Windows)]
         [InlineData("TargetFramework", "netstandard1.4")]
         [InlineData("TargetFrameworks", "netstandard1.4;net46")]

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectReferencesTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectReferencesTaskTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace NuGet.Build.Tasks.Test
+{
+    public class GetRestoreProjectReferencesTaskTests
+    {
+        [Fact]
+        public void Execute_WithPackMetadata_CopiesMetadataToRestoreGraphItem()
+        {
+            // Arrange
+            var task = new GetRestoreProjectReferencesTask()
+            {
+                BuildEngine = new TestBuildEngine(),
+                ParentProjectPath = Path.Combine("src", "ProjectA", "ProjectA.csproj"),
+                ProjectUniqueName = "ProjectA",
+                TargetFrameworks = "net10.0",
+                ProjectReferences = new ITaskItem[]
+                {
+                    new MockTaskItem(Path.Combine("..", "ProjectB", "ProjectB.csproj"))
+                    {
+                        ["Pack"] = "true",
+                        ["PackagePath"] = "analyzers/dotnet/cs"
+                    }
+                }
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result, "Task failed");
+            Assert.Single(task.RestoreGraphItems);
+            Assert.Equal("true", task.RestoreGraphItems[0].GetMetadata("Pack"));
+            Assert.Equal("analyzers/dotnet/cs", task.RestoreGraphItems[0].GetMetadata("PackagePath"));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -112,6 +112,41 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        public void Write_ReadWriteProjectReferencePackMetadata()
+        {
+            // Arrange
+            var json = @"{
+  ""restore"": {
+    ""projectUniqueName"": ""projectUniqueName"",
+    ""projectName"": ""projectName"",
+    ""projectPath"": ""projectPath"",
+    ""projectStyle"": ""PackageReference"",
+    ""frameworks"": {
+      ""net45"": {
+        ""framework"": ""net45"",
+        ""targetAlias"": ""net45"",
+        ""projectReferences"": {
+          ""referenceUniqueName"": {
+            ""projectPath"": ""referencePath"",
+            ""pack"": true,
+            ""packagePath"": ""analyzers/dotnet/cs""
+          }
+        }
+      }
+    }
+  },
+  ""frameworks"": {
+    ""net45"": {
+        ""framework"": ""net45""
+    }
+  }
+}";
+
+            // Act & Assert
+            VerifyJsonPackageSpecRoundTrip(json);
+        }
+
+        [Fact]
         public void Write_ReadWriteWarningProperties()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreReferenceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreReferenceTests.cs
@@ -117,6 +117,52 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        public void Equals_WithPack(bool left, bool right, bool expected)
+        {
+            var leftSide = new ProjectRestoreReference()
+            {
+                ProjectPath = "path",
+                ProjectUniqueName = "path",
+                Pack = left
+            };
+
+            var rightSide = new ProjectRestoreReference()
+            {
+                ProjectPath = "path",
+                ProjectUniqueName = "path",
+                Pack = right
+            };
+
+            AssertEquality(expected, leftSide, rightSide);
+        }
+
+        [Theory]
+        [InlineData("lib/netstandard2.0", "lib/netstandard2.0", true)]
+        [InlineData("lib/netstandard2.0", "analyzers/dotnet/cs", false)]
+        [InlineData(null, null, true)]
+        public void Equals_WithPackagePath(string left, string right, bool expected)
+        {
+            var leftSide = new ProjectRestoreReference()
+            {
+                ProjectPath = "path",
+                ProjectUniqueName = "path",
+                PackagePath = left
+            };
+
+            var rightSide = new ProjectRestoreReference()
+            {
+                ProjectPath = "path",
+                ProjectUniqueName = "path",
+                PackagePath = right
+            };
+
+            AssertEquality(expected, leftSide, rightSide);
+        }
+
+        [Theory]
         [InlineData("path1", "path1", true)]
         [InlineData("path1", "path2", false)]
         [InlineData("", "", true)]
@@ -222,6 +268,52 @@ namespace NuGet.ProjectModel.Test
                 ProjectPath = "path",
                 ProjectUniqueName = "path",
                 ExcludeAssets = right
+            };
+
+            AssertHashCode(expected, leftSide, rightSide);
+        }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        public void HashCode_WithPack(bool left, bool right, bool expected)
+        {
+            var leftSide = new ProjectRestoreReference()
+            {
+                ProjectPath = "path",
+                ProjectUniqueName = "path",
+                Pack = left
+            };
+
+            var rightSide = new ProjectRestoreReference()
+            {
+                ProjectPath = "path",
+                ProjectUniqueName = "path",
+                Pack = right
+            };
+
+            AssertHashCode(expected, leftSide, rightSide);
+        }
+
+        [Theory]
+        [InlineData("lib/netstandard2.0", "lib/netstandard2.0", true)]
+        [InlineData("lib/netstandard2.0", "analyzers/dotnet/cs", false)]
+        [InlineData(null, null, true)]
+        public void HashCode_WithPackagePath(string left, string right, bool expected)
+        {
+            var leftSide = new ProjectRestoreReference()
+            {
+                ProjectPath = "path",
+                ProjectUniqueName = "path",
+                PackagePath = left
+            };
+
+            var rightSide = new ProjectRestoreReference()
+            {
+                ProjectPath = "path",
+                ProjectUniqueName = "path",
+                PackagePath = right
             };
 
             AssertHashCode(expected, leftSide, rightSide);

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -374,6 +374,16 @@ project TFMs found: {string.Join(", ", compiledTfms.Keys.Select(k => k.ToString(
                     destFileName: Path.Combine(pathToSdkInCli, assembly.Name),
                     overwrite: true);
             }
+
+            File.Copy(
+                sourceFileName: Path.Combine(
+                    Directory.GetParent(artifactsDirectory).FullName,
+                    "src",
+                    "NuGet.Core",
+                    "NuGet.Build.Tasks",
+                    "NuGet.Build.Tasks.Pack.targets"),
+                destFileName: Path.Combine(pathToSdkInCli, "NuGet.Build.Tasks.Pack.targets"),
+                overwrite: true);
         }
 
         public static void WriteGlobalJson(string path)


### PR DESCRIPTION
## Summary
- Adds restored `ProjectReference` `Pack` and `PackagePath` metadata across MSBuild, static graph, Visual Studio nomination, and project.assets.json round-tripping.
- Carries `Pack` and `PackagePath` through restore graph project-reference items so the assets file can identify bundled project references during pack.
- Collects opted-in project reference outputs during pack without rebuilding references, including symbols and package path overrides.
- Suppresses bundled project references as nuspec dependencies and promotes package dependencies reachable through bundled projects.
- Updates the functional test SDK patching to copy the modified `NuGet.Build.Tasks.Pack.targets` alongside the patched task assemblies.

## Test plan
- Passed: `dotnet build test\NuGet.Core.Tests\NuGet.ProjectModel.Test\NuGet.ProjectModel.Test.csproj /m:1`
- Passed: `dotnet build test\NuGet.Core.FuncTests\Dotnet.Integration.Test\Dotnet.Integration.Test.csproj /m:1`
- Added: `GetRestoreProjectReferencesTaskTests.Execute_WithPackMetadata_CopiesMetadataToRestoreGraphItem`
- CI: rerunning after `356773281`, which fixes the missing restore graph metadata that kept `pack: true` out of `project.assets.json`.

Fixes NuGet/Home#3891.