### PR TITLE
Get override paths via global properties in static restore

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyProjectAdapter.cs
@@ -35,6 +35,10 @@ internal class LegacyProjectAdapter : IProject
 
     public IReadOnlyDictionary<string, ITargetFramework> TargetFrameworks { get; }
 
+    // LegacyProjectAdapter is used only in Visual Studio, where global properties
+    // (command line arguments like /p:Property=Value) are not applicable.
+    public string? GetGlobalProperty(string propertyName) => null;
+
     private class TargetFrameworkAdapter : ITargetFramework
     {
         private readonly IVsProjectAdapter _projectAdapter;

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildProjectInstance.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildProjectInstance.cs
@@ -55,14 +55,16 @@ namespace NuGet.Build.Tasks.Console
 
         public string GetGlobalProperty(string property)
         {
-            string value = GetPropertyValue(property).Trim();
-
-            if (string.IsNullOrWhiteSpace(value))
+            if (_projectInstance.GlobalProperties.TryGetValue(property, out string value))
             {
-                return null;
+                string trimmed = value?.Trim();
+                if (!string.IsNullOrWhiteSpace(trimmed))
+                {
+                    return trimmed;
+                }
             }
 
-            return value;
+            return null;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -801,7 +801,7 @@ namespace NuGet.Build.Tasks.Console
                     binaryLoggerParameters,
                     createProjectFactory: static (string projectPath, (ProjectInstance projectInstance, string targetFramework) args) =>
                     {
-                        var adapter = new RestoreProjectAdapter(args.projectInstance.FullPath);
+                        var adapter = new RestoreProjectAdapter(args.projectInstance.FullPath, args.projectInstance.GlobalProperties);
                         adapter.AddTargetFramework(args.targetFramework, new TargetFrameworkAdapter(args.projectInstance));
                         return adapter;
                     },

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/RestoreProjectAdapter.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/RestoreProjectAdapter.cs
@@ -13,11 +13,12 @@ namespace NuGet.Build.Tasks.Console
 {
     internal class RestoreProjectAdapter : IProject
     {
-        public RestoreProjectAdapter(string fullPath)
+        public RestoreProjectAdapter(string fullPath, IDictionary<string, string> globalProperties)
         {
             FullPath = fullPath ?? throw new ArgumentNullException(nameof(fullPath));
             Directory = Path.GetDirectoryName(fullPath) ?? throw new ArgumentNullException(nameof(fullPath));
 
+            _globalProperties = globalProperties;
             _targetFrameworks = new(StringComparer.OrdinalIgnoreCase);
         }
 
@@ -28,6 +29,8 @@ namespace NuGet.Build.Tasks.Console
         public ITargetFramework OuterBuild { get; private set; }
 
         public IReadOnlyDictionary<string, ITargetFramework> TargetFrameworks => _targetFrameworks;
+
+        private readonly IDictionary<string, string> _globalProperties;
 
         private ConcurrentDictionary<string, ITargetFramework> _targetFrameworks;
 
@@ -50,6 +53,20 @@ namespace NuGet.Build.Tasks.Console
                 var targetFramework = OuterBuild.GetProperty("TargetFramework") ?? string.Empty;
                 _targetFrameworks.TryAdd(targetFramework, OuterBuild);
             }
+        }
+
+        public string GetGlobalProperty(string propertyName)
+        {
+            if (_globalProperties.TryGetValue(propertyName, out string value))
+            {
+                string trimmed = value?.Trim();
+                if (!string.IsNullOrWhiteSpace(trimmed))
+                {
+                    return trimmed;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
 const NuGet.Commands.Restore.Utility.PackageSpecFactory.EnvironmentVariableName = "NUGET_USE_NEW_PACKAGESPEC_FACTORY" -> string!
+NuGet.Commands.Restore.IProject.GetGlobalProperty(string! propertyName) -> string?

--- a/src/NuGet.Core/NuGet.Commands/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Commands/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
 const NuGet.Commands.Restore.Utility.PackageSpecFactory.EnvironmentVariableName = "NUGET_USE_NEW_PACKAGESPEC_FACTORY" -> string!
+NuGet.Commands.Restore.IProject.GetGlobalProperty(string! propertyName) -> string?

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/IProject.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/IProject.cs
@@ -28,5 +28,14 @@ namespace NuGet.Commands.Restore
         /// The inner build  <see langword="null"/>
         /// </summary>
         public IReadOnlyDictionary<string, ITargetFramework> TargetFrameworks { get; }
+
+        /// <summary>
+        /// Get the value for a global property in the project.
+        /// Global properties represent values set via command line arguments (e.g. /p:Property=Value),
+        /// which take highest priority over properties defined in the project file.
+        /// </summary>
+        /// <param name="propertyName">The name of the global property.</param>
+        /// <returns>The value of the requested global property, or <see langword="null"/> if the property was not set as a global property.</returns>
+        string? GetGlobalProperty(string propertyName);
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
@@ -155,7 +155,7 @@ namespace NuGet.Commands.Restore.Utility
                         outerBuild.GetProperty("MSBuildStartupDirectory"),
                         project.Directory,
                         SplitPropertyValueOrNull(outerBuild, "RestoreFallbackFolders"),
-                        SplitPropertyValueOrNull(outerBuild, "RestoreFallbackFolders"),
+                        project.SplitGlobalPropertyValueOrNull("RestoreFallbackFolders"),
                         project.TargetFrameworks.Values.SelectMany(i => MSBuildStringUtility.Split(i.GetProperty("RestoreAdditionalProjectFallbackFolders"))),
                         project.TargetFrameworks.Values.SelectMany(i => MSBuildStringUtility.Split(i.GetProperty("RestoreAdditionalProjectFallbackFoldersExcludes"))),
                         settings),
@@ -448,7 +448,7 @@ namespace NuGet.Commands.Restore.Utility
         internal static string GetPackagesPath(IProject project, ISettings settings)
         {
             var packagesPath = GetValue(
-                () => UriUtility.GetAbsolutePath(project.Directory, project.OuterBuild.GetProperty("RestorePackagesPath")),
+                () => UriUtility.GetAbsolutePath(project.Directory, project.GetGlobalProperty("RestorePackagesPath")),
                 () => UriUtility.GetAbsolutePath(project.Directory, project.OuterBuild.GetProperty("RestorePackagesPath")),
                 () => SettingsUtility.GetGlobalPackagesFolder(settings));
 
@@ -782,7 +782,7 @@ namespace NuGet.Commands.Restore.Utility
         private static string GetRepositoryPath(IProject project, ISettings settings)
         {
             var path = GetValue(
-                () => UriUtility.GetAbsolutePath(project.Directory, project.OuterBuild.GetProperty("RestoreRepositoryPath")),
+                () => UriUtility.GetAbsolutePath(project.Directory, project.GetGlobalProperty("RestoreRepositoryPath")),
                 () => UriUtility.GetAbsolutePath(project.Directory, project.OuterBuild.GetProperty("RestoreRepositoryPath")),
                 () => SettingsUtility.GetRepositoryPath(settings),
                 () =>
@@ -831,10 +831,10 @@ namespace NuGet.Commands.Restore.Utility
         internal static List<PackageSource> GetSources(IProject project, ISettings settings)
         {
             return GetSources(
-                project.OuterBuild.GetProperty("OriginalMSBuildStartupDirectory"),
+                project.GetGlobalProperty("OriginalMSBuildStartupDirectory"),
                 project.Directory,
                 project.OuterBuild.SplitPropertyValueOrNull("RestoreSources"),
-                project.OuterBuild.SplitPropertyValueOrNull("RestoreSources"),
+                project.SplitGlobalPropertyValueOrNull("RestoreSources"),
                 project.TargetFrameworks.Values.SelectMany(i => MSBuildStringUtility.Split(i.GetProperty("RestoreAdditionalProjectSources"))),
                 settings)
                 .Select(i => new PackageSource(i))
@@ -969,6 +969,19 @@ namespace NuGet.Commands.Restore.Utility
         private static string[]? SplitPropertyValueOrNull(this ITargetFramework project, string name)
         {
             string? value = project.GetProperty(name);
+
+            return value is null ? null : MSBuildStringUtility.Split(value);
+        }
+
+        /// <summary>
+        /// Splits the value of the specified global property and returns an array if the property has a value, otherwise returns <code>null</code>.
+        /// </summary>
+        /// <param name="project">The <see cref="IProject" /> to get the global property value from.</param>
+        /// <param name="name">The name of the global property to get the value of and split.</param>
+        /// <returns>A <see cref="T:string[]" /> containing the split value of the global property if it had a value, otherwise <code>null</code>.</returns>
+        private static string[]? SplitGlobalPropertyValueOrNull(this IProject project, string name)
+        {
+            string? value = project.GetGlobalProperty(name);
 
             return value is null ? null : MSBuildStringUtility.Split(value);
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -4218,5 +4218,74 @@ EndGlobal";
                 Assert.Equal(related, item.Properties["related"]);
             }
         }
+
+        [Theory]
+        [InlineData(false, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(true, true, false)]
+        [InlineData(true, true, true)]
+        public async Task DotnetRestore_GlobalPropertyRestoreSources_OverridesProjectProperty(bool useGlobalProperty, bool useStaticGraphRestore, bool usePackageSpecFactory)
+        {
+            // Arrange
+            using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
+
+            const string packageId = "TestPackage";
+            var package100 = new SimpleTestPackageContext(packageId, "1.0.0");
+            var package200 = new SimpleTestPackageContext(packageId, "2.0.0");
+
+            // Create two source directories with different versions
+            var source1 = Path.Combine(pathContext.WorkingDirectory, "source1");
+            var source2 = Path.Combine(pathContext.WorkingDirectory, "source2");
+            Directory.CreateDirectory(source1);
+            Directory.CreateDirectory(source2);
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(source1, PackageSaveMode.Defaultv3, package100);
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(source2, PackageSaveMode.Defaultv3, package200);
+
+            // Create project with a floating version PackageReference, and RestoreSources pointing to source1 (which has v1.0.0)
+            var projectA = SimpleTestProjectContext.CreateNETCore(
+                "projectA",
+                pathContext.SolutionRoot,
+                NuGetFramework.Parse("net8.0"));
+
+            var packageRef = new SimpleTestPackageContext(packageId, "1.0.0");
+            packageRef.Version = "*";
+            projectA.AddPackageToAllFrameworks(packageRef);
+            projectA.Properties.Add("RestoreSources", "../../source1");
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            solution.Projects.Add(projectA);
+            solution.Create();
+
+            var environmentVariables = new Dictionary<string, string>
+            {
+                { PackageSpecFactory.EnvironmentVariableName, usePackageSpecFactory.ToString() }
+            };
+
+            // Build restore arguments
+            string arguments = $"restore projectA{Path.DirectorySeparatorChar}projectA.csproj";
+            if (useStaticGraphRestore)
+            {
+                arguments += " /p:RestoreUseStaticGraphEvaluation=true";
+            }
+            if (useGlobalProperty)
+            {
+                arguments += " /p:RestoreSources=../source2";
+            }
+
+            // Act
+            _dotnetFixture.RunDotnetExpectSuccess(
+                pathContext.SolutionRoot,
+                arguments,
+                environmentVariables,
+                testOutputHelper: _testOutputHelper);
+
+            // Assert - check which version was extracted into the global packages folder
+            string expectedVersion = useGlobalProperty ? "2.0.0" : "1.0.0";
+            var packageDirectory = Path.Combine(pathContext.UserPackagesFolder, packageId.ToLowerInvariant(), expectedVersion);
+            Directory.Exists(packageDirectory).Should().BeTrue($"expected {packageId} {expectedVersion} to be in the global packages folder");
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -4226,7 +4226,7 @@ EndGlobal";
         [InlineData(true, false, false)]
         [InlineData(true, true, false)]
         [InlineData(true, true, true)]
-        public async Task DotnetRestore_GlobalPropertyRestoreSources_OverridesProjectProperty(bool useGlobalProperty, bool useStaticGraphRestore, bool usePackageSpecFactory)
+        public async Task DotnetRestore_RestoreSourcesWithRelativePaths_ResolvedCorrectPath(bool useGlobalProperty, bool useStaticGraphRestore, bool usePackageSpecFactory)
         {
             // Arrange
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();

--- a/test/TestUtilities/Test.Utility/TestPackageSpecFactory.cs
+++ b/test/TestUtilities/Test.Utility/TestPackageSpecFactory.cs
@@ -370,6 +370,16 @@ public class TestPackageSpecFactory
         public required string Directory { get; init; }
         public required ITargetFramework OuterBuild { get; init; }
         public required IReadOnlyDictionary<string, ITargetFramework> TargetFrameworks { get; init; }
+        public Dictionary<string, string>? GlobalProperties { get; init; }
+
+        public string? GetGlobalProperty(string propertyName)
+        {
+            if (GlobalProperties is not null && GlobalProperties.TryGetValue(propertyName, out var value))
+            {
+                return value;
+            }
+            return null;
+        }
     }
 
     internal record TestTargetFramework : ITargetFramework


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14904

## Description

As per the linked issue, when a project file has a property `<RestoreSources>` with a relative path, normal restore would always resolve the relative path using the project directory as the base path, but static graph restore would use the process current working directory as the base path.

This was due to a bug in MSBuildProjectInstance, where `GetGlobalProperty` would incorrectly get the evaluated project properties, instead of the global properties.  Since PackageSpecFactory was a copy of static graph restore, it had the same bug, so both need to be fixed.

I validated the integration test fails without the change and passes with the change.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ Although there's a behavior change, it's aligning static graph restore with normal restore
