### PR TITLE
Fix formatting warning

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -941,26 +941,26 @@ namespace NuGet.Commands
             // Used when logging package id specific messages, we need to know the target graph name
             string targetGraphName = pair.Name;
 
-        // Used to start over when a dependency has multiple descendants of an item to be evicted.
-        //
-        // Project
-        // ├── A 1.0.0
-        // │   └── B 1.0.0
-        // │       └── C 1.0.0
-        // │           └── D 1.0.0
-        // └── X 2.0.0
-        //     └── Y 2.0.0
-        //         └── G 2.0.0
-        //             └── B 2.0.0
-        // The items are processed in the following order:
-        // Chose A 1.0.0 and X 1.0.0
-        // Chose B 1.0.0 and Y 2.0.0
-        // Chose C 1.0.0 and G 2.0.0
-        // Chose D 1.0.0 and B 2.0.0, but B 2.0.0 should evict C 1.0.0 and D 1.0.0
-        //
-        // In this case, the entire walk is started over and B 1.0.0 is left out of the graph, leading to C 1.0.0 and D 1.0.0 also being left out.
-        //
         StartOver:
+            // Used to start over when a dependency has multiple descendants of an item to be evicted.
+            //
+            // Project
+            // ├── A 1.0.0
+            // │   └── B 1.0.0
+            // │       └── C 1.0.0
+            // │           └── D 1.0.0
+            // └── X 2.0.0
+            //     └── Y 2.0.0
+            //         └── G 2.0.0
+            //             └── B 2.0.0
+            // The items are processed in the following order:
+            // Chose A 1.0.0 and X 1.0.0
+            // Chose B 1.0.0 and Y 2.0.0
+            // Chose C 1.0.0 and G 2.0.0
+            // Chose D 1.0.0 and B 2.0.0, but B 2.0.0 should evict C 1.0.0 and D 1.0.0
+            //
+            // In this case, the entire walk is started over and B 1.0.0 is left out of the graph, leading to C 1.0.0 and D 1.0.0 also being left out.
+            //
             restartCount++;
 
             dependencyGraphItemQueue.Clear();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: build warning

## Description

The .NET 10.0.200 SDK changed how the formatting validation works on goto labels. In 10.0.100 you would have comments at the reduced indentation level that the `label:` has, whereas 10.0.200 and later expects it to be at the indentation that other code is at.

By moving the comment under the label, both 10.0.100 and 10.0.200 expect the same indentation, so we no longer get warnings/errors in one but not the other.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
