### PR TITLE
Use TestCategory to control test promotion

### DIFF
--- a/build/runsettings.proj
+++ b/build/runsettings.proj
@@ -20,12 +20,19 @@
             Properties="RunName=NuGet.Tests.Apex;
             FileName=NuGet.Tests.Apex.dll;" />
 
-        <!-- NuGet.Tests.Apex.Gate.runsettings (VS test gate - runs only [TestCategory("Gate")] tests) -->
+        <!-- NuGet.Tests.Apex.StagingGate.runsettings (VS staging test gate - runs only [TestCategory("StagingGate")] tests) -->
         <MSBuild
             Projects="template.runsettingsproj"
-            Properties="RunName=NuGet.Tests.Apex.Gate;
+            Properties="RunName=NuGet.Tests.Apex.StagingGate;
             FileName=NuGet.Tests.Apex.dll;
-            TestCaseFilter=TestCategory=Gate;" />
+            TestCaseFilter=TestCategory=StagingGate;" />
+
+        <!-- NuGet.Tests.Apex.CanaryGate.runsettings (VS canary test gate - runs only [TestCategory("CanaryGate")] tests) -->
+        <MSBuild
+            Projects="template.runsettingsproj"
+            Properties="RunName=NuGet.Tests.Apex.CanaryGate;
+            FileName=NuGet.Tests.Apex.dll;
+            TestCaseFilter=TestCategory=CanaryGate;" />
 
         <!-- NuGet.Tests.Apex.Daily.runsettings -->
         <MSBuild

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -83,9 +83,8 @@ stages:
       isOfficialBuild: ${{ parameters.isOfficialBuild }}
       BuildRTM: "false"
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
-      RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
+      RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)'
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
-      NuGetTestGateDropName: 'TestGate/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)'
     pool:
       name: VSEng-MicroBuildVSStable
     templateContext:
@@ -130,17 +129,6 @@ stages:
         usePat: true
         dropMetadataContainerName: 'DropMetadata-RunSettings'
         # need to make daily Apex test pipeline build its own tests, and remove this from official pipeline
-        codeSignValidationEnabled: false
-
-      - output: artifactsDrop
-        displayName: 'Publish test gate drop'
-        condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-        dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: '$(NuGetTestGateDropName)'
-        sourcePath: '$(Build.StagingDirectory)\RunSettings'
-        toLowerCase: false
-        usePat: true
-        dropMetadataContainerName: 'DropMetadata-TestGate'
         codeSignValidationEnabled: false
 
       - output: artifactsDrop

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -85,8 +85,7 @@ stages:
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
       RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
-      NuGetStagingGateDropName: 'StagingGate/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)'
-      NuGetCanaryGateDropName: 'CanaryGate/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)'
+      NuGetTestGateDropName: 'TestGate/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)'
     pool:
       name: VSEng-MicroBuildVSStable
     templateContext:
@@ -134,25 +133,14 @@ stages:
         codeSignValidationEnabled: false
 
       - output: artifactsDrop
-        displayName: 'Publish staging gate drop'
+        displayName: 'Publish test gate drop'
         condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: '$(NuGetStagingGateDropName)'
+        buildNumber: '$(NuGetTestGateDropName)'
         sourcePath: '$(Build.StagingDirectory)\RunSettings'
         toLowerCase: false
         usePat: true
-        dropMetadataContainerName: 'DropMetadata-StagingGate'
-        codeSignValidationEnabled: false
-
-      - output: artifactsDrop
-        displayName: 'Publish canary gate drop'
-        condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
-        dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: '$(NuGetCanaryGateDropName)'
-        sourcePath: '$(Build.StagingDirectory)\RunSettings'
-        toLowerCase: false
-        usePat: true
-        dropMetadataContainerName: 'DropMetadata-CanaryGate'
+        dropMetadataContainerName: 'DropMetadata-TestGate'
         codeSignValidationEnabled: false
 
       - output: artifactsDrop

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -85,7 +85,8 @@ stages:
       SemanticVersion: $[stageDependencies.Initialize.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
       RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
-      NuGetTestGateDropName: 'TestGate/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)'
+      NuGetStagingGateDropName: 'StagingGate/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)'
+      NuGetCanaryGateDropName: 'CanaryGate/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildNumber)'
     pool:
       name: VSEng-MicroBuildVSStable
     templateContext:
@@ -133,14 +134,25 @@ stages:
         codeSignValidationEnabled: false
 
       - output: artifactsDrop
-        displayName: 'Publish test gate drop'
+        displayName: 'Publish staging gate drop'
         condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: '$(NuGetTestGateDropName)'
+        buildNumber: '$(NuGetStagingGateDropName)'
         sourcePath: '$(Build.StagingDirectory)\RunSettings'
         toLowerCase: false
         usePat: true
-        dropMetadataContainerName: 'DropMetadata-TestGate'
+        dropMetadataContainerName: 'DropMetadata-StagingGate'
+        codeSignValidationEnabled: false
+
+      - output: artifactsDrop
+        displayName: 'Publish canary gate drop'
+        condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'))"
+        dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+        buildNumber: '$(NuGetCanaryGateDropName)'
+        sourcePath: '$(Build.StagingDirectory)\RunSettings'
+        toLowerCase: false
+        usePat: true
+        dropMetadataContainerName: 'DropMetadata-CanaryGate'
         codeSignValidationEnabled: false
 
       - output: artifactsDrop

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -235,7 +235,7 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
+        [TestCategory("StagingGate")]
         public async Task InstallAndUpdatePackageFromUI_NetCoreProject_Succeeds()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -373,7 +373,7 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        [TestCategory("Gate")]
+        [TestCategory("StagingGate")]
         public async Task VerifyDeletedAssetsFileIsBackByReloadingProject()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3752

## Description

Splits the single VS test gate into two separate gates and drops:

 - StagingGate - existing Gate tests renamed to StagingGate, with its own runsettings and drop URL
 - CanaryGate - new gate for promoted tests only.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
