### PR TITLE
Fix NU1601/NU1604 alias warnings in UnexpectedDependencyMessages

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
@@ -133,38 +133,41 @@ namespace NuGet.Commands
         {
             var messages = new List<RestoreLogMessage>();
 
-            // Group by framework to get project dependencies, then check each graph.
-            foreach (var frameworkGroup in graphs.GroupBy(e => e.Graph.Framework))
+            // Check each graph individually using its target alias to get the correct dependencies.
+            foreach (var indexedGraph in graphs)
             {
-                // Get dependencies from the project
-                var dependencies = project.GetPackageDependenciesForFramework(frameworkGroup.Key)
-                                              .Where(e => !ignoreIds.Contains(e.Name, StringComparer.OrdinalIgnoreCase))
-                                              .Where(IsNonFloatingPackageDependency);
+                // Use the alias to look up the correct per-alias dependencies.
+                // For alias projects, TargetAlias is non-empty and uniquely identifies the target framework.
+                // For non-alias projects, fall back to framework-based lookup.
+                string targetAlias = indexedGraph.Graph.TargetAlias;
+                IEnumerable<LibraryDependency> dependencies = !string.IsNullOrEmpty(targetAlias)
+                    ? project.GetTargetFramework(targetAlias)!.Dependencies
+                    : project.GetPackageDependenciesForFramework(indexedGraph.Graph.Framework);
 
                 foreach (var dependency in dependencies)
                 {
-                    // Graphs may have different versions of the resolved package
-                    foreach (var indexedGraph in frameworkGroup)
+                    if (ignoreIds.Contains(dependency.Name, StringComparer.OrdinalIgnoreCase)
+                        || !IsNonFloatingPackageDependency(dependency))
                     {
-                        var minVersion = dependency.LibraryRange.VersionRange?.MinVersion;
-                        if (minVersion != null && dependency.LibraryRange.VersionRange.IsMinInclusive)
+                        continue;
+                    }
+
+                    var minVersion = dependency.LibraryRange.VersionRange?.MinVersion;
+                    if (minVersion != null && dependency.LibraryRange.VersionRange.IsMinInclusive)
+                    {
+                        var match = indexedGraph.GetItemById(dependency.Name, LibraryType.Package);
+
+                        if (match != null && match.Key.Version > minVersion)
                         {
-                            // Ignore floating or version-less (project) dependencies
-                            // Avoid warnings for non-packages
-                            var match = indexedGraph.GetItemById(dependency.Name, LibraryType.Package);
+                            var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_DependencyBumpedUp,
+                                dependency.LibraryRange.Name,
+                                dependency.LibraryRange.VersionRange.PrettyPrint(),
+                                match.Key.Name,
+                                match.Key.Version);
 
-                            if (match != null && match.Key.Version > minVersion)
-                            {
-                                var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_DependencyBumpedUp,
-                                    dependency.LibraryRange.Name,
-                                    dependency.LibraryRange.VersionRange.PrettyPrint(),
-                                    match.Key.Name,
-                                    match.Key.Version);
+                            var graphName = indexedGraph.Graph.TargetGraphName;
 
-                                var graphName = indexedGraph.Graph.TargetGraphName;
-
-                                messages.Add(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1601, message, match.Key.Name, graphName));
-                            }
+                            messages.Add(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1601, message, match.Key.Name, graphName));
                         }
                     }
                 }
@@ -316,11 +319,11 @@ namespace NuGet.Commands
         /// </summary>
         private static string[] GetDependencyTargetGraphs(PackageSpec spec, LibraryDependency dependency)
         {
-            var infos = new List<TargetFrameworkInformation>();
-            // Add all tfms where the dependency is found
-            infos.AddRange(spec.TargetFrameworks.Where(e => e.Dependencies.Contains(dependency)));
-            // Convert framework to target graph name.
-            return infos.Select(e => e.FrameworkName.ToString()).ToArray();
+            // Add all tfms where the dependency is found and use the alias name if available.
+            return spec.TargetFrameworks
+                .Where(e => e.Dependencies.Contains(dependency))
+                .Select(e => string.IsNullOrEmpty(e.TargetAlias) ? e.FrameworkName.ToString() : e.TargetAlias)
+                .ToArray();
         }
 
     }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_Aliases.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommand_Aliases.cs
@@ -977,6 +977,321 @@ namespace NuGet.Commands.FuncTest
             result.LockFile.LogMessages.Should().Contain(m => m.Message.Contains(invalidAlias));
         }
 
+        // Two aliases of the same framework (net472) with different versions of the same package.
+        // Each alias resolves exactly its requested version. NU1601 should not fire on any graph.
+        [Theory]
+        [InlineData("1.0.0", "2.0.0-preview.1")]          // stable + preview
+        [InlineData("1.0.0", "2.0.0")]                     // both stable
+        [InlineData("1.0.0-preview.1", "2.0.0-preview.1")] // both preview
+        public async Task RestoreCommand_WithAliasesOfSameFramework_DifferentVersionsPerAlias_Succeeds(string appleVersion, string bananaVersion)
+        {
+            using var pathContext = new SimpleTestPathContext();
+            var rootProject = $@"
+            {{
+              ""frameworks"": {{
+                ""apple"": {{
+                    ""framework"": ""net472"",
+                    ""targetAlias"": ""apple"",
+                    ""dependencies"": {{
+                            ""PackageA"": {{
+                                ""version"": ""[{appleVersion},)"",
+                                ""target"": ""Package""
+                            }}
+                    }}
+                }},
+                ""banana"": {{
+                    ""framework"": ""net472"",
+                    ""targetAlias"": ""banana"",
+                    ""dependencies"": {{
+                            ""PackageA"": {{
+                                ""version"": ""[{bananaVersion},)"",
+                                ""target"": ""Package""
+                            }}
+                    }}
+                }}
+              }}
+            }}";
+
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                new SimpleTestPackageContext("PackageA", appleVersion),
+                new SimpleTestPackageContext("PackageA", bananaVersion));
+
+            var logger = new TestLogger();
+            var result = await RunRestoreAsync(pathContext, forceEvaluate: false, logger, projectSpec);
+
+            result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+            // Both aliases should resolve their correct package version
+            var alias1Target = result.LockFile.GetTarget("apple", null);
+            alias1Target.Libraries.Should().ContainSingle(e => e.Name!.Equals("PackageA"));
+            alias1Target.Libraries[0].Version.Should().Be(new NuGetVersion(appleVersion));
+
+            var alias2Target = result.LockFile.GetTarget("banana", null);
+            alias2Target.Libraries.Should().ContainSingle(e => e.Name!.Equals("PackageA"));
+            alias2Target.Libraries[0].Version.Should().Be(new NuGetVersion(bananaVersion));
+
+            result.LockFile.LogMessages.Should().BeEmpty(
+                because: "each alias resolves its own requested version — no bump occurred");
+        }
+
+        // NU1604: Project dependency has a non-inclusive lower bound (e.g., (1.0.0, )).
+        // apple has PackageA (1.0.0, ) → NU1604 (missing lower bound)
+        // banana has PackageA [2.0.0, ) → no NU1604 (inclusive lower bound, version exists)
+        [Fact]
+        public async Task RestoreCommand_WithAliasesOfSameFramework_DifferentRangesPerAliasAndMissingLowerBound_NU1604OnlyOnAffectedAlias()
+        {
+            using var pathContext = new SimpleTestPathContext();
+            var rootProject = @"
+            {
+              ""frameworks"": {
+                ""apple"": {
+                    ""framework"": ""net472"",
+                    ""targetAlias"": ""apple"",
+                    ""dependencies"": {
+                            ""PackageA"": {
+                                ""version"": ""(1.0.0,)"",
+                                ""target"": ""Package""
+                            }
+                    }
+                },
+                ""banana"": {
+                    ""framework"": ""net472"",
+                    ""targetAlias"": ""banana"",
+                    ""dependencies"": {
+                            ""PackageA"": {
+                                ""version"": ""[2.0.0,)"",
+                                ""target"": ""Package""
+                            }
+                    }
+                }
+              }
+            }";
+
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                new SimpleTestPackageContext("PackageA", "1.0.1"),
+                new SimpleTestPackageContext("PackageA", "2.0.0"));
+
+            var logger = new TestLogger();
+            var result = await RunRestoreAsync(pathContext, forceEvaluate: false, logger, projectSpec);
+
+            result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+            result.LockFile.LogMessages.Should().HaveCount(1);
+            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1604);
+            result.LockFile.LogMessages[0].LibraryId.Should().Be("PackageA");
+
+            result.LockFile.LogMessages[0].TargetGraphs.Should().ContainSingle()
+                .Which.Should().Be("apple");
+        }
+
+        // NU1603: Requested min version does not exist on the feed.
+        // apple has PackageA [1.0.0, ) but only 1.0.1 exists → NU1603
+        // banana has PackageA [2.0.0, ) and 2.0.0 exists → no NU1603
+        [Fact]
+        public async Task RestoreCommand_WithAliasesOfSameFramework_MissingMinVersionOnOneAlias_NU1603OnlyOnAffectedAlias()
+        {
+            using var pathContext = new SimpleTestPathContext();
+            var rootProject = @"
+            {
+              ""frameworks"": {
+                ""apple"": {
+                    ""framework"": ""net472"",
+                    ""targetAlias"": ""apple"",
+                    ""dependencies"": {
+                            ""PackageA"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package""
+                            }
+                    }
+                },
+                ""banana"": {
+                    ""framework"": ""net472"",
+                    ""targetAlias"": ""banana"",
+                    ""dependencies"": {
+                            ""PackageA"": {
+                                ""version"": ""[2.0.0,)"",
+                                ""target"": ""Package""
+                            }
+                    }
+                }
+              }
+            }";
+
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            // 1.0.0 does NOT exist — only 1.0.1. 2.0.0 exists.
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource,
+                new SimpleTestPackageContext("PackageA", "1.0.1"),
+                new SimpleTestPackageContext("PackageA", "2.0.0"));
+
+            var logger = new TestLogger();
+            var result = await RunRestoreAsync(pathContext, forceEvaluate: false, logger, projectSpec);
+
+            result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+            result.LockFile.LogMessages.Should().HaveCount(1);
+            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1603);
+            result.LockFile.LogMessages[0].TargetGraphs.Should().ContainSingle()
+                .Which.Should().Be("apple");
+        }
+
+        // NU1602: Transitive dependency has a non-inclusive lower bound.
+        // apple: PackageA 1.0.0 → PackageB (> 1.0.0) → resolves to 1.0.1 → NU1602
+        // banana: PackageC 1.0.0 → PackageB [1.0.0, ) → resolves to 1.0.0 → no NU1602
+        [Fact]
+        public async Task RestoreCommand_WithAliasesOfSameFramework_TransitiveNonInclusiveLowerBound_NU1602OnlyOnAffectedAlias()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // PackageA 1.0.0 depends on PackageB (> 1.0.0) — non-inclusive lower bound
+            var pkgA = new SimpleTestPackageContext("PackageA", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("PackageB", "(1.0.0, )")]
+            };
+
+            // PackageC 1.0.0 depends on PackageB [1.0.0, ) — inclusive lower bound
+            var pkgB_1_0_0 = new SimpleTestPackageContext("PackageB", "1.0.0");
+            var pkgB_1_0_1 = new SimpleTestPackageContext("PackageB", "1.0.1");
+            var pkgC = new SimpleTestPackageContext("PackageC", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("PackageB", "1.0.0")]
+            };
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource, pkgA, pkgB_1_0_0, pkgB_1_0_1, pkgC);
+
+            var rootProject = @"
+            {
+              ""frameworks"": {
+                ""apple"": {
+                    ""framework"": ""net472"",
+                    ""targetAlias"": ""apple"",
+                    ""dependencies"": {
+                            ""PackageA"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package""
+                            }
+                    }
+                },
+                ""banana"": {
+                    ""framework"": ""net472"",
+                    ""targetAlias"": ""banana"",
+                    ""dependencies"": {
+                            ""PackageC"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package""
+                            }
+                    }
+                }
+              }
+            }";
+
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            var logger = new TestLogger();
+            var result = await RunRestoreAsync(pathContext, forceEvaluate: false, logger, projectSpec);
+
+            result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+            result.LockFile.LogMessages.Should().HaveCount(1);
+            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1602);
+            result.LockFile.LogMessages[0].TargetGraphs.Should().ContainSingle()
+                .Which.Should().Be("apple");
+        }
+
+        // NU1608: Transitive dependency resolved above its upper bound.
+        // apple: PackageA 1.0.0 → PackageB [1.0.0, 2.0.0), plus direct dep PackageB [2.0.0, )
+        //         PackageB resolves to 2.0.0, exceeding PackageA's upper bound → NU1608
+        // banana: PackageC 1.0.0 → PackageB [1.0.0, ) (no upper bound)
+        //         PackageB resolves fine → no NU1608
+        [Fact]
+        public async Task RestoreCommand_WithAliasesOfSameFramework_TransitiveAboveUpperBound_NU1608OnlyOnAffectedAlias()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // PackageA 1.0.0 depends on PackageB [1.0.0, 2.0.0) — has upper bound
+            var pkgA = new SimpleTestPackageContext("PackageA", "1.0.0");
+            pkgA.Nuspec = XDocument.Parse(
+                @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <package>
+                    <metadata>
+                        <id>PackageA</id>
+                        <version>1.0.0</version>
+                        <dependencies>
+                            <group>
+                                <dependency id=""PackageB"" version=""[1.0.0, 2.0.0)"" />
+                            </group>
+                        </dependencies>
+                    </metadata>
+                </package>");
+
+            // PackageC 1.0.0 depends on PackageB [1.0.0, ) — no upper bound
+            var pkgC = new SimpleTestPackageContext("PackageC", "1.0.0")
+            {
+                Dependencies = [new SimpleTestPackageContext("PackageB", "1.0.0")]
+            };
+
+            var pkgB = new SimpleTestPackageContext("PackageB", "2.0.0");
+
+            await SimpleTestPackageUtility.CreatePackagesAsync(
+                pathContext.PackageSource, pkgA, pkgB, pkgC);
+
+            // apple pulls in PackageA (which wants B < 2.0.0) AND directly requires PackageB >= 2.0.0.
+            // banana only has PackageC (which wants B >= 1.0.0) and directly requires PackageB >= 2.0.0 — no upper bound conflict.
+            var rootProject = @"
+            {
+              ""frameworks"": {
+                ""apple"": {
+                    ""framework"": ""net472"",
+                    ""targetAlias"": ""apple"",
+                    ""dependencies"": {
+                            ""PackageA"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package""
+                            },
+                            ""PackageB"": {
+                                ""version"": ""[2.0.0,)"",
+                                ""target"": ""Package""
+                            }
+                    }
+                },
+                ""banana"": {
+                    ""framework"": ""net472"",
+                    ""targetAlias"": ""banana"",
+                    ""dependencies"": {
+                            ""PackageC"": {
+                                ""version"": ""[1.0.0,)"",
+                                ""target"": ""Package""
+                            },
+                            ""PackageB"": {
+                                ""version"": ""[2.0.0,)"",
+                                ""target"": ""Package""
+                            }
+                    }
+                }
+              }
+            }";
+
+            var projectSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("Project1", pathContext.SolutionRoot, rootProject);
+
+            var logger = new TestLogger();
+            var result = await RunRestoreAsync(pathContext, forceEvaluate: false, logger, projectSpec);
+
+            result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+            result.LockFile.LogMessages.Should().HaveCount(1);
+            result.LockFile.LogMessages[0].Code.Should().Be(NuGetLogCode.NU1608);
+            result.LockFile.LogMessages[0].TargetGraphs.Should().ContainSingle()
+                .Which.Should().Be("apple");
+        }
+
         internal static Task<RestoreResult> RunRestoreAsync(SimpleTestPathContext pathContext, params PackageSpec[] projects)
         {
             return RunRestoreAsync(pathContext, forceEvaluate: false, new TestLogger(), projects);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/UnexpectedDependencyMessagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/UnexpectedDependencyMessagesTests.cs
@@ -249,6 +249,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46/win10");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             var parent = new LibraryIdentity("z", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
             var child = new LibraryIdentity("x", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
             var dependency = new ResolvedDependencyKey(parent, VersionRange.Parse("[1.0.0, 3.0.0)"), child);
@@ -280,6 +281,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46/win10");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             var parent = new LibraryIdentity("z", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
             var child = new LibraryIdentity("x", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
             var dependency = new ResolvedDependencyKey(parent, VersionRange.Parse("[1.0.0, 3.0.0)"), child);
@@ -314,6 +316,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46/win10");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             var parent = new LibraryIdentity("z", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
             var child = new LibraryIdentity("x", NuGetVersion.Parse("2.5.0"), LibraryType.Package);
             var dependency = new ResolvedDependencyKey(parent, VersionRange.Parse("(, 3.0.0)"), child);
@@ -348,6 +351,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46/win10");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             var parent = new LibraryIdentity("z", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
             var child = new LibraryIdentity("x", NuGetVersion.Parse("2.5.0"), LibraryType.Package);
             var dependency = new ResolvedDependencyKey(parent, range, child);
@@ -381,6 +385,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46/win10");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             var targetGraphs = new[] { targetGraph.Object };
             var ignore = new HashSet<string>();
             var indexedGraphs = targetGraphs.Select(IndexedRestoreTargetGraph.Create).ToList();
@@ -405,6 +410,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46/win10");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             var targetGraphs = new[] { targetGraph.Object };
             var ignore = new HashSet<string>();
             var indexedGraphs = targetGraphs.Select(IndexedRestoreTargetGraph.Create).ToList();
@@ -429,6 +435,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46/win10");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             var targetGraphs = new[] { targetGraph.Object };
             var ignore = new HashSet<string>() { "X" };
             var indexedGraphs = targetGraphs.Select(IndexedRestoreTargetGraph.Create).ToList();
@@ -453,6 +460,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46/win10");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             var targetGraphs = new[] { targetGraph.Object };
             var ignore = new HashSet<string>();
             var indexedGraphs = targetGraphs.Select(IndexedRestoreTargetGraph.Create).ToList();
@@ -575,7 +583,7 @@ namespace NuGet.Commands.Test
 
             log.Code.Should().Be(NuGetLogCode.NU1604);
             log.TargetGraphs.Should().BeEquivalentTo(
-                new[] { NuGetFramework.Parse("netstandard2.0").DotNetFrameworkName },
+                new[] { "netstandard2.0" },
                 "net46 contains a valid range that should be filtered out");
         }
 
@@ -773,6 +781,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46/win10");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             var parent = new LibraryIdentity("z", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
             var child = new LibraryIdentity("x", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
             var dependency = new ResolvedDependencyKey(parent, VersionRange.Parse("1.0.0"), child);
@@ -813,6 +822,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46/win10");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             var parent = new LibraryIdentity("z", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
             var child = new LibraryIdentity("x", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
             var dependency = new ResolvedDependencyKey(parent, VersionRange.Parse("1.0.0"), child);
@@ -872,6 +882,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46/win10");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             var parent = new LibraryIdentity("z", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
             var child = new LibraryIdentity("x", NuGetVersion.Parse("2.5.0"), LibraryType.Package);
             var dependency = new ResolvedDependencyKey(parent, null, child);
@@ -890,6 +901,248 @@ namespace NuGet.Commands.Test
             testLogger.LogMessages.Select(e => e.Code).Should().NotContain(NuGetLogCode.NU1603);
         }
 
+        [Fact]
+        public void GetBumpedUpDependencies_TwoAliasesSameTFM_OnlyAffectedAliasWarns()
+        {
+            // apple requires x >= 1.0.0, banana requires x >= 2.0.0, both resolve x 2.0.0
+            // Only apple should get NU1601
+            var net46 = NuGetFramework.Parse("net46");
+            var tfi = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = net46,
+                    TargetAlias = "apple",
+                    Dependencies = ImmutableArray.Create(new LibraryDependency() { LibraryRange = new LibraryRange("x", VersionRange.Parse("1.0.0"), LibraryDependencyTarget.Package) })
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = net46,
+                    TargetAlias = "banana",
+                    Dependencies = ImmutableArray.Create(new LibraryDependency() { LibraryRange = new LibraryRange("x", VersionRange.Parse("2.0.0"), LibraryDependencyTarget.Package) })
+                }
+            };
+            var project = new PackageSpec(tfi) { Name = "proj" };
+
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>
+            {
+                new GraphItem<RemoteResolveResult>(new LibraryIdentity("x", NuGetVersion.Parse("2.0.0"), LibraryType.Package))
+            };
+
+            var appleGraph = new Mock<IRestoreTargetGraph>();
+            appleGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            appleGraph.SetupGet(e => e.TargetGraphName).Returns("apple");
+            appleGraph.SetupGet(e => e.Framework).Returns(net46);
+            appleGraph.SetupGet(e => e.TargetAlias).Returns("apple");
+
+            var bananaGraph = new Mock<IRestoreTargetGraph>();
+            bananaGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            bananaGraph.SetupGet(e => e.TargetGraphName).Returns("banana");
+            bananaGraph.SetupGet(e => e.Framework).Returns(net46);
+            bananaGraph.SetupGet(e => e.TargetAlias).Returns("banana");
+
+            var indexedGraphs = new[] { appleGraph.Object, bananaGraph.Object }.Select(IndexedRestoreTargetGraph.Create).ToList();
+            var ignore = new HashSet<string>();
+
+            var messages = UnexpectedDependencyMessages.GetBumpedUpDependencies(indexedGraphs, project, ignore).ToList();
+
+            messages.Should().HaveCount(1);
+            messages[0].Code.Should().Be(NuGetLogCode.NU1601);
+            messages[0].TargetGraphs.Should().BeEquivalentTo(new[] { "apple" });
+        }
+
+        [Fact]
+        public void GetBumpedUpDependencies_TwoAliasesSameTFM_NeitherBumped_NoWarning()
+        {
+            // Both apple and banana require x >= 2.0.0, resolve to 2.0.0 — no warning
+            var net46 = NuGetFramework.Parse("net46");
+            var tfi = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = net46,
+                    TargetAlias = "apple",
+                    Dependencies = ImmutableArray.Create(new LibraryDependency() { LibraryRange = new LibraryRange("x", VersionRange.Parse("2.0.0"), LibraryDependencyTarget.Package) })
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = net46,
+                    TargetAlias = "banana",
+                    Dependencies = ImmutableArray.Create(new LibraryDependency() { LibraryRange = new LibraryRange("x", VersionRange.Parse("2.0.0"), LibraryDependencyTarget.Package) })
+                }
+            };
+            var project = new PackageSpec(tfi) { Name = "proj" };
+
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>
+            {
+                new GraphItem<RemoteResolveResult>(new LibraryIdentity("x", NuGetVersion.Parse("2.0.0"), LibraryType.Package))
+            };
+
+            var appleGraph = new Mock<IRestoreTargetGraph>();
+            appleGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            appleGraph.SetupGet(e => e.TargetGraphName).Returns("apple");
+            appleGraph.SetupGet(e => e.Framework).Returns(net46);
+            appleGraph.SetupGet(e => e.TargetAlias).Returns("apple");
+
+            var bananaGraph = new Mock<IRestoreTargetGraph>();
+            bananaGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            bananaGraph.SetupGet(e => e.TargetGraphName).Returns("banana");
+            bananaGraph.SetupGet(e => e.Framework).Returns(net46);
+            bananaGraph.SetupGet(e => e.TargetAlias).Returns("banana");
+
+            var indexedGraphs = new[] { appleGraph.Object, bananaGraph.Object }.Select(IndexedRestoreTargetGraph.Create).ToList();
+            var ignore = new HashSet<string>();
+
+            UnexpectedDependencyMessages.GetBumpedUpDependencies(indexedGraphs, project, ignore).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetProjectDependenciesMissingLowerBounds_TwoAliasesSameTFM_OnlyAffectedAliasInTargetGraphs()
+        {
+            // apple has bad range (,2.0.0), banana has good range [1.0.0, 2.0.0)
+            // NU1604 TargetGraphs should only contain "apple"
+            var net46 = NuGetFramework.Parse("net46");
+            var tfi = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = net46,
+                    TargetAlias = "apple",
+                    Dependencies = ImmutableArray.Create(new LibraryDependency() { LibraryRange = new LibraryRange("x", VersionRange.Parse("(, 2.0.0)"), LibraryDependencyTarget.Package) })
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = net46,
+                    TargetAlias = "banana",
+                    Dependencies = ImmutableArray.Create(new LibraryDependency() { LibraryRange = new LibraryRange("x", VersionRange.Parse("[1.0.0, 2.0.0)"), LibraryDependencyTarget.Package) })
+                }
+            };
+            var project = new PackageSpec(tfi) { Name = "proj" };
+
+            var log = UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Single();
+
+            log.Code.Should().Be(NuGetLogCode.NU1604);
+            log.TargetGraphs.Should().BeEquivalentTo(new[] { "apple" });
+        }
+
+        [Fact]
+        public void GetBumpedUpDependencies_RIDGraphWithAlias_UsesAliasForDepLookup()
+        {
+            // Graph has TargetAlias="apple", TargetGraphName="apple/win-x64" (RID graph)
+            // Should find deps via alias and report graph name with RID
+            var net46 = NuGetFramework.Parse("net46");
+            var tfi = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = net46,
+                    TargetAlias = "apple",
+                    Dependencies = ImmutableArray.Create(new LibraryDependency() { LibraryRange = new LibraryRange("x", VersionRange.Parse("1.0.0"), LibraryDependencyTarget.Package) })
+                }
+            };
+            var project = new PackageSpec(tfi) { Name = "proj" };
+
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>
+            {
+                new GraphItem<RemoteResolveResult>(new LibraryIdentity("x", NuGetVersion.Parse("2.0.0"), LibraryType.Package))
+            };
+
+            var ridGraph = new Mock<IRestoreTargetGraph>();
+            ridGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            ridGraph.SetupGet(e => e.TargetGraphName).Returns("apple/win-x64");
+            ridGraph.SetupGet(e => e.Framework).Returns(net46);
+            ridGraph.SetupGet(e => e.TargetAlias).Returns("apple");
+
+            var indexedGraphs = new[] { ridGraph.Object }.Select(IndexedRestoreTargetGraph.Create).ToList();
+            var ignore = new HashSet<string>();
+
+            var log = UnexpectedDependencyMessages.GetBumpedUpDependencies(indexedGraphs, project, ignore).Single();
+
+            log.Code.Should().Be(NuGetLogCode.NU1601);
+            log.TargetGraphs.Should().BeEquivalentTo(new[] { "apple/win-x64" });
+        }
+
+        [Fact]
+        public void GetProjectDependenciesMissingLowerBounds_BothAliasesHaveBadRange_BothInTargetGraphs()
+        {
+            // Both apple and banana have bad range — both should appear in TargetGraphs
+            var net46 = NuGetFramework.Parse("net46");
+            var badRange = VersionRange.Parse("(, 2.0.0)");
+            var dep = new LibraryDependency() { LibraryRange = new LibraryRange("x", badRange, LibraryDependencyTarget.Package) };
+            var tfi = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = net46,
+                    TargetAlias = "apple",
+                    Dependencies = ImmutableArray.Create(dep)
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = net46,
+                    TargetAlias = "banana",
+                    Dependencies = ImmutableArray.Create(dep)
+                }
+            };
+            var project = new PackageSpec(tfi) { Name = "proj" };
+
+            var log = UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Single();
+
+            log.Code.Should().Be(NuGetLogCode.NU1604);
+            log.TargetGraphs.Should().BeEquivalentTo(new[] { "apple", "banana" });
+        }
+
+        [Fact]
+        public void GetMissingLowerBounds_WithAlias_TargetGraphNameIncludesAlias()
+        {
+            // Graph with TargetGraphName = "apple", has resolved dep with missing lower bound
+            var range = VersionRange.Parse("(, 5.0.0]");
+            var parent = new LibraryIdentity("a", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("b", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, range, child);
+            var dependencySet = new HashSet<ResolvedDependencyKey>() { dependency };
+
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.ResolvedDependencies).Returns(dependencySet);
+            targetGraph.SetupGet(e => e.TargetGraphName).Returns("apple");
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>();
+
+            var log = UnexpectedDependencyMessages.GetMissingLowerBounds(targetGraphs, ignore).Single();
+
+            log.Code.Should().Be(NuGetLogCode.NU1602);
+            log.TargetGraphs.Should().BeEquivalentTo(new[] { "apple" });
+        }
+
+        [Fact]
+        public void GetDependenciesAboveUpperBounds_WithAlias_TargetGraphNameIncludesAlias()
+        {
+            // Graph with TargetGraphName = "apple", has dep above upper bound
+            var testLogger = new TestLogger();
+            var depY = new LibraryDependency()
+            {
+                LibraryRange = new LibraryRange("y", VersionRange.Parse("[1.0.0]"), LibraryDependencyTarget.Package)
+            };
+            var itemX = GetItem("x", "1.0.0", LibraryType.Package, depY);
+            var itemY = GetItem("y", "2.0.0", LibraryType.Package);
+
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>() { itemX, itemY };
+
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            targetGraph.SetupGet(e => e.TargetGraphName).Returns("apple");
+            targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("apple");
+            targetGraph.SetupGet(e => e.ResolvedDependencies).Returns(new HashSet<ResolvedDependencyKey>());
+            var indexedGraphs = new[] { targetGraph.Object }.Select(IndexedRestoreTargetGraph.Create).ToList();
+
+            var messages = UnexpectedDependencyMessages.GetDependenciesAboveUpperBounds(indexedGraphs, testLogger).ToList();
+
+            messages.Should().HaveCount(1);
+            messages[0].Code.Should().Be(NuGetLogCode.NU1608);
+            messages[0].TargetGraphs.Should().BeEquivalentTo(new[] { "apple" });
+        }
+
         private static List<TargetFrameworkInformation> GetTFI(NuGetFramework framework, params LibraryRange[] dependencies)
         {
             return new List<TargetFrameworkInformation>()
@@ -897,6 +1150,7 @@ namespace NuGet.Commands.Test
                 new TargetFrameworkInformation()
                 {
                     FrameworkName = framework,
+                    TargetAlias = framework.GetShortFolderName(),
                     Dependencies = dependencies.Select(e => new LibraryDependency(){ LibraryRange = e }).ToImmutableArray()
                 }
             };
@@ -908,6 +1162,7 @@ namespace NuGet.Commands.Test
             targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
             targetGraph.SetupGet(e => e.TargetGraphName).Returns("net46");
             targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            targetGraph.SetupGet(e => e.TargetAlias).Returns("net46");
             targetGraph.SetupGet(e => e.ResolvedDependencies).Returns(new HashSet<ResolvedDependencyKey>());
             var targetGraphs = new[] { targetGraph.Object };
             var indexedGraphs = targetGraphs.Select(IndexedRestoreTargetGraph.Create).ToList();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

Fixes: https://github.com/NuGet/Home/issues/14877

## Description

Fix NU1601 and NU1604 warnings being incorrectly generated when multiple framework aliases target the same TFM.

**NU1601**: `GetBumpedUpDependencies` grouped graphs by `NuGetFramework`, conflating aliases that share a TFM. Now iterates per-graph using `IRestoreTargetGraph.TargetAlias` for dependency lookup.

**NU1604**: `GetDependencyTargetGraphs` returned `FrameworkName.ToString()` instead of the alias name. Now uses `TargetFrameworkInformation.TargetAlias` when available.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.