### PR TITLE
Fix package type query parameter for V3 search, add capability check

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageSearchResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageSearchResourceV3Provider.cs
@@ -25,10 +25,11 @@ namespace NuGet.Protocol
             if (serviceIndex != null)
             {
                 var endpoints = serviceIndex.GetServiceEntryUris(ServiceTypes.SearchQueryService);
+                var packageTypeCapableEndpoints = serviceIndex.GetServiceEntryUris(ServiceTypes.SearchQueryService350);
                 var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
 
                 // construct a new resource
-                curResource = new PackageSearchResourceV3(httpSourceResource.HttpSource, endpoints);
+                curResource = new PackageSearchResourceV3(httpSourceResource.HttpSource, endpoints, packageTypeCapableEndpoints);
             }
 
             return new Tuple<bool, INuGetResource>(curResource != null, curResource);

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -24,18 +24,21 @@ namespace NuGet.Protocol
     {
         private readonly HttpSource _client;
         private readonly Uri[] _searchEndpoints;
+        private readonly HashSet<Uri> _packageTypeCapableEndpoints;
         private readonly IEnvironmentVariableReader _environmentVariableReader;
 
-        internal PackageSearchResourceV3(HttpSource client, IEnumerable<Uri> searchEndpoints)
-            : this(client, searchEndpoints, environmentVariableReader: null)
-        {
-        }
-
-        internal PackageSearchResourceV3(HttpSource client, IEnumerable<Uri> searchEndpoints, IEnvironmentVariableReader environmentVariableReader)
+        internal PackageSearchResourceV3(
+            HttpSource client,
+            IEnumerable<Uri> searchEndpoints,
+            IEnumerable<Uri> packageTypeCapableEndpoints = null,
+            IEnvironmentVariableReader environmentVariableReader = null)
             : base()
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _searchEndpoints = searchEndpoints?.ToArray() ?? throw new ArgumentNullException(nameof(searchEndpoints));
+            _packageTypeCapableEndpoints = packageTypeCapableEndpoints == null
+                ? null
+                : new HashSet<Uri>(packageTypeCapableEndpoints);
             _environmentVariableReader = environmentVariableReader;
         }
 
@@ -97,11 +100,32 @@ namespace NuGet.Protocol
                     Common.ILogger log,
                     CancellationToken cancellationToken)
         {
-            log.LogVerbose($"Found {_searchEndpoints.Length} search endpoints.");
+            var packageTypeFilterRequested = filters.PackageTypes != null && filters.PackageTypes.Any();
 
-            for (var i = 0; i < _searchEndpoints.Length; i++)
+            if (packageTypeFilterRequested)
             {
-                var endpoint = _searchEndpoints[i];
+                if (filters.PackageTypes.Count() > 1)
+                {
+                    throw new ArgumentException(Strings.Protocol_PackageTypeFilterMultipleNotSupported, nameof(filters));
+                }
+
+                if (_packageTypeCapableEndpoints == null || _packageTypeCapableEndpoints.Count == 0)
+                {
+                    throw new NotSupportedException(Strings.Protocol_PackageTypeFilterNotSupported);
+                }
+            }
+
+            // When package type filtering is requested, only iterate endpoints that advertise
+            // SearchQueryService/3.5.0. Otherwise, use the full set of search endpoints.
+            var endpoints = packageTypeFilterRequested
+                ? _packageTypeCapableEndpoints.ToArray()
+                : _searchEndpoints;
+
+            log.LogVerbose($"Found {endpoints.Length} search endpoints.");
+
+            for (var i = 0; i < endpoints.Length; i++)
+            {
+                var endpoint = endpoints[i];
 
                 // The search term comes in already encoded from VS
                 var queryUrl = new UriBuilder(endpoint.AbsoluteUri);
@@ -126,13 +150,11 @@ namespace NuGet.Protocol
                     queryString += "&" + frameworks;
                 }
 
-                if (filters.PackageTypes != null
-                    && filters.PackageTypes.Any())
+                if (packageTypeFilterRequested)
                 {
-                    var types = string.Join("&",
-                        filters.PackageTypes.Select(
-                            s => "packageTypeFilter=" + s));
-                    queryString += "&" + types;
+                    // SearchQueryService/3.5.0 specifies a single 'packageType' parameter.
+                    // Multi-value inputs are rejected above; here the collection has exactly one entry.
+                    queryString += "&packageType=" + filters.PackageTypes.First();
                 }
 
                 queryString += "&semVerLevel=2.0.0";
@@ -150,7 +172,7 @@ namespace NuGet.Protocol
                 {
                     throw;
                 }
-                catch when (i < _searchEndpoints.Length - 1)
+                catch when (i < endpoints.Length - 1)
                 {
                     // Ignore all failures until the last endpoint
                 }

--- a/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ServiceTypes.cs
@@ -16,11 +16,13 @@ namespace NuGet.Protocol
         public static readonly string Version490 = "/4.9.0";
         public static readonly string Version500 = "/5.0.0";
         public static readonly string Version510 = "/5.1.0";
+        internal const string Version350 = "/3.5.0";
         internal const string Version670 = "/6.7.0";
         internal const string Version6110 = "/6.11.0";
         internal const string Version6130 = "/6.13.0";
 
         public static readonly string[] SearchQueryService = { "SearchQueryService" + Versioned, "SearchQueryService" + Version340, "SearchQueryService" + Version300beta };
+        internal static readonly string[] SearchQueryService350 = { "SearchQueryService" + Version350 };
         public static readonly string[] RegistrationsBaseUrl = { $"RegistrationsBaseUrl{Versioned}", $"RegistrationsBaseUrl{Version360}", $"RegistrationsBaseUrl{Version340}", $"RegistrationsBaseUrl{Version300rc}", $"RegistrationsBaseUrl{Version300beta}", "RegistrationsBaseUrl" };
         public static readonly string[] SearchAutocompleteService = { "SearchAutocompleteService" + Versioned, "SearchAutocompleteService" + Version300beta };
         public static readonly string[] ReportAbuse = { "ReportAbuseUriTemplate" + Versioned, "ReportAbuseUriTemplate" + Version300 };

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -934,6 +934,24 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The source does not support filtering search results by package type..
+        /// </summary>
+        internal static string Protocol_PackageTypeFilterNotSupported {
+            get {
+                return ResourceManager.GetString("Protocol_PackageTypeFilterNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The source supports filtering by only one package type at a time..
+        /// </summary>
+        internal static string Protocol_PackageTypeFilterMultipleNotSupported {
+            get {
+                return ResourceManager.GetString("Protocol_PackageTypeFilterMultipleNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The path &apos;{0}&apos; for the selected source could not be resolved..
         /// </summary>
         internal static string Protocol_Search_LocalSourceNotFound {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -189,6 +189,12 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
   <data name="Protocol_MissingVersion" xml:space="preserve">
     <value>The source does not have the 'version' property.</value>
   </data>
+  <data name="Protocol_PackageTypeFilterNotSupported" xml:space="preserve">
+    <value>The source does not support filtering search results by package type.</value>
+  </data>
+  <data name="Protocol_PackageTypeFilterMultipleNotSupported" xml:space="preserve">
+    <value>The source supports filtering by only one package type at a time.</value>
+  </data>
   <data name="Protocol_PackageMetadataError" xml:space="preserve">
     <value>An error occurred while retrieving package metadata for '{0}' from source '{1}'.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.cs.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.cs.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">Při načítání metadat balíčku pro {0} ze zdroje {1} došlo k chybě.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">Cesta {0} pro vybraný prostředek se nedala přeložit.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.de.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.de.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">Fehler beim Abrufen von Paketmetadaten für "{0}" aus der Quelle "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">Der Pfad "{0}" für die ausgewählte Quelle konnte nicht aufgelöst werden.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.es.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.es.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">Error al recuperar los metadatos del paquete de "{0}" desde el origen "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">No se pudo resolver la ruta de acceso '{0}' del origen seleccionado.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.fr.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.fr.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">Une erreur s'est produite pendant la récupération des métadonnées de package pour '{0}' à partir de la source '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">Impossible de résoudre le chemin '{0}' de la source sélectionnée.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.it.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.it.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">Si è verificato un errore durante il recupero dei metadati del pacchetto per '{0}' dall'origine '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">Non è stato possibile risolvere il percorso '{0}' per l'origine selezionata.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ja.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ja.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">ソース '{1}' から '{0}' のパッケージ メタデータを取得するときにエラーが発生しました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">選択したソースのパス '{0}' を解決できませんでした。</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ko.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ko.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">'{1}' 원본에서 '{0}'에 대한 패키지 메타데이터를 검색하는 동안 오류가 발생했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">선택한 소스에 대한 '{0}' 경로를 확인할 수 없습니다.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pl.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pl.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">Wystąpił błąd podczas pobierania metadanych pakietu „{0}” ze źródła „{1}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">Nie można rozpoznać ścieżki „{0}” dla wybranego źródła.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.pt-BR.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">Ocorreu um erro ao recuperar metadados do pacote para '{0}' da origem '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">Não foi possível resolver o caminho '{0}' para a fonte selecionada.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ru.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.ru.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">Произошла ошибка при извлечении метаданных пакета для "{0}" из источника "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">Не удалось разрешить путь «{0}» для выбранного источника.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.tr.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.tr.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">'{1}' kaynağından '{0}' paket meta verileri alınırken bir hata oluştu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">Seçilen kaynağa ait '{0}' yolu çözümlenemedi.</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hans.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">从源“{1}”检索“{0}”的包元数据时出错。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">无法解析选定源的路径“{0}”。</target>

--- a/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.Protocol/xlf/Strings.zh-Hant.xlf
@@ -505,6 +505,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</note>
         <target state="translated">從來源 '{1}' 擷取 '{0}' 的套件中繼資料時發生錯誤。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterMultipleNotSupported">
+        <source>The source supports filtering by only one package type at a time.</source>
+        <target state="new">The source supports filtering by only one package type at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Protocol_PackageTypeFilterNotSupported">
+        <source>The source does not support filtering search results by package type.</source>
+        <target state="new">The source does not support filtering search results by package type.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Protocol_Search_LocalSourceNotFound">
         <source>The path '{0}' for the selected source could not be resolved.</source>
         <target state="translated">選取的來源路徑 '{0}' 無法解析。</target>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
@@ -26,7 +26,7 @@ namespace NuGet.Protocol.Tests
         {
             var envReader = new Mock<IEnvironmentVariableReader>();
             envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar)).Returns(useStj);
-            return new PackageSearchResourceV3(httpSource, searchEndpoints, envReader.Object);
+            return new PackageSearchResourceV3(httpSource, searchEndpoints, environmentVariableReader: envReader.Object);
         }
 
         [Theory]
@@ -540,6 +540,127 @@ namespace NuGet.Protocol.Tests
             versions[0].DownloadCount.Should().Be(50000);
             versions[1].Version.ToNormalizedString().Should().Be("2.0.0");
             versions[1].DownloadCount.Should().Be(50000);
+        }
+
+        [Fact]
+        public async Task PackageSearchResourceV3_PackageTypeFilter_UsesPackageTypeQueryParameter()
+        {
+            // Arrange
+            var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
+
+            var responses = new Dictionary<string, string>();
+            responses.Add(
+                serviceAddress + "?q=any&skip=0&take=1&prerelease=false" +
+                "&packageType=Dependency&semVerLevel=2.0.0",
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.V3Search.json", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
+            var endpoint = new Uri(serviceAddress);
+
+            // Mark this endpoint as advertising SearchQueryService/3.5.0.
+            var packageSearchResourceV3 = new PackageSearchResourceV3(httpSource, new[] { endpoint }, new[] { endpoint });
+
+            var searchFilter = new SearchFilter(includePrerelease: false)
+            {
+                PackageTypes = new[] { "Dependency" }
+            };
+
+            // Act
+            var packages = await packageSearchResourceV3.Search(
+                "any",
+                searchFilter,
+                skip: 0,
+                take: 1,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            // Assert
+            // The response is only registered for the URL that uses the corrected
+            // 'packageType=' query parameter, so receiving any results proves the
+            // client is no longer sending the legacy 'packageTypeFilter=' name.
+            packages.ToArray().Length.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public async Task PackageSearchResourceV3_PackageTypeFilter_WithoutCapableEndpoint_ThrowsNotSupported()
+        {
+            // Arrange
+            var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), new Dictionary<string, string>());
+
+            // No SearchQueryService/3.5.0 endpoints provided.
+            var packageSearchResourceV3 = new PackageSearchResourceV3(httpSource, new[] { new Uri(serviceAddress) });
+
+            var searchFilter = new SearchFilter(includePrerelease: false)
+            {
+                PackageTypes = new[] { "Dependency" }
+            };
+
+            // Act & Assert
+            await Assert.ThrowsAsync<NotSupportedException>(() => packageSearchResourceV3.Search(
+                "any",
+                searchFilter,
+                skip: 0,
+                take: 1,
+                NullLogger.Instance,
+                CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task PackageSearchResourceV3_NoPackageTypeFilter_DoesNotIncludePackageTypeParameter()
+        {
+            // Arrange: register a response only for a URL that does NOT contain packageType=.
+            var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
+
+            var responses = new Dictionary<string, string>();
+            responses.Add(
+                serviceAddress + "?q=any&skip=0&take=1&prerelease=false&semVerLevel=2.0.0",
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.V3Search.json", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
+            var packageSearchResourceV3 = new PackageSearchResourceV3(httpSource, new[] { new Uri(serviceAddress) });
+
+            var searchFilter = new SearchFilter(includePrerelease: false);
+
+            // Act
+            var packages = await packageSearchResourceV3.Search(
+                "any",
+                searchFilter,
+                skip: 0,
+                take: 1,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            // Assert
+            packages.ToArray().Length.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public async Task PackageSearchResourceV3_PackageTypeFilter_WithMultipleValues_ThrowsArgumentException()
+        {
+            // Arrange
+            var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), new Dictionary<string, string>());
+            var endpoint = new Uri(serviceAddress);
+
+            // Endpoint is package-type capable, so the failure must come from the multi-value check.
+            var packageSearchResourceV3 = new PackageSearchResourceV3(httpSource, new[] { endpoint }, new[] { endpoint });
+
+            var searchFilter = new SearchFilter(includePrerelease: false)
+            {
+                PackageTypes = new[] { "Dependency", "DotnetTool" }
+            };
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(() => packageSearchResourceV3.Search(
+                "any",
+                searchFilter,
+                skip: 0,
+                take: 1,
+                NullLogger.Instance,
+                CancellationToken.None));
         }
     }
 }


### PR DESCRIPTION
# Bug

Fixes: https://github.com/NuGet/Home/issues/8915
Related (closed) prior attempt: https://github.com/NuGet/NuGet.Client/pull/5991

## Description

`PackageSearchResourceV3` was sending the package-type filter using the legacy `packageTypeFilter` query parameter. The [`SearchQueryService/3.5.0`](https://learn.microsoft.com/en-us/nuget/api/search-query-service-resource#searchqueryservice350) specification uses `packageType`. As a result, `SearchFilter.PackageTypes` has been silently ignored by nuget.org and other compliant V3 sources for as long as the property has existed publicly.

This PR is intentionally **scoped to the bug fix plus capability detection**. The broader API redesign and local-source support discussed in #5991 are deferred to follow-up issues so this PR can land without re-litigating the same design conversation.

### What this PR does

1. **Send the correct query parameter.** `packageType=` (single value) instead of `packageTypeFilter=`.
2. **Capability detection via the service index.** A new internal `SearchQueryService350` entry is fetched separately. When `SearchFilter.PackageTypes` is set on a source that does not advertise `SearchQueryService/3.5.0`, the resource throws `NotSupportedException` instead of silently returning unfiltered results that the caller assumes are filtered. This addresses the primary concern raised by @zivkan in #5991.
3. **Endpoint routing.** Filtered queries are routed only to capable endpoints; unfiltered queries continue to use the existing endpoint set, so behavior is unchanged when no filter is requested.
4. **Tests** for: correct query parameter, capability rejection, and unchanged behavior when no filter is requested.

### What this PR explicitly does NOT do (and why)

| Deferred change | Reason |
|---|---|
| Reshape `SearchFilter.PackageTypes` (`IEnumerable<string>` → `string`) | This would be a breaking public API change. The current shipped API is preserved; only the first value is sent, matching the protocol contract. The reshape can be tracked separately. |
| Add package-type filtering to `LocalPackageSearchResource` | Independent change with its own design considerations (e.g. how nuspec package types map). Not required to fix the reported bug. |
| Decide aggregated-source ("All") behavior when one source is non-capable | Per the discussion in #5991, this is a front-end concern. `NotSupportedException` gives the front-end a clean signal to skip non-capable sources. |

### Behavior change

Callers who previously set `SearchFilter.PackageTypes` against a V3 source that does not advertise `SearchQueryService/3.5.0` used to get **unfiltered** results (silently broken). They will now get a `NotSupportedException`. This is a strict correctness improvement: the caller's intent was never being honoured before, and now they get an explicit signal.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. _(no user-facing settings changed; the fix is in the protocol layer)_
