### PR TITLE
NuGet.Protocol nullable enablement - Converters, Events, DependencyInfo

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -276,6 +276,32 @@ For example the following are correct:
 
 Many of the guidelines, wherever possible, and potentially some not listed here, are enforced by an [EditorConfig](https://editorconfig.org "EditorConfig homepage") file (`.editorconfig`) at the root of the repository.
 
+## Prefer Immutability and Non-Null Types
+
+When writing new code or refactoring existing code, prefer types that are immutable and non-null. Immutable objects are easier to reason about, thread-safe by construction, and enable compiler optimizations — the JIT can cache property reads, skip defensive copies for readonly structs, and in some cases eliminate bounds checks. Non-null types make illegal states unrepresentable and push error detection from runtime to compile time.
+
+### Property accessor guidelines
+
+Use the most restrictive accessor that the code actually needs:
+
+| Scenario | Pattern | Example |
+|---|---|---|
+| Must be provided, immutable after creation | `required init` | `public required string Id { get; init; }` |
+| Optional at creation, immutable after | `init` | `public bool Listed { get; init; }` |
+| Collection, never replaced | get-only + inline init | `public IList<Item> Items { get; } = new List<Item>();` |
+| Truly mutable state | `set` | `public int RetryCount { get; set; }` |
+
+Think of it as a spectrum: **`required init`** > **`init`** > **`set`**. Use the most restrictive accessor that works.
+
+- **`{ get; init; }`** over `{ get; set; }` for properties set only at construction time. This is especially valuable for data-carrying types (DTOs, info objects, result types).
+- **`{ get; }` (get-only)** for collection properties initialized inline. There's no reason to expose a setter if the collection itself is never replaced, only mutated via `.Add()`.
+- **`required`** over accepting `null!` initializers for properties that must be provided. `required init` enforces that callers set the value, and the value is immutable once set.
+- **`readonly` fields** wherever the field isn't reassigned after construction. (This is already mentioned in the C# Coding Style section above, but bears repeating in this context.)
+
+### Non-null bias
+
+Default to non-null types. Only mark a type as nullable (`?`) when the value is genuinely optional — configuration, cache misses, "not found" semantics. Don't replace null with sentinel values (`string.Empty`, `Array.Empty<T>()`) if downstream code would silently misbehave — empty should not become the new null.
+
 ### Getting or Setting Environment Variables
 
 Environment variables apply to the entire process and are considered static state which can cause test issues since multiple tests can be running in parallel reading or updating the same variable.

--- a/docs/skills/nullable-enablement/SKILL.md
+++ b/docs/skills/nullable-enablement/SKILL.md
@@ -9,15 +9,28 @@ This skill guides the process of enabling C# nullable reference types on files i
 
 The work is inherently incremental — don't try to migrate an entire project at once. Work in batches of related files, fix cascading warnings, build, and repeat.
 
+## Coding Guidelines for Nullable Migration
+
+Nullable migration is a rare chance to modernize internal types. Beyond just annotating, apply the immutability and non-null design principles from [`docs/coding-guidelines.md`](../../coding-guidelines.md#prefer-immutability-and-non-null-types) — prefer `required init` over `set`, get-only collections, and `readonly` fields. The migration touchpoint is the natural moment to tighten up these types.
+
+### Fix Stale Contracts, Don't Paper Over Them
+
+During nullable annotation you'll sometimes discover that a method's actual behavior doesn't match its documented contract — e.g., a method documented as "returns null if not found" that actually returns an empty object, or dead null checks in callers. Don't just annotate what the code does today. If the internal method's contract is wrong, fix it:
+
+- If a method is documented to return null but never does, decide whether to make it return null (honest contract) or update the docs (honest documentation).
+- Prefer the semantically correct option — returning null for "not found" is usually cleaner than returning an empty shell object with uninitialized properties.
+- Since internal methods have no public API surface risk, you can change their contracts freely.
+
 ## Annotation Philosophy: Prefer Non-Null
 
 The default mindset when annotating is **non-null unless proven otherwise**. Before marking something `?`, ask: "Can I make this non-null instead?" Sometimes a small, non-breaking code change can eliminate nullability — and that's preferable to marking something nullable. But be careful not to replace null problems with empty-value problems.
 
 **Good non-null opportunities:**
-- **Use `required`** on internal/private types so the constructor enforces initialization.
+- **Use `required`** on internal/private types so the constructor enforces initialization. The `required` keyword works on net472 via the shared polyfill `RequiredModifierAttributes.cs` (and `IsExternalInit.cs` for `init`). If the target project doesn't include them, add `<Compile Include="$(SharedDirectory)\RequiredModifierAttributes.cs" />` and `<Compile Include="$(SharedDirectory)\IsExternalInit.cs" />` to the csproj under the `<ItemGroup Label="NuGet Shared">` section. Check `NuGet.Packaging.csproj` as a reference.
 - **Set a property in the constructor** instead of relying on callers to set it later.
 - **Use `??` or `?? throw`** at assignment sites to guarantee non-null storage.
 - **Initialize a field** to a sensible default — but only when the consuming code already handles that default gracefully. Don't initialize to `string.Empty` or `Array.Empty<T>()` if downstream code would silently misbehave with an empty value instead of correctly handling null. Empty should not become the new null.
+- **Use `null!` initializer** when `required` can't work (e.g., the property is set by external code after construction, not in an initializer). Add a comment explaining why.
 
 **When `?` is the right answer:**
 - The value is genuinely optional — configuration, cache misses, "not found" semantics.
@@ -172,14 +185,17 @@ NuGet.Protocol.Core.Types.PackageDownloadContext.PackageDownloadContext(NuGet.Pr
 After each batch of changes, build the affected project to ensure zero warnings/errors:
 
 ```
-msbuild src\NuGet.Core\<ProjectName>\<ProjectName>.csproj /t:Build /p:Configuration=Release
+dotnet msbuild src\NuGet.Core\<ProjectName>\<ProjectName>.csproj -v:q
 ```
 
-or use the solution filter:
+Also build the test projects to catch cascading warnings:
 
 ```
-msbuild NuGet-Src.slnf /t:Build /p:Configuration=Release
+dotnet msbuild test\NuGet.Core.Tests\<ProjectName>.Tests\<ProjectName>.Tests.csproj -v:q
+dotnet msbuild test\NuGet.Core.FuncTests\<ProjectName>.FuncTest\<ProjectName>.FuncTest.csproj -v:q
 ```
+
+`dotnet msbuild` builds all TFMs without needing a restore step, unlike `dotnet build` which may fail on some TFMs with NETSDK1005 (missing restore for net8.0). Use `dotnet msbuild` as the default build command.
 
 Common build errors after nullable migration:
 

--- a/src/NuGet.Core/NuGet.Protocol/Converters/FingerprintsConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/FingerprintsConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
@@ -16,7 +14,7 @@ namespace NuGet.Protocol
 
         public override bool CanWrite => false;
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             var v = JsonUtility.LoadJson(reader);
 
@@ -24,13 +22,13 @@ namespace NuGet.Protocol
 
             foreach (var fingerprint in v)
             {
-                dict[fingerprint.Key] = fingerprint.Value.ToString();
+                dict[fingerprint.Key] = fingerprint.Value?.ToString() ?? string.Empty;
             }
 
             return new Fingerprints(dict);
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
@@ -52,7 +52,7 @@ namespace NuGet.Protocol
         /// <param name="json">JSON representation of object</param>
         public static T? FromJson<T>(this string json)
         {
-            return JsonConvert.DeserializeObject<T>(json, JsonExtensions.ObjectSerializationSettings)!;
+            return JsonConvert.DeserializeObject<T>(json, JsonExtensions.ObjectSerializationSettings);
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace NuGet.Protocol
         /// <param name="settings">The settings.</param>
         public static T? FromJson<T>(this string json, JsonSerializerSettings settings)
         {
-            return JsonConvert.DeserializeObject<T>(json, settings)!;
+            return JsonConvert.DeserializeObject<T>(json, settings);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace NuGet.Protocol
         /// <param name="jtoken">The JToken to be deserialized.</param>
         public static T? FromJToken<T>(this JToken jtoken)
         {
-            return jtoken.ToObject<T>(JsonExtensions.JsonObjectSerializer)!;
+            return jtoken.ToObject<T>(JsonExtensions.JsonObjectSerializer);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
@@ -1,10 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -52,9 +51,10 @@ namespace NuGet.Protocol
         /// </summary>
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="json">JSON representation of object</param>
+        [return: MaybeNull]
         public static T FromJson<T>(this string json)
         {
-            return JsonConvert.DeserializeObject<T>(json, JsonExtensions.ObjectSerializationSettings);
+            return JsonConvert.DeserializeObject<T>(json, JsonExtensions.ObjectSerializationSettings)!;
         }
 
         /// <summary>
@@ -63,9 +63,10 @@ namespace NuGet.Protocol
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="json">JSON representation of object</param>
         /// <param name="settings">The settings.</param>
+        [return: MaybeNull]
         public static T FromJson<T>(this string json, JsonSerializerSettings settings)
         {
-            return JsonConvert.DeserializeObject<T>(json, settings);
+            return JsonConvert.DeserializeObject<T>(json, settings)!;
         }
 
         /// <summary>
@@ -73,7 +74,7 @@ namespace NuGet.Protocol
         /// </summary>
         /// <param name="json">JSON representation of object</param>
         /// <param name="type">The object type.</param>
-        public static object FromJson(this string json, Type type)
+        public static object? FromJson(this string json, Type type)
         {
             return JsonConvert.DeserializeObject(json, type, JsonExtensions.ObjectSerializationSettings);
         }
@@ -92,9 +93,10 @@ namespace NuGet.Protocol
         /// </summary>
         /// <typeparam name="T">Type of object.</typeparam>
         /// <param name="jtoken">The JToken to be deserialized.</param>
+        [return: MaybeNull]
         public static T FromJToken<T>(this JToken jtoken)
         {
-            return jtoken.ToObject<T>(JsonExtensions.JsonObjectSerializer);
+            return jtoken.ToObject<T>(JsonExtensions.JsonObjectSerializer)!;
         }
 
         /// <summary>
@@ -102,7 +104,7 @@ namespace NuGet.Protocol
         /// </summary>
         /// <param name="jtoken">The JToken to be deserialized.</param>
         /// <param name="type">The object type.</param>
-        public static object FromJToken(this JToken jtoken, Type type)
+        public static object? FromJToken(this JToken jtoken, Type type)
         {
             return jtoken.ToObject(type, JsonExtensions.JsonObjectSerializer);
         }
@@ -113,6 +115,7 @@ namespace NuGet.Protocol
         /// <typeparam name="T">Type of property to return.</typeparam>
         /// <param name="jobject">The JObject to be deserialized.</param>
         /// <param name="propertyName">The property name.</param>
+        [return: MaybeNull]
         public static T GetJObjectProperty<T>(this JObject jobject, string propertyName)
         {
             var targetProperty = jobject.GetValue(propertyName: propertyName, comparison: StringComparison.OrdinalIgnoreCase);
@@ -127,7 +130,7 @@ namespace NuGet.Protocol
                 return null;
             }
 
-            return (bool)value.Value;
+            return (bool)value.Value!;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -51,8 +50,7 @@ namespace NuGet.Protocol
         /// </summary>
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="json">JSON representation of object</param>
-        [return: MaybeNull]
-        public static T FromJson<T>(this string json)
+        public static T? FromJson<T>(this string json)
         {
             return JsonConvert.DeserializeObject<T>(json, JsonExtensions.ObjectSerializationSettings)!;
         }
@@ -63,8 +61,7 @@ namespace NuGet.Protocol
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="json">JSON representation of object</param>
         /// <param name="settings">The settings.</param>
-        [return: MaybeNull]
-        public static T FromJson<T>(this string json, JsonSerializerSettings settings)
+        public static T? FromJson<T>(this string json, JsonSerializerSettings settings)
         {
             return JsonConvert.DeserializeObject<T>(json, settings)!;
         }
@@ -93,8 +90,7 @@ namespace NuGet.Protocol
         /// </summary>
         /// <typeparam name="T">Type of object.</typeparam>
         /// <param name="jtoken">The JToken to be deserialized.</param>
-        [return: MaybeNull]
-        public static T FromJToken<T>(this JToken jtoken)
+        public static T? FromJToken<T>(this JToken jtoken)
         {
             return jtoken.ToObject<T>(JsonExtensions.JsonObjectSerializer)!;
         }
@@ -115,8 +111,7 @@ namespace NuGet.Protocol
         /// <typeparam name="T">Type of property to return.</typeparam>
         /// <param name="jobject">The JObject to be deserialized.</param>
         /// <param name="propertyName">The property name.</param>
-        [return: MaybeNull]
-        public static T GetJObjectProperty<T>(this JObject jobject, string propertyName)
+        public static T? GetJObjectProperty<T>(this JObject jobject, string propertyName)
         {
             var targetProperty = jobject.GetValue(propertyName: propertyName, comparison: StringComparison.OrdinalIgnoreCase);
             return targetProperty != null ? targetProperty.FromJToken<T>() : default(T);

--- a/src/NuGet.Core/NuGet.Protocol/Converters/MetadataFieldConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/MetadataFieldConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using Newtonsoft.Json;
@@ -16,7 +14,7 @@ namespace NuGet.Protocol
 
         public override bool CanWrite => false;
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             if (reader.TokenType == JsonToken.Null)
             {
@@ -32,7 +30,7 @@ namespace NuGet.Protocol
             return serializer.Deserialize<string>(reader);
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Protocol/Converters/MetadataStringOrArrayConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/MetadataStringOrArrayConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 
@@ -14,7 +12,7 @@ namespace NuGet.Protocol
 
         public override bool CanWrite => false;
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             if (reader.TokenType == JsonToken.Null || reader.TokenType == JsonToken.None)
             {
@@ -24,13 +22,13 @@ namespace NuGet.Protocol
             if (reader.TokenType == JsonToken.String)
             {
                 var str = serializer.Deserialize<string>(reader);
-                return string.IsNullOrWhiteSpace(str) ? null : new string[] { str };
+                return string.IsNullOrWhiteSpace(str) ? null : new string[] { str! };
             }
 
             return serializer.Deserialize<string[]>(reader);
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Protocol/Converters/NuGetFrameworkConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/NuGetFrameworkConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 using NuGet.Frameworks;
@@ -11,22 +9,21 @@ namespace NuGet.Protocol.Converters
 {
     internal class NuGetFrameworkConverter : JsonConverter<NuGetFramework>
     {
-        public override void WriteJson(JsonWriter writer, NuGetFramework value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, NuGetFramework? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }
 
-        public override NuGetFramework ReadJson(JsonReader reader, Type objectType, NuGetFramework existingValue, bool hasExistingValue, JsonSerializer serializer)
+        public override NuGetFramework ReadJson(JsonReader reader, Type objectType, NuGetFramework? existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            var value = reader.Value.ToString();
-            var framework = NuGetFramework.AnyFramework;
+            var value = reader.Value?.ToString();
 
             if (!string.IsNullOrEmpty(value))
             {
-                framework = NuGetFramework.Parse(value);
+                return NuGetFramework.Parse(value!);
             }
 
-            return framework;
+            return NuGetFramework.AnyFramework;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Converters/NuGetVersionConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/NuGetVersionConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 using NuGet.Versioning;
@@ -11,14 +9,14 @@ namespace NuGet.Protocol
 {
     public class NuGetVersionConverter : JsonConverter
     {
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
-            serializer.Serialize(writer, value.ToString());
+            serializer.Serialize(writer, value?.ToString());
         }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
-            return reader.TokenType != JsonToken.Null ? NuGetVersion.Parse(serializer.Deserialize<string>(reader)) : null;
+            return reader.TokenType != JsonToken.Null ? NuGetVersion.Parse(serializer.Deserialize<string>(reader)!) : null;
         }
 
         public override bool CanConvert(Type objectType) => objectType == typeof(NuGetVersion);

--- a/src/NuGet.Core/NuGet.Protocol/Converters/ParserConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/ParserConstants.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol

--- a/src/NuGet.Core/NuGet.Protocol/Converters/SemanticVersionConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/SemanticVersionConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 using NuGet.Versioning;
@@ -29,9 +27,9 @@ namespace NuGet.Protocol
         /// <param name="existingValue">The existing value of the object.</param>
         /// <param name="serializer">A serializer.</param>
         /// <returns>A <see cref="SemanticVersion" /> object.</returns>
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
-            return reader.TokenType != JsonToken.Null ? SemanticVersion.Parse(serializer.Deserialize<string>(reader)) : null;
+            return reader.TokenType != JsonToken.Null ? SemanticVersion.Parse(serializer.Deserialize<string>(reader)!) : null;
         }
 
         /// <summary>
@@ -40,9 +38,9 @@ namespace NuGet.Protocol
         /// <param name="writer">A JSON writer.</param>
         /// <param name="value">A value to serialize.</param>
         /// <param name="serializer">A serializer.</param>
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
-            var semanticVersion = (SemanticVersion)value;
+            var semanticVersion = (SemanticVersion)value!;
 
             serializer.Serialize(writer, semanticVersion.ToString());
         }

--- a/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 using NuGet.Protocol.Core.Types;
@@ -16,15 +14,15 @@ namespace NuGet.Protocol
 
         public override bool CanWrite => false;
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             var v = JsonUtility.LoadJson(reader);
-            var nugetVersion = NuGetVersion.Parse(v.Value<string>("version"));
+            var nugetVersion = NuGetVersion.Parse(v.Value<string>("version")!);
             var count = v.Value<long?>("downloads");
             return new VersionInfo(nugetVersion, count);
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/DependencyInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/DependencyInfo.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
-using System;
 using System.Globalization;
 using NuGet.Versioning;
 
@@ -11,13 +8,17 @@ namespace NuGet.Protocol
 {
     internal class DependencyInfo
     {
-        public string Id { get; set; }
-        public VersionRange Range { get; set; }
-        public RegistrationInfo RegistrationInfo { get; set; }
+        public required string Id { get; init; }
+        public required VersionRange Range { get; init; }
+
+        /// <summary>
+        /// NULL_INC: Set externally by the resolver after construction.
+        /// </summary>
+        public RegistrationInfo RegistrationInfo { get; set; } = null!;
 
         public override string ToString()
         {
-            return String.Format(CultureInfo.InvariantCulture, "{0} {1}", Id, Range);
+            return string.Format(CultureInfo.InvariantCulture, "{0} {1}", Id, Range);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/PackageInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/PackageInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -12,20 +10,18 @@ namespace NuGet.Protocol
 {
     internal class PackageInfo
     {
-        public RegistrationInfo Registration { get; set; }
-        public bool Listed { get; set; }
-        public NuGetVersion Version { get; set; }
-        public Uri PackageContent { get; set; }
-        public IList<DependencyInfo> Dependencies { get; private set; }
-
-        public PackageInfo()
-        {
-            Dependencies = new List<DependencyInfo>();
-        }
+        /// <summary>
+        /// NULL_INC: Set by <see cref="RegistrationInfo.Add"/> after construction.
+        /// </summary>
+        public RegistrationInfo Registration { get; set; } = null!;
+        public bool Listed { get; init; }
+        public required NuGetVersion Version { get; init; }
+        public required Uri PackageContent { get; init; }
+        public IList<DependencyInfo> Dependencies { get; } = new List<DependencyInfo>();
 
         public override string ToString()
         {
-            return String.Format(CultureInfo.InvariantCulture, "{0} {1}", Registration.Id, Version.ToNormalizedString());
+            return string.Format(CultureInfo.InvariantCulture, "{0} {1}", Registration.Id, Version.ToNormalizedString());
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationInfo.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 
@@ -11,14 +8,9 @@ namespace NuGet.Protocol
 {
     internal class RegistrationInfo
     {
-        public string Id { get; set; }
-        public bool IncludePrerelease { get; set; }
-        public IList<PackageInfo> Packages { get; private set; }
-
-        public RegistrationInfo()
-        {
-            Packages = new List<PackageInfo>();
-        }
+        public required string Id { get; init; }
+        public required bool IncludePrerelease { get; init; }
+        public IList<PackageInfo> Packages { get; } = new List<PackageInfo>();
 
         public void Add(PackageInfo packageInfo)
         {
@@ -28,7 +20,7 @@ namespace NuGet.Protocol
 
         public override string ToString()
         {
-            return String.Format(CultureInfo.InvariantCulture, "{0} Packages: {1}", Id, Packages.Count);
+            return string.Format(CultureInfo.InvariantCulture, "{0} Packages: {1}", Id, Packages.Count);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -66,17 +64,17 @@ namespace NuGet.Protocol
 
             IList<Task<JObject>> rangeTasks = new List<Task<JObject>>();
 
-            foreach (JObject item in index["items"])
+            foreach (JObject item in index["items"]!)
             {
-                var lower = NuGetVersion.Parse(item["lower"].ToString());
-                var upper = NuGetVersion.Parse(item["upper"].ToString());
+                var lower = NuGetVersion.Parse(item["lower"]!.ToString());
+                var upper = NuGetVersion.Parse(item["upper"]!.ToString());
 
                 if (range.DoesRangeSatisfy(lower, upper))
                 {
-                    JToken items;
+                    JToken? items;
                     if (!item.TryGetValue("items", out items))
                     {
-                        var rangeUri = item["@id"].ToString();
+                        var rangeUri = item["@id"]!.ToString();
 
                         rangeTasks.Add(httpSource.GetAsync(
                             new HttpSourceCachedRequest(

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -44,10 +42,10 @@ namespace NuGet.Protocol
                     throw new InvalidDataException(registrationUri.AbsoluteUri);
                 }
 
-                foreach (JObject packageObj in rangeObj["items"])
+                foreach (JObject packageObj in rangeObj["items"]!)
                 {
-                    var catalogEntry = (JObject)packageObj["catalogEntry"];
-                    var version = NuGetVersion.Parse(catalogEntry["version"].ToString());
+                    var catalogEntry = (JObject)packageObj["catalogEntry"]!;
+                    var version = NuGetVersion.Parse(catalogEntry["version"]!.ToString());
 
                     if (range.Satisfies(version))
                     {
@@ -67,16 +65,16 @@ namespace NuGet.Protocol
         /// <returns>Returns the RemoteSourceDependencyInfo object corresponding to this package version</returns>
         private static RemoteSourceDependencyInfo ProcessPackageVersion(JObject packageObj, NuGetVersion version)
         {
-            var catalogEntry = (JObject)packageObj["catalogEntry"];
+            var catalogEntry = (JObject)packageObj["catalogEntry"]!;
 
             var listed = catalogEntry.GetBoolean("listed") ?? true;
 
-            var id = catalogEntry.Value<string>("id");
+            var id = catalogEntry.Value<string>("id")!;
 
             var identity = new PackageIdentity(id, version);
             var dependencyGroups = new List<PackageDependencyGroup>();
 
-            var dependencyGroupsArray = (JArray)catalogEntry["dependencyGroups"];
+            var dependencyGroupsArray = (JArray?)catalogEntry["dependencyGroups"];
 
             if (dependencyGroupsArray != null)
             {
@@ -87,7 +85,7 @@ namespace NuGet.Protocol
 
                     var groupDependencies = new List<PackageDependency>();
 
-                    JToken dependenciesObj;
+                    JToken? dependenciesObj;
 
                     // Packages with no dependencies have 'dependencyGroups' but no 'dependencies'
                     if (dependencyGroupObj.TryGetValue("dependencies", out dependenciesObj))
@@ -96,8 +94,8 @@ namespace NuGet.Protocol
                         for (int j = 0; j < dependencies.Count; j++)
                         {
                             var dependencyObj = (JObject)dependencies[j];
-                            var dependencyId = dependencyObj.Value<string>("id");
-                            var dependencyRange = RegistrationUtility.CreateVersionRange(dependencyObj.Value<string>("range"));
+                            var dependencyId = dependencyObj.Value<string>("id")!;
+                            var dependencyRange = RegistrationUtility.CreateVersionRange(dependencyObj.Value<string>("range")!);
 
                             groupDependencies.Add(new PackageDependency(dependencyId, dependencyRange));
                         }
@@ -107,7 +105,7 @@ namespace NuGet.Protocol
                 }
             }
 
-            var contentUri = packageObj.Value<string>("packageContent");
+            var contentUri = packageObj.Value<string>("packageContent")!;
 
             return new RemoteSourceDependencyInfo(identity, listed, dependencyGroups, contentUri);
         }
@@ -115,8 +113,8 @@ namespace NuGet.Protocol
         /// <summary>
         /// Retrieve a registration blob
         /// </summary>
-        /// <returns>Returns Null if the package does not exist</returns>
-        public static async Task<RegistrationInfo> GetRegistrationInfo(
+        /// <returns>Returns null if the package does not exist.</returns>
+        public static async Task<RegistrationInfo?> GetRegistrationInfo(
             HttpSource httpClient,
             Uri registrationUri,
             string packageId,
@@ -130,9 +128,17 @@ namespace NuGet.Protocol
             var frameworkReducer = new FrameworkReducer();
             var dependencies = await GetDependencies(httpClient, registrationUri, packageId, range, cacheContext, log, token);
 
-            var registrationInfo = new RegistrationInfo();
+            if (!dependencies.Any())
+            {
+                return null;
+            }
 
-            registrationInfo.IncludePrerelease = true;
+            var registrationInfo = new RegistrationInfo
+            {
+                Id = packageId,
+                IncludePrerelease = true
+            };
+
             foreach (var item in dependencies)
             {
                 var packageInfo = new PackageInfo
@@ -167,7 +173,6 @@ namespace NuGet.Protocol
                 }
 
                 registrationInfo.Add(packageInfo);
-                registrationInfo.Id = item.Identity.Id;
             }
 
             return registrationInfo;
@@ -182,7 +187,7 @@ namespace NuGet.Protocol
 
             if (dependencyGroupObj["targetFramework"] != null)
             {
-                framework = NuGetFramework.Parse(dependencyGroupObj["targetFramework"].ToString());
+                framework = NuGetFramework.Parse(dependencyGroupObj["targetFramework"]!.ToString());
             }
 
             return framework;

--- a/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnosticHttpEventBase.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnosticHttpEventBase.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Events

--- a/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnostics.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnostics.cs
@@ -1,27 +1,25 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 namespace NuGet.Protocol.Events
 {
     public static class ProtocolDiagnostics
     {
         public delegate void ProtocolDiagnosticHttpEventHandler(ProtocolDiagnosticHttpEvent pdEvent);
 
-        public static event ProtocolDiagnosticHttpEventHandler HttpEvent;
+        public static event ProtocolDiagnosticHttpEventHandler? HttpEvent;
 
         public delegate void ProtocolDiagnosticResourceEventHandler(ProtocolDiagnosticResourceEvent pdrEvent);
 
-        public static event ProtocolDiagnosticResourceEventHandler ResourceEvent;
+        public static event ProtocolDiagnosticResourceEventHandler? ResourceEvent;
 
         public delegate void ProtocolDiagnosticsNupkgCopiedEventHandler(ProtocolDiagnosticNupkgCopiedEvent ncEvent);
 
-        public static event ProtocolDiagnosticsNupkgCopiedEventHandler NupkgCopiedEvent;
+        public static event ProtocolDiagnosticsNupkgCopiedEventHandler? NupkgCopiedEvent;
 
         public delegate void ProtocolDiagnosticServiceIndexEntryEventHandler(ProtocolDiagnosticServiceIndexEntryEvent pdEvent);
 
-        public static event ProtocolDiagnosticServiceIndexEntryEventHandler ServiceIndexEntryEvent;
+        public static event ProtocolDiagnosticServiceIndexEntryEventHandler? ServiceIndexEntryEvent;
 
         internal static void RaiseEvent(ProtocolDiagnosticHttpEvent pdEvent)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnosticsStream.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Events/ProtocolDiagnosticsStream.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -14,7 +12,7 @@ namespace NuGet.Protocol.Events
     internal sealed class ProtocolDiagnosticsStream : Stream
     {
         private readonly Stream _baseStream;
-        private ProtocolDiagnosticInProgressHttpEvent _inProgressEvent;
+        private ProtocolDiagnosticInProgressHttpEvent? _inProgressEvent;
         private readonly Stopwatch _stopwatch;
         private long _bytes;
         private readonly Action<ProtocolDiagnosticHttpEvent> _diagnosticEvent;

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -37,10 +37,12 @@
     <Compile Include="$(SharedDirectory)\EncodingUtility.cs" />
     <Compile Include="$(SharedDirectory)\EqualityUtility.cs" />
     <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs" />
+    <Compile Include="$(SharedDirectory)\IsExternalInit.cs" />
     <Compile Include="$(SharedDirectory)\NoAllocEnumerateExtensions.cs" />
     <Compile Include="$(SharedDirectory)\NullableAttributes.cs" />
     <Compile Include="$(SharedDirectory)\NuGetFeatureFlags.cs" />
     <Compile Include="$(SharedDirectory)\AotCompatibilityAttributes.cs" />
+    <Compile Include="$(SharedDirectory)\RequiredModifierAttributes.cs" />
     <Compile Include="$(SharedDirectory)\SimplePool.cs" />
     <Compile Include="$(SharedDirectory)\StringBuilderPool.cs" />
     <Compile Include="$(SharedDirectory)\TaskResult.cs" />

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -372,10 +372,10 @@ NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.HttpStatusCode.get -> int?
 NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.IsCancelled.get -> bool
 NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.IsLastAttempt.get -> bool
 NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.IsRetry.get -> bool
-~NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.ProtocolDiagnosticHttpEventBase(NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase other) -> void
-~NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.ProtocolDiagnosticHttpEventBase(string source, System.Uri url, System.TimeSpan? headerDuration, int? httpStatusCode, bool isRetry, bool isCancelled, bool isLastAttempt) -> void
-~NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.Source.get -> string
-~NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.Url.get -> System.Uri
+NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.ProtocolDiagnosticHttpEventBase(NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase! other) -> void
+NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.ProtocolDiagnosticHttpEventBase(string! source, System.Uri! url, System.TimeSpan? headerDuration, int? httpStatusCode, bool isRetry, bool isCancelled, bool isLastAttempt) -> void
+NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.Source.get -> string!
+NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.Url.get -> System.Uri!
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.FileSize.get -> long
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.ProtocolDiagnosticNupkgCopiedEvent(string! source, long fileSize) -> void
@@ -1923,10 +1923,10 @@ static NuGet.Protocol.Core.Types.NullSourceCacheContext.Instance.get -> NuGet.Pr
 static NuGet.Protocol.Core.Types.UserAgent.SetUserAgent(System.Net.Http.HttpClient! client) -> void
 static NuGet.Protocol.Core.Types.UserAgent.SetUserAgentString(NuGet.Protocol.Core.Types.UserAgentStringBuilder! builder) -> void
 static NuGet.Protocol.Core.Types.UserAgent.UserAgentString.get -> string!
-static NuGet.Protocol.Events.ProtocolDiagnostics.HttpEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticHttpEventHandler
-static NuGet.Protocol.Events.ProtocolDiagnostics.NupkgCopiedEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticsNupkgCopiedEventHandler
-static NuGet.Protocol.Events.ProtocolDiagnostics.ResourceEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticResourceEventHandler
-static NuGet.Protocol.Events.ProtocolDiagnostics.ServiceIndexEntryEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticServiceIndexEntryEventHandler
+static NuGet.Protocol.Events.ProtocolDiagnostics.HttpEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticHttpEventHandler?
+static NuGet.Protocol.Events.ProtocolDiagnostics.NupkgCopiedEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticsNupkgCopiedEventHandler?
+static NuGet.Protocol.Events.ProtocolDiagnostics.ResourceEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticResourceEventHandler?
+static NuGet.Protocol.Events.ProtocolDiagnostics.ServiceIndexEntryEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticServiceIndexEntryEventHandler?
 ~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV2(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
 ~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.ProviderFactory factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>
 ~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -2024,8 +2024,8 @@ static NuGet.Protocol.JsonExtensions.ToJson(this object! obj, Newtonsoft.Json.Fo
 ~static NuGet.Protocol.Plugins.PluginManager.Instance.get -> NuGet.Protocol.Plugins.IPluginManager
 ~static NuGet.Protocol.Plugins.TimeoutUtilities.GetTimeout(string timeoutInSeconds, System.TimeSpan fallbackTimeout) -> System.TimeSpan
 static NuGet.Protocol.Plugins.TimeoutUtilities.IsValid(System.TimeSpan timeout) -> bool
-~static NuGet.Protocol.RegistrationUtility.CreateVersionRange(string stringToParse) -> NuGet.Versioning.VersionRange
-~static NuGet.Protocol.RegistrationUtility.LoadRanges(NuGet.Protocol.HttpSource httpSource, System.Uri registrationUri, string packageId, NuGet.Versioning.VersionRange range, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>>
+static NuGet.Protocol.RegistrationUtility.CreateVersionRange(string! stringToParse) -> NuGet.Versioning.VersionRange!
+static NuGet.Protocol.RegistrationUtility.LoadRanges(NuGet.Protocol.HttpSource! httpSource, System.Uri! registrationUri, string! packageId, NuGet.Versioning.VersionRange! range, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject!>!>!
 static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri! uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
 ~static NuGet.Protocol.SemaphoreSlimThrottle.CreateBinarySemaphore() -> NuGet.Protocol.SemaphoreSlimThrottle
 ~static NuGet.Protocol.SemaphoreSlimThrottle.CreateSemaphoreThrottle(int initialCount) -> NuGet.Protocol.SemaphoreSlimThrottle

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1958,12 +1958,12 @@ static NuGet.Protocol.Events.ProtocolDiagnostics.ServiceIndexEntryEvent -> NuGet
 ~static NuGet.Protocol.HttpStreamValidation.ValidateNupkg(string uri, System.IO.Stream stream) -> void
 ~static NuGet.Protocol.HttpStreamValidation.ValidateXml(string uri, System.IO.Stream stream) -> void
 static NuGet.Protocol.JsonExtensions.FromJToken(this Newtonsoft.Json.Linq.JToken! jtoken, System.Type! type) -> object?
-static NuGet.Protocol.JsonExtensions.FromJToken<T>(this Newtonsoft.Json.Linq.JToken! jtoken) -> T
+static NuGet.Protocol.JsonExtensions.FromJToken<T>(this Newtonsoft.Json.Linq.JToken! jtoken) -> T?
 static NuGet.Protocol.JsonExtensions.FromJson(this string! json, System.Type! type) -> object?
-static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json) -> T
-static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json, Newtonsoft.Json.JsonSerializerSettings! settings) -> T
+static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json) -> T?
+static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json, Newtonsoft.Json.JsonSerializerSettings! settings) -> T?
 static NuGet.Protocol.JsonExtensions.GetBoolean(this Newtonsoft.Json.Linq.JObject! json, string! propertyName) -> bool?
-static NuGet.Protocol.JsonExtensions.GetJObjectProperty<T>(this Newtonsoft.Json.Linq.JObject! jobject, string! propertyName) -> T
+static NuGet.Protocol.JsonExtensions.GetJObjectProperty<T>(this Newtonsoft.Json.Linq.JObject! jobject, string! propertyName) -> T?
 static NuGet.Protocol.JsonExtensions.ToJToken(this object! obj) -> Newtonsoft.Json.Linq.JToken!
 static NuGet.Protocol.JsonExtensions.ToJson(this object! obj, Newtonsoft.Json.Formatting formatting = Newtonsoft.Json.Formatting.None) -> string!
 ~static NuGet.Protocol.LocalFolderUtility.EnsurePackageFileExists(string packagePath, System.Collections.Generic.IEnumerable<string> matchingPackagePaths) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1578,56 +1578,56 @@ const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.First = "First" -
 const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.Last = "Last" -> string!
 const NuGet.Protocol.Core.Types.NuGetTestMode.NuGetTestClientName = "NuGet Test Client" -> string!
 const NuGet.Protocol.JsonExtensions.JsonSerializationMaxDepth = 512 -> int
-~const NuGet.Protocol.JsonProperties.AdvisoryUrl = "advisoryUrl" -> string
-~const NuGet.Protocol.JsonProperties.AllRepositorySigned = "allRepositorySigned" -> string
-~const NuGet.Protocol.JsonProperties.AlternatePackage = "alternatePackage" -> string
-~const NuGet.Protocol.JsonProperties.Authors = "authors" -> string
-~const NuGet.Protocol.JsonProperties.ContentUrl = "contentUrl" -> string
-~const NuGet.Protocol.JsonProperties.Created = "created" -> string
-~const NuGet.Protocol.JsonProperties.Data = "data" -> string
-~const NuGet.Protocol.JsonProperties.Dependencies = "dependencies" -> string
-~const NuGet.Protocol.JsonProperties.DependencyGroups = "dependencyGroups" -> string
-~const NuGet.Protocol.JsonProperties.Deprecation = "deprecation" -> string
-~const NuGet.Protocol.JsonProperties.DeprecationMessage = "message" -> string
-~const NuGet.Protocol.JsonProperties.DeprecationReasons = "reasons" -> string
-~const NuGet.Protocol.JsonProperties.Description = "description" -> string
-~const NuGet.Protocol.JsonProperties.DownloadCount = "totalDownloads" -> string
-~const NuGet.Protocol.JsonProperties.Fingerprints = "fingerprints" -> string
-~const NuGet.Protocol.JsonProperties.IconUrl = "iconUrl" -> string
-~const NuGet.Protocol.JsonProperties.Issuer = "issuer" -> string
-~const NuGet.Protocol.JsonProperties.Language = "language" -> string
-~const NuGet.Protocol.JsonProperties.LastEdited = "lastEdited" -> string
-~const NuGet.Protocol.JsonProperties.LatestVersion = "latestVersion" -> string
-~const NuGet.Protocol.JsonProperties.LicenseExpression = "licenseExpression" -> string
-~const NuGet.Protocol.JsonProperties.LicenseExpressionVersion = "licenseExpressionVersion" -> string
-~const NuGet.Protocol.JsonProperties.LicenseUrl = "licenseUrl" -> string
-~const NuGet.Protocol.JsonProperties.Listed = "listed" -> string
-~const NuGet.Protocol.JsonProperties.MinimumClientVersion = "minClientVersion" -> string
-~const NuGet.Protocol.JsonProperties.NotAfter = "notAfter" -> string
-~const NuGet.Protocol.JsonProperties.NotBefore = "notBefore" -> string
-~const NuGet.Protocol.JsonProperties.Owners = "owners" -> string
-~const NuGet.Protocol.JsonProperties.PackageContent = "packageContent" -> string
-~const NuGet.Protocol.JsonProperties.PackageId = "id" -> string
-~const NuGet.Protocol.JsonProperties.PrefixReserved = "verified" -> string
-~const NuGet.Protocol.JsonProperties.ProjectUrl = "projectUrl" -> string
-~const NuGet.Protocol.JsonProperties.Published = "published" -> string
-~const NuGet.Protocol.JsonProperties.Range = "range" -> string
-~const NuGet.Protocol.JsonProperties.ReadmeFileUrl = "readmeFileUrl" -> string
-~const NuGet.Protocol.JsonProperties.ReadmeUrl = "readmeUrl" -> string
-~const NuGet.Protocol.JsonProperties.RequireLicenseAcceptance = "requireLicenseAcceptance" -> string
-~const NuGet.Protocol.JsonProperties.Severity = "severity" -> string
-~const NuGet.Protocol.JsonProperties.SigningCertificates = "signingCertificates" -> string
-~const NuGet.Protocol.JsonProperties.Subject = "subject" -> string
-~const NuGet.Protocol.JsonProperties.SubjectId = "@id" -> string
-~const NuGet.Protocol.JsonProperties.Summary = "summary" -> string
-~const NuGet.Protocol.JsonProperties.Tags = "tags" -> string
-~const NuGet.Protocol.JsonProperties.TargetFramework = "targetFramework" -> string
-~const NuGet.Protocol.JsonProperties.Title = "title" -> string
-~const NuGet.Protocol.JsonProperties.Type = "@type" -> string
-~const NuGet.Protocol.JsonProperties.Url = "url" -> string
-~const NuGet.Protocol.JsonProperties.Version = "version" -> string
-~const NuGet.Protocol.JsonProperties.Versions = "versions" -> string
-~const NuGet.Protocol.JsonProperties.Vulnerabilities = "vulnerabilities" -> string
+const NuGet.Protocol.JsonProperties.AdvisoryUrl = "advisoryUrl" -> string!
+const NuGet.Protocol.JsonProperties.AllRepositorySigned = "allRepositorySigned" -> string!
+const NuGet.Protocol.JsonProperties.AlternatePackage = "alternatePackage" -> string!
+const NuGet.Protocol.JsonProperties.Authors = "authors" -> string!
+const NuGet.Protocol.JsonProperties.ContentUrl = "contentUrl" -> string!
+const NuGet.Protocol.JsonProperties.Created = "created" -> string!
+const NuGet.Protocol.JsonProperties.Data = "data" -> string!
+const NuGet.Protocol.JsonProperties.Dependencies = "dependencies" -> string!
+const NuGet.Protocol.JsonProperties.DependencyGroups = "dependencyGroups" -> string!
+const NuGet.Protocol.JsonProperties.Deprecation = "deprecation" -> string!
+const NuGet.Protocol.JsonProperties.DeprecationMessage = "message" -> string!
+const NuGet.Protocol.JsonProperties.DeprecationReasons = "reasons" -> string!
+const NuGet.Protocol.JsonProperties.Description = "description" -> string!
+const NuGet.Protocol.JsonProperties.DownloadCount = "totalDownloads" -> string!
+const NuGet.Protocol.JsonProperties.Fingerprints = "fingerprints" -> string!
+const NuGet.Protocol.JsonProperties.IconUrl = "iconUrl" -> string!
+const NuGet.Protocol.JsonProperties.Issuer = "issuer" -> string!
+const NuGet.Protocol.JsonProperties.Language = "language" -> string!
+const NuGet.Protocol.JsonProperties.LastEdited = "lastEdited" -> string!
+const NuGet.Protocol.JsonProperties.LatestVersion = "latestVersion" -> string!
+const NuGet.Protocol.JsonProperties.LicenseExpression = "licenseExpression" -> string!
+const NuGet.Protocol.JsonProperties.LicenseExpressionVersion = "licenseExpressionVersion" -> string!
+const NuGet.Protocol.JsonProperties.LicenseUrl = "licenseUrl" -> string!
+const NuGet.Protocol.JsonProperties.Listed = "listed" -> string!
+const NuGet.Protocol.JsonProperties.MinimumClientVersion = "minClientVersion" -> string!
+const NuGet.Protocol.JsonProperties.NotAfter = "notAfter" -> string!
+const NuGet.Protocol.JsonProperties.NotBefore = "notBefore" -> string!
+const NuGet.Protocol.JsonProperties.Owners = "owners" -> string!
+const NuGet.Protocol.JsonProperties.PackageContent = "packageContent" -> string!
+const NuGet.Protocol.JsonProperties.PackageId = "id" -> string!
+const NuGet.Protocol.JsonProperties.PrefixReserved = "verified" -> string!
+const NuGet.Protocol.JsonProperties.ProjectUrl = "projectUrl" -> string!
+const NuGet.Protocol.JsonProperties.Published = "published" -> string!
+const NuGet.Protocol.JsonProperties.Range = "range" -> string!
+const NuGet.Protocol.JsonProperties.ReadmeFileUrl = "readmeFileUrl" -> string!
+const NuGet.Protocol.JsonProperties.ReadmeUrl = "readmeUrl" -> string!
+const NuGet.Protocol.JsonProperties.RequireLicenseAcceptance = "requireLicenseAcceptance" -> string!
+const NuGet.Protocol.JsonProperties.Severity = "severity" -> string!
+const NuGet.Protocol.JsonProperties.SigningCertificates = "signingCertificates" -> string!
+const NuGet.Protocol.JsonProperties.Subject = "subject" -> string!
+const NuGet.Protocol.JsonProperties.SubjectId = "@id" -> string!
+const NuGet.Protocol.JsonProperties.Summary = "summary" -> string!
+const NuGet.Protocol.JsonProperties.Tags = "tags" -> string!
+const NuGet.Protocol.JsonProperties.TargetFramework = "targetFramework" -> string!
+const NuGet.Protocol.JsonProperties.Title = "title" -> string!
+const NuGet.Protocol.JsonProperties.Type = "@type" -> string!
+const NuGet.Protocol.JsonProperties.Url = "url" -> string!
+const NuGet.Protocol.JsonProperties.Version = "version" -> string!
+const NuGet.Protocol.JsonProperties.Versions = "versions" -> string!
+const NuGet.Protocol.JsonProperties.Vulnerabilities = "vulnerabilities" -> string!
 ~const NuGet.Protocol.StsAuthenticationHandler.STSEndPointHeader = "X-NuGet-STS-EndPoint" -> string
 ~const NuGet.Protocol.StsAuthenticationHandler.STSRealmHeader = "X-NuGet-STS-Realm" -> string
 ~const NuGet.Protocol.StsAuthenticationHandler.STSTokenHeader = "X-NuGet-STS-Token" -> string
@@ -1700,10 +1700,10 @@ override NuGet.Protocol.DownloadTimeoutStream.SetLength(long value) -> void
 ~override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
 ~override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
 ~override NuGet.Protocol.FindLocalPackagesResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.FingerprintsConverter.CanConvert(System.Type objectType) -> bool
+override NuGet.Protocol.FingerprintsConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.FingerprintsConverter.CanWrite.get -> bool
-~override NuGet.Protocol.FingerprintsConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.FingerprintsConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.FingerprintsConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object!
+override NuGet.Protocol.FingerprintsConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 override NuGet.Protocol.HttpFileSystemBasedFindPackageByIdResource.CopyNupkgToStreamAsync(string! id, NuGet.Versioning.NuGetVersion! version, System.IO.Stream! destination, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 override NuGet.Protocol.HttpFileSystemBasedFindPackageByIdResource.DoesPackageExistAsync(string! id, NuGet.Versioning.NuGetVersion! version, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 override NuGet.Protocol.HttpFileSystemBasedFindPackageByIdResource.GetAllVersionsAsync(string! id, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
@@ -1751,10 +1751,10 @@ override NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) 
 ~override NuGet.Protocol.LocalV3FindPackageByIdResource.GetDependencyInfoAsync(string id, NuGet.Versioning.NuGetVersion version, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo>
 ~override NuGet.Protocol.LocalV3FindPackageByIdResource.GetPackageDownloaderAsync(NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.IPackageDownloader>
 ~override NuGet.Protocol.LocalV3FindPackageByIdResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.MetadataFieldConverter.CanConvert(System.Type objectType) -> bool
+override NuGet.Protocol.MetadataFieldConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.MetadataFieldConverter.CanWrite.get -> bool
-~override NuGet.Protocol.MetadataFieldConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.MetadataFieldConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.MetadataFieldConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
+override NuGet.Protocol.MetadataFieldConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 ~override NuGet.Protocol.MetadataResourceV2Feed.Exists(NuGet.Packaging.Core.PackageIdentity identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
 ~override NuGet.Protocol.MetadataResourceV2Feed.Exists(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
 ~override NuGet.Protocol.MetadataResourceV2Feed.GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NuGet.Versioning.NuGetVersion>>>
@@ -1767,9 +1767,9 @@ override NuGet.Protocol.MetadataFieldConverter.CanWrite.get -> bool
 ~override NuGet.Protocol.MetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
-~override NuGet.Protocol.NuGetVersionConverter.CanConvert(System.Type objectType) -> bool
-~override NuGet.Protocol.NuGetVersionConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.NuGetVersionConverter.CanConvert(System.Type! objectType) -> bool
+override NuGet.Protocol.NuGetVersionConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
+override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 ~override NuGet.Protocol.ODataServiceDocumentResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
@@ -1871,9 +1871,9 @@ override NuGet.Protocol.SafeUriConverter.CanRead.get -> bool
 override NuGet.Protocol.SafeUriConverter.CanWrite.get -> bool
 override NuGet.Protocol.SafeUriConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.SafeUriConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
-~override NuGet.Protocol.SemanticVersionConverter.CanConvert(System.Type objectType) -> bool
-~override NuGet.Protocol.SemanticVersionConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.SemanticVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.SemanticVersionConverter.CanConvert(System.Type! objectType) -> bool
+override NuGet.Protocol.SemanticVersionConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
+override NuGet.Protocol.SemanticVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 ~override NuGet.Protocol.ServerWarningLogHandler.SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>
 ~override NuGet.Protocol.ServiceIndexResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.StsAuthenticationHandler.SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>
@@ -1882,10 +1882,10 @@ override NuGet.Protocol.SafeUriConverter.WriteJson(Newtonsoft.Json.JsonWriter! w
 ~override NuGet.Protocol.V2FeedListResource.Source.get -> string
 ~override NuGet.Protocol.V2FeedListResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.V3FeedListResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.VersionInfoConverter.CanConvert(System.Type objectType) -> bool
+override NuGet.Protocol.VersionInfoConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.VersionInfoConverter.CanWrite.get -> bool
-~override NuGet.Protocol.VersionInfoConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.VersionInfoConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.VersionInfoConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object!
+override NuGet.Protocol.VersionInfoConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 override NuGet.Protocol.VersionRangeConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.VersionRangeConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.VersionRangeConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
@@ -1957,15 +1957,15 @@ static NuGet.Protocol.Events.ProtocolDiagnostics.ServiceIndexEntryEvent -> NuGet
 ~static NuGet.Protocol.HttpStreamValidation.ValidateJObject(string uri, System.IO.Stream stream) -> void
 ~static NuGet.Protocol.HttpStreamValidation.ValidateNupkg(string uri, System.IO.Stream stream) -> void
 ~static NuGet.Protocol.HttpStreamValidation.ValidateXml(string uri, System.IO.Stream stream) -> void
-~static NuGet.Protocol.JsonExtensions.FromJToken(this Newtonsoft.Json.Linq.JToken jtoken, System.Type type) -> object
-~static NuGet.Protocol.JsonExtensions.FromJToken<T>(this Newtonsoft.Json.Linq.JToken jtoken) -> T
-~static NuGet.Protocol.JsonExtensions.FromJson(this string json, System.Type type) -> object
-~static NuGet.Protocol.JsonExtensions.FromJson<T>(this string json) -> T
-~static NuGet.Protocol.JsonExtensions.FromJson<T>(this string json, Newtonsoft.Json.JsonSerializerSettings settings) -> T
-~static NuGet.Protocol.JsonExtensions.GetBoolean(this Newtonsoft.Json.Linq.JObject json, string propertyName) -> bool?
-~static NuGet.Protocol.JsonExtensions.GetJObjectProperty<T>(this Newtonsoft.Json.Linq.JObject jobject, string propertyName) -> T
-~static NuGet.Protocol.JsonExtensions.ToJToken(this object obj) -> Newtonsoft.Json.Linq.JToken
-~static NuGet.Protocol.JsonExtensions.ToJson(this object obj, Newtonsoft.Json.Formatting formatting = Newtonsoft.Json.Formatting.None) -> string
+static NuGet.Protocol.JsonExtensions.FromJToken(this Newtonsoft.Json.Linq.JToken! jtoken, System.Type! type) -> object?
+static NuGet.Protocol.JsonExtensions.FromJToken<T>(this Newtonsoft.Json.Linq.JToken! jtoken) -> T
+static NuGet.Protocol.JsonExtensions.FromJson(this string! json, System.Type! type) -> object?
+static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json) -> T
+static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json, Newtonsoft.Json.JsonSerializerSettings! settings) -> T
+static NuGet.Protocol.JsonExtensions.GetBoolean(this Newtonsoft.Json.Linq.JObject! json, string! propertyName) -> bool?
+static NuGet.Protocol.JsonExtensions.GetJObjectProperty<T>(this Newtonsoft.Json.Linq.JObject! jobject, string! propertyName) -> T
+static NuGet.Protocol.JsonExtensions.ToJToken(this object! obj) -> Newtonsoft.Json.Linq.JToken!
+static NuGet.Protocol.JsonExtensions.ToJson(this object! obj, Newtonsoft.Json.Formatting formatting = Newtonsoft.Json.Formatting.None) -> string!
 ~static NuGet.Protocol.LocalFolderUtility.EnsurePackageFileExists(string packagePath, System.Collections.Generic.IEnumerable<string> matchingPackagePaths) -> void
 ~static NuGet.Protocol.LocalFolderUtility.GenerateNupkgMetadataFile(string nupkgPath, string installPath, string hashPath, string nupkgMetadataPath) -> void
 ~static NuGet.Protocol.LocalFolderUtility.GetAndVerifyRootDirectory(string root) -> System.IO.DirectoryInfo
@@ -2044,7 +2044,7 @@ static readonly NuGet.Protocol.HttpRetryHandlerRequest.DefaultDownloadTimeout ->
 static readonly NuGet.Protocol.HttpRetryHandlerRequest.DefaultMaxTries -> int
 static readonly NuGet.Protocol.HttpSourceAuthenticationHandler.MaxAuthRetries -> int
 static readonly NuGet.Protocol.HttpSourceRequest.DefaultRequestTimeout -> System.TimeSpan
-~static readonly NuGet.Protocol.JsonExtensions.ObjectSerializationSettings -> Newtonsoft.Json.JsonSerializerSettings
+static readonly NuGet.Protocol.JsonExtensions.ObjectSerializationSettings -> Newtonsoft.Json.JsonSerializerSettings!
 static readonly NuGet.Protocol.Plugins.PluginConstants.CloseTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.PluginConstants.IdleTimeout -> System.TimeSpan
 ~static readonly NuGet.Protocol.Plugins.PluginConstants.PluginArguments -> System.Collections.Generic.IEnumerable<string>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1574,56 +1574,56 @@ const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.First = "First" -
 const NuGet.Protocol.Core.Types.NuGetResourceProviderPositions.Last = "Last" -> string!
 const NuGet.Protocol.Core.Types.NuGetTestMode.NuGetTestClientName = "NuGet Test Client" -> string!
 const NuGet.Protocol.JsonExtensions.JsonSerializationMaxDepth = 512 -> int
-~const NuGet.Protocol.JsonProperties.AdvisoryUrl = "advisoryUrl" -> string
-~const NuGet.Protocol.JsonProperties.AllRepositorySigned = "allRepositorySigned" -> string
-~const NuGet.Protocol.JsonProperties.AlternatePackage = "alternatePackage" -> string
-~const NuGet.Protocol.JsonProperties.Authors = "authors" -> string
-~const NuGet.Protocol.JsonProperties.ContentUrl = "contentUrl" -> string
-~const NuGet.Protocol.JsonProperties.Created = "created" -> string
-~const NuGet.Protocol.JsonProperties.Data = "data" -> string
-~const NuGet.Protocol.JsonProperties.Dependencies = "dependencies" -> string
-~const NuGet.Protocol.JsonProperties.DependencyGroups = "dependencyGroups" -> string
-~const NuGet.Protocol.JsonProperties.Deprecation = "deprecation" -> string
-~const NuGet.Protocol.JsonProperties.DeprecationMessage = "message" -> string
-~const NuGet.Protocol.JsonProperties.DeprecationReasons = "reasons" -> string
-~const NuGet.Protocol.JsonProperties.Description = "description" -> string
-~const NuGet.Protocol.JsonProperties.DownloadCount = "totalDownloads" -> string
-~const NuGet.Protocol.JsonProperties.Fingerprints = "fingerprints" -> string
-~const NuGet.Protocol.JsonProperties.IconUrl = "iconUrl" -> string
-~const NuGet.Protocol.JsonProperties.Issuer = "issuer" -> string
-~const NuGet.Protocol.JsonProperties.Language = "language" -> string
-~const NuGet.Protocol.JsonProperties.LastEdited = "lastEdited" -> string
-~const NuGet.Protocol.JsonProperties.LatestVersion = "latestVersion" -> string
-~const NuGet.Protocol.JsonProperties.LicenseExpression = "licenseExpression" -> string
-~const NuGet.Protocol.JsonProperties.LicenseExpressionVersion = "licenseExpressionVersion" -> string
-~const NuGet.Protocol.JsonProperties.LicenseUrl = "licenseUrl" -> string
-~const NuGet.Protocol.JsonProperties.Listed = "listed" -> string
-~const NuGet.Protocol.JsonProperties.MinimumClientVersion = "minClientVersion" -> string
-~const NuGet.Protocol.JsonProperties.NotAfter = "notAfter" -> string
-~const NuGet.Protocol.JsonProperties.NotBefore = "notBefore" -> string
-~const NuGet.Protocol.JsonProperties.Owners = "owners" -> string
-~const NuGet.Protocol.JsonProperties.PackageContent = "packageContent" -> string
-~const NuGet.Protocol.JsonProperties.PackageId = "id" -> string
-~const NuGet.Protocol.JsonProperties.PrefixReserved = "verified" -> string
-~const NuGet.Protocol.JsonProperties.ProjectUrl = "projectUrl" -> string
-~const NuGet.Protocol.JsonProperties.Published = "published" -> string
-~const NuGet.Protocol.JsonProperties.Range = "range" -> string
-~const NuGet.Protocol.JsonProperties.ReadmeFileUrl = "readmeFileUrl" -> string
-~const NuGet.Protocol.JsonProperties.ReadmeUrl = "readmeUrl" -> string
-~const NuGet.Protocol.JsonProperties.RequireLicenseAcceptance = "requireLicenseAcceptance" -> string
-~const NuGet.Protocol.JsonProperties.Severity = "severity" -> string
-~const NuGet.Protocol.JsonProperties.SigningCertificates = "signingCertificates" -> string
-~const NuGet.Protocol.JsonProperties.Subject = "subject" -> string
-~const NuGet.Protocol.JsonProperties.SubjectId = "@id" -> string
-~const NuGet.Protocol.JsonProperties.Summary = "summary" -> string
-~const NuGet.Protocol.JsonProperties.Tags = "tags" -> string
-~const NuGet.Protocol.JsonProperties.TargetFramework = "targetFramework" -> string
-~const NuGet.Protocol.JsonProperties.Title = "title" -> string
-~const NuGet.Protocol.JsonProperties.Type = "@type" -> string
-~const NuGet.Protocol.JsonProperties.Url = "url" -> string
-~const NuGet.Protocol.JsonProperties.Version = "version" -> string
-~const NuGet.Protocol.JsonProperties.Versions = "versions" -> string
-~const NuGet.Protocol.JsonProperties.Vulnerabilities = "vulnerabilities" -> string
+const NuGet.Protocol.JsonProperties.AdvisoryUrl = "advisoryUrl" -> string!
+const NuGet.Protocol.JsonProperties.AllRepositorySigned = "allRepositorySigned" -> string!
+const NuGet.Protocol.JsonProperties.AlternatePackage = "alternatePackage" -> string!
+const NuGet.Protocol.JsonProperties.Authors = "authors" -> string!
+const NuGet.Protocol.JsonProperties.ContentUrl = "contentUrl" -> string!
+const NuGet.Protocol.JsonProperties.Created = "created" -> string!
+const NuGet.Protocol.JsonProperties.Data = "data" -> string!
+const NuGet.Protocol.JsonProperties.Dependencies = "dependencies" -> string!
+const NuGet.Protocol.JsonProperties.DependencyGroups = "dependencyGroups" -> string!
+const NuGet.Protocol.JsonProperties.Deprecation = "deprecation" -> string!
+const NuGet.Protocol.JsonProperties.DeprecationMessage = "message" -> string!
+const NuGet.Protocol.JsonProperties.DeprecationReasons = "reasons" -> string!
+const NuGet.Protocol.JsonProperties.Description = "description" -> string!
+const NuGet.Protocol.JsonProperties.DownloadCount = "totalDownloads" -> string!
+const NuGet.Protocol.JsonProperties.Fingerprints = "fingerprints" -> string!
+const NuGet.Protocol.JsonProperties.IconUrl = "iconUrl" -> string!
+const NuGet.Protocol.JsonProperties.Issuer = "issuer" -> string!
+const NuGet.Protocol.JsonProperties.Language = "language" -> string!
+const NuGet.Protocol.JsonProperties.LastEdited = "lastEdited" -> string!
+const NuGet.Protocol.JsonProperties.LatestVersion = "latestVersion" -> string!
+const NuGet.Protocol.JsonProperties.LicenseExpression = "licenseExpression" -> string!
+const NuGet.Protocol.JsonProperties.LicenseExpressionVersion = "licenseExpressionVersion" -> string!
+const NuGet.Protocol.JsonProperties.LicenseUrl = "licenseUrl" -> string!
+const NuGet.Protocol.JsonProperties.Listed = "listed" -> string!
+const NuGet.Protocol.JsonProperties.MinimumClientVersion = "minClientVersion" -> string!
+const NuGet.Protocol.JsonProperties.NotAfter = "notAfter" -> string!
+const NuGet.Protocol.JsonProperties.NotBefore = "notBefore" -> string!
+const NuGet.Protocol.JsonProperties.Owners = "owners" -> string!
+const NuGet.Protocol.JsonProperties.PackageContent = "packageContent" -> string!
+const NuGet.Protocol.JsonProperties.PackageId = "id" -> string!
+const NuGet.Protocol.JsonProperties.PrefixReserved = "verified" -> string!
+const NuGet.Protocol.JsonProperties.ProjectUrl = "projectUrl" -> string!
+const NuGet.Protocol.JsonProperties.Published = "published" -> string!
+const NuGet.Protocol.JsonProperties.Range = "range" -> string!
+const NuGet.Protocol.JsonProperties.ReadmeFileUrl = "readmeFileUrl" -> string!
+const NuGet.Protocol.JsonProperties.ReadmeUrl = "readmeUrl" -> string!
+const NuGet.Protocol.JsonProperties.RequireLicenseAcceptance = "requireLicenseAcceptance" -> string!
+const NuGet.Protocol.JsonProperties.Severity = "severity" -> string!
+const NuGet.Protocol.JsonProperties.SigningCertificates = "signingCertificates" -> string!
+const NuGet.Protocol.JsonProperties.Subject = "subject" -> string!
+const NuGet.Protocol.JsonProperties.SubjectId = "@id" -> string!
+const NuGet.Protocol.JsonProperties.Summary = "summary" -> string!
+const NuGet.Protocol.JsonProperties.Tags = "tags" -> string!
+const NuGet.Protocol.JsonProperties.TargetFramework = "targetFramework" -> string!
+const NuGet.Protocol.JsonProperties.Title = "title" -> string!
+const NuGet.Protocol.JsonProperties.Type = "@type" -> string!
+const NuGet.Protocol.JsonProperties.Url = "url" -> string!
+const NuGet.Protocol.JsonProperties.Version = "version" -> string!
+const NuGet.Protocol.JsonProperties.Versions = "versions" -> string!
+const NuGet.Protocol.JsonProperties.Vulnerabilities = "vulnerabilities" -> string!
 ~override NuGet.Protocol.AutoCompleteResourceV2Feed.IdStartsWith(string packageIdPrefix, bool includePrerelease, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
 ~override NuGet.Protocol.AutoCompleteResourceV2Feed.VersionStartsWith(string packageId, string versionPrefix, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
 ~override NuGet.Protocol.AutoCompleteResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
@@ -1691,10 +1691,10 @@ override NuGet.Protocol.DownloadTimeoutStream.SetLength(long value) -> void
 ~override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
 ~override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
 ~override NuGet.Protocol.FindLocalPackagesResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.FingerprintsConverter.CanConvert(System.Type objectType) -> bool
+override NuGet.Protocol.FingerprintsConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.FingerprintsConverter.CanWrite.get -> bool
-~override NuGet.Protocol.FingerprintsConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.FingerprintsConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.FingerprintsConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object!
+override NuGet.Protocol.FingerprintsConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 override NuGet.Protocol.HttpFileSystemBasedFindPackageByIdResource.CopyNupkgToStreamAsync(string! id, NuGet.Versioning.NuGetVersion! version, System.IO.Stream! destination, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 override NuGet.Protocol.HttpFileSystemBasedFindPackageByIdResource.DoesPackageExistAsync(string! id, NuGet.Versioning.NuGetVersion! version, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 override NuGet.Protocol.HttpFileSystemBasedFindPackageByIdResource.GetAllVersionsAsync(string! id, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
@@ -1742,10 +1742,10 @@ override NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) 
 ~override NuGet.Protocol.LocalV3FindPackageByIdResource.GetDependencyInfoAsync(string id, NuGet.Versioning.NuGetVersion version, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo>
 ~override NuGet.Protocol.LocalV3FindPackageByIdResource.GetPackageDownloaderAsync(NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.IPackageDownloader>
 ~override NuGet.Protocol.LocalV3FindPackageByIdResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.MetadataFieldConverter.CanConvert(System.Type objectType) -> bool
+override NuGet.Protocol.MetadataFieldConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.MetadataFieldConverter.CanWrite.get -> bool
-~override NuGet.Protocol.MetadataFieldConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.MetadataFieldConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.MetadataFieldConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
+override NuGet.Protocol.MetadataFieldConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 ~override NuGet.Protocol.MetadataResourceV2Feed.Exists(NuGet.Packaging.Core.PackageIdentity identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
 ~override NuGet.Protocol.MetadataResourceV2Feed.Exists(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
 ~override NuGet.Protocol.MetadataResourceV2Feed.GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NuGet.Versioning.NuGetVersion>>>
@@ -1758,9 +1758,9 @@ override NuGet.Protocol.MetadataFieldConverter.CanWrite.get -> bool
 ~override NuGet.Protocol.MetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
-~override NuGet.Protocol.NuGetVersionConverter.CanConvert(System.Type objectType) -> bool
-~override NuGet.Protocol.NuGetVersionConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.NuGetVersionConverter.CanConvert(System.Type! objectType) -> bool
+override NuGet.Protocol.NuGetVersionConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
+override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 ~override NuGet.Protocol.ODataServiceDocumentResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
@@ -1862,9 +1862,9 @@ override NuGet.Protocol.SafeUriConverter.CanRead.get -> bool
 override NuGet.Protocol.SafeUriConverter.CanWrite.get -> bool
 override NuGet.Protocol.SafeUriConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.SafeUriConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
-~override NuGet.Protocol.SemanticVersionConverter.CanConvert(System.Type objectType) -> bool
-~override NuGet.Protocol.SemanticVersionConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.SemanticVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.SemanticVersionConverter.CanConvert(System.Type! objectType) -> bool
+override NuGet.Protocol.SemanticVersionConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
+override NuGet.Protocol.SemanticVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 ~override NuGet.Protocol.ServerWarningLogHandler.SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>
 ~override NuGet.Protocol.ServiceIndexResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.SymbolPackageUpdateResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
@@ -1872,10 +1872,10 @@ override NuGet.Protocol.SafeUriConverter.WriteJson(Newtonsoft.Json.JsonWriter! w
 ~override NuGet.Protocol.V2FeedListResource.Source.get -> string
 ~override NuGet.Protocol.V2FeedListResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.V3FeedListResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.VersionInfoConverter.CanConvert(System.Type objectType) -> bool
+override NuGet.Protocol.VersionInfoConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.VersionInfoConverter.CanWrite.get -> bool
-~override NuGet.Protocol.VersionInfoConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override NuGet.Protocol.VersionInfoConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override NuGet.Protocol.VersionInfoConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object!
+override NuGet.Protocol.VersionInfoConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 override NuGet.Protocol.VersionRangeConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.VersionRangeConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.VersionRangeConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
@@ -1947,15 +1947,15 @@ static NuGet.Protocol.Events.ProtocolDiagnostics.ServiceIndexEntryEvent -> NuGet
 ~static NuGet.Protocol.HttpStreamValidation.ValidateJObject(string uri, System.IO.Stream stream) -> void
 ~static NuGet.Protocol.HttpStreamValidation.ValidateNupkg(string uri, System.IO.Stream stream) -> void
 ~static NuGet.Protocol.HttpStreamValidation.ValidateXml(string uri, System.IO.Stream stream) -> void
-~static NuGet.Protocol.JsonExtensions.FromJToken(this Newtonsoft.Json.Linq.JToken jtoken, System.Type type) -> object
-~static NuGet.Protocol.JsonExtensions.FromJToken<T>(this Newtonsoft.Json.Linq.JToken jtoken) -> T
-~static NuGet.Protocol.JsonExtensions.FromJson(this string json, System.Type type) -> object
-~static NuGet.Protocol.JsonExtensions.FromJson<T>(this string json) -> T
-~static NuGet.Protocol.JsonExtensions.FromJson<T>(this string json, Newtonsoft.Json.JsonSerializerSettings settings) -> T
-~static NuGet.Protocol.JsonExtensions.GetBoolean(this Newtonsoft.Json.Linq.JObject json, string propertyName) -> bool?
-~static NuGet.Protocol.JsonExtensions.GetJObjectProperty<T>(this Newtonsoft.Json.Linq.JObject jobject, string propertyName) -> T
-~static NuGet.Protocol.JsonExtensions.ToJToken(this object obj) -> Newtonsoft.Json.Linq.JToken
-~static NuGet.Protocol.JsonExtensions.ToJson(this object obj, Newtonsoft.Json.Formatting formatting = Newtonsoft.Json.Formatting.None) -> string
+static NuGet.Protocol.JsonExtensions.FromJToken(this Newtonsoft.Json.Linq.JToken! jtoken, System.Type! type) -> object?
+static NuGet.Protocol.JsonExtensions.FromJToken<T>(this Newtonsoft.Json.Linq.JToken! jtoken) -> T
+static NuGet.Protocol.JsonExtensions.FromJson(this string! json, System.Type! type) -> object?
+static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json) -> T
+static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json, Newtonsoft.Json.JsonSerializerSettings! settings) -> T
+static NuGet.Protocol.JsonExtensions.GetBoolean(this Newtonsoft.Json.Linq.JObject! json, string! propertyName) -> bool?
+static NuGet.Protocol.JsonExtensions.GetJObjectProperty<T>(this Newtonsoft.Json.Linq.JObject! jobject, string! propertyName) -> T
+static NuGet.Protocol.JsonExtensions.ToJToken(this object! obj) -> Newtonsoft.Json.Linq.JToken!
+static NuGet.Protocol.JsonExtensions.ToJson(this object! obj, Newtonsoft.Json.Formatting formatting = Newtonsoft.Json.Formatting.None) -> string!
 ~static NuGet.Protocol.LocalFolderUtility.EnsurePackageFileExists(string packagePath, System.Collections.Generic.IEnumerable<string> matchingPackagePaths) -> void
 ~static NuGet.Protocol.LocalFolderUtility.GenerateNupkgMetadataFile(string nupkgPath, string installPath, string hashPath, string nupkgMetadataPath) -> void
 ~static NuGet.Protocol.LocalFolderUtility.GetAndVerifyRootDirectory(string root) -> System.IO.DirectoryInfo
@@ -2032,7 +2032,7 @@ static readonly NuGet.Protocol.HttpRetryHandlerRequest.DefaultDownloadTimeout ->
 static readonly NuGet.Protocol.HttpRetryHandlerRequest.DefaultMaxTries -> int
 static readonly NuGet.Protocol.HttpSourceAuthenticationHandler.MaxAuthRetries -> int
 static readonly NuGet.Protocol.HttpSourceRequest.DefaultRequestTimeout -> System.TimeSpan
-~static readonly NuGet.Protocol.JsonExtensions.ObjectSerializationSettings -> Newtonsoft.Json.JsonSerializerSettings
+static readonly NuGet.Protocol.JsonExtensions.ObjectSerializationSettings -> Newtonsoft.Json.JsonSerializerSettings!
 static readonly NuGet.Protocol.Plugins.PluginConstants.CloseTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.PluginConstants.IdleTimeout -> System.TimeSpan
 ~static readonly NuGet.Protocol.Plugins.PluginConstants.PluginArguments -> System.Collections.Generic.IEnumerable<string>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -372,10 +372,10 @@ NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.HttpStatusCode.get -> int?
 NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.IsCancelled.get -> bool
 NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.IsLastAttempt.get -> bool
 NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.IsRetry.get -> bool
-~NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.ProtocolDiagnosticHttpEventBase(NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase other) -> void
-~NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.ProtocolDiagnosticHttpEventBase(string source, System.Uri url, System.TimeSpan? headerDuration, int? httpStatusCode, bool isRetry, bool isCancelled, bool isLastAttempt) -> void
-~NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.Source.get -> string
-~NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.Url.get -> System.Uri
+NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.ProtocolDiagnosticHttpEventBase(NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase! other) -> void
+NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.ProtocolDiagnosticHttpEventBase(string! source, System.Uri! url, System.TimeSpan? headerDuration, int? httpStatusCode, bool isRetry, bool isCancelled, bool isLastAttempt) -> void
+NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.Source.get -> string!
+NuGet.Protocol.Events.ProtocolDiagnosticHttpEventBase.Url.get -> System.Uri!
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.FileSize.get -> long
 NuGet.Protocol.Events.ProtocolDiagnosticNupkgCopiedEvent.ProtocolDiagnosticNupkgCopiedEvent(string! source, long fileSize) -> void
@@ -1913,10 +1913,10 @@ static NuGet.Protocol.Core.Types.NullSourceCacheContext.Instance.get -> NuGet.Pr
 static NuGet.Protocol.Core.Types.UserAgent.SetUserAgent(System.Net.Http.HttpClient! client) -> void
 static NuGet.Protocol.Core.Types.UserAgent.SetUserAgentString(NuGet.Protocol.Core.Types.UserAgentStringBuilder! builder) -> void
 static NuGet.Protocol.Core.Types.UserAgent.UserAgentString.get -> string!
-static NuGet.Protocol.Events.ProtocolDiagnostics.HttpEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticHttpEventHandler
-static NuGet.Protocol.Events.ProtocolDiagnostics.NupkgCopiedEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticsNupkgCopiedEventHandler
-static NuGet.Protocol.Events.ProtocolDiagnostics.ResourceEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticResourceEventHandler
-static NuGet.Protocol.Events.ProtocolDiagnostics.ServiceIndexEntryEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticServiceIndexEntryEventHandler
+static NuGet.Protocol.Events.ProtocolDiagnostics.HttpEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticHttpEventHandler?
+static NuGet.Protocol.Events.ProtocolDiagnostics.NupkgCopiedEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticsNupkgCopiedEventHandler?
+static NuGet.Protocol.Events.ProtocolDiagnostics.ResourceEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticResourceEventHandler?
+static NuGet.Protocol.Events.ProtocolDiagnostics.ServiceIndexEntryEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticServiceIndexEntryEventHandler?
 ~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV2(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
 ~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.ProviderFactory factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>
 ~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1948,12 +1948,12 @@ static NuGet.Protocol.Events.ProtocolDiagnostics.ServiceIndexEntryEvent -> NuGet
 ~static NuGet.Protocol.HttpStreamValidation.ValidateNupkg(string uri, System.IO.Stream stream) -> void
 ~static NuGet.Protocol.HttpStreamValidation.ValidateXml(string uri, System.IO.Stream stream) -> void
 static NuGet.Protocol.JsonExtensions.FromJToken(this Newtonsoft.Json.Linq.JToken! jtoken, System.Type! type) -> object?
-static NuGet.Protocol.JsonExtensions.FromJToken<T>(this Newtonsoft.Json.Linq.JToken! jtoken) -> T
+static NuGet.Protocol.JsonExtensions.FromJToken<T>(this Newtonsoft.Json.Linq.JToken! jtoken) -> T?
 static NuGet.Protocol.JsonExtensions.FromJson(this string! json, System.Type! type) -> object?
-static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json) -> T
-static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json, Newtonsoft.Json.JsonSerializerSettings! settings) -> T
+static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json) -> T?
+static NuGet.Protocol.JsonExtensions.FromJson<T>(this string! json, Newtonsoft.Json.JsonSerializerSettings! settings) -> T?
 static NuGet.Protocol.JsonExtensions.GetBoolean(this Newtonsoft.Json.Linq.JObject! json, string! propertyName) -> bool?
-static NuGet.Protocol.JsonExtensions.GetJObjectProperty<T>(this Newtonsoft.Json.Linq.JObject! jobject, string! propertyName) -> T
+static NuGet.Protocol.JsonExtensions.GetJObjectProperty<T>(this Newtonsoft.Json.Linq.JObject! jobject, string! propertyName) -> T?
 static NuGet.Protocol.JsonExtensions.ToJToken(this object! obj) -> Newtonsoft.Json.Linq.JToken!
 static NuGet.Protocol.JsonExtensions.ToJson(this object! obj, Newtonsoft.Json.Formatting formatting = Newtonsoft.Json.Formatting.None) -> string!
 ~static NuGet.Protocol.LocalFolderUtility.EnsurePackageFileExists(string packagePath, System.Collections.Generic.IEnumerable<string> matchingPackagePaths) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -2012,8 +2012,8 @@ static NuGet.Protocol.JsonExtensions.ToJson(this object! obj, Newtonsoft.Json.Fo
 ~static NuGet.Protocol.Plugins.PluginManager.Instance.get -> NuGet.Protocol.Plugins.IPluginManager
 ~static NuGet.Protocol.Plugins.TimeoutUtilities.GetTimeout(string timeoutInSeconds, System.TimeSpan fallbackTimeout) -> System.TimeSpan
 static NuGet.Protocol.Plugins.TimeoutUtilities.IsValid(System.TimeSpan timeout) -> bool
-~static NuGet.Protocol.RegistrationUtility.CreateVersionRange(string stringToParse) -> NuGet.Versioning.VersionRange
-~static NuGet.Protocol.RegistrationUtility.LoadRanges(NuGet.Protocol.HttpSource httpSource, System.Uri registrationUri, string packageId, NuGet.Versioning.VersionRange range, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>>
+static NuGet.Protocol.RegistrationUtility.CreateVersionRange(string! stringToParse) -> NuGet.Versioning.VersionRange!
+static NuGet.Protocol.RegistrationUtility.LoadRanges(NuGet.Protocol.HttpSource! httpSource, System.Uri! registrationUri, string! packageId, NuGet.Versioning.VersionRange! range, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject!>!>!
 static NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3.CreateOrNull(System.Uri! uriTemplate) -> NuGet.Protocol.Resources.OwnerDetailsUriTemplateResourceV3?
 ~static NuGet.Protocol.SemaphoreSlimThrottle.CreateBinarySemaphore() -> NuGet.Protocol.SemaphoreSlimThrottle
 ~static NuGet.Protocol.SemaphoreSlimThrottle.CreateSemaphoreThrottle(int initialCount) -> NuGet.Protocol.SemaphoreSlimThrottle

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DependencyInfoResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DependencyInfoResourceV3.cs
@@ -75,10 +75,9 @@ namespace NuGet.Protocol
                 var singleVersion = new VersionRange(minVersion: package.Version, includeMinVersion: true, maxVersion: package.Version, includeMaxVersion: true);
                 var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, package.Id, singleVersion, cacheContext, projectFramework, log, token);
 
-                // regInfo is null if the server returns a 404 for the package to indicate that it does not exist
+                // regInfo is null if the package does not exist
                 if (regInfo != null)
                 {
-                    // Parse package and dependeny info from the blob
                     result = GetPackagesFromRegistration(regInfo, token).FirstOrDefault();
                 }
 
@@ -113,13 +112,10 @@ namespace NuGet.Protocol
                 // Retrieve the registration blob
                 var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, packageId, VersionRange.All, cacheContext, projectFramework, log, token);
 
-                // regInfo is null if the server returns a 404 for the package to indicate that it does not exist
+                // regInfo is null if the package does not exist
                 if (regInfo != null)
                 {
-                    // Parse package and dependeny info from the blob
                     var packages = GetPackagesFromRegistration(regInfo, token);
-
-                    // Filter on prerelease
                     results.AddRange(packages);
                 }
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSearchMetadataContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/PackageSearchMetadataContextInfoFormatterTests.cs
@@ -68,7 +68,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
                         PackageDetailsUrl = new Uri("http://nuget.org"),
                         Authors = "authors",
                         DependencySets = new List<PackageDependencyGroup>{ new PackageDependencyGroup(new NuGetFramework(".NETFramework", new Version(4,5)), new List<PackageDependency>() { new PackageDependency("a") }) },
-                        Vulnerabilities = new PackageVulnerabilityMetadata[] { JsonExtensions.FromJson<PackageVulnerabilityMetadata>("{ 'AdvisoryUrl': 'http://www.nuget.org', 'Severity': '2' }") },
+                        Vulnerabilities = new PackageVulnerabilityMetadata[] { JsonExtensions.FromJson<PackageVulnerabilityMetadata>("{ 'AdvisoryUrl': 'http://www.nuget.org', 'Severity': '2' }")! },
                         Description = "description",
                         DownloadCount = 1000,
                         IconUrl = new Uri("http://nuget.org"),

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/SearchResultContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/SearchResultContextInfoFormatterTests.cs
@@ -46,7 +46,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
                 Identity = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("4.3.0")),
                 PackageDetailsUrl = new Uri("http://nuget.org"),
                 Authors = "Microsoft",
-                Vulnerabilities = new List<PackageVulnerabilityMetadata> { JsonExtensions.FromJson<PackageVulnerabilityMetadata>("{ 'AdvisoryUrl': 'http://www.nuget.org', 'Severity': '2' }") }
+                Vulnerabilities = new List<PackageVulnerabilityMetadata> { JsonExtensions.FromJson<PackageVulnerabilityMetadata>("{ 'AdvisoryUrl': 'http://www.nuget.org', 'Severity': '2' }")! }
              }
         };
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfo/TrimTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfo/TrimTests.cs
@@ -21,13 +21,15 @@ namespace NuGet.Protocol.Tests
 
             var pkgInfo1 = new PackageInfo
             {
-                Version = NuGetVersion.Parse("0.0.1")
+                Version = NuGetVersion.Parse("0.0.1"),
+                PackageContent = new System.Uri("https://example.com/package1/0.0.1")
             };
             regInfo.Add(pkgInfo1);
 
             var pkgInfo2 = new PackageInfo
             {
-                Version = NuGetVersion.Parse("1.0.0")
+                Version = NuGetVersion.Parse("1.0.0"),
+                PackageContent = new System.Uri("https://example.com/package1/1.0.0")
             };
             regInfo.Add(pkgInfo2);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/JsonExtensionsTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/JsonExtensionsTest.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol.Tests
             var metaData = token.FromJToken<PackageSearchMetadata>();
 
             // Assert
-            Assert.Null(metaData.ProjectUrl);
+            Assert.Null(metaData!.ProjectUrl);
         }
 
         [Fact]
@@ -33,8 +33,8 @@ namespace NuGet.Protocol.Tests
             var metaData = token.FromJToken<PackageSearchMetadata>();
 
             // Assert
-            Assert.Equal(metaData.DeprecationMetadata, await metaData.GetDeprecationMetadataAsync());
-            Assert.Equal(new[] { "CriticalBugs", "Legacy" }, metaData.DeprecationMetadata.Reasons);
+            Assert.Equal(metaData!.DeprecationMetadata, await metaData.GetDeprecationMetadataAsync());
+            Assert.Equal(new[] { "CriticalBugs", "Legacy" }, metaData.DeprecationMetadata!.Reasons);
             Assert.Equal("this is a message", metaData.DeprecationMetadata.Message);
             Assert.Null(metaData.DeprecationMetadata.AlternatePackage);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Model/PackageSearchMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Model/PackageSearchMetadataTests.cs
@@ -19,8 +19,8 @@ namespace NuGet.Protocol.Tests
             var cache = new MetadataReferenceCache();
             var authors1 = new StringBuilder().Append("Contoso").ToString();
             var authors2 = new StringBuilder().Append("Contoso").ToString();
-            var metadata1 = new JObject { ["authors"] = authors1, ["description"] = "desc" }.FromJToken<PackageSearchMetadata>();
-            var metadata2 = new JObject { ["authors"] = authors2, ["description"] = "other" }.FromJToken<PackageSearchMetadata>();
+            var metadata1 = new JObject { ["authors"] = authors1, ["description"] = "desc" }.FromJToken<PackageSearchMetadata>()!;
+            var metadata2 = new JObject { ["authors"] = authors2, ["description"] = "other" }.FromJToken<PackageSearchMetadata>()!;
             Assert.NotSame(metadata1.Authors, metadata2.Authors);
 
             // Act


### PR DESCRIPTION
# Bug

Progress: https://github.com/NuGet/Home/issues/14851

## Description

Continues nullable enablement for `NuGet.Protocol`. Removes `#nullable disable` from Converters, Events, and DependencyInfo files. Adds ""Prefer Immutability and Non-Null Types"" section to `docs/coding-guidelines.md`.

### Design decisions worth reviewing

1. **`GetRegistrationInfo` now returns `RegistrationInfo?` (null for not-found)**
   The method's XML doc has said ""Returns Null if the package does not exist"" since 2015, but the implementation never actually returned null — it returned an empty `RegistrationInfo` with `Id = null`. Fixed by making the method actually return null when empty, and making `RegistrationInfo.Id` a `required string`. The callers in `DependencyInfoResourceV3` already had the null checks — they were dead code that is now live.

2. **`required init` on internal types**
   `DependencyInfo`, `PackageInfo`, and `RegistrationInfo` use `required init` for properties set at construction, get-only for collections. All callers already use object initializers, so no behavioral change.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
