### PR TITLE
Fix flaky tests and MockServer test host timeout

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,7 @@
 - Always format before submitting a pull request.
 - Before implementing any code changes, read all files in the `docs/` folder. It contains the NuGet development guidelines, including rules for SDKAnalysisLevel gating, public API policies, error handling patterns, and feature design requirements.
 - Do not manually edit `.xlf` files. These files are generated from `.resx` files during build and are managed by the OneLocBuild localization pipeline — any manual edits will be overwritten. When adding or modifying localized strings, edit only the `.resx` file, then build. The build will regenerate the `.Designer.cs` and `.xlf` files. Include all three (`.resx`, `.Designer.cs`, `.xlf`) in your pull request.
+- Branches should be named as `dev-<user>-<topic>` (e.g., `dev-nkolev92-fixFlakyTest`).
 
 ## Coding Standards
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadRunnerTests.cs
@@ -158,9 +158,9 @@ public class PackageDownloadRunnerTests
         using var pathContext = new SimpleTestPathContext();
         using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
 
-        using var cache = new SourceCacheContext();
+        var cache = new SourceCacheContext();
         var logger = new Mock<ILoggerWithColor>();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var token = CancellationToken.None;
 
         var sourceRepo = Repository.Factory.GetCoreV3(mockServer.ServiceIndexUri);
 
@@ -186,7 +186,7 @@ public class PackageDownloadRunnerTests
             cache,
             logger.Object,
             includePrerelease: false,
-            cts.Token);
+            token);
 
         mockServer.Stop();
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Download/PackageDownloadRunnerTests.cs
@@ -158,9 +158,9 @@ public class PackageDownloadRunnerTests
         using var pathContext = new SimpleTestPathContext();
         using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
 
-        var cache = new SourceCacheContext();
+        using var cache = new SourceCacheContext();
         var logger = new Mock<ILoggerWithColor>();
-        var token = CancellationToken.None;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
         var sourceRepo = Repository.Factory.GetCoreV3(mockServer.ServiceIndexUri);
 
@@ -186,7 +186,7 @@ public class PackageDownloadRunnerTests
             cache,
             logger.Object,
             includePrerelease: false,
-            token);
+            cts.Token);
 
         mockServer.Stop();
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageArchiveReaderTests.cs
@@ -18,7 +18,6 @@ using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
-using Test.Utility.Signing;
 using Xunit;
 
 namespace NuGet.Packaging.Test
@@ -1863,48 +1862,6 @@ namespace NuGet.Packaging.Test
                 var expectedResult = Convert.ToBase64String(new CryptoHashProvider("SHA512").CalculateHash(test.Stream));
 
                 Assert.Equal(expectedResult, result);
-            }
-        }
-
-        [NetFxCIOnlyFact]
-        public async Task GetContentHash_IsSameForUnsignedAndSignedPackageAsync()
-        {
-            // this test will create an unsigned package, copy it, then sign it. then compare the contentHash
-            var nupkg = new SimpleTestPackageContext("Package.Content.Hash.Test", "1.0.0");
-
-            using (var unsignedDir = TestDirectory.Create())
-            {
-                var nupkgFileName = $"{nupkg.Identity.Id}.{nupkg.Identity.Version}.nupkg";
-                var nupkgFileInfo = await nupkg.CreateAsFileAsync(unsignedDir, nupkgFileName);
-
-                using (var signedDir = TestDirectory.Create())
-                {
-                    Uri timestampService = null;
-                    var signatureHashAlgorithm = HashAlgorithmName.SHA256;
-                    var timestampHashAlgorithm = HashAlgorithmName.SHA256;
-
-                    var signedPackagePath = Path.Combine(signedDir.Path, nupkgFileName);
-
-                    using (var trustedCert = SigningTestUtility.GenerateTrustedTestCertificate())
-                    using (var originalPackage = File.OpenRead(nupkgFileInfo.FullName))
-                    using (var signedPackage = File.Open(signedPackagePath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
-                    using (var request = new AuthorSignPackageRequest(
-                        trustedCert.Source.Cert,
-                        signatureHashAlgorithm,
-                        timestampHashAlgorithm))
-                    {
-                        await SignedArchiveTestUtility.CreateSignedPackageAsync(request, originalPackage, signedPackage, timestampService);
-                    }
-
-                    using (var unsignedReader = new PackageArchiveReader(nupkgFileInfo.FullName))
-                    using (var signedReader = new PackageArchiveReader(signedPackagePath))
-                    {
-                        var contentHashUnsigned = unsignedReader.GetContentHash(CancellationToken.None);
-                        var contentHashSigned = signedReader.GetContentHash(CancellationToken.None);
-
-                        Assert.Equal(contentHashUnsigned, contentHashSigned);
-                    }
-                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/PackageArchiveReaderSigningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/PackageArchiveReaderSigningTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Internal.NuGet.Testing.SignedPackages;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Test.Utility;
+using Test.Utility.Signing;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    // This test class is in the SigningTestsCollection because it uses TrustedTestCert,
+    // which mutates the shared CodeSigningRootX509Store. Without collection serialization,
+    // it can race with other signing tests that build X509 chains using the same store.
+    [Collection(SigningTestsCollection.Name)]
+    public class PackageArchiveReaderSigningTests
+    {
+        [NetFxCIOnlyFact]
+        public async Task GetContentHash_IsSameForUnsignedAndSignedPackageAsync()
+        {
+            // this test will create an unsigned package, copy it, then sign it. then compare the contentHash
+            var nupkg = new SimpleTestPackageContext("Package.Content.Hash.Test", "1.0.0");
+
+            using (var unsignedDir = TestDirectory.Create())
+            {
+                var nupkgFileName = $"{nupkg.Identity.Id}.{nupkg.Identity.Version}.nupkg";
+                var nupkgFileInfo = await nupkg.CreateAsFileAsync(unsignedDir, nupkgFileName);
+
+                using (var signedDir = TestDirectory.Create())
+                {
+                    Uri timestampService = null;
+                    var signatureHashAlgorithm = HashAlgorithmName.SHA256;
+                    var timestampHashAlgorithm = HashAlgorithmName.SHA256;
+
+                    var signedPackagePath = Path.Combine(signedDir.Path, nupkgFileName);
+
+                    using (var trustedCert = SigningTestUtility.GenerateTrustedTestCertificate())
+                    using (var originalPackage = File.OpenRead(nupkgFileInfo.FullName))
+                    using (var signedPackage = File.Open(signedPackagePath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+                    using (var request = new AuthorSignPackageRequest(
+                        trustedCert.Source.Cert,
+                        signatureHashAlgorithm,
+                        timestampHashAlgorithm))
+                    {
+                        await SignedArchiveTestUtility.CreateSignedPackageAsync(request, originalPackage, signedPackage, timestampService);
+                    }
+
+                    using (var unsignedReader = new PackageArchiveReader(nupkgFileInfo.FullName))
+                    using (var signedReader = new PackageArchiveReader(signedPackagePath))
+                    {
+                        var contentHashUnsigned = unsignedReader.GetContentHash(CancellationToken.None);
+                        var contentHashSigned = signedReader.GetContentHash(CancellationToken.None);
+
+                        Assert.Equal(contentHashUnsigned, contentHashSigned);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/PackageArchiveReaderSigningTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/PackageArchiveReaderSigningTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Threading;
@@ -35,7 +33,7 @@ namespace NuGet.Packaging.Test
 
                 using (var signedDir = TestDirectory.Create())
                 {
-                    Uri timestampService = null;
+                    Uri? timestampService = null;
                     var signatureHashAlgorithm = HashAlgorithmName.SHA256;
                     var timestampHashAlgorithm = HashAlgorithmName.SHA256;
 

--- a/test/TestUtilities/Test.Utility/MockServer.cs
+++ b/test/TestUtilities/Test.Utility/MockServer.cs
@@ -29,6 +29,7 @@ namespace Test.Utility
     public class MockServer : IDisposable
     {
         private Task _listenerTask;
+        private CancellationTokenSource _cts;
         private bool _disposed = false;
         private AuthenticationSchemes _authenticationSchemes;
         private HttpListener _listener;
@@ -97,7 +98,8 @@ namespace Test.Utility
             }
             while (_listener == null);
 
-            _listenerTask = Task.Factory.StartNew(() => HandleRequest());
+            _cts = new CancellationTokenSource();
+            _listenerTask = Task.Run(() => HandleRequestAsync(_cts.Token));
         }
 
         /// <summary>
@@ -107,19 +109,23 @@ namespace Test.Utility
         {
             try
             {
+                _cts?.Cancel();
                 _listener?.Abort();
 
                 Task task = _listenerTask;
 
                 _listenerTask = null;
 
-                // Use a bounded wait to prevent hanging the test host if Abort()
-                // doesn't immediately unblock the listener's GetContext() call.
-                task?.Wait(TimeSpan.FromSeconds(5));
+                task?.Wait();
             }
             catch (Exception ex)
             {
                 Debug.Fail(ex.ToString());
+            }
+            finally
+            {
+                _cts?.Dispose();
+                _cts = null;
             }
         }
 
@@ -357,22 +363,26 @@ namespace Test.Utility
             }
         }
 
-        private void HandleRequest()
+        private async Task HandleRequestAsync(CancellationToken cancellationToken)
         {
-            while (true)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {
-                    if (_listener == null)
+                    if (_listener == null || !_listener.IsListening)
                     {
                         return;
                     }
 
-                    var context = _listener.GetContext();
+                    var contextTask = _listener.GetContextAsync();
 
-                    GenerateResponse(context);
-
-                    RequestObserver(context);
+                    // Wait for either a request or cancellation.
+                    using (cancellationToken.Register(() => _listener?.Abort()))
+                    {
+                        var context = await contextTask;
+                        GenerateResponse(context);
+                        RequestObserver(context);
+                    }
                 }
                 catch (ObjectDisposedException)
                 {
@@ -394,6 +404,10 @@ namespace Test.Utility
                         System.Console.WriteLine("Unexpected error code: {0}. Ex: {1}", ex.ErrorCode, ex);
                         throw;
                     }
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
                 }
             }
         }

--- a/test/TestUtilities/Test.Utility/MockServer.cs
+++ b/test/TestUtilities/Test.Utility/MockServer.cs
@@ -113,7 +113,9 @@ namespace Test.Utility
 
                 _listenerTask = null;
 
-                task?.Wait();
+                // Use a bounded wait to prevent hanging the test host if Abort()
+                // doesn't immediately unblock the listener's GetContext() call.
+                task?.Wait(TimeSpan.FromSeconds(5));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Engineering

## Description

Fix test host crashes caused by MockServer.Stop() hanging indefinitely, and fix a signing test race condition.

- Refactor MockServer.HandleRequest to use async GetContextAsync with CancellationToken instead of synchronous GetContext, which has no reliable cancellation mechanism and can block indefinitely when Abort() is called
- Extract signing test from PackageArchiveReaderTests into SigningTestsCollection to prevent parallel test race condition with shared certificate store

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.