### PR TITLE
Add NuGetVersionStjConverter

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/NuGetVersionStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/NuGetVersionStjConverter.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using NuGet.Versioning;
@@ -21,7 +20,7 @@ namespace NuGet.Protocol.Converters
             {
                 JsonTokenType.Null => null,
                 JsonTokenType.String => reader.GetString(),
-                JsonTokenType.Number => Encoding.UTF8.GetString(reader.ValueSpan.ToArray()),
+                JsonTokenType.Number => reader.CoerceScalarTokenToString(),
                 _ => throw new JsonException(string.Format(System.Globalization.CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType))
             };
 

--- a/src/NuGet.Core/NuGet.Protocol/Converters/NuGetVersionStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/NuGetVersionStjConverter.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NuGet.Versioning;
+
+namespace NuGet.Protocol.Converters
+{
+    /// <remarks>
+    /// NSJ equivalent: <see cref="NuGetVersionConverter"/> (registered globally in <see cref="JsonExtensions.ObjectSerializationSettings"/>).
+    /// Used by <see cref="NuGetVersion"/> properties.
+    /// </remarks>
+    internal sealed class NuGetVersionStjConverter : JsonConverter<NuGetVersion>
+    {
+        public override NuGetVersion? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string? str = reader.TokenType switch
+            {
+                JsonTokenType.Null => null,
+                JsonTokenType.String => reader.GetString(),
+                JsonTokenType.Number => Encoding.UTF8.GetString(reader.ValueSpan.ToArray()),
+                _ => throw new JsonException(string.Format(System.Globalization.CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType))
+            };
+
+            return str is null ? null : NuGetVersion.Parse(str);
+        }
+
+        public override void Write(Utf8JsonWriter writer, NuGetVersion value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(value.ToString());
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/NuGetVersionStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/NuGetVersionStjConverterTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using FluentAssertions;
+using Newtonsoft.Json;
+using NuGet.Protocol.Converters;
+using NuGet.Versioning;
+using Xunit;
+using StjSerializer = System.Text.Json.JsonSerializer;
+
+namespace NuGet.Protocol.Tests.Converters
+{
+    public class NuGetVersionStjConverterTests
+    {
+        private class NsjWrapper
+        {
+            [Newtonsoft.Json.JsonConverter(typeof(NuGetVersionConverter))]
+            [Newtonsoft.Json.JsonProperty("v")]
+            public NuGetVersion? Value { get; set; }
+        }
+
+        private class StjWrapper
+        {
+            [System.Text.Json.Serialization.JsonConverter(typeof(NuGetVersionStjConverter))]
+            [System.Text.Json.Serialization.JsonPropertyName("v")]
+            public NuGetVersion? Value { get; set; }
+        }
+
+        private static NuGetVersion? DeserializeWithNsj(string json)
+            => JsonConvert.DeserializeObject<NsjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        private static NuGetVersion? DeserializeWithStj(string json)
+            => StjSerializer.Deserialize<StjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        [Theory]
+        [InlineData("\"1.2.3\"", "1.2.3")]
+        [InlineData("\"1.0.0-beta.1\"", "1.0.0-beta.1")]
+        [InlineData("null", null)]
+        [InlineData("42", "42.0.0")]
+        public void Read_ValidVersionString_Succeeds(string json, string? expectedVersion)
+        {
+            // Arrange
+            var expected = expectedVersion is null ? null : NuGetVersion.Parse(expectedVersion);
+
+            // Act
+            var stjResult = DeserializeWithStj(json);
+            var nsjResult = DeserializeWithNsj(json);
+
+            // Assert
+            stjResult.Should().BeEquivalentTo(expected);
+            nsjResult.Should().BeEquivalentTo(stjResult);
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("[\"1.0.0\"]")]
+        [InlineData("{\"version\":\"1.0.0\"}")]
+        public void Read_InvalidToken_Throws(string json)
+        {
+            // Act
+            var stjAct = () => DeserializeWithStj(json);
+            var nsjAct = () => DeserializeWithNsj(json);
+
+            // Assert
+            stjAct.Should().Throw<System.Text.Json.JsonException>();
+            nsjAct.Should().Throw<System.Exception>();
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14881

## Description

 This is a focused slice of https://github.com/NuGet/NuGet.Client/pull/7301, split per-converter to make reviewing easier.

Converters are being migrated first so that the upcoming Registration resource migrations don't become bloated PRs.

 `NuGetVersionStjConverter` deserializes `NuGetVersion` from JSON strings (and numeric tokens for parity with NSJ), returning null for null inputs and throwing on unexpected token types. Used by version properties on protocol model classes.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
