### PR TITLE
Use branch-push CI for pr.yml

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -41,12 +41,9 @@ variables:
 trigger:
   branches:
     include:
-    - dev
-
-pr:
-  branches:
-    include:
     - '*'
+
+pr: none
 
 stages:
 - ${{ if eq(parameters.RunUnitTestsOnWindows, true) }}:


### PR DESCRIPTION
# Bug

Fixes:

## Description

This change switches `eng/pipelines/pr.yml` from GitHub PR validation to branch-push CI.

Azure Pipelines queues a new validation build when a draft PR is moved to ready for review, even when the same commit SHA has already completed successfully. By disabling `pr:` triggers and relying on source-branch push builds instead, the build that already ran on the branch can satisfy the required check without a second run on the draft-to-ready transition.

Customer reports:

- https://developercommunity.visualstudio.com/t/Pipelines-are-uselessly-triggered-again/11032682

This doesn't need ported to older branches since this is not a correctness issue.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
