### PR TITLE
Add SafeBoolStjConverter

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/SafeBoolStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/SafeBoolStjConverter.cs
@@ -23,7 +23,7 @@ namespace NuGet.Protocol.Converters
                 case JsonTokenType.Null:
                     return false;
                 case JsonTokenType.String:
-                    return bool.TryParse(reader.GetString()?.Trim(), out bool flag) && flag;
+                    return bool.TryParse(reader.GetString(), out bool flag) && flag;
                 case JsonTokenType.Number:
                     return reader.TryGetInt64(out long l) && l == 1;
                 default:

--- a/src/NuGet.Core/NuGet.Protocol/Converters/SafeBoolStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/SafeBoolStjConverter.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NuGet.Protocol.Converters
+{
+    /// <remarks>
+    /// NSJ equivalent: <see cref="SafeBoolConverter"/>.
+    /// Used by: <see cref="PackageSearchMetadata.RequireLicenseAcceptance"/>.
+    /// </remarks>
+    internal sealed class SafeBoolStjConverter : JsonConverter<bool>
+    {
+        public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.True:
+                    return true;
+                case JsonTokenType.False:
+                case JsonTokenType.Null:
+                    return false;
+                case JsonTokenType.String:
+                    return bool.TryParse(reader.GetString()?.Trim(), out bool flag) && flag;
+                case JsonTokenType.Number:
+                    return reader.TryGetInt64(out long l) && l == 1;
+                default:
+                    reader.Skip();
+                    return false;
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/SafeBoolStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/SafeBoolStjConverterTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using FluentAssertions;
+using Newtonsoft.Json;
+using NuGet.Protocol.Converters;
+using Xunit;
+using StjSerializer = System.Text.Json.JsonSerializer;
+
+namespace NuGet.Protocol.Tests.Converters
+{
+    public class SafeBoolStjConverterTests
+    {
+        private class NsjWrapper
+        {
+            [Newtonsoft.Json.JsonConverter(typeof(SafeBoolConverter))]
+            [Newtonsoft.Json.JsonProperty("v")]
+            public bool Value { get; set; }
+        }
+
+        private class StjWrapper
+        {
+            [System.Text.Json.Serialization.JsonConverter(typeof(SafeBoolStjConverter))]
+            [System.Text.Json.Serialization.JsonPropertyName("v")]
+            public bool Value { get; set; }
+        }
+
+        private static bool DeserializeWithNsj(string json)
+            => JsonConvert.DeserializeObject<NsjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        private static bool DeserializeWithStj(string json)
+            => StjSerializer.Deserialize<StjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        [Theory]
+        [InlineData("true", true)]
+        [InlineData("false", false)]
+        [InlineData("null", false)]
+        [InlineData("1", true)]
+        [InlineData("0", false)]
+        [InlineData("\"true\"", true)]
+        [InlineData("\"True\"", true)]
+        [InlineData("\"false\"", false)]
+        [InlineData("\"invalid\"", false)]
+        [InlineData("\"  true  \"", true)]
+        [InlineData("\"  \"", false)]
+        [InlineData("{}", false)]
+        [InlineData("[]", false)]
+        public void Read_ValidBoolInput_Succeeds(string json, bool expected)
+        {
+            // Act
+            var stjResult = DeserializeWithStj(json);
+            var nsjResult = DeserializeWithNsj(json);
+
+            // Assert
+            stjResult.Should().Be(expected);
+            nsjResult.Should().Be(stjResult);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14884
Related: https://github.com/NuGet/Home/issues/14846

## Description

 This is a focused slice of https://github.com/NuGet/NuGet.Client/pull/7301, split per-converter to make reviewing
 easier.

Converters are being migrated first so that the upcoming Registration resource migrations don't become bloated PRs.

`SafeBoolStjConverter` safely deserializes booleans from various token types. used by `PackageSearchMetadata.RequireLicenseAcceptance`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
