### PR TITLE
Clarify xlf localization guidance in docs and copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 - When creating pull requests, always follow the [PR template](PULL_REQUEST_TEMPLATE.md).
 - Always format before submitting a pull request.
 - Before implementing any code changes, read all files in the `docs/` folder. It contains the NuGet development guidelines, including rules for SDKAnalysisLevel gating, public API policies, error handling patterns, and feature design requirements.
-- Do not edit xlf files directly. These are generated from resx files and any manual changes will be overwritten. Instead, edit the resx files and build to update the xlf files.
+- Do not manually edit `.xlf` files. These files are generated from `.resx` files during build and are managed by the OneLocBuild localization pipeline — any manual edits will be overwritten. When adding or modifying localized strings, edit only the `.resx` file, then build. The build will regenerate the `.Designer.cs` and `.xlf` files. Include all three (`.resx`, `.Designer.cs`, `.xlf`) in your pull request.
 
 ## Coding Standards
 

--- a/docs/localizability.md
+++ b/docs/localizability.md
@@ -13,9 +13,9 @@ Therefore, all strings that are displayed to users must use resx file resources,
      The entries in the resx are not sorted, so you can add the new string as the last element in the file.
 1. Build the project.
    If you did not use Visual Studio to edit the *resx* file, this will update the corresponding *.Designer.cs* file with a new class property that can be used to get the string value.
-   Regardless of how you edited the resx file, building will update all the *xlf* files, copying the English translation.
-   This is normal.
-   It sets an attribute to specify that the resource is new, and the [OneLocBuild][1] workflow will later create a pull request with the actual translations.
+   Regardless of how you edited the resx file, building will update all the *xlf* files locally, copying the English translation.
+   This is expected — **include the `.xlf` changes in your pull request** along with the `.resx` and `.Designer.cs` changes.
+   The [OneLocBuild][1] pipeline will later create a separate PR with the actual translations for the new strings.
 1. Use the string in whatever output message the code change requires.
 
 If the string has words or phrases that should not be translated in any language, in the comment section of the resx, use something like `{Locked="allowUntrustedRoot"}`.


### PR DESCRIPTION
# Bug

Fixes: N/A - Engineering improvement (documentation only)

## Description

Clarifies the xlf localization guidance in both .github/copilot-instructions.md and docs/localizability.md.

The previous wording was ambiguous about whether .xlf files should be included in PRs. This caused the Copilot code reviewer to incorrectly flag build-generated .xlf changes as unwanted (see https://github.com/NuGet/NuGet.Client/pull/7301#discussion_r3164897174).

**Changes:**
- **copilot-instructions.md**: Clarifies that .xlf files should not be *manually edited*, but build-generated .xlf changes should be included in PRs alongside .resx and .Designer.cs.
- **docs/localizability.md**: Clarifies that build-generated .xlf changes should be included in the PR, and that OneLocBuild handles actual translations separately.

## PR Checklist
- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.

N/A - Documentation-only change. No tests needed.