### PR TITLE
Add NuGetFrameworkStjConverter

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/NuGetFrameworkStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/NuGetFrameworkStjConverter.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using NuGet.Frameworks;
@@ -24,7 +23,7 @@ namespace NuGet.Protocol.Converters
                 JsonTokenType.String => reader.GetString(),
                 JsonTokenType.True => "True",
                 JsonTokenType.False => "False",
-                JsonTokenType.Number => Encoding.UTF8.GetString(reader.ValueSpan.ToArray()),
+                JsonTokenType.Number => reader.CoerceScalarTokenToString(),
                 _ => throw new JsonException(string.Format(System.Globalization.CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType))
             };
 

--- a/src/NuGet.Core/NuGet.Protocol/Converters/NuGetFrameworkStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/NuGetFrameworkStjConverter.cs
@@ -20,6 +20,7 @@ namespace NuGet.Protocol.Converters
         {
             string? value = reader.TokenType switch
             {
+                JsonTokenType.Null => null,
                 JsonTokenType.String => reader.GetString(),
                 JsonTokenType.True => "True",
                 JsonTokenType.False => "False",

--- a/src/NuGet.Core/NuGet.Protocol/Converters/NuGetFrameworkStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/NuGetFrameworkStjConverter.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NuGet.Frameworks;
+
+namespace NuGet.Protocol.Converters
+{
+    /// <remarks>
+    /// NSJ equivalent: <see cref="NuGetFrameworkConverter"/> (registered globally in <see cref="JsonExtensions.ObjectSerializationSettings"/>).
+    /// Used by: <see cref="NuGetFramework"/> properties.
+    /// </remarks>
+    internal sealed class NuGetFrameworkStjConverter : JsonConverter<NuGetFramework>
+    {
+        public override bool HandleNull => true;
+        public override NuGetFramework Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string? value = reader.TokenType switch
+            {
+                JsonTokenType.String => reader.GetString(),
+                JsonTokenType.True => "True",
+                JsonTokenType.False => "False",
+                JsonTokenType.Number => Encoding.UTF8.GetString(reader.ValueSpan.ToArray()),
+                _ => throw new JsonException(string.Format(System.Globalization.CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType))
+            };
+
+            return string.IsNullOrEmpty(value) ? NuGetFramework.AnyFramework : NuGetFramework.Parse(value!);
+        }
+
+        public override void Write(Utf8JsonWriter writer, NuGetFramework value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value.GetShortFolderName());
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Converters/NuGetFrameworkStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/NuGetFrameworkStjConverter.cs
@@ -17,12 +17,13 @@ namespace NuGet.Protocol.Converters
         public override bool HandleNull => true;
         public override NuGetFramework Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            // Delegate parsing to NuGetFramework.Parse. it handles unknown/unsupported values gracefully.
             string? value = reader.TokenType switch
             {
                 JsonTokenType.Null => null,
                 JsonTokenType.String => reader.GetString(),
-                JsonTokenType.True => "True",
-                JsonTokenType.False => "False",
+                JsonTokenType.True => bool.TrueString,
+                JsonTokenType.False => bool.FalseString,
                 JsonTokenType.Number => reader.CoerceScalarTokenToString(),
                 _ => throw new JsonException(string.Format(System.Globalization.CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType))
             };

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/NuGetFrameworkStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/NuGetFrameworkStjConverterTests.cs
@@ -39,7 +39,7 @@ namespace NuGet.Protocol.Tests.Converters
         [InlineData("null", null)]
         [InlineData("42", "42")]
         [InlineData("true", "True")]
-        public void Read_ValidFrameworkString_Succeeds(string json, string? expectedShortName)
+        public void Read_ScalarToken_DelegatesToNuGetFrameworkParse(string json, string? expectedShortName)
         {
             // Arrange
             var expected = expectedShortName is null ? NuGetFramework.AnyFramework : NuGetFramework.Parse(expectedShortName);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/NuGetFrameworkStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/NuGetFrameworkStjConverterTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using FluentAssertions;
+using Newtonsoft.Json;
+using NuGet.Frameworks;
+using NuGet.Protocol.Converters;
+using Xunit;
+using StjSerializer = System.Text.Json.JsonSerializer;
+
+namespace NuGet.Protocol.Tests.Converters
+{
+    public class NuGetFrameworkStjConverterTests
+    {
+        private class NsjWrapper
+        {
+            [Newtonsoft.Json.JsonConverter(typeof(NuGetFrameworkConverter))]
+            [Newtonsoft.Json.JsonProperty("v")]
+            public NuGetFramework? Value { get; set; }
+        }
+
+        private class StjWrapper
+        {
+            [System.Text.Json.Serialization.JsonConverter(typeof(NuGetFrameworkStjConverter))]
+            [System.Text.Json.Serialization.JsonPropertyName("v")]
+            public NuGetFramework? Value { get; set; }
+        }
+
+        private static NuGetFramework? DeserializeWithNsj(string json)
+            => JsonConvert.DeserializeObject<NsjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        private static NuGetFramework? DeserializeWithStj(string json)
+            => StjSerializer.Deserialize<StjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        [Theory]
+        [InlineData("\"net8.0\"", "net8.0")]
+        [InlineData("\"net472\"", "net472")]
+        [InlineData("\"\"", null)]
+        [InlineData("42", "42")]
+        [InlineData("true", "True")]
+        public void Read_ValidFrameworkString_Succeeds(string json, string? expectedShortName)
+        {
+            // Arrange
+            var expected = expectedShortName is null ? NuGetFramework.AnyFramework : NuGetFramework.Parse(expectedShortName);
+
+            // Act
+            var stjResult = DeserializeWithStj(json);
+            var nsjResult = DeserializeWithNsj(json);
+
+            // Assert
+            stjResult.Should().Be(expected);
+            nsjResult.Should().Be(stjResult);
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("[\"net8.0\"]")]
+        [InlineData("{\"framework\":\"net8.0\"}")]
+        public void Read_InvalidToken_Throws(string json)
+        {
+            // Act
+            var stjAct = () => DeserializeWithStj(json);
+            var nsjAct = () => DeserializeWithNsj(json);
+
+            // Assert
+            stjAct.Should().Throw<System.Text.Json.JsonException>();
+            nsjAct.Should().Throw<System.Exception>();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/NuGetFrameworkStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/NuGetFrameworkStjConverterTests.cs
@@ -36,6 +36,7 @@ namespace NuGet.Protocol.Tests.Converters
         [InlineData("\"net8.0\"", "net8.0")]
         [InlineData("\"net472\"", "net472")]
         [InlineData("\"\"", null)]
+        [InlineData("null", null)]
         [InlineData("42", "42")]
         [InlineData("true", "True")]
         public void Read_ValidFrameworkString_Succeeds(string json, string? expectedShortName)
@@ -53,7 +54,6 @@ namespace NuGet.Protocol.Tests.Converters
         }
 
         [Theory]
-        [InlineData("null")]
         [InlineData("[\"net8.0\"]")]
         [InlineData("{\"framework\":\"net8.0\"}")]
         public void Read_InvalidToken_Throws(string json)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14880

## Description


This is a focused slice of https://github.com/NuGet/NuGet.Client/pull/7301, split per-converter to make reviewing easier.

Converters are being migrated first so that the upcoming Registration resource migrations don't become
bloated PRs.

`NuGetFrameworkStjConverter` deserializes `NuGetFramework` from JSON scalar tokens  maintaining full behavioral parity with the NSJ `NuGetFrameworkConverter`. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
