### PR TITLE
Simplify ProjectFileUtils.AddItem overloads

### DIFF
--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/RestoreCommandTests.cs
@@ -1372,7 +1372,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
                                 name: "NuGetAuditSuppress",
                                 identity: advisoryUrl1,
                                 framework: NuGetFramework.AnyFramework,
-                                properties: new Dictionary<string, string>(),
                                 attributes: new Dictionary<string, string>());
             xmlA.Save(projectA.ProjectPath);
 
@@ -1383,7 +1382,6 @@ namespace NuGet.CommandLine.FuncTest.Commands
                                 name: "NuGetAuditSuppress",
                                 identity: advisoryUrl2,
                                 framework: NuGetFramework.AnyFramework,
-                                properties: new Dictionary<string, string>(),
                                 attributes: new Dictionary<string, string>());
             xmlB.Save(projectB.ProjectPath);
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -3654,7 +3654,6 @@ EndProject";
                                 name: "NuGetAuditSuppress",
                                 identity: advisoryUrl1,
                                 framework: NuGetFramework.AnyFramework,
-                                properties: new Dictionary<string, string>(),
                                 attributes: new Dictionary<string, string>());
             xmlA.Save(projectA.ProjectPath);
 
@@ -3665,7 +3664,6 @@ EndProject";
                                 name: "NuGetAuditSuppress",
                                 identity: advisoryUrl2,
                                 framework: NuGetFramework.AnyFramework,
-                                properties: new Dictionary<string, string>(),
                                 attributes: new Dictionary<string, string>());
             xmlB.Save(projectB.ProjectPath);
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -59,14 +59,12 @@ namespace NuGet.CommandLine.Test
                 ProjectFileUtils.AddItem(doc,
                     "PackageReference", "z",
                     NuGetFramework.Parse("netcoreapp1.0"),
-                    new Dictionary<string, string>(),
                     new Dictionary<string, string>() { { "Version", "1.*" } });
 
                 // x *
                 ProjectFileUtils.AddItem(doc,
                     "PackageReference", "x",
                     NuGetFramework.Parse("netcoreapp1.0"),
-                    new Dictionary<string, string>(),
                     new Dictionary<string, string>() { { "Version", "*" } });
 
                 doc.Save(projectA.ProjectPath);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -6598,7 +6598,7 @@ namespace NuGet.CommandLine.Test
                                     xml,
                                     "PackageDownload",
                                     packageX1.Id,
-                                    NuGetFramework.AnyFramework,
+                                    string.Empty,
                                     props,
                                     attributes);
 
@@ -6795,7 +6795,7 @@ namespace NuGet.CommandLine.Test
                                     xml,
                                     "PackageDownload",
                                     packageX1.Id,
-                                    NuGetFramework.AnyFramework,
+                                    string.Empty,
                                     props,
                                     attributes);
 
@@ -7092,7 +7092,7 @@ namespace NuGet.CommandLine.Test
                                     xml,
                                     "FrameworkReference",
                                     "FrameworkRefY",
-                                    NuGetFramework.AnyFramework,
+                                    string.Empty,
                                     props,
                                     attributes);
 
@@ -7175,7 +7175,7 @@ namespace NuGet.CommandLine.Test
                                     xml,
                                     "FrameworkReference",
                                     "FrameworkRefY",
-                                    NuGetFramework.AnyFramework,
+                                    string.Empty,
                                     props,
                                     attributes);
                 attributes.Add("PrivateAssets", "all");
@@ -7183,7 +7183,7 @@ namespace NuGet.CommandLine.Test
                                     xml,
                                     "FrameworkReference",
                                     "FrameworkRefSupressed",
-                                    NuGetFramework.AnyFramework,
+                                    string.Empty,
                                     props,
                                     attributes);
 
@@ -10977,7 +10977,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                                     xml,
                                     item,
                                     "X",
-                                    NuGetFramework.AnyFramework,
+                                    string.Empty,
                                     new Dictionary<string, string>(),
                                     attributes);
 
@@ -10987,7 +10987,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                                     xml,
                                     item,
                                     "X",
-                                    NuGetFramework.AnyFramework,
+                                    string.Empty,
                                     new Dictionary<string, string>(),
                                     attributes);
                 xml.Save(projectA.ProjectPath);
@@ -11045,7 +11045,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                                     xml,
                                     "PackageReference",
                                     "X",
-                                    NuGetFramework.AnyFramework,
+                                    string.Empty,
                                     new Dictionary<string, string>(),
                                     new Dictionary<string, string>());
                 xml.Save(projectA.ProjectPath);
@@ -11268,7 +11268,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                     xml,
                     "PackageReference",
                     "D",
-                    NuGetFramework.AnyFramework,
+                    string.Empty,
                     new Dictionary<string, string>(),
                     new Dictionary<string, string>());
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -116,21 +116,7 @@ EndGlobal";
 
                 _dotnetFixture.CreateDotnetNewProject(pathContext.SolutionRoot, projectName, "classlib -f netstandard2.0", testOutputHelper: _testOutputHelper);
 
-                using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
-                {
-                    var xml = XDocument.Load(stream);
-
-                    var attributes = new Dictionary<string, string>() { { "Version", "1.0.0" } };
-
-                    ProjectFileUtils.AddItem(
-                        xml,
-                        "PackageReference",
-                        "TestPackage.AuthorSigned",
-                        string.Empty,
-                        attributes);
-
-                    ProjectFileUtils.WriteXmlToFile(xml, stream);
-                }
+                ProjectFileUtils.AddItem(projectFile, "PackageReference", "TestPackage.AuthorSigned", string.Empty, new Dictionary<string, string>() { { "Version", "1.0.0" } });
 
                 _dotnetFixture.RestoreProjectExpectSuccess(workingDirectory, projectName, testOutputHelper: _testOutputHelper);
             }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -127,7 +127,6 @@ EndGlobal";
                         "PackageReference",
                         "TestPackage.AuthorSigned",
                         string.Empty,
-                        new Dictionary<string, string>(),
                         attributes);
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -3241,7 +3241,7 @@ namespace ClassLibrary
                         xml,
                         itemType,
                         "abc.png",
-                        NuGetFramework.AnyFramework,
+                        string.Empty,
                         properties,
                         attributes);
 
@@ -4347,7 +4347,7 @@ namespace ClassLibrary
                         xml,
                         "None",
                         licenseFileName,
-                        NuGetFramework.AnyFramework,
+                        string.Empty,
                         properties,
                         attributes);
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
@@ -4449,7 +4449,7 @@ namespace ClassLibrary
                         xml,
                         "None",
                         realLicenseFileName,
-                        NuGetFramework.AnyFramework,
+                        string.Empty,
                         properties,
                         attributes);
 
@@ -4608,7 +4608,7 @@ namespace ClassLibrary
                         xml,
                         "None",
                         licenseFileName,
-                        NuGetFramework.AnyFramework,
+                        string.Empty,
                         properties,
                         attributes);
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
@@ -4692,7 +4692,7 @@ namespace ClassLibrary
                         xml,
                         "None",
                         licenseFileName,
-                        NuGetFramework.AnyFramework,
+                        string.Empty,
                         properties,
                         attributes);
                     ProjectFileUtils.WriteXmlToFile(xml, stream);

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -1779,7 +1779,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                                 name: "NuGetAuditSuppress",
                                 identity: advisoryUrl1,
                                 framework: NuGetFramework.AnyFramework,
-                                properties: new Dictionary<string, string>(),
                                 attributes: new Dictionary<string, string>());
             xmlA.Save(projectA.ProjectPath);
 
@@ -1790,7 +1789,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                                 name: "NuGetAuditSuppress",
                                 identity: advisoryUrl2,
                                 framework: NuGetFramework.AnyFramework,
-                                properties: new Dictionary<string, string>(),
                                 attributes: new Dictionary<string, string>());
             xmlB.Save(projectB.ProjectPath);
 

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
@@ -74,6 +74,29 @@ namespace NuGet.Test.Utility
         }
 
         /// <summary>
+        /// Opens a project file, adds an MSBuild item, and writes it back.
+        /// </summary>
+        /// <param name="projectFilePath">The full path to the project file.</param>
+        /// <param name="name">The MSBuild item type (e.g. <c>PackageReference</c>).</param>
+        /// <param name="identity">The value of the <c>Include</c> attribute on the item element.</param>
+        /// <param name="framework">
+        /// The short TFM string used to generate a per-TFM condition on the <c>ItemGroup</c>.
+        /// Pass an empty string to emit the item unconditionally.
+        /// </param>
+        /// <param name="attributes">XML attributes to add on the item element itself (e.g. <c>Version="1.0.0"</c>).</param>
+        public static void AddItem(string projectFilePath,
+            string name,
+            string identity,
+            string framework,
+            Dictionary<string, string> attributes)
+        {
+            using var stream = File.Open(projectFilePath, FileMode.Open, FileAccess.ReadWrite);
+            var xml = XDocument.Load(stream);
+            AddItem(xml, name, identity, framework, attributes);
+            WriteXmlToFile(xml, stream);
+        }
+
+        /// <summary>
         /// Adds a new MSBuild item to the project file inside a new <c>ItemGroup</c>.
         /// When <paramref name="framework"/> is a specific framework, a <c>Condition</c> attribute of the form
         /// <c>'$(TargetFramework)' == '&lt;tfm&gt;'</c> is added to the <c>ItemGroup</c>; otherwise no condition is emitted.

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
@@ -73,6 +73,28 @@ namespace NuGet.Test.Utility
             return StringComparer.OrdinalIgnoreCase.Equals(MSBuildStringUtility.TrimAndGetNullForEmpty(condition), elementCondition);
         }
 
+        /// <summary>
+        /// Adds a new MSBuild item to the project file inside a new <c>ItemGroup</c>.
+        /// When <paramref name="framework"/> is a specific framework, a <c>Condition</c> attribute of the form
+        /// <c>'$(TargetFramework)' == '&lt;tfm&gt;'</c> is added to the <c>ItemGroup</c>; otherwise no condition is emitted.
+        /// Scenarios:
+        /// <list type="bullet">
+        ///     <item>Adding a <c>PackageReference</c> item</item>
+        ///     <item>Adding a <c>PackageVersion</c> item</item>
+        ///     <item>Adding a <c>FrameworkReference</c> item</item>
+        ///     <item>Adding a <c>NuGetAuditSuppress</c> item</item>
+        ///     <item>Adding a <c>PrunePackageReference</c> item</item>
+        /// </list>
+        /// </summary>
+        /// <param name="doc">The project XML document to modify.</param>
+        /// <param name="name">The MSBuild item type (e.g. <c>PackageReference</c>, <c>FrameworkReference</c>).</param>
+        /// <param name="identity">The value of the <c>Include</c> attribute on the item element.</param>
+        /// <param name="framework">
+        /// The target framework used to generate a per-TFM condition on the <c>ItemGroup</c>.
+        /// Pass <see cref="NuGetFramework.AnyFramework"/> (or any non-specific framework) to emit the item unconditionally.
+        /// </param>
+        /// <param name="properties">Child XML elements to add under the item element (e.g. <c>&lt;Version&gt;1.0.0&lt;/Version&gt;</c>).</param>
+        /// <param name="attributes">XML attributes to add on the item element itself (e.g. <c>Version="1.0.0"</c>).</param>
         public static void AddItem(XDocument doc,
             string name,
             string identity,
@@ -84,6 +106,64 @@ namespace NuGet.Test.Utility
                 framework?.IsSpecificFramework == true ? framework.GetShortFolderName() : string.Empty, properties, attributes);
         }
 
+        /// <summary>
+        /// Adds a new MSBuild item to the project file inside a new <c>ItemGroup</c>.
+        /// When <paramref name="framework"/> is a non-empty string, a <c>Condition</c> attribute of the form
+        /// <c>'$(TargetFramework)' == '&lt;tfm&gt;'</c> is added to the <c>ItemGroup</c>; pass an empty string to emit the item unconditionally.
+        /// Item metadata is expressed as XML attributes on the item element. For most scenarios this overload is preferred over
+        /// the one that accepts both <c>properties</c> and <c>attributes</c>.
+        /// Scenarios:
+        /// <list type="bullet">
+        ///     <item>Adding a <c>PackageReference</c> item</item>
+        ///     <item>Adding a <c>PackageVersion</c> item</item>
+        ///     <item>Adding a <c>FrameworkReference</c> item</item>
+        ///     <item>Adding a <c>NuGetAuditSuppress</c> item</item>
+        ///     <item>Adding a <c>PrunePackageReference</c> item</item>
+        /// </list>
+        /// </summary>
+        /// <param name="doc">The project XML document to modify.</param>
+        /// <param name="name">The MSBuild item type (e.g. <c>PackageReference</c>, <c>FrameworkReference</c>).</param>
+        /// <param name="identity">The value of the <c>Include</c> attribute on the item element.</param>
+        /// <param name="framework">
+        /// The short TFM string used to generate a per-TFM condition on the <c>ItemGroup</c> (e.g. <c>"net8.0"</c>).
+        /// Pass an empty string to emit the item unconditionally.
+        /// </param>
+        /// <param name="attributes">XML attributes to add on the item element itself (e.g. <c>Version="1.0.0"</c>).</param>
+        public static void AddItem(XDocument doc,
+           string name,
+           string identity,
+           string framework,
+           Dictionary<string, string> attributes)
+        {
+            AddItem(doc, name, identity, framework, properties: [], attributes);
+        }
+
+        /// <summary>
+        /// Adds a new MSBuild item to the project file inside a new <c>ItemGroup</c>.
+        /// When <paramref name="framework"/> is a non-empty string, a <c>Condition</c> attribute of the form
+        /// <c>'$(TargetFramework)' == '&lt;tfm&gt;'</c> is added to the <c>ItemGroup</c>; pass an empty string to emit the item unconditionally.
+        /// This overload accepts both <paramref name="attributes"/> (written as XML attributes on the item element) and
+        /// <paramref name="properties"/> (written as child XML elements). While MSBuild evaluates both equivalently as item metadata,
+        /// prefer the overload that only takes <paramref name="attributes"/> for new call sites — it is more concise and matches
+        /// the SDK-style project convention of expressing metadata as attributes.
+        /// Use this overload only when a caller must distinguish between attribute-style and element-style metadata.
+        /// <list type="bullet">
+        ///     <item>Adding a <c>PackageReference</c> item</item>
+        ///     <item>Adding a <c>PackageVersion</c> item</item>
+        ///     <item>Adding a <c>FrameworkReference</c> item</item>
+        ///     <item>Adding a <c>NuGetAuditSuppress</c> item</item>
+        ///     <item>Adding a <c>PrunePackageReference</c> item</item>
+        /// </list>
+        /// </summary>
+        /// <param name="doc">The project XML document to modify.</param>
+        /// <param name="name">The MSBuild item type (e.g. <c>PackageReference</c>, <c>FrameworkReference</c>).</param>
+        /// <param name="identity">The value of the <c>Include</c> attribute on the item element.</param>
+        /// <param name="framework">
+        /// The short TFM string used to generate a per-TFM condition on the <c>ItemGroup</c> (e.g. <c>"net8.0"</c>).
+        /// Pass an empty string to emit the item unconditionally.
+        /// </param>
+        /// <param name="properties">Child XML elements to add under the item element (e.g. <c>&lt;Version&gt;1.0.0&lt;/Version&gt;</c>).</param>
+        /// <param name="attributes">XML attributes to add on the item element itself (e.g. <c>Version="1.0.0"</c>).</param>
         public static void AddItem(XDocument doc,
             string name,
             string identity,

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
@@ -93,17 +93,15 @@ namespace NuGet.Test.Utility
         /// The target framework used to generate a per-TFM condition on the <c>ItemGroup</c>.
         /// Pass <see cref="NuGetFramework.AnyFramework"/> (or any non-specific framework) to emit the item unconditionally.
         /// </param>
-        /// <param name="properties">Child XML elements to add under the item element (e.g. <c>&lt;Version&gt;1.0.0&lt;/Version&gt;</c>).</param>
         /// <param name="attributes">XML attributes to add on the item element itself (e.g. <c>Version="1.0.0"</c>).</param>
         public static void AddItem(XDocument doc,
             string name,
             string identity,
             NuGetFramework framework,
-            Dictionary<string, string> properties,
             Dictionary<string, string> attributes)
         {
             AddItem(doc, name, identity,
-                framework?.IsSpecificFramework == true ? framework.GetShortFolderName() : string.Empty, properties, attributes);
+                framework?.IsSpecificFramework == true ? framework.GetShortFolderName() : string.Empty, attributes);
         }
 
         /// <summary>

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
@@ -75,6 +75,8 @@ namespace NuGet.Test.Utility
 
         /// <summary>
         /// Opens a project file, adds an MSBuild item, and writes it back.
+        /// This is the simplest method for adding an item to a project file, but it is not the most efficient if you need to add multiple items since it opens and writes the file for each item added.
+        /// Prefer this method whenever there you only need to do 1 item change.
         /// </summary>
         /// <param name="projectFilePath">The full path to the project file.</param>
         /// <param name="name">The MSBuild item type (e.g. <c>PackageReference</c>).</param>

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -633,7 +633,7 @@ namespace NuGet.Test.Utility
                             xml,
                             "PackageReference",
                             package.Id,
-                            referenceFramework,
+                            referenceFramework?.IsSpecificFramework == true ? referenceFramework.GetShortFolderName() : string.Empty,
                             props,
                             attributes);
                     }
@@ -663,7 +663,7 @@ namespace NuGet.Test.Utility
                             xml,
                             "PackageDownload",
                             package.Id,
-                            referenceFramework,
+                            referenceFramework?.IsSpecificFramework == true ? referenceFramework.GetShortFolderName() : string.Empty,
                             props,
                             attributes);
                     }
@@ -710,7 +710,7 @@ namespace NuGet.Test.Utility
                             xml,
                             "ProjectReference",
                             $"{project.ProjectPath}",
-                            referenceFramework,
+                            referenceFramework?.IsSpecificFramework == true ? referenceFramework.GetShortFolderName() : string.Empty,
                             props,
                             new Dictionary<string, string>());
                     }
@@ -735,7 +735,7 @@ namespace NuGet.Test.Utility
                         xml,
                         "DotNetCliToolReference",
                         $"{tool.Id}",
-                        NuGetFramework.AnyFramework,
+                        string.Empty,
                         props,
                         attributes);
                 }
@@ -770,7 +770,7 @@ namespace NuGet.Test.Utility
                         xml,
                         "ProjectReference",
                         $"{project.ProjectPath}",
-                        NuGetFramework.AnyFramework,
+                        string.Empty,
                         props,
                         new Dictionary<string, string>());
                 }


### PR DESCRIPTION
# Bug

<!-- Engineering/test change only - no issue required. -->

## Description

Simplifies `ProjectFileUtils.AddItem` overloads and updates callers:

- Removes the `properties` parameter from the `NuGetFramework` overload, since all callers passed an empty dictionary. Callers that need element-style metadata use the `string framework` overload instead.
- Adds a new file-based `AddItem` overload that takes a project file path, handles open/load/write internally, reducing boilerplate at call sites.

The goal of this change is to enable PRs like https://github.com/NuGet/NuGet.Client/commit/6250b357fafa46692b85a58b2b7071518b0a97b4 to be much much much simpler. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.