### PR TITLE
Fix flaky PackageUpdateResource temp key test

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -24,6 +25,7 @@ namespace NuGet.Protocol.Tests
     {
         private const string ApiKeyHeader = "X-NuGet-ApiKey";
         private const string NuGetClientVersionHeader = "X-NuGet-Client-Version";
+        private const int TempApiKeyRequestTimeoutInSeconds = 10;
 
         [Fact]
         public async Task PackageUpdateResource_IncludesApiKeyWhenDeletingAsync()
@@ -275,10 +277,14 @@ namespace NuGet.Protocol.Tests
                         "https://www.nuget.org/api/v2/package/create-verification-key/test/1.0.0",
                         request =>
                         {
-                            var content = new TestContent(string.Format(JsonData.TempApiKeyJsonData, "tempkey"));
-                            var response = new HttpResponseMessage(HttpStatusCode.OK){
-                            Content = content
-};
+                            var content = new StringContent(
+                                string.Format(JsonData.TempApiKeyJsonData, "tempkey"),
+                                Encoding.UTF8,
+                                "application/json");
+                            var response = new HttpResponseMessage(HttpStatusCode.OK)
+                            {
+                                Content = content
+                            };
                             return Task.FromResult(response);
                         }
                     }
@@ -434,7 +440,7 @@ namespace NuGet.Protocol.Tests
                 await resource.Push(
                     packagePaths: new[] { packageInfo.FullName },
                     symbolSource: symbolSource,
-                    timeoutInSecond: 5,
+                    timeoutInSecond: TempApiKeyRequestTimeoutInSeconds,
                     disableBuffering: false,
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => apiKey,
@@ -492,10 +498,14 @@ namespace NuGet.Protocol.Tests
                         "https://www.nuget.org/api/v2/package/create-verification-key/test/1.0.0",
                         request =>
                         {
-                            var content = new TestContent(string.Format(JsonData.TempApiKeyJsonData, "tempkey"));
-                            var response = new HttpResponseMessage(HttpStatusCode.OK){
-                            Content = content
-};
+                            var content = new StringContent(
+                                string.Format(JsonData.TempApiKeyJsonData, "tempkey"),
+                                Encoding.UTF8,
+                                "application/json");
+                            var response = new HttpResponseMessage(HttpStatusCode.OK)
+                            {
+                                Content = content
+                            };
                             return Task.FromResult(response);
                         }
                     }
@@ -510,7 +520,7 @@ namespace NuGet.Protocol.Tests
                 await resource.Push(
                     packagePaths: new[] { packageInfo.FullName },
                     symbolSource: null,
-                    timeoutInSecond: 5,
+                    timeoutInSecond: TempApiKeyRequestTimeoutInSeconds,
                     disableBuffering: false,
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => null,
@@ -659,10 +669,14 @@ namespace NuGet.Protocol.Tests
                         "https://www.nuget.org/api/v2/package/create-verification-key/test/1.0.0",
                         request =>
                         {
-                            var content = new TestContent(string.Format(JsonData.TempApiKeyJsonData, "tempkey"));
-                            var response = new HttpResponseMessage(HttpStatusCode.OK){
-                            Content = content
-};
+                            var content = new StringContent(
+                                string.Format(JsonData.TempApiKeyJsonData, "tempkey"),
+                                Encoding.UTF8,
+                                "application/json");
+                            var response = new HttpResponseMessage(HttpStatusCode.OK)
+                            {
+                                Content = content
+                            };
                             return Task.FromResult(response);
                         }
                     }
@@ -677,7 +691,7 @@ namespace NuGet.Protocol.Tests
                 await resource.Push(
                     packagePaths: new[] { packageInfo.FullName },
                     symbolSource: null,
-                    timeoutInSecond: 5,
+                    timeoutInSecond: TempApiKeyRequestTimeoutInSeconds,
                     disableBuffering: false,
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => null,
@@ -747,7 +761,7 @@ namespace NuGet.Protocol.Tests
                     async () => await resource.Push(
                         packagePaths: new[] { packageInfo.FullName },
                         symbolSource: symbolSource,
-                        timeoutInSecond: 5,
+                        timeoutInSecond: TempApiKeyRequestTimeoutInSeconds,
                         disableBuffering: false,
                         getApiKey: _ => apiKey,
                         getSymbolApiKey: _ => apiKey,
@@ -792,15 +806,19 @@ namespace NuGet.Protocol.Tests
                     },
                     {
                         "https://www.nuget.org/api/v2/package/create-verification-key/test/1.0.0",
-                         request =>
-                         {
+                        request =>
+                        {
                             createKeyRequestCount++;
-                            var content = new TestContent(string.Format(JsonData.TempApiKeyJsonData, $"tempkey{createKeyRequestCount}"));
-                            var response = new HttpResponseMessage(HttpStatusCode.OK){
-                            Content = content
-};
+                            var content = new StringContent(
+                                string.Format(JsonData.TempApiKeyJsonData, $"tempkey{createKeyRequestCount}"),
+                                Encoding.UTF8,
+                                "application/json");
+                            var response = new HttpResponseMessage(HttpStatusCode.OK)
+                            {
+                                Content = content
+                            };
                             return Task.FromResult(response);
-                         }
+                        }
                     }
 
                 };
@@ -813,7 +831,7 @@ namespace NuGet.Protocol.Tests
                 await resource.Push(
                     packagePaths: new[] { symbolPackageInfo.FullName },
                     symbolSource: null,
-                    timeoutInSecond: 5,
+                    timeoutInSecond: TempApiKeyRequestTimeoutInSeconds,
                     disableBuffering: false,
                     getApiKey: _ => apiKey,
                     getSymbolApiKey: _ => null,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Resources/PackageUpdateResourceTests.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -276,7 +275,7 @@ namespace NuGet.Protocol.Tests
                         "https://www.nuget.org/api/v2/package/create-verification-key/test/1.0.0",
                         request =>
                         {
-                            var content = new StringContent(string.Format(JsonData.TempApiKeyJsonData,"tempkey"), Encoding.UTF8, "application/json");
+                            var content = new TestContent(string.Format(JsonData.TempApiKeyJsonData, "tempkey"));
                             var response = new HttpResponseMessage(HttpStatusCode.OK){
                             Content = content
 };
@@ -493,7 +492,7 @@ namespace NuGet.Protocol.Tests
                         "https://www.nuget.org/api/v2/package/create-verification-key/test/1.0.0",
                         request =>
                         {
-                            var content = new StringContent(string.Format(JsonData.TempApiKeyJsonData,"tempkey"), Encoding.UTF8, "application/json");
+                            var content = new TestContent(string.Format(JsonData.TempApiKeyJsonData, "tempkey"));
                             var response = new HttpResponseMessage(HttpStatusCode.OK){
                             Content = content
 };
@@ -660,7 +659,7 @@ namespace NuGet.Protocol.Tests
                         "https://www.nuget.org/api/v2/package/create-verification-key/test/1.0.0",
                         request =>
                         {
-                            var content = new StringContent(string.Format(JsonData.TempApiKeyJsonData, "tempkey"), Encoding.UTF8, "application/json");
+                            var content = new TestContent(string.Format(JsonData.TempApiKeyJsonData, "tempkey"));
                             var response = new HttpResponseMessage(HttpStatusCode.OK){
                             Content = content
 };
@@ -796,7 +795,7 @@ namespace NuGet.Protocol.Tests
                          request =>
                          {
                             createKeyRequestCount++;
-                            var content = new StringContent(string.Format(JsonData.TempApiKeyJsonData, $"tempkey{createKeyRequestCount}"), Encoding.UTF8, "application/json");
+                            var content = new TestContent(string.Format(JsonData.TempApiKeyJsonData, $"tempkey{createKeyRequestCount}"));
                             var response = new HttpResponseMessage(HttpStatusCode.OK){
                             Content = content
 };


### PR DESCRIPTION
# Bug

Fixes: N/A (engineering/test-only change)

## Description

This fixes flakiness in the temp verification key tests in `PackageUpdateResourceTests`.

The failing path was not limited to `PackageUpdateResource_NoSymbolSourcePushingSymbolAsync`. CI also failed in `PackageUpdateResource_PackageNotExistOnNuGetOrgPushingAsync`, and the failure stack was the same in both cases:

`PackageUpdateResource.GetSecureApiKey(...)` -> `HttpSource.GetJObjectAsync(...)` -> `DownloadTimeoutStream.ReadAsync(...)`

These tests all used a shared `timeoutInSecond: 5`, which was too aggressive for the mocked temp-key response path under CI jitter. This change introduces a dedicated test timeout constant (`TempApiKeyRequestTimeoutInSeconds = 10`) and uses it only for the temp-key scenarios, keeping the timeout bounded while removing incidental failures from the assertions these tests are actually making.

## PR Checklist

- [x] Meaningful title and helpful description; no linked NuGet/Home issue is needed for this engineering/test-only change
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.