### PR TITLE
Revert "Add install, update gate tests"

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetUITestCase.cs
@@ -908,6 +908,37 @@ namespace NuGet.Tests.Apex.Daily
             CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
         }
 
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        public async Task VerifyDeletedAssetsFileIsBackByReloadingProject()
+        {
+            // Arrange
+            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
+
+            NuGetApexTestService nugetTestService = GetNuGetTestService();
+            _pathContext.Settings.SetPackageFormatToPackageReference();
+
+            SolutionService solutionService = VisualStudio.Get<SolutionService>();
+            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
+            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreConsoleApp, "TestProject");
+            VisualStudio.ClearOutputWindow();
+            solutionService.SaveAll();
+
+            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
+            NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
+            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
+
+            var assetsFilePath = CommonUtility.GetAssetsFilePath(project.FullPath);
+            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
+            File.Delete(assetsFilePath);
+
+            // Act
+            CommonUtility.AutoRestorePackageByReloadingProject(VisualStudio, project);
+
+            // Assert
+            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
+        }
+
         public override void Dispose()
         {
             _pathContext.Dispose();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/IVsServicesTestCase.cs
@@ -25,6 +25,7 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(LongerTimeout)]
+        [TestCategory("Gate")]
         public void SimpleInstallFromIVsInstaller()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -233,40 +233,6 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        [TestMethod]
-        [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
-        public async Task InstallAndUpdatePackageFromUI_NetCoreProject_Succeeds()
-        {
-            // Arrange
-            using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger);
-            var packageName = "NetCoreUpdateTestPackage";
-            var packageVersion1 = "1.0.0";
-            var packageVersion2 = "2.0.0";
-
-            await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion1);
-            await CommonUtility.CreatePackageInSourceAsync(testContext.PackageSource, packageName, packageVersion2);
-
-            VisualStudio.AssertNoErrors();
-
-            // Act
-            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
-            var nugetTestService = GetNuGetTestService();
-            var uiwindow = nugetTestService.GetUIWindowfromProject(testContext.Project);
-            uiwindow.InstallPackageFromUI(packageName, packageVersion1);
-            testContext.SolutionService.Build();
-            testContext.NuGetApexTestService.WaitForAutoRestore();
-            CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersion1, Logger);
-
-            uiwindow.UpdatePackageFromUI(packageName, packageVersion2);
-            testContext.SolutionService.Build();
-            testContext.NuGetApexTestService.WaitForAutoRestore();
-
-            // Assert
-            VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
-            CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName, packageVersion2, Logger);
-        }
-
         // There  is a bug with VS or Apex where NetCoreConsoleApp and NetCoreClassLib create netcore 2.1 projects that are not supported by the sdk
         // Commenting out any NetCoreConsoleApp or NetCoreClassLib template and swapping it for NetStandardClassLib as both are package ref.
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -371,37 +371,6 @@ namespace NuGet.Tests.Apex
             CommonUtility.AssertPackageInPackagesConfig(VisualStudio, project, TestPackageName, TestPackageVersionV2, Logger);
         }
 
-        [TestMethod]
-        [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
-        public async Task VerifyDeletedAssetsFileIsBackByReloadingProject()
-        {
-            // Arrange
-            await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
-
-            NuGetApexTestService nugetTestService = GetNuGetTestService();
-
-            SolutionService solutionService = VisualStudio.Get<SolutionService>();
-            solutionService.CreateEmptySolution("TestSolution", _pathContext.SolutionRoot);
-            ProjectTestExtension project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreConsoleApp, "TestProject");
-            VisualStudio.ClearOutputWindow();
-            solutionService.SaveAll();
-
-            CommonUtility.OpenNuGetPackageManagerWithDte(VisualStudio, Logger);
-            NuGetUIProjectTestExtension uiwindow = nugetTestService.GetUIWindowfromProject(project);
-            uiwindow.InstallPackageFromUI(TestPackageName, TestPackageVersionV1);
-
-            var assetsFilePath = CommonUtility.GetAssetsFilePath(project.FullPath);
-            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
-            File.Delete(assetsFilePath);
-
-            // Act
-            CommonUtility.AutoRestorePackageByReloadingProject(VisualStudio, project);
-
-            // Assert
-            CommonUtility.WaitForFileExists(new FileInfo(assetsFilePath));
-        }
-
         public override void Dispose()
         {
             _pathContext.Dispose();


### PR DESCRIPTION
Reverts NuGet/NuGet.Client#7265

These tests failed on their first run. And that blocks insertions as they are run on NuGet insertion PRs.