### PR TITLE
Remove duplicate E2E tests and migrate BuildIntegrated tests to Apex

### DIFF
--- a/.copilot/skills/apex-migration/SKILL.md
+++ b/.copilot/skills/apex-migration/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: apex-migration
 description: >-
-  Migrate NuGet PowerShell E2E tests to C# Apex tests. Use this skill whenever the user asks to
-  migrate, convert, or port a PowerShell end-to-end test from test/EndToEnd/tests/ to an Apex test
-  in test/NuGet.Tests.Apex/. Also trigger when the user mentions "Apex test", "migrate PS test",
-  "E2E test migration", "PMC test", or references any PowerShell test function like
-  Install-PackageTest or Update-PackageTest and wants it rewritten in C#. Even if the user just
-  says "migrate this test" while looking at a PS E2E file, use this skill.
+  Migrate NuGet PowerShell E2E tests to C# Apex tests. 
+Use this skill whenever the user asks to migrate, convert, or port a PowerShell end-to-end test from test/EndToEnd/tests/ to an Apex test in test/NuGet.Tests.Apex/. 
+Also trigger when the user mentions "Apex test", "migrate PS test", "E2E test migration", "PMC test", or references any PowerShell test function like Install-PackageTest or Update-PackageTest and wants it rewritten in C#. Even if the user just says "migrate this test" while looking at a PS E2E file, use this skill.
+Also trigger whenever the user wants to write a new Apex test.
 ---
 
 # Migrating PowerShell E2E Tests to Apex Tests
@@ -88,6 +86,18 @@ session. It can execute **any** PowerShell command, not just NuGet commands. Thi
 state — global variables (`$global:InstallVar`), registered functions
 (`Test-Path function:\Get-World`), environment checks — can all be queried and asserted via
 `Execute()` + `IsMessageFoundInPMC()`. Do not skip tests just because they assert PS session state.
+
+**Project-level build operations:**
+
+| Scenario | Apex API |
+|---|---|
+| Clean (deletes obj/bin) | `testContext.Project.Clean()` |
+| Rebuild | `testContext.Project.Rebuild()` |
+| Cache file path | `CommonUtility.GetCacheFilePath(testContext.Project)` |
+| Wait for file to appear | `CommonUtility.WaitForFileExists(path)` |
+| Wait for file to disappear | `CommonUtility.WaitForFileNotExists(path)` |
+
+For single-project solutions, project-level Clean/Rebuild is equivalent to solution-level.
 
 ## Assertion mapping
 
@@ -208,18 +218,37 @@ public async Task DescriptiveTestNameAsync()
 
 ### Data-driven tests (multiple project templates)
 
-When the same scenario applies to multiple project types, use `[DataTestMethod]`:
+When the same scenario applies to multiple project types, use `[DataTestMethod]` or `[DynamicData]`:
 ```csharp
 [DataTestMethod]
-[DataRow(ProjectTemplate.NetCoreConsoleApp)]
-[DataRow(ProjectTemplate.NetStandardClassLib)]
+[DynamicData(nameof(GetPackageReferenceTemplates), DynamicDataSourceType.Method)]
 [Timeout(DefaultTimeout)]
-public async Task InstallPackageForMultipleProjectTypesAsync(ProjectTemplate projectTemplate)
+public async Task InstallPackageAsync(ProjectTemplate projectTemplate)
 {
-    using var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger);
+    using var simpleTestPathContext = new SimpleTestPathContext();
+    EnsurePackageReferenceFormat(simpleTestPathContext, projectTemplate);
+    using var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger,
+        simpleTestPathContext: simpleTestPathContext);
     // ... test body
 }
+
+// Yields both legacy and SDK-style PackageReference templates
+private static IEnumerable<object[]> GetPackageReferenceTemplates()
+{
+    yield return new object[] { ProjectTemplate.ConsoleApplication };
+    yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
+}
+
+// Only legacy (ConsoleApplication) needs this; SDK projects ignore it
+private static void EnsurePackageReferenceFormat(SimpleTestPathContext context, ProjectTemplate template)
+{
+    if (template == ProjectTemplate.ConsoleApplication)
+        context.Settings.SetPackageFormatToPackageReference();
+}
 ```
+
+Use `[DynamicData]` over `[DataRow]` when the template set is reused across multiple tests in the
+same class. This ensures one test method covers both legacy and SDK-style PackageReference projects.
 
 ### Multi-targeted project tests
 
@@ -241,6 +270,8 @@ using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCor
 - Use `var` for local variables except value tuples (use decomposed names).
 - The test class inherits `SharedVisualStudioHostTestClass` which provides `VisualStudio` and `Logger`.
 - Get PMC console via `GetConsole(testContext.Project)` helper method in the test class.
+- Don't use the method-delegates-to-async-helper pattern unless the helper is actually called from
+  multiple classes. Inline the test logic directly in the test method.
 
 ## Tests that should NOT be migrated
 
@@ -292,4 +323,20 @@ Skip PS tests that:
   `httpCacheFolder` — causing packages to pollute the user's real global packages folder. Instead
   use `simpleTestPathContext.Settings.AddSource()` and `AddPackageSourceMapping()` to layer config
   on top of the defaults.
+- **Legacy PackageReference projects don't auto-restore** — never call `WaitForAutoRestore()` for
+  `ConsoleApplication` with `SetPackageFormatToPackageReference()`. Only SDK-style projects
+  (e.g., `NetCoreConsoleApp`) auto-restore on project open.
+- **Always check for existing Apex coverage before migrating** — search the Apex test files for
+  equivalent scenarios. Common negative tests like `UpdatePackageFromPMCNotInstalled_Fails` and
+  `UninstallPackageFromPMCNotInstalled_Fails` already exist. If covered, just delete the PS test.
+- **Daily vs regular Apex cadence matters** — a test in `NuGet.Tests.Apex.Daily` does NOT count as
+  coverage for removing an E2E test that runs on every PR. Only regular Apex tests
+  (`NuGet.Tests.Apex`) provide equivalent gating.
 
+## Learnings (continuously updated)
+
+This section captures lessons learned from actual migration runs that don't fit neatly into the sections above. **Update this section after every migration run** with new discoveries or corrections.
+
+### 2026-05-20: PackageReferenceTestCase patterns
+
+- **PR #7246 incorrectly removed `Test-NetCoreConsoleAppClean`** — it was claimed to be covered by Apex Daily's `VerifyCacheFileInsideObjFolder`, but that test is in Daily (different cadence) and bundles 3 behaviors. We properly covered it by adding `NetCoreConsoleApp` to `GetPackageReferenceTemplates()` in `PackageReferenceTestCase.CleanDeletesCacheFile`.

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -1,42 +1,3 @@
-# install multiple packages into a project
-function Test-BuildIntegratedInstallMultiplePackages {
-    # Arrange
-    $project = New-BuildIntegratedProj UAPApp
-
-    # Act
-    Install-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.7
-    Install-Package DotNetRDF -version 1.0.8.3533
-
-    # Assert
-    Assert-PackageReferenceExists $project NuGet.Versioning 1.0.7
-    Assert-PackageReferenceExists $project DotNetRDF 1.0.8.3533
-    Assert-NetCorePackageInLockFile $project NuGet.Versioning 1.0.7
-    Assert-NetCorePackageInLockFile $project DotNetRDF 1.0.8.3533
-    Assert-NetCorePackageInLockFile $project Newtonsoft.Json 6.0.8
-    Assert-PackageReferenceAssetsFileRuntimeAssembly $project lib/portable-net40+win/NuGet.Versioning.dll
-    Assert-PackageReferenceAssetsFileRuntimeAssembly $project lib/net45/Newtonsoft.Json.dll
-    Assert-PackageReferenceAssetsFileRuntimeAssembly $project lib/net40/dotNetRDF.dll
-}
-
-# install and then uninstall multiple packages
-function Test-BuildIntegratedInstallAndUninstallAll {
-    # Arrange
-    $project = New-BuildIntegratedProj UAPApp
-
-    # Act
-    Install-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.7
-    Install-Package DotNetRDF  -ProjectName $project.Name -version 1.0.8.3533
-    Uninstall-Package NuGet.Versioning -ProjectName $project.Name
-    Uninstall-Package DotNetRDF -ProjectName $project.Name
-
-    # Assert
-    Assert-NetCoreNoPackageReference $project NuGet.Versioning
-    Assert-NetCoreNoPackageReference $project DotNetRDF
-    Assert-NetCorePackageNotInLockFile $project NuGet.Versioning
-    Assert-NetCorePackageNotInLockFile $project DotNetRDF
-    Assert-NetCorePackageNotInLockFile $project Newtonsoft.Json
-}
-
 # install a package with dependencies
 function Test-BuildIntegratedInstallAndVerifyLockFileContainsChildDependency {
     # Arrange
@@ -49,22 +10,6 @@ function Test-BuildIntegratedInstallAndVerifyLockFileContainsChildDependency {
     Assert-NetCorePackageInLockFile $project WindowsAzure.MobileServices 1.0.2
     Assert-NetCoreNoPackageReference $project WindowsAzure.MobileServices
 } 
-
-function Test-BuildIntegratedUpdateNonExistantPackage {
-    # Arrange
-    $project = New-BuildIntegratedProj UAPApp
-
-    # Act and Assert
-    Assert-Throws { Update-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.6 } "'NuGet.Versioning' was not installed in any project. Update failed."
-}
-
-function Test-BuildIntegratedUninstallNonExistantPackage {
-    # Arrange
-    $project = New-BuildIntegratedProj UAPApp
-
-    # Act and Assert
-    Assert-Throws { Uninstall-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.6 } "Package 'NuGet.Versioning' to be uninstalled could not be found in project 'UAPApp'"
-}
 
 function Test-BuildIntegratedLockFileIsCreatedOnBuild {
     # Arrange
@@ -360,21 +305,6 @@ function Test-BuildIntegratedParentProjectIsRestoredAfterInstallWithClassLibInTr
     Assert-NetCorePackageInLockFile $project1 NuGet.Versioning 1.0.7
 }
 
-function Test-BuildIntegratedCleanDeleteCacheFile {
-    # Arrange
-    $project = New-BuildIntegratedProj UAPApp
-
-    Install-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.7
-    Build-Solution
-    
-    Assert-ProjectCacheFileExists $project
-
-    #Act
-    Clean-Solution
-
-    #Assert
-    Assert-ProjectCacheFileNotExists $project
-}
 function Test-InconsistencyBetweenAssetsAndProjectFile{
     param()
 
@@ -417,58 +347,6 @@ function Remove-PackageReference {
     $node.ParentNode.RemoveChild($node)
 
     $doc.Save($projectPath)
-}
-
-function Test-BuildIntegratedLegacyCleanDeleteCacheFile {
-    # Arrange
-    $project = New-Project PackageReferenceClassLibrary
-    $project | Install-Package Newtonsoft.Json -Version 13.0.1
-    Build-Solution
-    Assert-ProjectCacheFileExists $project
-
-    #Act
-    Clean-Solution
-
-    #Assert
-    Assert-ProjectCacheFileNotExists $project
-}
-
-function Test-BuildIntegratedRebuildDoesNotDeleteCacheFile {
-    # Arrange
-    $project = New-BuildIntegratedProj UAPApp
-    Install-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.7
-    Build-Solution
-    Assert-ProjectCacheFileExists $project
-
-    AdviseSolutionEvents
-
-    #Act
-    Rebuild-Solution
-
-    WaitUntilRebuildCompleted
-    UnadviseSolutionEvents
-
-    #Assert
-    Assert-ProjectCacheFileExists $project
-}
-
-function Test-BuildIntegratedLegacyRebuildDoesNotDeleteCacheFile {
-    # Arrange
-    $project = New-Project PackageReferenceClassLibrary
-    $project | Install-Package Newtonsoft.Json -Version 13.0.1
-    Build-Solution
-    Assert-ProjectCacheFileExists $project
-
-    AdviseSolutionEvents
-
-    #Act
-    Rebuild-Solution
-
-    WaitUntilRebuildCompleted
-    UnadviseSolutionEvents
-
-    #Assert
-    Assert-ProjectCacheFileExists $project
 }
 
 function Test-BuildIntegratedRestoreAfterInstall {

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -1,17 +1,3 @@
-# basic install into a build integrated project
-function Test-BuildIntegratedInstallPackage {
-    # Arrange
-    $project = New-BuildIntegratedProj UAPApp
-
-    # Act
-    Install-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.7
-
-    # Assert
-    Assert-PackageReferenceExists $project NuGet.Versioning 1.0.7
-    Assert-NetCorePackageInLockFile $project NuGet.Versioning 1.0.7
-    Assert-PackageReferenceAssetsFileRuntimeAssembly $project lib/portable-net40+win/NuGet.Versioning.dll
-}
-
 # install multiple packages into a project
 function Test-BuildIntegratedInstallMultiplePackages {
     # Arrange
@@ -63,35 +49,6 @@ function Test-BuildIntegratedInstallAndVerifyLockFileContainsChildDependency {
     Assert-NetCorePackageInLockFile $project WindowsAzure.MobileServices 1.0.2
     Assert-NetCoreNoPackageReference $project WindowsAzure.MobileServices
 } 
-
-# basic uninstall
-function Test-BuildIntegratedUninstallPackage {
-    # Arrange
-    $project = New-BuildIntegratedProj UAPApp
-    Install-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.7
-
-    # Act
-    Uninstall-Package NuGet.Versioning -ProjectName $project.Name
-
-    # Assert
-    Assert-NetCoreNoPackageReference $project NuGet.Versioning
-    Assert-NetCorePackageNotInLockFile $project NuGet.Versioning
-}
-
-# basic update package
-function Test-BuildIntegratedUpdatePackage {
-    # Arrange
-    $project = New-BuildIntegratedProj UAPApp
-    Install-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.5
-
-    # Act
-    Update-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.6
-
-    # Assert
-    Assert-PackageReferenceExists $project NuGet.Versioning 1.0.6
-    Assert-NetCorePackageInLockFile $project NuGet.Versioning 1.0.6
-    Assert-PackageReferenceAssetsFileRuntimeAssembly $project lib/portable-net40+win/NuGet.Versioning.dll
-}
 
 function Test-BuildIntegratedUpdateNonExistantPackage {
     # Arrange

--- a/test/EndToEnd/tests/FindPackageTest.ps1
+++ b/test/EndToEnd/tests/FindPackageTest.ps1
@@ -62,18 +62,6 @@ function Test-FindPackageByIdAndPrereleaseVersion {
 	Assert-True $packages[0].Versions[0].ToString() -eq "5.0.0-beta"
 }
 
-function Test-FindPackageByIdExactMatch {
-    [SkipTest('https://github.com/NuGet/Home/issues/10066')]
-    param()
-
-   # Act 
-    $packages = Find-Package TestPackage.OverwriteTest -ExactMatch
-    
-    # Assert 
-	Assert-True $packages[0].Count -eq 1
-    Assert-True $packages[0].Id -eq TestPackage.OverwriteTest
-	Assert-True $packages[0].Versions[0].ToString() -eq "1.0.0"
-}
 
 function Test-FindPackageByIdWithAllVersions {
     # Act 

--- a/test/EndToEnd/tests/GetPackageTest.ps1
+++ b/test/EndToEnd/tests/GetPackageTest.ps1
@@ -123,46 +123,7 @@ function Test-GetPackageAcceptsRelativePathSource2 {
 
 
 
-function Test-GetPackageForProjectReturnsCorrectPackages2 {
-    # Arrange
-    $p1 = New-ConsoleApplication
-    $p2 = New-ClassLibrary
-
-    Install-Package jQuery -Version 1.5 -Source $context.RepositoryPath -ProjectName $p1.Name
-    Install-Package MyAwesomeLibrary -Version 1.0 -Source $context.RepositoryPath -ProjectName $p2.Name
-
-    # Act
-    $result = @(Get-Package -ProjectName $p1.Name)
-
-    # Assert
-    Assert-AreEqual 1 $result.Count
-    Assert-AreEqual "jQuery" $result[0].Id
-    Assert-AreEqual "1.5.0" $result[0].Version
-}
-
-
-
-function Test-GetPackageWithoutProjectNameReturnsInstalledPackagesInTheSolution {
-    param(
-        $context
-    )
-
-    # Arrange
-    $p1 = New-ConsoleApplication
-    $p2 = New-ClassLibrary
-
-    Install-Package jQuery -Source $context.RepositoryPath -Project $p1.Name
-    Install-Package netfx-Guard -Source $context.RepositoryPath -Project $p2.Name
-
-    # Act
-    $result = @(Get-Package)
-
-    # Assert
-    Assert-AreEqual 2 $result.Count
-    Assert-AreEqual "jQuery" $result[0].Id
-    Assert-AreEqual "netfx-Guard" $result[1].Id
-}
-
+function Test-ZipPackageLoadsReleaseNotesAttribute {
 function Test-ZipPackageLoadsReleaseNotesAttribute {
     param(
         $context

--- a/test/EndToEnd/tests/LegacyPackageRefProjectTest.ps1
+++ b/test/EndToEnd/tests/LegacyPackageRefProjectTest.ps1
@@ -8,25 +8,6 @@ function Test-UwpPackageRefClassLibraryCreate {
     Assert-NetCoreProjectCreation $project
 }
 
-# install package test for uwp legacy csproj package ref
-function Test-UwpPackageRefClassLibInstallPackage {
-
-    # Arrange
-    $project = New-UwpPackageRefClassLibrary UwpLibrary1
-    $id = 'Nuget.versioning'
-    $version = '3.5.0'
-    Assert-NetCoreProjectCreation $project
-
-    # Act
-    Install-Package $id -ProjectName $project.Name -version $version
-    $project.Save($project.FullName)
-
-    # Assert
-    $packageRefs = @(Get-MsBuildItems $project 'PackageReference')
-    Assert-AreEqual 2 $packageRefs.Count
-    Assert-AreEqual $packageRefs[1].GetMetadataValue("Identity") 'Nuget.Versioning' 
-    Assert-AreEqual $packageRefs[1].GetMetadataValue("Version") '3.5.0'
-}
 
 function Test-WPFPackageVersionNoInclusiveLowerBoundNU1604 {
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex.Daily/NuGetConsoleTestCase.cs
@@ -16,8 +16,6 @@ namespace NuGet.Tests.Apex.Daily
     [TestClass]
     public class NuGetConsoleTestCase : SharedVisualStudioHostTestClass
     {
-        private const string AndroidFeedName = "AndroidFeed";
-        private const string AndroidFeedUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-a8cd27e4/nuget/v3/index.json";
 
         [DataTestMethod]
         [DataRow(ProjectTemplate.NetCoreConsoleApp)]
@@ -96,124 +94,6 @@ namespace NuGet.Tests.Apex.Daily
                         CommonUtility.AssertPackageReferenceExists(testContext.Project, packageName2, packageVersion4, Logger);
                     }
                     VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
-                    Assert.IsTrue(VisualStudio.HasNoErrorsInOutputWindows());
-                }
-            }
-        }
-
-        [Ignore("MAUI projects cause UAC prompt for the remainder of the test run, blocking all tests video recordings")]
-        [DataTestMethod]
-        [DynamicData(nameof(GetMauiTemplates), DynamicDataSourceType.Method)]
-        [Timeout(DefaultTimeout)]
-        public async Task InstallPackageForPRInPMC(ProjectTemplate projectTemplate)
-        {
-            using (var simpleTestPathContext = new SimpleTestPathContext())
-            {
-                // Arrange
-                var packageName = "TestPackage";
-                var v100 = "1.0.0";
-                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, v100);
-                simpleTestPathContext.Settings.AddSource(NuGetConstants.NuGetHostName, NuGetConstants.V3FeedUrl);
-                simpleTestPathContext.Settings.AddSource(AndroidFeedName, AndroidFeedUrl);
-
-                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
-                {
-                    VisualStudio.AssertNoErrors();
-                    testContext.SolutionService.Build();
-
-                    // Act
-                    var nugetConsole = GetConsole(testContext.Project);
-
-                    nugetConsole.InstallPackageFromPMC(packageName, v100);
-                    testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
-
-                    // Assert
-                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
-                    CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, v100, Logger);
-                    Assert.IsTrue(VisualStudio.HasNoErrorsInOutputWindows());
-                }
-            }
-        }
-
-        [Ignore("MAUI projects cause UAC prompt for the remainder of the test run, blocking all tests video recordings")]
-        [DataTestMethod]
-        [DynamicData(nameof(GetMauiTemplates), DynamicDataSourceType.Method)]
-        [Timeout(DefaultTimeout)]
-        public async Task UpdatePackageForPRInPMC(ProjectTemplate projectTemplate)
-        {
-            using (var simpleTestPathContext = new SimpleTestPathContext())
-            {
-                // Arrange
-                var packageName = "TestPackage";
-                var v100 = "1.0.0";
-                var v200 = "2.0.0";
-
-                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, v100);
-                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, v200);
-                simpleTestPathContext.Settings.AddSource(NuGetConstants.NuGetHostName, NuGetConstants.V3FeedUrl);
-                simpleTestPathContext.Settings.AddSource(AndroidFeedName, AndroidFeedUrl);
-
-                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
-                {
-                    VisualStudio.AssertNoErrors();
-                    testContext.SolutionService.Build();
-
-                    // Act
-                    var nugetConsole = GetConsole(testContext.Project);
-
-                    nugetConsole.InstallPackageFromPMC(packageName, v100);
-                    testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
-
-                    nugetConsole.UpdatePackageFromPMC(packageName, v200);
-                    testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
-
-                    // Assert
-                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
-                    CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, v200, Logger);
-                    Assert.IsTrue(VisualStudio.HasNoErrorsInOutputWindows());
-                }
-            }
-        }
-
-        [Ignore("MAUI projects cause UAC prompt for the remainder of the test run, blocking all tests video recordings")]
-        [DataTestMethod]
-        [DynamicData(nameof(GetMauiTemplates), DynamicDataSourceType.Method)]
-        [Timeout(DefaultTimeout)]
-        public async Task UninstallPackageForPRInPMC(ProjectTemplate projectTemplate)
-        {
-            using (var simpleTestPathContext = new SimpleTestPathContext())
-            {
-                // Arrange
-                var PackageName = "TestPackage";
-                var v100 = "1.0.0";
-
-                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, PackageName, v100);
-                simpleTestPathContext.Settings.AddSource(NuGetConstants.NuGetHostName, NuGetConstants.V3FeedUrl);
-                simpleTestPathContext.Settings.AddSource(AndroidFeedName, AndroidFeedUrl);
-
-                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
-                {
-                    VisualStudio.AssertNoErrors();
-                    testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
-
-                    // Act
-                    var nugetConsole = GetConsole(testContext.Project);
-
-                    nugetConsole.InstallPackageFromPMC(PackageName, v100);
-                    testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
-
-                    nugetConsole.UninstallPackageFromPMC(PackageName);
-                    testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
-
-                    // Assert
-                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
-                    CommonUtility.AssertPackageNotInAssetsFile(VisualStudio, testContext.Project, PackageName, v100, Logger);
                     Assert.IsTrue(VisualStudio.HasNoErrorsInOutputWindows());
                 }
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -638,7 +638,6 @@ namespace NuGet.Tests.Apex
             Assert.IsTrue(File.Exists(uniqueContentFile), $"'{uniqueContentFile}' should exist");
         }
 
-        [Ignore("https://github.com/NuGet/Home/issues/12899")]
         [DataTestMethod]
         [DataRow(ProjectTemplate.ClassLibrary, false)]
         [DataRow(ProjectTemplate.NetStandardClassLib, true)]
@@ -669,7 +668,7 @@ namespace NuGet.Tests.Apex
             nugetConsole.Execute("Update-Package -Reinstall");
 
             // Assert
-            var expectedMessage = $"The `-Reinstall` parameter does not apply to PackageReference based projects `{Path.GetFileNameWithoutExtension(testContext.Project.UniqueName)}`.";
+            var expectedMessage = $"The -Reinstall parameter does not apply to PackageReference based projects `{Path.GetFileNameWithoutExtension(testContext.Project.UniqueName)}`.";
             nugetConsole.IsMessageFoundInPMC(expectedMessage).Should().Be(warns, because: nugetConsole.GetText());
             VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
             VisualStudio.HasNoErrorsInOutputWindows().Should().BeTrue();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/PackageReferenceTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/PackageReferenceTestCase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,33 +13,10 @@ namespace NuGet.Tests.Apex
     [TestClass]
     public class PackageReferenceTestCase : SharedVisualStudioHostTestClass
     {
-        // Legacy PackageReference: a classic (non-SDK) csproj that uses PackageReference format.
-        // Requires calling simpleTestPathContext.Settings.SetPackageFormatToPackageReference() before creating the project.
         [DataTestMethod]
-        [DynamicData(nameof(GetLegacyPackageReferenceTemplates), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetPackageReferenceTemplates), DynamicDataSourceType.Method)]
         [Timeout(DefaultTimeout)]
         public async Task InstallPackage_PMC(ProjectTemplate projectTemplate)
-        {
-            await InstallPackage_PMCAsync(projectTemplate);
-        }
-
-        [DataTestMethod]
-        [DynamicData(nameof(GetLegacyPackageReferenceTemplates), DynamicDataSourceType.Method)]
-        [Timeout(DefaultTimeout)]
-        public async Task UpdatePackage_PMC(ProjectTemplate projectTemplate)
-        {
-            await UpdatePackage_PMCAsync(projectTemplate);
-        }
-
-        [DataTestMethod]
-        [DynamicData(nameof(GetLegacyPackageReferenceTemplates), DynamicDataSourceType.Method)]
-        [Timeout(DefaultTimeout)]
-        public async Task UninstallPackage_PMC(ProjectTemplate projectTemplate)
-        {
-            await UninstallPackage_PMCAsync(projectTemplate);
-        }
-
-        public async Task InstallPackage_PMCAsync(ProjectTemplate projectTemplate)
         {
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
@@ -46,7 +24,7 @@ namespace NuGet.Tests.Apex
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
                 await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion);
-                simpleTestPathContext.Settings.SetPackageFormatToPackageReference();
+                EnsurePackageReferenceFormat(simpleTestPathContext, projectTemplate);
 
                 using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
                 {
@@ -58,7 +36,6 @@ namespace NuGet.Tests.Apex
 
                     nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
                     testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
 
                     // Assert
                     VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
@@ -68,7 +45,10 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        public async Task UpdatePackage_PMCAsync(ProjectTemplate projectTemplate)
+        [DataTestMethod]
+        [DynamicData(nameof(GetPackageReferenceTemplates), DynamicDataSourceType.Method)]
+        [Timeout(DefaultTimeout)]
+        public async Task UpdatePackage_PMC(ProjectTemplate projectTemplate)
         {
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
@@ -79,7 +59,7 @@ namespace NuGet.Tests.Apex
 
                 await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion1);
                 await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion2);
-                simpleTestPathContext.Settings.SetPackageFormatToPackageReference();
+                EnsurePackageReferenceFormat(simpleTestPathContext, projectTemplate);
 
                 using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
                 {
@@ -91,11 +71,9 @@ namespace NuGet.Tests.Apex
 
                     nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
                     testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
 
                     nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
                     testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
 
                     // Assert
                     VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
@@ -105,7 +83,10 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        public async Task UninstallPackage_PMCAsync(ProjectTemplate projectTemplate)
+        [DataTestMethod]
+        [DynamicData(nameof(GetPackageReferenceTemplates), DynamicDataSourceType.Method)]
+        [Timeout(DefaultTimeout)]
+        public async Task UninstallPackage_PMC(ProjectTemplate projectTemplate)
         {
             using (var simpleTestPathContext = new SimpleTestPathContext())
             {
@@ -114,24 +95,21 @@ namespace NuGet.Tests.Apex
                 var packageVersion = "1.0.0";
 
                 await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion);
-                simpleTestPathContext.Settings.SetPackageFormatToPackageReference();
+                EnsurePackageReferenceFormat(simpleTestPathContext, projectTemplate);
 
                 using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
                 {
                     VisualStudio.AssertNoErrors();
                     testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
 
                     // Act
                     var nugetConsole = GetConsole(testContext.Project);
 
                     nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
                     testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
 
                     nugetConsole.UninstallPackageFromPMC(packageName);
                     testContext.SolutionService.Build();
-                    testContext.NuGetApexTestService.WaitForAutoRestore();
 
                     // Assert
                     VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
@@ -141,11 +119,175 @@ namespace NuGet.Tests.Apex
             }
         }
 
-        // Legacy PackageReference: a classic (non-SDK) csproj that uses PackageReference format.
-        // Requires calling simpleTestPathContext.Settings.SetPackageFormatToPackageReference() before creating the project.
-        public static IEnumerable<object[]> GetLegacyPackageReferenceTemplates()
+        [DataTestMethod]
+        [DynamicData(nameof(GetPackageReferenceTemplates), DynamicDataSourceType.Method)]
+        [Timeout(DefaultTimeout)]
+        public async Task InstallMultiplePackages_PMC(ProjectTemplate projectTemplate)
         {
+            using (var simpleTestPathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageName1 = "TestPackage1";
+                var packageVersion1 = "1.0.0";
+                var packageName2 = "TestPackage2";
+                var packageVersion2 = "1.2.3";
+
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName1, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName2, packageVersion2);
+                EnsurePackageReferenceFormat(simpleTestPathContext, projectTemplate);
+
+                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
+                {
+                    VisualStudio.AssertNoErrors();
+                    testContext.SolutionService.Build();
+
+                    // Act
+                    var nugetConsole = GetConsole(testContext.Project);
+
+                    nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1);
+                    testContext.SolutionService.Build();
+
+                    nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2);
+                    testContext.SolutionService.Build();
+
+                    // Assert
+                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+                    CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName1, packageVersion1, Logger);
+                    CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName2, packageVersion2, Logger);
+                    Assert.IsTrue(VisualStudio.HasNoErrorsInOutputWindows());
+                }
+            }
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetPackageReferenceTemplates), DynamicDataSourceType.Method)]
+        [Timeout(DefaultTimeout)]
+        public async Task InstallAndUninstallAllPackages_PMC(ProjectTemplate projectTemplate)
+        {
+            using (var simpleTestPathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageName1 = "TestPackage1";
+                var packageVersion1 = "1.0.0";
+                var packageName2 = "TestPackage2";
+                var packageVersion2 = "1.2.3";
+
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName1, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName2, packageVersion2);
+                EnsurePackageReferenceFormat(simpleTestPathContext, projectTemplate);
+
+                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
+                {
+                    VisualStudio.AssertNoErrors();
+                    testContext.SolutionService.Build();
+
+                    var nugetConsole = GetConsole(testContext.Project);
+
+                    // Act - Install both
+                    nugetConsole.InstallPackageFromPMC(packageName1, packageVersion1);
+                    testContext.SolutionService.Build();
+
+                    nugetConsole.InstallPackageFromPMC(packageName2, packageVersion2);
+                    testContext.SolutionService.Build();
+
+                    // Act - Uninstall both
+                    nugetConsole.UninstallPackageFromPMC(packageName1);
+                    testContext.SolutionService.Build();
+
+                    nugetConsole.UninstallPackageFromPMC(packageName2);
+                    testContext.SolutionService.Build();
+
+                    // Assert
+                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+                    CommonUtility.AssertPackageNotInAssetsFile(VisualStudio, testContext.Project, packageName1, packageVersion1, Logger);
+                    CommonUtility.AssertPackageNotInAssetsFile(VisualStudio, testContext.Project, packageName2, packageVersion2, Logger);
+                    Assert.IsTrue(VisualStudio.HasNoErrorsInOutputWindows());
+                }
+            }
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetPackageReferenceTemplates), DynamicDataSourceType.Method)]
+        [Timeout(DefaultTimeout)]
+        public async Task CleanDeletesCacheFile(ProjectTemplate projectTemplate)
+        {
+            using (var simpleTestPathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageName = "TestPackage";
+                var packageVersion = "1.0.0";
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion);
+                EnsurePackageReferenceFormat(simpleTestPathContext, projectTemplate);
+
+                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
+                {
+                    var nugetConsole = GetConsole(testContext.Project);
+
+                    nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
+                    testContext.SolutionService.Build();
+
+                    FileInfo cacheFilePath = CommonUtility.GetCacheFilePath(testContext.Project.FullPath);
+                    CommonUtility.WaitForFileExists(cacheFilePath);
+
+                    // Act
+                    testContext.Project.Clean();
+
+                    // Assert
+                    CommonUtility.WaitForFileNotExists(cacheFilePath);
+                }
+            }
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetPackageReferenceTemplates), DynamicDataSourceType.Method)]
+        [Timeout(DefaultTimeout)]
+        public async Task RebuildDoesNotDeleteCacheFile(ProjectTemplate projectTemplate)
+        {
+            using (var simpleTestPathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageName = "TestPackage";
+                var packageVersion = "1.0.0";
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion);
+                EnsurePackageReferenceFormat(simpleTestPathContext, projectTemplate);
+
+                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
+                {
+                    var nugetConsole = GetConsole(testContext.Project);
+
+                    nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
+                    testContext.SolutionService.Build();
+
+                    FileInfo cacheFilePath = CommonUtility.GetCacheFilePath(testContext.Project.FullPath);
+                    CommonUtility.WaitForFileExists(cacheFilePath);
+
+                    // Act
+                    testContext.Project.Rebuild();
+
+                    // Assert
+                    CommonUtility.WaitForFileExists(cacheFilePath);
+                }
+            }
+        }
+
+        /// <summary>
+        /// For legacy (non-SDK) projects like ConsoleApplication, sets the default package format to PackageReference.
+        /// SDK-style projects (e.g. NetCoreConsoleApp) are always PackageReference, so this is a no-op for them.
+        /// </summary>
+        private static void EnsurePackageReferenceFormat(SimpleTestPathContext simpleTestPathContext, ProjectTemplate projectTemplate)
+        {
+            if (projectTemplate == ProjectTemplate.ConsoleApplication)
+            {
+                simpleTestPathContext.Settings.SetPackageFormatToPackageReference();
+            }
+        }
+
+        public static IEnumerable<object[]> GetPackageReferenceTemplates()
+        {
+            // Legacy PackageReference: classic (non-SDK) csproj, requires SetPackageFormatToPackageReference() before project creation.
             yield return new object[] { ProjectTemplate.ConsoleApplication };
+            // SDK-style: inherently PackageReference.
+            yield return new object[] { ProjectTemplate.NetCoreConsoleApp };
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/PackageReferenceTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/PackageReferenceTestCase.cs
@@ -1,0 +1,151 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Test.Apex.VisualStudio.Solution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NuGet.Test.Utility;
+
+namespace NuGet.Tests.Apex
+{
+    [TestClass]
+    public class PackageReferenceTestCase : SharedVisualStudioHostTestClass
+    {
+        // Legacy PackageReference: a classic (non-SDK) csproj that uses PackageReference format.
+        // Requires calling simpleTestPathContext.Settings.SetPackageFormatToPackageReference() before creating the project.
+        [DataTestMethod]
+        [DynamicData(nameof(GetLegacyPackageReferenceTemplates), DynamicDataSourceType.Method)]
+        [Timeout(DefaultTimeout)]
+        public async Task InstallPackage_PMC(ProjectTemplate projectTemplate)
+        {
+            await InstallPackage_PMCAsync(projectTemplate);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetLegacyPackageReferenceTemplates), DynamicDataSourceType.Method)]
+        [Timeout(DefaultTimeout)]
+        public async Task UpdatePackage_PMC(ProjectTemplate projectTemplate)
+        {
+            await UpdatePackage_PMCAsync(projectTemplate);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetLegacyPackageReferenceTemplates), DynamicDataSourceType.Method)]
+        [Timeout(DefaultTimeout)]
+        public async Task UninstallPackage_PMC(ProjectTemplate projectTemplate)
+        {
+            await UninstallPackage_PMCAsync(projectTemplate);
+        }
+
+        public async Task InstallPackage_PMCAsync(ProjectTemplate projectTemplate)
+        {
+            using (var simpleTestPathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageName = "TestPackage";
+                var packageVersion = "1.0.0";
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion);
+                simpleTestPathContext.Settings.SetPackageFormatToPackageReference();
+
+                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
+                {
+                    VisualStudio.AssertNoErrors();
+                    testContext.SolutionService.Build();
+
+                    // Act
+                    var nugetConsole = GetConsole(testContext.Project);
+
+                    nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
+
+                    // Assert
+                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+                    CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, Logger);
+                    Assert.IsTrue(VisualStudio.HasNoErrorsInOutputWindows());
+                }
+            }
+        }
+
+        public async Task UpdatePackage_PMCAsync(ProjectTemplate projectTemplate)
+        {
+            using (var simpleTestPathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageName = "TestPackage";
+                var packageVersion1 = "1.0.0";
+                var packageVersion2 = "2.0.0";
+
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion1);
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion2);
+                simpleTestPathContext.Settings.SetPackageFormatToPackageReference();
+
+                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
+                {
+                    VisualStudio.AssertNoErrors();
+                    testContext.SolutionService.Build();
+
+                    // Act
+                    var nugetConsole = GetConsole(testContext.Project);
+
+                    nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
+
+                    nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
+
+                    // Assert
+                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+                    CommonUtility.AssertPackageInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion2, Logger);
+                    Assert.IsTrue(VisualStudio.HasNoErrorsInOutputWindows());
+                }
+            }
+        }
+
+        public async Task UninstallPackage_PMCAsync(ProjectTemplate projectTemplate)
+        {
+            using (var simpleTestPathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageName = "TestPackage";
+                var packageVersion = "1.0.0";
+
+                await CommonUtility.CreatePackageInSourceAsync(simpleTestPathContext.PackageSource, packageName, packageVersion);
+                simpleTestPathContext.Settings.SetPackageFormatToPackageReference();
+
+                using (var testContext = new ApexTestContext(VisualStudio, projectTemplate, Logger, simpleTestPathContext: simpleTestPathContext))
+                {
+                    VisualStudio.AssertNoErrors();
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
+
+                    // Act
+                    var nugetConsole = GetConsole(testContext.Project);
+
+                    nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
+
+                    nugetConsole.UninstallPackageFromPMC(packageName);
+                    testContext.SolutionService.Build();
+                    testContext.NuGetApexTestService.WaitForAutoRestore();
+
+                    // Assert
+                    VisualStudio.AssertNuGetOutputDoesNotHaveErrors();
+                    CommonUtility.AssertPackageNotInAssetsFile(VisualStudio, testContext.Project, packageName, packageVersion, Logger);
+                    Assert.IsTrue(VisualStudio.HasNoErrorsInOutputWindows());
+                }
+            }
+        }
+
+        // Legacy PackageReference: a classic (non-SDK) csproj that uses PackageReference format.
+        // Requires calling simpleTestPathContext.Settings.SetPackageFormatToPackageReference() before creating the project.
+        public static IEnumerable<object[]> GetLegacyPackageReferenceTemplates()
+        {
+            yield return new object[] { ProjectTemplate.ConsoleApplication };
+        }
+    }
+}


### PR DESCRIPTION
# Bug

Fixes: https://github.com/NuGet/Home/issues/10066
Fixes: https://github.com/NuGet/Home/issues/12899
Progress: https://github.com/NuGet/Client.Engineering/issues/2085

## Description

Remove duplicate E2E tests that are already covered by Apex, and migrate BuildIntegrated tests to a new `PackageReferenceTestCase.cs` in the regular Apex project.

**Removed E2E tests (duplicates within E2E or already in Apex):**
- `Test-UwpPackageRefClassLibInstallPackage` — duplicate of `Test-BuildIntegratedInstallPackage` within E2E
- `Test-GetPackageForProjectReturnsCorrectPackages2` — covered by Apex `GetPackageFromPMCForProject_ReturnsCorrectPackagesAsync`
- `Test-GetPackageWithoutProjectNameReturnsInstalledPackagesInTheSolution` — covered by Apex `GetPackageFromPMC_ListsInstalledPackagesAsync`
- `Test-FindPackageByIdExactMatch` — covered by Apex `VerifyCmdFindPackageExactMatchInPMC`
- `Test-BuildIntegratedUpdateNonExistantPackage` — covered by Apex `UpdatePackageFromPMCNotInstalled_Fails`
- `Test-BuildIntegratedUninstallNonExistantPackage` — covered by Apex `UninstallPackageFromPMCNotInstalled_Fails`

**Migrated E2E tests to Apex `PackageReferenceTestCase`:**
- `Test-BuildIntegratedInstallPackage` → `InstallPackage_PMC`
- `Test-BuildIntegratedUpdatePackage` → `UpdatePackage_PMC`
- `Test-BuildIntegratedUninstallPackage` → `UninstallPackage_PMC`
- `Test-BuildIntegratedInstallMultiplePackages` → `InstallMultiplePackages_PMC`
- `Test-BuildIntegratedInstallAndUninstallAll` → `InstallAndUninstallAllPackages_PMC`
- `Test-BuildIntegratedCleanDeleteCacheFile` + `Test-BuildIntegratedLegacyCleanDeleteCacheFile` → `CleanDeletesCacheFile`
- `Test-BuildIntegratedRebuildDoesNotDeleteCacheFile` + `Test-BuildIntegratedLegacyRebuildDoesNotDeleteCacheFile` → `RebuildDoesNotDeleteCacheFile`

All tests run with both `ConsoleApplication` (legacy PR via `SetPackageFormatToPackageReference()`) and `NetCoreConsoleApp` (SDK-style), also covering `Test-NetCoreConsoleAppClean` and `Test-NetCoreConsoleAppRebuildDoesNotDeleteCacheFile` that were removed in PR #7246.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
