### PR TITLE
Add SafeUriStjConverter

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/SafeUriStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/SafeUriStjConverter.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NuGet.Protocol.Converters
+{
+    /// <remarks>
+    /// NSJ equivalent: <see cref="SafeUriConverter"/>.
+    /// Used by: <see cref="PackageSearchMetadata.LicenseUrl"/>, <see cref="PackageSearchMetadata.ProjectUrl"/>,
+    /// <see cref="PackageSearchMetadata.ReadmeUrl"/>, <see cref="PackageVulnerabilityMetadata.AdvisoryUrl"/>.
+    /// </remarks>
+    internal sealed class SafeUriStjConverter : JsonConverter<Uri>
+    {
+        public override Uri? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                Uri.TryCreate(reader.GetString()?.Trim(), UriKind.Absolute, out Uri? uri);
+                return uri;
+            }
+
+            reader.Skip();
+            return null;
+        }
+
+        public override void Write(Utf8JsonWriter writer, Uri value, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/SafeUriStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/SafeUriStjConverterTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NuGet.Protocol.Converters;
+using Xunit;
+using StjSerializer = System.Text.Json.JsonSerializer;
+
+namespace NuGet.Protocol.Tests.Converters
+{
+    public class SafeUriStjConverterTests
+    {
+        private class NsjWrapper
+        {
+            [Newtonsoft.Json.JsonConverter(typeof(SafeUriConverter))]
+            [Newtonsoft.Json.JsonProperty("v")]
+            public Uri? Value { get; set; }
+        }
+
+        private class StjWrapper
+        {
+            [System.Text.Json.Serialization.JsonConverter(typeof(SafeUriStjConverter))]
+            [System.Text.Json.Serialization.JsonPropertyName("v")]
+            public Uri? Value { get; set; }
+        }
+
+        private static Uri? DeserializeWithNsj(string json)
+            => JsonConvert.DeserializeObject<NsjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        private static Uri? DeserializeWithStj(string json)
+            => StjSerializer.Deserialize<StjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        [Theory]
+        [InlineData("\"https://contoso.test/path\"", "https://contoso.test/path")]
+        [InlineData("\"  https://contoso.test/path  \"", "https://contoso.test/path")]
+        [InlineData("\"not a uri\"", null)]
+        [InlineData("null", null)]
+        [InlineData("42", null)]
+        [InlineData("{}", null)]
+        [InlineData("[]", null)]
+        public void Read_ValidUriInput_Succeeds(string json, string? expectedUri)
+        {
+            // Arrange
+            var expected = expectedUri is null ? null : new Uri(expectedUri);
+
+            // Act
+            var stjResult = DeserializeWithStj(json);
+            var nsjResult = DeserializeWithNsj(json);
+
+            // Assert
+            stjResult.Should().Be(expected);
+            nsjResult.Should().Be(stjResult);
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14885
Related: https://github.com/NuGet/Home/issues/14846

## Description

 This is a focused slice of https://github.com/NuGet/NuGet.Client/pull/7301, split per-converter to make reviewing
 easier.

Converters are being migrated first so that the upcoming Registration resource migrations don't become bloated PRs.

`SafeUriStjConverter` safely deserializes URIs, returning null for invalid or non-string inputs. used by `LicenseUrl, 
ProjectUrl, ReadmeUrl, and AdvisoryUrl`. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
