### PR TITLE
Fix NU1201 for C++/CLI project referencing native C++ project with AssetTargetFallback

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -215,18 +215,7 @@ namespace NuGet.ProjectModel
                 // Record all frameworks in the project
                 library[KnownLibraryProperties.ProjectFrameworks] = frameworks;
 
-                var targetFrameworkInfo = packageSpec.GetNearestTargetFramework(targetFramework, alias);
-
-                // FrameworkReducer.GetNearest does not consider ATF since it is used for more than just compat
-                if (targetFrameworkInfo.FrameworkName == null && targetFramework is AssetTargetFallbackFramework atfFramework)
-                {
-                    targetFrameworkInfo = packageSpec.GetNearestTargetFramework(atfFramework.AsFallbackFramework(), alias);
-                }
-
-                if (targetFrameworkInfo.FrameworkName == null && targetFramework is DualCompatibilityFramework mcfFramework)
-                {
-                    targetFrameworkInfo = packageSpec.GetNearestTargetFramework(mcfFramework.AsFallbackFramework(), alias);
-                }
+                var targetFrameworkInfo = GetNearestTargetFrameworkWithFallbacks(packageSpec, targetFramework, alias);
 
                 library[KnownLibraryProperties.TargetFrameworkInformation] = targetFrameworkInfo;
 
@@ -250,10 +239,7 @@ namespace NuGet.ProjectModel
 
             if (!_useLegacyAssetTargetFallbackBehavior)
             {
-                if (targetFrameworkInfo.FrameworkName == null && targetFramework is AssetTargetFallbackFramework atfFramework)
-                {
-                    targetFrameworkInfo = packageSpec.GetNearestTargetFramework(atfFramework.AsFallbackFramework(), targetAlias: targetAlias);
-                }
+                targetFrameworkInfo = GetNearestTargetFrameworkWithFallbacks(packageSpec, targetFramework, targetAlias, targetFrameworkInfo);
             }
 
             if (targetFrameworkInfo.FrameworkName == null)
@@ -305,6 +291,49 @@ namespace NuGet.ProjectModel
             }
 
             return dependencies;
+        }
+
+        /// <summary>
+        /// Resolves the nearest target framework with fallback precedence matching the package path:
+        /// 1. Root framework (exact or nearest)
+        /// 2. DualCompatibilityFramework secondary (e.g., native for C++/CLI)
+        /// 3. AssetTargetFallback imports (e.g., net472)
+        /// </summary>
+        private static TargetFrameworkInformation GetNearestTargetFrameworkWithFallbacks(
+            PackageSpec packageSpec,
+            NuGetFramework targetFramework,
+            string targetAlias,
+            TargetFrameworkInformation initialResult = null)
+        {
+            var targetFrameworkInfo = initialResult ?? packageSpec.GetNearestTargetFramework(targetFramework, targetAlias);
+
+            if (targetFrameworkInfo.FrameworkName != null)
+            {
+                return targetFrameworkInfo;
+            }
+
+            // Unwrap the root framework from ATF if present
+            NuGetFramework rootFramework = targetFramework is AssetTargetFallbackFramework atf
+                ? atf.RootFramework
+                : targetFramework;
+
+            // Try DualCompatibilityFramework secondary before ATF imports
+            if (rootFramework is DualCompatibilityFramework dcf)
+            {
+                targetFrameworkInfo = packageSpec.GetNearestTargetFramework(dcf.AsFallbackFramework(), targetAlias);
+                if (targetFrameworkInfo.FrameworkName != null)
+                {
+                    return targetFrameworkInfo;
+                }
+            }
+
+            // Try ATF imports last
+            if (targetFramework is AssetTargetFallbackFramework atfFramework)
+            {
+                targetFrameworkInfo = packageSpec.GetNearestTargetFramework(atfFramework.AsFallbackFramework(), targetAlias);
+            }
+
+            return targetFrameworkInfo;
         }
 
         private List<LibraryDependency> GetDependenciesFromExternalReference(ExternalProjectReference externalReference)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -3447,7 +3447,6 @@ namespace NuGet.Commands.FuncTest
         }
 
         // CppCli (net10.0-windows7.0 + secondaryFramework=native) -> CppNative (native)
-        // https://github.com/NuGet/Home/issues/14876
         [Fact]
         public async Task RestoreCommand_WithCPPCliProject_WithNativeProjectReference_Succeeds()
         {
@@ -3520,6 +3519,90 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.Libraries.Should().Contain(e => e.Name.Equals("A"));
             result.LockFile.LogMessages.Where(m => m.Code == NuGetLogCode.NU1201).Should().HaveCount(0,
                 "C++/CLI project with secondaryFramework=native should be compatible with native project references");
+        }
+
+        // CppCli (net10.0-windows7.0 + secondaryFramework=native) -> CppNative (native) with native package dependency
+        // Ensures the native project's package dependencies flow through correctly as transitive dependencies.
+        // https://github.com/NuGet/Home/issues/14876
+        [Fact]
+        public async Task RestoreCommand_WithCPPCliProject_WithNativeProjectReferenceWithPackageDependency_Succeeds()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // C++/CLI project: dual-compatible (net10.0-windows7.0 + native)
+            var cppCliProjectJson = @"
+                {
+                    ""frameworks"": {
+                        ""net10.0-windows7.0"": {
+                            ""targetAlias"" : ""net10.0"",
+                            ""assetTargetFallback"" : true,
+                            ""imports"" : [
+                                ""net461"",
+                                ""net462"",
+                                ""net47"",
+                                ""net471"",
+                                ""net472"",
+                                ""net48"",
+                                ""net481""
+                            ],
+                            ""secondaryFramework"" : ""native""
+                        }
+                    }
+                }";
+
+            // Native C++ project: targets native framework with a native package dependency
+            var nativeProjectJson = @"
+                {
+                    ""frameworks"": {
+                        ""native"": {
+                            ""dependencies"": {
+                                ""NativeLib"": {
+                                    ""version"" : ""1.0.0""
+                                }
+                            }
+                        }
+                    }
+                }";
+
+            // Arrange
+            var nativePackage = new SimpleTestPackageContext("NativeLib", "1.0.0");
+            nativePackage.AddFile("lib/native/NativeLib.dll");
+
+            var nativeTransitive = new SimpleTestPackageContext("NativeLib.Transitive", "1.0.0");
+            nativeTransitive.AddFile("lib/native/NativeLib.Transitive.dll");
+
+            nativePackage.PerFrameworkDependencies.Add(CommonFrameworks.Native,
+                new List<SimpleTestPackageContext> { nativeTransitive });
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                nativePackage,
+                nativeTransitive);
+
+            var logger = new TestLogger();
+
+            var cppCliProject = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec(
+                "CppCli", pathContext.SolutionRoot, cppCliProjectJson);
+            var nativeProject = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec(
+                "CppNative", pathContext.SolutionRoot, nativeProjectJson);
+
+            cppCliProject = cppCliProject.WithTestProjectReference(nativeProject);
+            CreateFakeProjectFile(nativeProject);
+
+            // Act
+            var result = await new RestoreCommand(
+                ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, cppCliProject, nativeProject))
+                .ExecuteAsync();
+            await result.CommitAsync(logger, CancellationToken.None);
+
+            // Assert
+            result.Success.Should().BeTrue(because: logger.ShowMessages());
+            result.LockFile.Libraries.Should().HaveCount(3);
+            result.LockFile.Libraries.Should().Contain(e => e.Name.Equals("CppNative"));
+            result.LockFile.Libraries.Should().Contain(e => e.Name.Equals("NativeLib"));
+            result.LockFile.Libraries.Should().Contain(e => e.Name.Equals("NativeLib.Transitive"));
+            result.LockFile.LogMessages.Where(m => m.Code == NuGetLogCode.NU1201).Should().HaveCount(0);
         }
 
         // CppNative (native) -> CppCli (net10.0-windows7.0 + secondaryFramework=native)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -3446,6 +3446,145 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.LogMessages.Should().HaveCount(0);
         }
 
+        // CppCli (net10.0-windows7.0 + secondaryFramework=native) -> CppNative (native)
+        // https://github.com/NuGet/Home/issues/14876
+        [Fact]
+        public async Task RestoreCommand_WithCPPCliProject_WithNativeProjectReference_Succeeds()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // C++/CLI project: dual-compatible (net10.0-windows7.0 + native) with a package dependency
+            var cppCliProjectJson = @"
+                {
+                    ""frameworks"": {
+                        ""net10.0-windows7.0"": {
+                            ""targetAlias"" : ""net10.0"",
+                            ""assetTargetFallback"" : true,
+                            ""imports"" : [
+                                ""net461"",
+                                ""net462"",
+                                ""net47"",
+                                ""net471"",
+                                ""net472"",
+                                ""net48"",
+                                ""net481""
+                            ],
+                            ""secondaryFramework"" : ""native"",
+                            ""dependencies"": {
+                                ""A"": {
+                                    ""version"" : ""1.0.0""
+                                }
+                            }
+                        }
+                    }
+                }";
+
+            // Native C++ project: targets only native framework
+            var nativeProjectJson = @"
+                {
+                    ""frameworks"": {
+                        ""native"": {
+                            ""dependencies"": {
+                            }
+                        }
+                    }
+                }";
+
+            // Arrange
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext("A", "1.0.0"));
+
+            var logger = new TestLogger();
+
+            var cppCliProject = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec(
+                "CppCli", pathContext.SolutionRoot, cppCliProjectJson);
+            var nativeProject = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec(
+                "CppNative", pathContext.SolutionRoot, nativeProjectJson);
+
+            cppCliProject = cppCliProject.WithTestProjectReference(nativeProject);
+            CreateFakeProjectFile(nativeProject);
+
+            // Act
+            var result = await new RestoreCommand(
+                ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, cppCliProject, nativeProject))
+                .ExecuteAsync();
+            await result.CommitAsync(logger, CancellationToken.None);
+
+            // Assert: After fix, restore should succeed — C++/CLI project with
+            // secondaryFramework=native should be compatible with native project references.
+            result.Success.Should().BeTrue(because: logger.ShowMessages());
+            result.LockFile.Libraries.Should().HaveCount(2);
+            result.LockFile.Libraries.Should().Contain(e => e.Name.Equals("CppNative"));
+            result.LockFile.Libraries.Should().Contain(e => e.Name.Equals("A"));
+            result.LockFile.LogMessages.Where(m => m.Code == NuGetLogCode.NU1201).Should().HaveCount(0,
+                "C++/CLI project with secondaryFramework=native should be compatible with native project references");
+        }
+
+        // CppNative (native) -> CppCli (net10.0-windows7.0 + secondaryFramework=native)
+        // A native project referencing a C++/CLI project is not expected to be compatible.
+        [Fact]
+        public async Task RestoreCommand_WithNativeProject_WithCPPCliProjectReference_RaisesNU1201()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Native C++ project: targets only native framework, references the C++/CLI project
+            var nativeProjectJson = @"
+                {
+                    ""frameworks"": {
+                        ""native"": {
+                            ""dependencies"": {
+                            }
+                        }
+                    }
+                }";
+
+            // C++/CLI project: dual-compatible (net10.0-windows7.0 + native)
+            var cppCliProjectJson = @"
+                {
+                    ""frameworks"": {
+                        ""net10.0-windows7.0"": {
+                            ""targetAlias"" : ""net10.0"",
+                            ""assetTargetFallback"" : true,
+                            ""imports"" : [
+                                ""net461"",
+                                ""net462"",
+                                ""net47"",
+                                ""net471"",
+                                ""net472"",
+                                ""net48"",
+                                ""net481""
+                            ],
+                            ""secondaryFramework"" : ""native"",
+                            ""dependencies"": {
+                            }
+                        }
+                    }
+                }";
+
+            // Arrange
+            var logger = new TestLogger();
+
+            var nativeProject = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec(
+                "CppNative", pathContext.SolutionRoot, nativeProjectJson);
+            var cppCliProject = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec(
+                "CppCli", pathContext.SolutionRoot, cppCliProjectJson);
+
+            nativeProject = nativeProject.WithTestProjectReference(cppCliProject);
+            CreateFakeProjectFile(cppCliProject);
+
+            // Act
+            var result = await new RestoreCommand(
+                ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, nativeProject, cppCliProject))
+                .ExecuteAsync();
+            await result.CommitAsync(logger, CancellationToken.None);
+
+            // Assert: NU1201 is expected — a native project cannot consume a C++/CLI project.
+            result.Success.Should().BeFalse(because: logger.ShowMessages());
+            result.LockFile.LogMessages.Should().Contain(m => m.Code == NuGetLogCode.NU1201);
+        }
+
         // Project1(net5.0) -> A(net472) -> B(net472)
         [Fact]
         public async Task Restore_WhenPackageSelectedWithATF_ItsDependenciesAreIncluded_AndATFWarningsAreRaised()


### PR DESCRIPTION
# Bug

Fixes: https://github.com/NuGet/Home/issues/14876

## Description

When a C++/CLI project with both `assetTargetFallback` and `secondaryFramework` (`DualCompatibilityFramework`) references a native C++ project, restore fails with NU1201:

> Project CppNative is not compatible with net10.0-windows7.0 (.NETCoreApp,Version=v10.0). Project CppNative supports: native (native,Version=v0.0)

### Root Cause

In `PackageSpecReferenceDependencyProvider`, the framework resolution for project references had two separate type checks:

1. `is AssetTargetFallbackFramework` — matched first, tried ATF imports (net461-net481) but not the secondary `native` framework
2. `is DualCompatibilityFramework` — never reached because `AssetTargetFallbackFramework` does not inherit from `DualCompatibilityFramework`

When both ATF and DCF are combined (as they are for real C++/CLI projects), the secondary framework was lost.

### Fix

Extracted a shared `GetNearestTargetFrameworkWithFallbacks` helper that follows the same precedence as the package path (`LockFileUtils`):

1. Root framework (exact/nearest)
2. DualCompatibilityFramework secondary (e.g., `native`) — **before** imports
3. AssetTargetFallback imports (e.g., `net472`)

Applied to both `GetLibrary()` and `GetDependenciesFromSpecRestoreMetadata()` in `PackageSpecReferenceDependencyProvider`.

### Tests Added

- `RestoreCommand_WithCPPCliProject_WithNativeProjectReference_Succeeds` — C++/CLI -> native project reference (the bug repro)
- `RestoreCommand_WithCPPCliProject_WithNativeProjectReferenceWithPackageDependency_Succeeds` — C++/CLI -> native project with transitive native package dependencies
- `RestoreCommand_WithNativeProject_WithCPPCliProjectReference_RaisesNU1201` — native -> C++/CLI raises NU1201 (expected behavior)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
