### PR TITLE
Add VersionInfoStjConverter

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoStjConverter.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace NuGet.Protocol.Converters
+{
+    /// <remarks>
+    /// NSJ equivalent: <see cref="VersionInfoConverter"/> (registered globally in <see cref="JsonExtensions.ObjectSerializationSettings"/>).
+    /// Used by: <see cref="VersionInfo"/> entries.
+    /// </remarks>
+    internal sealed class VersionInfoStjConverter : JsonConverter<VersionInfo>
+    {
+        public override bool HandleNull => true;
+        public override VersionInfo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType));
+            }
+
+            string? version = null;
+            long? downloads = null;
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    continue;
+                }
+
+                var propName = reader.GetString();
+                reader.Read();
+
+                if (string.Equals(propName, JsonProperties.Version, StringComparison.Ordinal))
+                {
+                    version = reader.GetString();
+                }
+                else if (string.Equals(propName, "downloads", StringComparison.Ordinal))
+                {
+                    downloads = reader.TokenType == JsonTokenType.Null ? null : reader.GetInt64();
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            if (string.IsNullOrEmpty(version))
+            {
+                throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_RequiredJsonPropertyMissing, JsonProperties.Version));
+            }
+
+            return new VersionInfo(NuGetVersion.Parse(version!), downloads);
+        }
+
+        public override void Write(Utf8JsonWriter writer, VersionInfo value, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoStjConverter.cs
@@ -51,7 +51,7 @@ namespace NuGet.Protocol.Converters
                     downloads = reader.TokenType switch
                     {
                         JsonTokenType.Null => null,
-                        JsonTokenType.Number => reader.GetInt64(),
+                        JsonTokenType.Number => reader.TryGetInt64(out long longValue) ? longValue : Convert.ToInt64(reader.GetDouble()),
                         JsonTokenType.String => long.Parse(reader.GetString()!, CultureInfo.InvariantCulture),
                         _ => throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType))
                     };

--- a/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/VersionInfoStjConverter.cs
@@ -39,11 +39,22 @@ namespace NuGet.Protocol.Converters
 
                 if (string.Equals(propName, JsonProperties.Version, StringComparison.Ordinal))
                 {
-                    version = reader.GetString();
+                    version = reader.TokenType switch
+                    {
+                        JsonTokenType.String => reader.GetString(),
+                        JsonTokenType.Number => reader.CoerceScalarTokenToString(),
+                        _ => throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType))
+                    };
                 }
                 else if (string.Equals(propName, "downloads", StringComparison.Ordinal))
                 {
-                    downloads = reader.TokenType == JsonTokenType.Null ? null : reader.GetInt64();
+                    downloads = reader.TokenType switch
+                    {
+                        JsonTokenType.Null => null,
+                        JsonTokenType.Number => reader.GetInt64(),
+                        JsonTokenType.String => long.Parse(reader.GetString()!, CultureInfo.InvariantCulture),
+                        _ => throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType))
+                    };
                 }
                 else
                 {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionInfoStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionInfoStjConverterTests.cs
@@ -38,6 +38,8 @@ namespace NuGet.Protocol.Tests.Converters
         [InlineData("""{"version":"2.0.0-beta"}""", "2.0.0-beta", null)]
         [InlineData("""{"version":"1.0.0","downloads":null}""", "1.0.0", null)]
         [InlineData("""{"version":"1.0.0","extra":"ignored","downloads":5}""", "1.0.0", 5L)]
+        [InlineData("""{"version":1,"downloads":5}""", "1.0.0", 5L)]
+        [InlineData("""{"version":"1.0.0","downloads":"500"}""", "1.0.0", 500L)]
         public void Read_ValidObject_Succeeds(string json, string expectedVersion, long? expectedDownloads)
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionInfoStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionInfoStjConverterTests.cs
@@ -40,6 +40,9 @@ namespace NuGet.Protocol.Tests.Converters
         [InlineData("""{"version":"1.0.0","extra":"ignored","downloads":5}""", "1.0.0", 5L)]
         [InlineData("""{"version":1,"downloads":5}""", "1.0.0", 5L)]
         [InlineData("""{"version":"1.0.0","downloads":"500"}""", "1.0.0", 500L)]
+        [InlineData("""{"version":"1.0.0","downloads":5.0}""", "1.0.0", 5L)]
+        [InlineData("""{"version":"1.0.0","downloads":5.5}""", "1.0.0", 6L)]
+        [InlineData("""{"version":"1.0.0","downloads":1e3}""", "1.0.0", 1000L)]
         public void Read_ValidObject_Succeeds(string json, string expectedVersion, long? expectedDownloads)
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionInfoStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/VersionInfoStjConverterTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using FluentAssertions;
+using Newtonsoft.Json;
+using NuGet.Protocol.Converters;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Xunit;
+using StjSerializer = System.Text.Json.JsonSerializer;
+
+namespace NuGet.Protocol.Tests.Converters
+{
+    public class VersionInfoStjConverterTests
+    {
+        private class NsjWrapper
+        {
+            [Newtonsoft.Json.JsonConverter(typeof(VersionInfoConverter))]
+            [Newtonsoft.Json.JsonProperty("v")]
+            public VersionInfo? Value { get; set; }
+        }
+
+        private class StjWrapper
+        {
+            [System.Text.Json.Serialization.JsonConverter(typeof(VersionInfoStjConverter))]
+            [System.Text.Json.Serialization.JsonPropertyName("v")]
+            public VersionInfo? Value { get; set; }
+        }
+
+        private static VersionInfo? DeserializeWithNsj(string json)
+            => JsonConvert.DeserializeObject<NsjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        private static VersionInfo? DeserializeWithStj(string json)
+            => StjSerializer.Deserialize<StjWrapper>($"{{\"v\":{json}}}")!.Value;
+
+        [Theory]
+        [InlineData("""{"version":"1.0.0","downloads":12345}""", "1.0.0", 12345L)]
+        [InlineData("""{"version":"2.0.0-beta"}""", "2.0.0-beta", null)]
+        [InlineData("""{"version":"1.0.0","downloads":null}""", "1.0.0", null)]
+        [InlineData("""{"version":"1.0.0","extra":"ignored","downloads":5}""", "1.0.0", 5L)]
+        public void Read_ValidObject_Succeeds(string json, string expectedVersion, long? expectedDownloads)
+        {
+            // Arrange
+            var expected = new VersionInfo(NuGetVersion.Parse(expectedVersion), expectedDownloads);
+
+            // Act
+            var stjResult = DeserializeWithStj(json);
+            var nsjResult = DeserializeWithNsj(json);
+
+            // Assert
+            stjResult.Should().BeEquivalentTo(expected);
+            nsjResult.Should().BeEquivalentTo(stjResult);
+        }
+
+        [Theory]
+        [InlineData("""{"downloads":100}""")]
+        [InlineData("""{"version":""}""")]
+        [InlineData("""{"VERSION":"1.0.0","downloads":100}""")]
+        [InlineData("null")]
+        [InlineData("\"1.0.0\"")]
+        [InlineData("42")]
+        public void Read_InvalidInput_Throws(string json)
+        {
+            // Act
+            var stjAct = () => DeserializeWithStj(json);
+            var nsjAct = () => DeserializeWithNsj(json);
+
+            // Assert
+            stjAct.Should().Throw<System.Text.Json.JsonException>();
+            nsjAct.Should().Throw<System.Exception>();
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14882

## Description

 This is a focused slice of https://github.com/NuGet/NuGet.Client/pull/7301, split per-converter to make reviewing easier.

  Converters are being migrated first so that the upcoming Registration resource migrations don't become bloated PRs.

  `VersionInfoStjConverter` deserializes `VersionInfo` objects from JSON by reading version (required) and downloads (optional) properties maintaining full behavioral parity with the NSJ `VersionInfoConverter`. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
