### PR TITLE
Add MetadataFieldStjConverter with parity tests

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/MetadataFieldStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/MetadataFieldStjConverter.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NuGet.Protocol.Converters
+{
+    /// <summary>
+    /// Reads a JSON string or array of strings into a single comma-separated string.
+    /// Equivalent to <see cref="MetadataFieldConverter"/> for System.Text.Json.
+    /// </summary>
+    /// <remarks>
+    /// NSJ equivalent: <see cref="MetadataFieldConverter"/>.
+    /// Used by: <see cref="PackageSearchMetadata.Authors"/>, <see cref="PackageSearchMetadata.Tags"/>.
+    /// </remarks>
+    internal sealed class MetadataFieldStjConverter : JsonConverter<string>
+    {
+        public override bool HandleNull => true;
+
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return string.Empty;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartArray)
+            {
+                string? first = null;
+                List<string>? rest = null;
+
+                while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                {
+                    string? s = reader.TokenType == JsonTokenType.Null
+                        ? null
+                        : reader.CoerceScalarTokenToString();
+
+                    if (string.IsNullOrWhiteSpace(s)) { continue; }
+
+                    if (first is null)
+                    {
+                        first = s;
+                    }
+                    else
+                    {
+                        (rest ??= []).Add(s!);
+                    }
+                }
+
+                if (first is null) { return string.Empty; }
+                if (rest is null) { return first; }
+                return first + ", " + string.Join(", ", rest);
+            }
+
+            return reader.CoerceScalarTokenToString();
+        }
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+            => throw new NotSupportedException();
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Converters/Utf8JsonReaderExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/Utf8JsonReaderExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+
+namespace NuGet.Protocol.Converters
+{
+    internal static class Utf8JsonReaderExtensions
+    {
+        /// <summary>
+        /// Reads the current JSON scalar token (String, Number, True, or False) as a string,
+        /// coercing non-string types to their string representations — matching Newtonsoft.Json's
+        /// <c>serializer.Deserialize&lt;string&gt;</c> and <c>JToken.Value&lt;string&gt;()</c> behavior.
+        /// Throws <see cref="JsonException"/> for non-scalar tokens (including Null — handle that in the caller).
+        /// </summary>
+        internal static string CoerceScalarTokenToString(this ref Utf8JsonReader reader)
+        {
+            return reader.TokenType switch
+            {
+                JsonTokenType.String => reader.GetString()!,
+                JsonTokenType.True => bool.TrueString,
+                JsonTokenType.False => bool.FalseString,
+                JsonTokenType.Number => reader.HasValueSequence
+                    ? Encoding.UTF8.GetString(reader.ValueSequence.ToArray())
+                    : Encoding.UTF8.GetString(reader.ValueSpan.ToArray()),
+                _ => throw new JsonException(string.Format(System.Globalization.CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType))
+            };
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -205,6 +205,15 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unexpected JSON token type &apos;{0}&apos;..
+        /// </summary>
+        internal static string Error_UnexpectedJsonToken {
+            get {
+                return ResourceManager.GetString("Error_UnexpectedJsonToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Required property &apos;{0}&apos; not found in JSON..
         /// </summary>
         internal static string Error_RequiredJsonPropertyMissing {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -543,6 +543,9 @@ The "s" should be localized to the abbreviation for seconds.</comment>
     <value>Expected package {0} {1}, but got package {2} {3}</value>
     <comment>0 and 2 are package names, and 1 and 3 are version numbers</comment>
   </data>
+  <data name="Error_UnexpectedJsonToken" xml:space="preserve">
+    <value>Unexpected JSON token type '{0}'.</value>
+  </data>
   <data name="Error_RequiredJsonPropertyMissing" xml:space="preserve">
     <value>Required property '{0}' not found in JSON.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.cs.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">Při přístupu ke zdroji {0} server odpověděl zprávou HTTP 403 Zakázáno. To naznačuje, že server ověřil vaši identitu, ale nepovolil vám přístup k požadovanému prostředku. Poskytněte přihlašovací údaje, které mají oprávnění zobrazit tento prostředek.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.de.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">Der Server hat beim Zugriff auf die Quelle "{0}" mit dem HTTP-Fehler "403 – Verboten" geantwortet. Dies weist darauf hin, dass der Server Ihre Identität authentifiziert hat, Ihnen aber keinen Zugriff auf die angeforderte Ressource gewährt. Geben Sie Anmeldeinformationen mit Berechtigungen zum Anzeigen dieser Ressource an.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.es.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">El servidor respondió con HTTP "403 Prohibido" al acceder al origen "{0}". Este hecho hace pensar que el servidor ha autenticado la identidad pero no le ha permitido acceder al recurso solicitado. Proporcione credenciales que tengan permiso para ver este recurso.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.fr.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">Le serveur a répondu avec HTTP '403 Interdit' lors de l'accès à la source '{0}'. Le serveur vous a identifié, mais ne vous a pas autorisé à accéder à la ressource demandée. Fournissez des informations d'identification autorisées à afficher cette ressource.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.it.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">Il server ha restituito un errore HTTP '403: accesso non consentito' durante l'accesso all'origine '{0}'. Questo suggerisce che il server ha autenticato l'identità dell'utente ma non ha consentito l'accesso alla risorsa richiesta. Specificare credenziali autorizzate a visualizzare questa risorsa.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ja.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">ソース '{0}' にアクセスするときに、サーバーが HTTP「403 アクセス不可」で応答しました。サーバーが身元を認証したものの、要求されたリソースにアクセスするためのアクセス許可がないことを示します。このリソースを表示するためのアクセス許可を持つ資格情報を提供してください。</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ko.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">'{0}' 원본에 액세스할 때 서버에서 HTTP '403 사용 권한 없음'으로 응답했습니다. 서버에서 ID를 인증했지만 요청된 리소스에 대한 액세스를 허용하지 않았습니다. 이 리소스를 볼 수 있는 권한이 있는 자격 증명을 제공하세요.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pl.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">Serwer wysłał odpowiedź HTTP 403 „Zabronione” podczas uzyskiwania dostępu do źródła „{0}”. Może to oznaczać, że serwer uwierzytelnił Twoją tożsamość, ale nie zezwolił Ci na dostęp do żądanego źródła. Podaj poświadczenia z uprawnieniami do wyświetlania tego zasobu.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pt-BR.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">O servidor respondeu com HTTP '403 Proibido' ao acessar a origem '{0}'. Isso sugere que o servidor autenticou sua identidade, mas não permitiu que você acessasse o recurso solicitado. Forneça credenciais que tenham permissões para exibir esse recurso.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ru.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">При попытке обратиться к источнику "{0}" сервер вернул сообщение "HTTP 403 — запрещено". Это значит, что сервер проверил подлинность вашего удостоверения, но запретил доступ к запрошенному ресурсу. Укажите учетные данные, которым разрешено просматривать этот ресурс.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.tr.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">'{0}' kaynağına erişilirken sunucu HTTP '403 Yasak' yanıtı döndürdü. Bu, sunucunun kimliğinizi doğruladığı, ancak size istenen kaynağa erişim izni vermediği anlamına gelir. Bu kaynağı görüntüleme iznine sahip kimlik bilgilerini sağlayın.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hans.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">访问源“{0}”时，服务器响应为 HTTP“403 禁止访问”。这表明服务器已验证你的身份，但不允许访问你请求的资源。请提供有权查看此资源的凭据。</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hant.xlf
@@ -89,6 +89,11 @@
         <target state="new">Required property '{0}' not found in JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_UnexpectedJsonToken">
+        <source>Unexpected JSON token type '{0}'.</source>
+        <target state="new">Unexpected JSON token type '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Http_CredentialsForForbidden">
         <source>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</source>
         <target state="translated">存取來源 '{0}' 時，伺服器回應了 HTTP '403 禁止'。這表示伺服器已驗證您的身分識別，但未允許您存取要求的資源。請提供有權檢視此資源的認證。</target>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/MetadataFieldStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/MetadataFieldStjConverterTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NuGet.Protocol.Converters;
+using Xunit;
+using StjSerializer = System.Text.Json.JsonSerializer;
+
+namespace NuGet.Protocol.Tests.Converters
+{
+    public class MetadataFieldStjConverterTests
+    {
+        private class NsjWrapper
+        {
+            [Newtonsoft.Json.JsonConverter(typeof(MetadataFieldConverter))]
+            [Newtonsoft.Json.JsonProperty("v")]
+            public string? Value { get; set; }
+        }
+
+        private class StjWrapper
+        {
+            [System.Text.Json.Serialization.JsonConverter(typeof(MetadataFieldStjConverter))]
+            [System.Text.Json.Serialization.JsonPropertyName("v")]
+            public string? Value { get; set; }
+        }
+
+        private static string? DeserializeWithNsj(string json)
+            => JsonConvert.DeserializeObject<NsjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        private static string? DeserializeWithStj(string json)
+            => StjSerializer.Deserialize<StjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        [Theory]
+        [InlineData("null", "")]
+        [InlineData("\"Alice\"", "Alice")]
+        [InlineData("\"\"", "")]
+        [InlineData("\"  \"", "  ")]
+        [InlineData("\"Alice, Bob\"", "Alice, Bob")]
+        [InlineData("[]", "")]
+        [InlineData("[\"Alice\"]", "Alice")]
+        [InlineData("[\"Alice\",\"Bob\",\"Charlie\"]", "Alice, Bob, Charlie")]
+        [InlineData("[\"Alice\",\"\",\"Bob\"]", "Alice, Bob")]
+        [InlineData("[\"Alice\",\"  \",\"Bob\"]", "Alice, Bob")]
+        [InlineData("[\"Alice\",null,\"Bob\"]", "Alice, Bob")]
+        [InlineData("[null,null]", "")]
+        [InlineData("[\"  \",\"\"]", "")]
+        public void Read_ValidStringOrArray_Succeeds(string json, string expected)
+        {
+            // Act
+            var stjResult = DeserializeWithStj(json);
+            var nsjResult = DeserializeWithNsj(json);
+
+            // Assert
+            stjResult.Should().Be(expected);
+            nsjResult.Should().Be(stjResult, "STJ and NSJ must produce identical output");
+        }
+
+        [Theory]
+        [InlineData("[\"Alice\",[\"nested\"],\"Bob\"]")]
+        [InlineData("[\"Alice\",{},\"Bob\"]")]
+        public void Read_NonConvertibleArrayElement_Throws(string json)
+        {
+            // Act
+            Action nsjAction = () => DeserializeWithNsj(json);
+            Action stjAction = () => DeserializeWithStj(json);
+
+            // Assert
+            nsjAction.Should().Throw<Exception>();
+            stjAction.Should().Throw<System.Text.Json.JsonException>();
+        }
+    }
+}
+


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14883
Related: https://github.com/NuGet/Home/issues/14846

## Description

 This is a focused slice of https://github.com/NuGet/NuGet.Client/pull/7301, split per-converter to make reviewing
 easier.

Converters are being migrated first so that the upcoming Registration resource migrations don't become bloated PRs.

Ensures `MetadataFieldStjConverter` behaves identically to the NSJ `MetadataFieldConverter` for all input types, and adds
parity tests that run both converters side-by-side to verify the outputs match.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
