### PR TITLE
Add Arcade post-build promotion stage

### DIFF
--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -334,3 +334,33 @@ steps:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_MULTILEVEL_LOOKUP: true
     condition: "and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false'))"
+
+  - task: PowerShell@1
+    displayName: "Create ReleaseConfigs artifact"
+    inputs:
+      scriptType: "inlineScript"
+      inlineScript: |
+        try {
+          if ([string]::IsNullOrWhiteSpace("$(BARBuildId)"))
+          {
+            throw "BARBuildId was not set by PublishToBuildAssetRegistry."
+          }
+
+          New-Item -ItemType Directory -Force -Path "$(Build.StagingDirectory)\ReleaseConfigs" | Out-Null
+          @(
+            "$(BARBuildId)"
+            "$(DefaultChannels)"
+            "$(IsStableBuild)"
+          ) | Set-Content -Path "$(Build.StagingDirectory)\ReleaseConfigs\ReleaseConfigs.txt"
+        } catch {
+          Write-Host "##vso[task.LogIssue type=error;]$_"
+          exit 1
+        }
+    condition: "and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false'))"
+
+  - template: /eng/common/templates-official/steps/publish-build-artifacts.yml
+    parameters:
+      displayName: "Publish ReleaseConfigs artifact"
+      pathToPublish: '$(Build.StagingDirectory)\ReleaseConfigs'
+      artifactName: 'ReleaseConfigs'
+      condition: "and(succeeded(),eq(variables['PublishArtifactsToDotNetBuildAssetRegistry'], 'true'), eq(variables['BuildRTM'], 'false'))"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -250,3 +250,14 @@ stages:
       parameters:
         BuildRTM: true
         SigningType: ${{ parameters.SigningType }}
+
+- ${{ if eq(parameters.isOfficialBuild, true) }}:
+  - template: /eng/common/templates-official/post-build/post-build.yml
+    parameters:
+      enableNugetValidation: false
+      enableSigningValidation: false
+      enableSourceLinkValidation: false
+      validateDependsOn:
+      - Build_Insertable
+      publishDependsOn:
+      - Build_Insertable


### PR DESCRIPTION
# Bug

Fixes: N/A (engineering change only)

## Description

Adds Arcade post-build promotion to the official pipeline by publishing the ReleaseConfigs handoff artifact after BAR registration and invoking the official post-build template after Build_Insertable with the extra asset validations disabled.

This may apply to 7.6.x and 7.3.x and 7.0.x, but only if it works :D 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
