### PR TITLE
Add MetadataStringOrArrayStjConverter

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/MetadataStringOrArrayStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/MetadataStringOrArrayStjConverter.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NuGet.Protocol.Converters
+{
+    /// <summary>
+    /// Reads a JSON string or array of strings into a <see cref="IReadOnlyList{T}"/> of strings.
+    /// Equivalent to <see cref="MetadataStringOrArrayConverter"/> for System.Text.Json.
+    /// </summary>
+    /// <remarks>
+    /// NSJ equivalent: <see cref="MetadataStringOrArrayConverter"/>.
+    /// Used by: <see cref="PackageSearchMetadata.OwnersList"/>.
+    /// </remarks>
+    internal sealed class MetadataStringOrArrayStjConverter : JsonConverter<IReadOnlyList<string>>
+    {
+        public override bool HandleNull => true;
+
+        public override IReadOnlyList<string>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType));
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var str = reader.GetString();
+                return string.IsNullOrWhiteSpace(str) ? null : [str!];
+            }
+
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType));
+            }
+
+            var values = new List<string>();
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+            {
+                string? s = reader.TokenType switch
+                {
+                    JsonTokenType.String => reader.GetString(),
+                    JsonTokenType.Null => null,
+                    JsonTokenType.True => "True",
+                    JsonTokenType.False => "False",
+                    JsonTokenType.Number => Encoding.UTF8.GetString(reader.ValueSpan.ToArray()),
+                    _ => throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType))
+                };
+                if (s is not null)
+                {
+                    values.Add(s);
+                }
+            }
+            return [.. values];
+        }
+
+        public override void Write(Utf8JsonWriter writer, IReadOnlyList<string> value, JsonSerializerOptions options)
+            => throw new NotSupportedException();
+    }
+}
+

--- a/src/NuGet.Core/NuGet.Protocol/Converters/MetadataStringOrArrayStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/MetadataStringOrArrayStjConverter.cs
@@ -19,8 +19,15 @@ namespace NuGet.Protocol.Converters
     /// </remarks>
     internal sealed class MetadataStringOrArrayStjConverter : JsonConverter<IReadOnlyList<string>>
     {
+        public override bool HandleNull => true;
+
         public override IReadOnlyList<string>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType));
+            }
+
             if (reader.TokenType == JsonTokenType.String)
             {
                 var str = reader.GetString();

--- a/src/NuGet.Core/NuGet.Protocol/Converters/MetadataStringOrArrayStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/MetadataStringOrArrayStjConverter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -40,24 +39,28 @@ namespace NuGet.Protocol.Converters
                 throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType));
             }
 
-            var values = new List<string>();
-            while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+            reader.Read();
+            if (reader.TokenType == JsonTokenType.EndArray)
             {
-                string? s = reader.TokenType switch
-                {
-                    JsonTokenType.String => reader.GetString(),
-                    JsonTokenType.Null => null,
-                    JsonTokenType.True => "True",
-                    JsonTokenType.False => "False",
-                    JsonTokenType.Number => Encoding.UTF8.GetString(reader.ValueSpan.ToArray()),
-                    _ => throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType))
-                };
-                if (s is not null)
-                {
-                    values.Add(s);
-                }
+                return Array.Empty<string>();
             }
-            return [.. values];
+
+            string? first = reader.TokenType == JsonTokenType.Null ? null : reader.CoerceScalarTokenToString();
+
+            reader.Read();
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                return new[] { first! };
+            }
+
+            var values = new List<string?> { first };
+            do
+            {
+                values.Add(reader.TokenType == JsonTokenType.Null ? null : reader.CoerceScalarTokenToString());
+            }
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndArray);
+
+            return values!;
         }
 
         public override void Write(Utf8JsonWriter writer, IReadOnlyList<string> value, JsonSerializerOptions options)

--- a/src/NuGet.Core/NuGet.Protocol/Converters/MetadataStringOrArrayStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/MetadataStringOrArrayStjConverter.cs
@@ -19,15 +19,8 @@ namespace NuGet.Protocol.Converters
     /// </remarks>
     internal sealed class MetadataStringOrArrayStjConverter : JsonConverter<IReadOnlyList<string>>
     {
-        public override bool HandleNull => true;
-
         public override IReadOnlyList<string>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType == JsonTokenType.Null)
-            {
-                throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType));
-            }
-
             if (reader.TokenType == JsonTokenType.String)
             {
                 var str = reader.GetString();
@@ -50,17 +43,25 @@ namespace NuGet.Protocol.Converters
             reader.Read();
             if (reader.TokenType == JsonTokenType.EndArray)
             {
-                return new[] { first! };
+                return first is null ? Array.Empty<string>() : new[] { first };
             }
 
-            var values = new List<string?> { first };
+            var values = new List<string>();
+            if (first is not null)
+            {
+                values.Add(first);
+            }
+
             do
             {
-                values.Add(reader.TokenType == JsonTokenType.Null ? null : reader.CoerceScalarTokenToString());
+                if (reader.TokenType != JsonTokenType.Null)
+                {
+                    values.Add(reader.CoerceScalarTokenToString());
+                }
             }
             while (reader.Read() && reader.TokenType != JsonTokenType.EndArray);
 
-            return values!;
+            return values;
         }
 
         public override void Write(Utf8JsonWriter writer, IReadOnlyList<string> value, JsonSerializerOptions options)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/MetadataStringOrArrayStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/MetadataStringOrArrayStjConverterTests.cs
@@ -34,6 +34,7 @@ namespace NuGet.Protocol.Tests.Converters
             => StjSerializer.Deserialize<StjWrapper>($"{{\"v\":{json}}}")!.Value;
 
         [Theory]
+        [InlineData("null", null)]
         [InlineData("\"\"", null)]
         [InlineData("\"   \"", null)]
         [InlineData("\"Alice\"", new[] { "Alice" })]
@@ -41,7 +42,6 @@ namespace NuGet.Protocol.Tests.Converters
         [InlineData("[\"Alice\"]", new[] { "Alice" })]
         [InlineData("[\"Alice\",\"Bob\",\"Charlie\"]", new[] { "Alice", "Bob", "Charlie" })]
         [InlineData("[\"Alice\",\"\",\"Bob\"]", new[] { "Alice", "", "Bob" })]
-        [InlineData("[\"Alice\",null,\"Bob\"]", new[] { "Alice", null, "Bob" })]
         public void Read_ValidStringOrArray_Succeeds(string json, string[]? expected)
         {
             // Act

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/MetadataStringOrArrayStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/MetadataStringOrArrayStjConverterTests.cs
@@ -41,6 +41,7 @@ namespace NuGet.Protocol.Tests.Converters
         [InlineData("[\"Alice\"]", new[] { "Alice" })]
         [InlineData("[\"Alice\",\"Bob\",\"Charlie\"]", new[] { "Alice", "Bob", "Charlie" })]
         [InlineData("[\"Alice\",\"\",\"Bob\"]", new[] { "Alice", "", "Bob" })]
+        [InlineData("[\"Alice\",null,\"Bob\"]", new[] { "Alice", null, "Bob" })]
         public void Read_ValidStringOrArray_Succeeds(string json, string[]? expected)
         {
             // Act

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/MetadataStringOrArrayStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/MetadataStringOrArrayStjConverterTests.cs
@@ -34,7 +34,6 @@ namespace NuGet.Protocol.Tests.Converters
             => StjSerializer.Deserialize<StjWrapper>($"{{\"v\":{json}}}")!.Value;
 
         [Theory]
-        [InlineData("null", null)]
         [InlineData("\"\"", null)]
         [InlineData("\"   \"", null)]
         [InlineData("\"Alice\"", new[] { "Alice" })]
@@ -54,17 +53,18 @@ namespace NuGet.Protocol.Tests.Converters
         }
 
         [Theory]
+        [InlineData("null")]
         [InlineData("[\"Alice\",[],\"Bob\"]")]
         [InlineData("[\"Alice\",{},\"Bob\"]")]
         public void Read_NonConvertibleArrayElement_Throws(string json)
         {
             // Act
-            Action nsjAction = () => DeserializeWithNsj(json);
             Action stjAction = () => DeserializeWithStj(json);
+            Action nsjAction = () => DeserializeWithNsj(json);
 
             // Assert
-            nsjAction.Should().Throw<Exception>();
             stjAction.Should().Throw<System.Text.Json.JsonException>();
+            nsjAction.Should().Throw<Newtonsoft.Json.JsonException>();
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/MetadataStringOrArrayStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/MetadataStringOrArrayStjConverterTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NuGet.Protocol.Converters;
+using Xunit;
+using StjSerializer = System.Text.Json.JsonSerializer;
+
+namespace NuGet.Protocol.Tests.Converters
+{
+    public class MetadataStringOrArrayStjConverterTests
+    {
+        private class NsjWrapper
+        {
+            [Newtonsoft.Json.JsonConverter(typeof(MetadataStringOrArrayConverter))]
+            [Newtonsoft.Json.JsonProperty("v")]
+            public IReadOnlyList<string>? Value { get; set; }
+        }
+
+        private class StjWrapper
+        {
+            [System.Text.Json.Serialization.JsonConverter(typeof(MetadataStringOrArrayStjConverter))]
+            [System.Text.Json.Serialization.JsonPropertyName("v")]
+            public IReadOnlyList<string>? Value { get; set; }
+        }
+
+        private static IReadOnlyList<string>? DeserializeWithNsj(string json)
+            => JsonConvert.DeserializeObject<NsjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        private static IReadOnlyList<string>? DeserializeWithStj(string json)
+            => StjSerializer.Deserialize<StjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        [Theory]
+        [InlineData("\"\"", null)]
+        [InlineData("\"   \"", null)]
+        [InlineData("\"Alice\"", new[] { "Alice" })]
+        [InlineData("[]", new string[0])]
+        [InlineData("[\"Alice\"]", new[] { "Alice" })]
+        [InlineData("[\"Alice\",\"Bob\",\"Charlie\"]", new[] { "Alice", "Bob", "Charlie" })]
+        [InlineData("[\"Alice\",\"\",\"Bob\"]", new[] { "Alice", "", "Bob" })]
+        public void Read_ValidStringOrArray_Succeeds(string json, string[]? expected)
+        {
+            // Act
+            var stjResult = DeserializeWithStj(json);
+            var nsjResult = DeserializeWithNsj(json);
+
+            // Assert
+            stjResult.Should().BeEquivalentTo(expected, o => o.WithStrictOrdering());
+            nsjResult.Should().BeEquivalentTo(stjResult, o => o.WithStrictOrdering());
+        }
+
+        [Theory]
+        [InlineData("[\"Alice\",[],\"Bob\"]")]
+        [InlineData("[\"Alice\",{},\"Bob\"]")]
+        public void Read_NonConvertibleArrayElement_Throws(string json)
+        {
+            // Act
+            Action nsjAction = () => DeserializeWithNsj(json);
+            Action stjAction = () => DeserializeWithStj(json);
+
+            // Assert
+            nsjAction.Should().Throw<Exception>();
+            stjAction.Should().Throw<System.Text.Json.JsonException>();
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Home/issues/14879

## Description

 This is a focused slice of https://github.com/NuGet/NuGet.Client/pull/7301, split per-converter to make reviewing easier.

  Converters are being migrated first so that the upcoming Registration resource migrations don't become bloated PRs.

  `MetadataStringOrArrayStjConverter` deserializes a JSON string or array of strings into an IReadOnlyList<string> maintaining full behavioral parity with the NSJ `MetadataStringOrArrayConverter`.

 **Intentional divergence from NSJ:** Null elements within an array `(e.g., ["owner1", null, "owner2"])` are filtered out rather than preserved. The NSJ converter passed them through as null values in the list
* one the type of ownerlist is IReadonlyList<string> not IReadonlyList<string?>
* two it does not make sense to pass in an owner list of string with one of them being null. It does not communicate any information about the owners.
  
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
