### PR TITLE
Enable nullable for NuGet.Protocol repository abstractions

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Download/PackageDownloadRunner.cs
@@ -194,6 +194,11 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.PackageDownload
             foreach (var repo in sourceRepositories)
             {
                 var finder = await repo.GetResourceAsync<PackageMetadataResource>(token);
+                if (finder is null)
+                {
+                    continue;
+                }
+
                 var packages = await finder.GetMetadataAsync(
                     packageWithNuGetVersion.Id,
                     includePrerelease,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateIO.cs
@@ -377,6 +377,10 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
         CancellationToken cancellationToken)
     {
         var packageMetadataResource = await source.GetResourceAsync<PackageMetadataResource>(cancellationToken);
+        if (packageMetadataResource is null)
+        {
+            return null;
+        }
 
         var packageDetails = await packageMetadataResource.GetMetadataAsync(
             packageId,
@@ -428,6 +432,10 @@ internal class PackageUpdateIO : IPackageUpdateIO, IDisposable
         CancellationToken cancellationToken)
     {
         var packageMetadataResource = await source.GetResourceAsync<PackageMetadataResource>(cancellationToken);
+        if (packageMetadataResource is null)
+        {
+            return null;
+        }
 
         var packageDetails = await packageMetadataResource.GetMetadataAsync(
             packageId,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
@@ -61,7 +61,7 @@ namespace NuGet.Commands
         {
             try
             {
-                IVulnerabilityInfoResource vulnerabilityInfoResource =
+                IVulnerabilityInfoResource? vulnerabilityInfoResource =
                     await _source.GetResourceAsync<IVulnerabilityInfoResource>(cancellationToken);
                 if (vulnerabilityInfoResource is null)
                 {

--- a/src/NuGet.Core/NuGet.PackageManagement/Audit/AuditChecker.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Audit/AuditChecker.cs
@@ -219,7 +219,7 @@ namespace NuGet.PackageManagement
             {
                 try
                 {
-                    IVulnerabilityInfoResource vulnerabilityInfoResource =
+                    IVulnerabilityInfoResource? vulnerabilityInfoResource =
                         await source.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None);
                     if (vulnerabilityInfoResource is null)
                     {

--- a/src/NuGet.Core/NuGet.Protocol/CachingSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/CachingSourceProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -28,6 +26,11 @@ namespace NuGet.Protocol
 
         public CachingSourceProvider(IPackageSourceProvider packageSourceProvider)
         {
+            if (packageSourceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(packageSourceProvider));
+            }
+
             _packageSourceProvider = packageSourceProvider;
 
             _resourceProviders.AddRange(Repository.Provider.GetCoreV3());
@@ -64,7 +67,12 @@ namespace NuGet.Protocol
 
         public SourceRepository CreateRepository(PackageSource source, FeedType type)
         {
-            if (_cachedSources.TryGetValue(source.Source, out SourceRepository cached))
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (_cachedSources.TryGetValue(source.Source, out SourceRepository? cached))
             {
                 return cached;
             }
@@ -74,6 +82,11 @@ namespace NuGet.Protocol
 
         public void AddSourceRepository(SourceRepository source)
         {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
             _cachedSources.TryAdd(source.PackageSource.Source, source);
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/DownloadResourceResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DownloadResourceResult.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.IO;
 using NuGet.Packaging;
@@ -15,9 +13,9 @@ namespace NuGet.Protocol.Core.Types
     public sealed class DownloadResourceResult : IDisposable
     {
         private bool _isDisposed;
-        private readonly Stream _stream;
-        private readonly PackageReaderBase _packageReader;
-        private readonly string _packageSource;
+        private readonly Stream? _stream;
+        private readonly PackageReaderBase? _packageReader;
+        private readonly string? _packageSource;
 
         /// <summary>
         /// Initializes a new <see cref="DownloadResourceResult" /> class.
@@ -44,7 +42,7 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="stream">A package stream.</param>
         /// <param name="source">A package source.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <see langword="null" />.</exception>
-        public DownloadResourceResult(Stream stream, string source)
+        public DownloadResourceResult(Stream stream, string? source)
         {
             if (stream == null)
             {
@@ -63,7 +61,7 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="packageReader">A package reader.</param>
         /// <param name="source">A package source.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="stream" /> is <see langword="null" />.</exception>
-        public DownloadResourceResult(Stream stream, PackageReaderBase packageReader, string source)
+        public DownloadResourceResult(Stream stream, PackageReaderBase? packageReader, string? source)
             : this(stream, source)
         {
             _packageReader = packageReader;
@@ -75,7 +73,7 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="packageReader">A package reader.</param>
         /// <param name="source">A package source.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageReader" /> is <see langword="null" />.</exception>
-        public DownloadResourceResult(PackageReaderBase packageReader, string source)
+        public DownloadResourceResult(PackageReaderBase packageReader, string? source)
         {
             if (packageReader == null)
             {
@@ -95,19 +93,19 @@ namespace NuGet.Protocol.Core.Types
         /// Gets the package <see cref="PackageStream"/>.
         /// </summary>
         /// <remarks>The value may be <see langword="null" />.</remarks>
-        public Stream PackageStream => _stream;
+        public Stream? PackageStream => _stream;
 
         /// <summary>
         /// Gets the source containing this package, if not from cache
         /// </summary>
         /// <remarks>The value may be <see langword="null" />.</remarks>
-        public string PackageSource => _packageSource;
+        public string? PackageSource => _packageSource;
 
         /// <summary>
         /// Gets the <see cref="PackageReaderBase"/> for the package.
         /// </summary>
         /// <remarks>The value may be <see langword="null" />.</remarks>
-        public PackageReaderBase PackageReader => _packageReader;
+        public PackageReaderBase? PackageReader => _packageReader;
 
         /// <summary>
         /// Disposes of this instance.

--- a/src/NuGet.Core/NuGet.Protocol/FeedTypePackageSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/FeedTypePackageSource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using NuGet.Configuration;
 
 namespace NuGet.Protocol

--- a/src/NuGet.Core/NuGet.Protocol/HttpResponseMessageExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpResponseMessageExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Net.Http;
 using NuGet.Common;

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -450,7 +450,9 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(throttle));
             }
 
-            Func<Task<HttpHandlerResource>> factory = () => source.GetResourceAsync<HttpHandlerResource>(CancellationToken.None);
+            Func<Task<HttpHandlerResource>> factory = async () =>
+                await source.GetResourceAsync<HttpHandlerResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpHandlerResource)}.");
 
             return new HttpSource(source.PackageSource, factory, throttle);
         }

--- a/src/NuGet.Core/NuGet.Protocol/ISourceRepositoryProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ISourceRepositoryProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using NuGet.Configuration;
 

--- a/src/NuGet.Core/NuGet.Protocol/ProviderComparer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/ProviderComparer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,20 +19,30 @@ namespace NuGet.Protocol.Core.Types
         }
 
         // higher goes last
-        public int Compare(INuGetResourceProvider providerA, INuGetResourceProvider providerB)
+        public int Compare(INuGetResourceProvider? providerA, INuGetResourceProvider? providerB)
         {
+            if (providerA == null)
+            {
+                throw new ArgumentNullException(nameof(providerA));
+            }
+
+            if (providerB == null)
+            {
+                throw new ArgumentNullException(nameof(providerB));
+            }
+
             if (StringComparer.Ordinal.Equals(providerA.Name, providerB.Name))
             {
                 return 0;
             }
 
             // empty names go last
-            if (String.IsNullOrEmpty(providerA.Name))
+            if (string.IsNullOrEmpty(providerA.Name))
             {
                 return 1;
             }
 
-            if (String.IsNullOrEmpty(providerB.Name))
+            if (string.IsNullOrEmpty(providerB.Name))
             {
                 return -1;
             }

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -18,13 +18,13 @@ NuGet.Protocol.AutoCompleteResourceV3
 NuGet.Protocol.AutoCompleteResourceV3Provider
 NuGet.Protocol.AutoCompleteResourceV3Provider.AutoCompleteResourceV3Provider() -> void
 NuGet.Protocol.CachingSourceProvider
-~NuGet.Protocol.CachingSourceProvider.AddSourceRepository(NuGet.Protocol.Core.Types.SourceRepository source) -> void
-~NuGet.Protocol.CachingSourceProvider.CachingSourceProvider(NuGet.Configuration.IPackageSourceProvider packageSourceProvider) -> void
-~NuGet.Protocol.CachingSourceProvider.CreateRepository(NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.CachingSourceProvider.CreateRepository(NuGet.Configuration.PackageSource source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.CachingSourceProvider.CreateRepository(string source) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.CachingSourceProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository>
-~NuGet.Protocol.CachingSourceProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider
+NuGet.Protocol.CachingSourceProvider.AddSourceRepository(NuGet.Protocol.Core.Types.SourceRepository! source) -> void
+NuGet.Protocol.CachingSourceProvider.CachingSourceProvider(NuGet.Configuration.IPackageSourceProvider! packageSourceProvider) -> void
+NuGet.Protocol.CachingSourceProvider.CreateRepository(NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.CachingSourceProvider.CreateRepository(NuGet.Configuration.PackageSource! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.CachingSourceProvider.CreateRepository(string! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.CachingSourceProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository!>!
+NuGet.Protocol.CachingSourceProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider!
 NuGet.Protocol.CachingUtility
 NuGet.Protocol.Core.Types.AutoCompleteResource
 NuGet.Protocol.Core.Types.AutoCompleteResource.AutoCompleteResource() -> void
@@ -34,13 +34,13 @@ NuGet.Protocol.Core.Types.DownloadResource
 NuGet.Protocol.Core.Types.DownloadResource.DownloadResource() -> void
 NuGet.Protocol.Core.Types.DownloadResourceResult
 NuGet.Protocol.Core.Types.DownloadResourceResult.Dispose() -> void
-~NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(NuGet.Packaging.PackageReaderBase packageReader, string source) -> void
+NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(NuGet.Packaging.PackageReaderBase! packageReader, string? source) -> void
 NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(NuGet.Protocol.Core.Types.DownloadResourceResultStatus status) -> void
-~NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(System.IO.Stream stream, NuGet.Packaging.PackageReaderBase packageReader, string source) -> void
-~NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(System.IO.Stream stream, string source) -> void
-~NuGet.Protocol.Core.Types.DownloadResourceResult.PackageReader.get -> NuGet.Packaging.PackageReaderBase
-~NuGet.Protocol.Core.Types.DownloadResourceResult.PackageSource.get -> string
-~NuGet.Protocol.Core.Types.DownloadResourceResult.PackageStream.get -> System.IO.Stream
+NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(System.IO.Stream! stream, NuGet.Packaging.PackageReaderBase? packageReader, string? source) -> void
+NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(System.IO.Stream! stream, string? source) -> void
+NuGet.Protocol.Core.Types.DownloadResourceResult.PackageReader.get -> NuGet.Packaging.PackageReaderBase?
+NuGet.Protocol.Core.Types.DownloadResourceResult.PackageSource.get -> string?
+NuGet.Protocol.Core.Types.DownloadResourceResult.PackageStream.get -> System.IO.Stream?
 NuGet.Protocol.Core.Types.DownloadResourceResult.SignatureVerified.get -> bool
 NuGet.Protocol.Core.Types.DownloadResourceResult.SignatureVerified.set -> void
 NuGet.Protocol.Core.Types.DownloadResourceResult.Status.get -> NuGet.Protocol.Core.Types.DownloadResourceResultStatus
@@ -104,10 +104,10 @@ NuGet.Protocol.Core.Types.IPackageSearchMetadata.RequireLicenseAcceptance.get ->
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Title.get -> string
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
 NuGet.Protocol.Core.Types.ISourceRepositoryProvider
-~NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.Core.Types.ISourceRepositoryProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository>
-~NuGet.Protocol.Core.Types.ISourceRepositoryProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider
+NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.Core.Types.ISourceRepositoryProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository!>!
+NuGet.Protocol.Core.Types.ISourceRepositoryProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider!
 NuGet.Protocol.Core.Types.LegacyFeedCapabilityResource
 NuGet.Protocol.Core.Types.LegacyFeedCapabilityResource.LegacyFeedCapabilityResource() -> void
 NuGet.Protocol.Core.Types.ListResource
@@ -307,16 +307,16 @@ NuGet.Protocol.Core.Types.SourcePackageDependencyInfo.SourcePackageDependencyInf
 NuGet.Protocol.Core.Types.SourceRepository
 NuGet.Protocol.Core.Types.SourceRepository.FeedTypeOverride.get -> NuGet.Protocol.FeedType
 NuGet.Protocol.Core.Types.SourceRepository.SourceRepository() -> void
-~NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource source, System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider> providers) -> void
-~NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource source, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> providers) -> void
-~NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource source, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> providers, NuGet.Protocol.FeedType feedTypeOverride) -> void
+NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource! source, System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider!>! providers) -> void
+NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource! source, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! providers) -> void
+NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource! source, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! providers, NuGet.Protocol.FeedType feedTypeOverride) -> void
 NuGet.Protocol.Core.Types.SourceRepositoryProvider
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository>
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.SourceRepositoryProvider(NuGet.Configuration.IPackageSourceProvider packageSourceProvider, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders) -> void
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.SourceRepositoryProvider(NuGet.Configuration.ISettings settings, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders) -> void
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository!>!
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider!
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.SourceRepositoryProvider(NuGet.Configuration.IPackageSourceProvider! packageSourceProvider, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders) -> void
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.SourceRepositoryProvider(NuGet.Configuration.ISettings! settings, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders) -> void
 NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3
 ~NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3.SourceUri.get -> System.Uri
 ~NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3.SymbolPackageUpdateResourceV3(string source, NuGet.Protocol.HttpSource httpSource) -> void
@@ -408,7 +408,7 @@ NuGet.Protocol.FeedType.HttpV3 = 2 -> NuGet.Protocol.FeedType
 NuGet.Protocol.FeedType.Undefined = 0 -> NuGet.Protocol.FeedType
 NuGet.Protocol.FeedTypePackageSource
 NuGet.Protocol.FeedTypePackageSource.FeedType.get -> NuGet.Protocol.FeedType
-~NuGet.Protocol.FeedTypePackageSource.FeedTypePackageSource(string source, NuGet.Protocol.FeedType feedType) -> void
+NuGet.Protocol.FeedTypePackageSource.FeedTypePackageSource(string! source, NuGet.Protocol.FeedType feedType) -> void
 NuGet.Protocol.FeedTypeResource
 NuGet.Protocol.FeedTypeResource.FeedType.get -> NuGet.Protocol.FeedType
 NuGet.Protocol.FeedTypeResource.FeedTypeResource(NuGet.Protocol.FeedType feedType) -> void
@@ -1649,7 +1649,7 @@ override NuGet.Protocol.Core.Types.NullSourceCacheContext.WithRefreshCacheTrue()
 override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.GetHashCode() -> int
 override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.ToString() -> string!
-~override NuGet.Protocol.Core.Types.SourceRepository.ToString() -> string
+override NuGet.Protocol.Core.Types.SourceRepository.ToString() -> string!
 ~override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackage(NuGet.Packaging.Core.PackageIdentity package, NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo>
 ~override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackages(string packageId, NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo>>
 ~override NuGet.Protocol.DependencyInfoResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
@@ -1911,15 +1911,15 @@ static NuGet.Protocol.Core.Types.OfflineFeedUtility.ThrowIfInvalidOrNotFound(str
 ~static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata, System.Func<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>> valueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
 ~static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata, System.Func<System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>> asyncValueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
 ~static NuGet.Protocol.Core.Types.PackageUpdateResource.ForceDeleteDirectory(string path) -> void
-~static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider> resourceProviders) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider
-~static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider> resourceProviders, string rootPath) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider
-~static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders, NuGet.Configuration.PackageSource source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders, string sourceUrl) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders, string sourceUrl, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.Core.Types.Repository.Factory.get -> NuGet.Protocol.Core.Types.Repository.RepositoryFactory
-~static NuGet.Protocol.Core.Types.Repository.Provider.get -> NuGet.Protocol.Core.Types.Repository.ProviderFactory
-~static NuGet.Protocol.Core.Types.Repository.Provider.set -> void
+static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider!>! resourceProviders) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider!
+static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider!>! resourceProviders, string? rootPath) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider!
+static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders, NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders, NuGet.Configuration.PackageSource! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders, string! sourceUrl) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders, string! sourceUrl, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.Core.Types.Repository.Factory.get -> NuGet.Protocol.Core.Types.Repository.RepositoryFactory!
+static NuGet.Protocol.Core.Types.Repository.Provider.get -> NuGet.Protocol.Core.Types.Repository.ProviderFactory!
+static NuGet.Protocol.Core.Types.Repository.Provider.set -> void
 static NuGet.Protocol.Core.Types.UserAgent.SetUserAgent(System.Net.Http.HttpClient! client) -> void
 static NuGet.Protocol.Core.Types.UserAgent.SetUserAgentString(NuGet.Protocol.Core.Types.UserAgentStringBuilder! builder) -> void
 static NuGet.Protocol.Core.Types.UserAgent.UserAgentString.get -> string!
@@ -1949,7 +1949,7 @@ static NuGet.Protocol.HttpRequestMessageFactory.Create(System.Net.Http.HttpMetho
 static NuGet.Protocol.HttpRequestMessageFactory.Create(System.Net.Http.HttpMethod! method, System.Uri! requestUri, NuGet.Protocol.HttpRequestMessageConfiguration! configuration) -> System.Net.Http.HttpRequestMessage!
 static NuGet.Protocol.HttpRequestMessageFactory.Create(System.Net.Http.HttpMethod! method, string! requestUri, NuGet.Common.ILogger! log) -> System.Net.Http.HttpRequestMessage!
 static NuGet.Protocol.HttpRequestMessageFactory.Create(System.Net.Http.HttpMethod! method, string! requestUri, NuGet.Protocol.HttpRequestMessageConfiguration! configuration) -> System.Net.Http.HttpRequestMessage!
-~static NuGet.Protocol.HttpResponseMessageExtensions.LogServerWarning(this System.Net.Http.HttpResponseMessage response, NuGet.Common.ILogger log) -> void
+static NuGet.Protocol.HttpResponseMessageExtensions.LogServerWarning(this System.Net.Http.HttpResponseMessage! response, NuGet.Common.ILogger! log) -> void
 static NuGet.Protocol.HttpSource.Create(NuGet.Protocol.Core.Types.SourceRepository! source) -> NuGet.Protocol.HttpSource!
 static NuGet.Protocol.HttpSource.Create(NuGet.Protocol.Core.Types.SourceRepository! source, NuGet.Protocol.IThrottle! throttle) -> NuGet.Protocol.HttpSource!
 static NuGet.Protocol.HttpSourceResourceProvider.Throttle.get -> NuGet.Protocol.IThrottle?
@@ -2083,7 +2083,7 @@ static readonly NuGet.Protocol.ServiceTypes.Version510 -> string!
 static readonly NuGet.Protocol.ServiceTypes.Versioned -> string!
 static readonly NuGet.Protocol.StreamExtensions.BufferSize -> int
 ~virtual NuGet.Protocol.Core.Types.DependencyInfoResource.ResolvePackages(string packageId, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo>>
-~virtual NuGet.Protocol.Core.Types.Repository.ProviderFactory.GetCoreV3() -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>
+virtual NuGet.Protocol.Core.Types.Repository.ProviderFactory.GetCoreV3() -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>!
 virtual NuGet.Protocol.Core.Types.ResourceProvider.After.get -> System.Collections.Generic.IEnumerable<string!>!
 virtual NuGet.Protocol.Core.Types.ResourceProvider.Before.get -> System.Collections.Generic.IEnumerable<string!>!
 virtual NuGet.Protocol.Core.Types.ResourceProvider.Name.get -> string!
@@ -2093,12 +2093,12 @@ virtual NuGet.Protocol.Core.Types.SourceCacheContext.Dispose(bool disposing) -> 
 virtual NuGet.Protocol.Core.Types.SourceCacheContext.GeneratedTempFolder.get -> string!
 virtual NuGet.Protocol.Core.Types.SourceCacheContext.GeneratedTempFolder.set -> void
 virtual NuGet.Protocol.Core.Types.SourceCacheContext.WithRefreshCacheTrue() -> NuGet.Protocol.Core.Types.SourceCacheContext!
-~virtual NuGet.Protocol.Core.Types.SourceRepository.GetFeedType(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.FeedType>
-~virtual NuGet.Protocol.Core.Types.SourceRepository.GetResource<T>() -> T
-~virtual NuGet.Protocol.Core.Types.SourceRepository.GetResource<T>(System.Threading.CancellationToken token) -> T
-~virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>() -> System.Threading.Tasks.Task<T>
-~virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
-~virtual NuGet.Protocol.Core.Types.SourceRepository.PackageSource.get -> NuGet.Configuration.PackageSource
+virtual NuGet.Protocol.Core.Types.SourceRepository.GetFeedType(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.FeedType>!
+virtual NuGet.Protocol.Core.Types.SourceRepository.GetResource<T>() -> T?
+virtual NuGet.Protocol.Core.Types.SourceRepository.GetResource<T>(System.Threading.CancellationToken token) -> T?
+virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>() -> System.Threading.Tasks.Task<T?>!
+virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T?>!
+virtual NuGet.Protocol.Core.Types.SourceRepository.PackageSource.get -> NuGet.Configuration.PackageSource!
 ~virtual NuGet.Protocol.FindLocalPackagesResource.Exists(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> bool
 ~virtual NuGet.Protocol.FindLocalPackagesResource.Exists(string packageId, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> bool
 virtual NuGet.Protocol.HttpSource.Dispose(bool disposing) -> void

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -18,13 +18,13 @@ NuGet.Protocol.AutoCompleteResourceV3
 NuGet.Protocol.AutoCompleteResourceV3Provider
 NuGet.Protocol.AutoCompleteResourceV3Provider.AutoCompleteResourceV3Provider() -> void
 NuGet.Protocol.CachingSourceProvider
-~NuGet.Protocol.CachingSourceProvider.AddSourceRepository(NuGet.Protocol.Core.Types.SourceRepository source) -> void
-~NuGet.Protocol.CachingSourceProvider.CachingSourceProvider(NuGet.Configuration.IPackageSourceProvider packageSourceProvider) -> void
-~NuGet.Protocol.CachingSourceProvider.CreateRepository(NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.CachingSourceProvider.CreateRepository(NuGet.Configuration.PackageSource source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.CachingSourceProvider.CreateRepository(string source) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.CachingSourceProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository>
-~NuGet.Protocol.CachingSourceProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider
+NuGet.Protocol.CachingSourceProvider.AddSourceRepository(NuGet.Protocol.Core.Types.SourceRepository! source) -> void
+NuGet.Protocol.CachingSourceProvider.CachingSourceProvider(NuGet.Configuration.IPackageSourceProvider! packageSourceProvider) -> void
+NuGet.Protocol.CachingSourceProvider.CreateRepository(NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.CachingSourceProvider.CreateRepository(NuGet.Configuration.PackageSource! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.CachingSourceProvider.CreateRepository(string! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.CachingSourceProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository!>!
+NuGet.Protocol.CachingSourceProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider!
 NuGet.Protocol.CachingUtility
 NuGet.Protocol.Core.Types.AutoCompleteResource
 NuGet.Protocol.Core.Types.AutoCompleteResource.AutoCompleteResource() -> void
@@ -34,13 +34,13 @@ NuGet.Protocol.Core.Types.DownloadResource
 NuGet.Protocol.Core.Types.DownloadResource.DownloadResource() -> void
 NuGet.Protocol.Core.Types.DownloadResourceResult
 NuGet.Protocol.Core.Types.DownloadResourceResult.Dispose() -> void
-~NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(NuGet.Packaging.PackageReaderBase packageReader, string source) -> void
+NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(NuGet.Packaging.PackageReaderBase! packageReader, string? source) -> void
 NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(NuGet.Protocol.Core.Types.DownloadResourceResultStatus status) -> void
-~NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(System.IO.Stream stream, NuGet.Packaging.PackageReaderBase packageReader, string source) -> void
-~NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(System.IO.Stream stream, string source) -> void
-~NuGet.Protocol.Core.Types.DownloadResourceResult.PackageReader.get -> NuGet.Packaging.PackageReaderBase
-~NuGet.Protocol.Core.Types.DownloadResourceResult.PackageSource.get -> string
-~NuGet.Protocol.Core.Types.DownloadResourceResult.PackageStream.get -> System.IO.Stream
+NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(System.IO.Stream! stream, NuGet.Packaging.PackageReaderBase? packageReader, string? source) -> void
+NuGet.Protocol.Core.Types.DownloadResourceResult.DownloadResourceResult(System.IO.Stream! stream, string? source) -> void
+NuGet.Protocol.Core.Types.DownloadResourceResult.PackageReader.get -> NuGet.Packaging.PackageReaderBase?
+NuGet.Protocol.Core.Types.DownloadResourceResult.PackageSource.get -> string?
+NuGet.Protocol.Core.Types.DownloadResourceResult.PackageStream.get -> System.IO.Stream?
 NuGet.Protocol.Core.Types.DownloadResourceResult.SignatureVerified.get -> bool
 NuGet.Protocol.Core.Types.DownloadResourceResult.SignatureVerified.set -> void
 NuGet.Protocol.Core.Types.DownloadResourceResult.Status.get -> NuGet.Protocol.Core.Types.DownloadResourceResultStatus
@@ -104,10 +104,10 @@ NuGet.Protocol.Core.Types.IPackageSearchMetadata.RequireLicenseAcceptance.get ->
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Title.get -> string
 ~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
 NuGet.Protocol.Core.Types.ISourceRepositoryProvider
-~NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.Core.Types.ISourceRepositoryProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository>
-~NuGet.Protocol.Core.Types.ISourceRepositoryProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider
+NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.Core.Types.ISourceRepositoryProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository!>!
+NuGet.Protocol.Core.Types.ISourceRepositoryProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider!
 NuGet.Protocol.Core.Types.LegacyFeedCapabilityResource
 NuGet.Protocol.Core.Types.LegacyFeedCapabilityResource.LegacyFeedCapabilityResource() -> void
 NuGet.Protocol.Core.Types.ListResource
@@ -307,16 +307,16 @@ NuGet.Protocol.Core.Types.SourcePackageDependencyInfo.SourcePackageDependencyInf
 NuGet.Protocol.Core.Types.SourceRepository
 NuGet.Protocol.Core.Types.SourceRepository.FeedTypeOverride.get -> NuGet.Protocol.FeedType
 NuGet.Protocol.Core.Types.SourceRepository.SourceRepository() -> void
-~NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource source, System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider> providers) -> void
-~NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource source, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> providers) -> void
-~NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource source, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> providers, NuGet.Protocol.FeedType feedTypeOverride) -> void
+NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource! source, System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider!>! providers) -> void
+NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource! source, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! providers) -> void
+NuGet.Protocol.Core.Types.SourceRepository.SourceRepository(NuGet.Configuration.PackageSource! source, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! providers, NuGet.Protocol.FeedType feedTypeOverride) -> void
 NuGet.Protocol.Core.Types.SourceRepositoryProvider
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository>
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.SourceRepositoryProvider(NuGet.Configuration.IPackageSourceProvider packageSourceProvider, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders) -> void
-~NuGet.Protocol.Core.Types.SourceRepositoryProvider.SourceRepositoryProvider(NuGet.Configuration.ISettings settings, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders) -> void
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.GetRepositories() -> System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourceRepository!>!
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.PackageSourceProvider.get -> NuGet.Configuration.IPackageSourceProvider!
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.SourceRepositoryProvider(NuGet.Configuration.IPackageSourceProvider! packageSourceProvider, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders) -> void
+NuGet.Protocol.Core.Types.SourceRepositoryProvider.SourceRepositoryProvider(NuGet.Configuration.ISettings! settings, System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders) -> void
 NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3
 ~NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3.SourceUri.get -> System.Uri
 ~NuGet.Protocol.Core.Types.SymbolPackageUpdateResourceV3.SymbolPackageUpdateResourceV3(string source, NuGet.Protocol.HttpSource httpSource) -> void
@@ -408,7 +408,7 @@ NuGet.Protocol.FeedType.HttpV3 = 2 -> NuGet.Protocol.FeedType
 NuGet.Protocol.FeedType.Undefined = 0 -> NuGet.Protocol.FeedType
 NuGet.Protocol.FeedTypePackageSource
 NuGet.Protocol.FeedTypePackageSource.FeedType.get -> NuGet.Protocol.FeedType
-~NuGet.Protocol.FeedTypePackageSource.FeedTypePackageSource(string source, NuGet.Protocol.FeedType feedType) -> void
+NuGet.Protocol.FeedTypePackageSource.FeedTypePackageSource(string! source, NuGet.Protocol.FeedType feedType) -> void
 NuGet.Protocol.FeedTypeResource
 NuGet.Protocol.FeedTypeResource.FeedType.get -> NuGet.Protocol.FeedType
 NuGet.Protocol.FeedTypeResource.FeedTypeResource(NuGet.Protocol.FeedType feedType) -> void
@@ -1642,7 +1642,7 @@ override NuGet.Protocol.Core.Types.NullSourceCacheContext.WithRefreshCacheTrue()
 override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.GetHashCode() -> int
 override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.ToString() -> string!
-~override NuGet.Protocol.Core.Types.SourceRepository.ToString() -> string
+override NuGet.Protocol.Core.Types.SourceRepository.ToString() -> string!
 ~override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackage(NuGet.Packaging.Core.PackageIdentity package, NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo>
 ~override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackages(string packageId, NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo>>
 ~override NuGet.Protocol.DependencyInfoResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
@@ -1901,15 +1901,15 @@ static NuGet.Protocol.Core.Types.OfflineFeedUtility.ThrowIfInvalidOrNotFound(str
 ~static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata, System.Func<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>> valueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
 ~static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata, System.Func<System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>> asyncValueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
 ~static NuGet.Protocol.Core.Types.PackageUpdateResource.ForceDeleteDirectory(string path) -> void
-~static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider> resourceProviders) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider
-~static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider> resourceProviders, string rootPath) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider
-~static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders, NuGet.Configuration.PackageSource source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders, string sourceUrl) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>> resourceProviders, string sourceUrl, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.Core.Types.Repository.Factory.get -> NuGet.Protocol.Core.Types.Repository.RepositoryFactory
-~static NuGet.Protocol.Core.Types.Repository.Provider.get -> NuGet.Protocol.Core.Types.Repository.ProviderFactory
-~static NuGet.Protocol.Core.Types.Repository.Provider.set -> void
+static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider!>! resourceProviders) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider!
+static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider!>! resourceProviders, string? rootPath) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider!
+static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders, NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders, NuGet.Configuration.PackageSource! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders, string! sourceUrl) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.Core.Types.Repository.CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>! resourceProviders, string! sourceUrl, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.Core.Types.Repository.Factory.get -> NuGet.Protocol.Core.Types.Repository.RepositoryFactory!
+static NuGet.Protocol.Core.Types.Repository.Provider.get -> NuGet.Protocol.Core.Types.Repository.ProviderFactory!
+static NuGet.Protocol.Core.Types.Repository.Provider.set -> void
 static NuGet.Protocol.Core.Types.UserAgent.SetUserAgent(System.Net.Http.HttpClient! client) -> void
 static NuGet.Protocol.Core.Types.UserAgent.SetUserAgentString(NuGet.Protocol.Core.Types.UserAgentStringBuilder! builder) -> void
 static NuGet.Protocol.Core.Types.UserAgent.UserAgentString.get -> string!
@@ -1939,7 +1939,7 @@ static NuGet.Protocol.HttpRequestMessageFactory.Create(System.Net.Http.HttpMetho
 static NuGet.Protocol.HttpRequestMessageFactory.Create(System.Net.Http.HttpMethod! method, System.Uri! requestUri, NuGet.Protocol.HttpRequestMessageConfiguration! configuration) -> System.Net.Http.HttpRequestMessage!
 static NuGet.Protocol.HttpRequestMessageFactory.Create(System.Net.Http.HttpMethod! method, string! requestUri, NuGet.Common.ILogger! log) -> System.Net.Http.HttpRequestMessage!
 static NuGet.Protocol.HttpRequestMessageFactory.Create(System.Net.Http.HttpMethod! method, string! requestUri, NuGet.Protocol.HttpRequestMessageConfiguration! configuration) -> System.Net.Http.HttpRequestMessage!
-~static NuGet.Protocol.HttpResponseMessageExtensions.LogServerWarning(this System.Net.Http.HttpResponseMessage response, NuGet.Common.ILogger log) -> void
+static NuGet.Protocol.HttpResponseMessageExtensions.LogServerWarning(this System.Net.Http.HttpResponseMessage! response, NuGet.Common.ILogger! log) -> void
 static NuGet.Protocol.HttpSource.Create(NuGet.Protocol.Core.Types.SourceRepository! source) -> NuGet.Protocol.HttpSource!
 static NuGet.Protocol.HttpSource.Create(NuGet.Protocol.Core.Types.SourceRepository! source, NuGet.Protocol.IThrottle! throttle) -> NuGet.Protocol.HttpSource!
 static NuGet.Protocol.HttpSourceResourceProvider.Throttle.get -> NuGet.Protocol.IThrottle?
@@ -2071,7 +2071,7 @@ static readonly NuGet.Protocol.ServiceTypes.Version510 -> string!
 static readonly NuGet.Protocol.ServiceTypes.Versioned -> string!
 static readonly NuGet.Protocol.StreamExtensions.BufferSize -> int
 ~virtual NuGet.Protocol.Core.Types.DependencyInfoResource.ResolvePackages(string packageId, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo>>
-~virtual NuGet.Protocol.Core.Types.Repository.ProviderFactory.GetCoreV3() -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>
+virtual NuGet.Protocol.Core.Types.Repository.ProviderFactory.GetCoreV3() -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>!
 virtual NuGet.Protocol.Core.Types.ResourceProvider.After.get -> System.Collections.Generic.IEnumerable<string!>!
 virtual NuGet.Protocol.Core.Types.ResourceProvider.Before.get -> System.Collections.Generic.IEnumerable<string!>!
 virtual NuGet.Protocol.Core.Types.ResourceProvider.Name.get -> string!
@@ -2081,12 +2081,12 @@ virtual NuGet.Protocol.Core.Types.SourceCacheContext.Dispose(bool disposing) -> 
 virtual NuGet.Protocol.Core.Types.SourceCacheContext.GeneratedTempFolder.get -> string!
 virtual NuGet.Protocol.Core.Types.SourceCacheContext.GeneratedTempFolder.set -> void
 virtual NuGet.Protocol.Core.Types.SourceCacheContext.WithRefreshCacheTrue() -> NuGet.Protocol.Core.Types.SourceCacheContext!
-~virtual NuGet.Protocol.Core.Types.SourceRepository.GetFeedType(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.FeedType>
-~virtual NuGet.Protocol.Core.Types.SourceRepository.GetResource<T>() -> T
-~virtual NuGet.Protocol.Core.Types.SourceRepository.GetResource<T>(System.Threading.CancellationToken token) -> T
-~virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>() -> System.Threading.Tasks.Task<T>
-~virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>
-~virtual NuGet.Protocol.Core.Types.SourceRepository.PackageSource.get -> NuGet.Configuration.PackageSource
+virtual NuGet.Protocol.Core.Types.SourceRepository.GetFeedType(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.FeedType>!
+virtual NuGet.Protocol.Core.Types.SourceRepository.GetResource<T>() -> T?
+virtual NuGet.Protocol.Core.Types.SourceRepository.GetResource<T>(System.Threading.CancellationToken token) -> T?
+virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>() -> System.Threading.Tasks.Task<T?>!
+virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T?>!
+virtual NuGet.Protocol.Core.Types.SourceRepository.PackageSource.get -> NuGet.Configuration.PackageSource!
 ~virtual NuGet.Protocol.FindLocalPackagesResource.Exists(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> bool
 ~virtual NuGet.Protocol.FindLocalPackagesResource.Exists(string packageId, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> bool
 virtual NuGet.Protocol.HttpSource.Dispose(bool disposing) -> void

--- a/src/NuGet.Core/NuGet.Protocol/Repository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Repository.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -106,6 +104,11 @@ namespace NuGet.Protocol.Core.Types
         [Obsolete("https://github.com/NuGet/Home/issues/8479")]
         public static ISourceRepositoryProvider CreateProvider(IEnumerable<INuGetResourceProvider> resourceProviders)
         {
+            if (resourceProviders == null)
+            {
+                throw new ArgumentNullException(nameof(resourceProviders));
+            }
+
             return new SourceRepositoryProvider(Settings.LoadDefaultSettings(null, null, null), CreateLazy(resourceProviders));
         }
 
@@ -114,8 +117,13 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <param name="rootPath">lowest folder path</param>
         [Obsolete("https://github.com/NuGet/Home/issues/8479")]
-        public static ISourceRepositoryProvider CreateProvider(IEnumerable<INuGetResourceProvider> resourceProviders, string rootPath)
+        public static ISourceRepositoryProvider CreateProvider(IEnumerable<INuGetResourceProvider> resourceProviders, string? rootPath)
         {
+            if (resourceProviders == null)
+            {
+                throw new ArgumentNullException(nameof(resourceProviders));
+            }
+
             return new SourceRepositoryProvider(Settings.LoadDefaultSettings(rootPath, null, null), CreateLazy(resourceProviders));
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/VulnerabilityInfoResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/VulnerabilityInfoResourceV3.cs
@@ -36,7 +36,8 @@ namespace NuGet.Protocol.Resources
         public async Task<IReadOnlyList<V3VulnerabilityIndexEntry>> GetVulnerabilityFilesAsync(SourceCacheContext cacheContext, ILogger log, CancellationToken cancellationToken)
         {
             Uri vulnerabilityIndexUrl = await GetIndexUrlAsync(cancellationToken);
-            HttpSourceResource httpSourceResource = await _sourceRepository.GetResourceAsync<HttpSourceResource>(cancellationToken);
+            HttpSourceResource httpSourceResource = await _sourceRepository.GetResourceAsync<HttpSourceResource>(cancellationToken)
+                ?? throw new InvalidOperationException($"The source '{_sourceRepository.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
 
             HttpSourceCacheContext httpSourceCacheContext = HttpSourceCacheContext.Create(cacheContext, isFirstAttempt: true);
             var request = new HttpSourceCachedRequest(vulnerabilityIndexUrl.OriginalString, "vuln_index", httpSourceCacheContext);
@@ -70,7 +71,8 @@ namespace NuGet.Protocol.Resources
 
             async Task<Uri> GetIndexUrlAsync(CancellationToken cancellationToken)
             {
-                ServiceIndexResourceV3 serviceIndex = await _sourceRepository.GetResourceAsync<ServiceIndexResourceV3>(cancellationToken);
+                ServiceIndexResourceV3 serviceIndex = await _sourceRepository.GetResourceAsync<ServiceIndexResourceV3>(cancellationToken)
+                    ?? throw new InvalidOperationException($"The source '{_sourceRepository.PackageSource.Source}' does not provide {nameof(ServiceIndexResourceV3)}.");
                 return serviceIndex.GetServiceEntryUri(ServiceTypes.VulnerabilityInfo);
             }
         }
@@ -88,7 +90,8 @@ namespace NuGet.Protocol.Resources
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            HttpSourceResource httpSourceResource = await _sourceRepository.GetResourceAsync<HttpSourceResource>(cancellationToken);
+            HttpSourceResource httpSourceResource = await _sourceRepository.GetResourceAsync<HttpSourceResource>(cancellationToken)
+                ?? throw new InvalidOperationException($"The source '{_sourceRepository.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
 
             HttpSourceCacheContext httpSourceCacheContext = HttpSourceCacheContext.Create(cacheContext, isFirstAttempt: true);
             var request = new HttpSourceCachedRequest(vulnerabilityPage.Url.OriginalString, "vuln_data_" + vulnerabilityPage.Name, httpSourceCacheContext);

--- a/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceRepository.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,8 +17,8 @@ namespace NuGet.Protocol.Core.Types
     public class SourceRepository
     {
         internal const int ProviderCacheTypes = 25;
-        private readonly Dictionary<Type, IReadOnlyList<INuGetResourceProvider>> _providerCache;
-        private readonly PackageSource _source;
+        private readonly Dictionary<Type, IReadOnlyList<INuGetResourceProvider>> _providerCache = new(ProviderCacheTypes);
+        private readonly PackageSource _source = null!; // Protected constructor is for subclasses that provide their own package source.
 
         /// <summary>
         /// Pre-determined feed type.
@@ -101,7 +99,8 @@ namespace NuGet.Protocol.Core.Types
         {
             if (FeedTypeOverride == FeedType.Undefined)
             {
-                var resource = await GetResourceAsync<FeedTypeResource>(token);
+                FeedTypeResource resource = await GetResourceAsync<FeedTypeResource>(token)
+                    ?? throw new InvalidOperationException($"The source '{PackageSource.Source}' does not provide {nameof(FeedTypeResource)}.");
                 return resource.FeedType;
             }
             else
@@ -115,7 +114,7 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <typeparam name="T">Expected resource type</typeparam>
         /// <returns>Null if the resource does not exist</returns>
-        public virtual T GetResource<T>() where T : class, INuGetResource
+        public virtual T? GetResource<T>() where T : class, INuGetResource
         {
             return GetResource<T>(CancellationToken.None);
         }
@@ -125,9 +124,9 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <typeparam name="T">Expected resource type</typeparam>
         /// <returns>Null if the resource does not exist</returns>
-        public virtual T GetResource<T>(CancellationToken token) where T : class, INuGetResource
+        public virtual T? GetResource<T>(CancellationToken token) where T : class, INuGetResource
         {
-            var task = GetResourceAsync<T>(token);
+            Task<T?> task = GetResourceAsync<T>(token);
             task.Wait(token);
 
             return task.Result;
@@ -138,7 +137,7 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <typeparam name="T">Expected resource type</typeparam>
         /// <returns>Null if the resource does not exist</returns>
-        public virtual async Task<T> GetResourceAsync<T>() where T : class, INuGetResource
+        public virtual async Task<T?> GetResourceAsync<T>() where T : class, INuGetResource
         {
             return await GetResourceAsync<T>(CancellationToken.None);
         }
@@ -148,12 +147,11 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <typeparam name="T">Expected resource type</typeparam>
         /// <returns>Null if the resource does not exist</returns>
-        public virtual async Task<T> GetResourceAsync<T>(CancellationToken token) where T : class, INuGetResource
+        public virtual async Task<T?> GetResourceAsync<T>(CancellationToken token) where T : class, INuGetResource
         {
             var resourceType = typeof(T);
-            IReadOnlyList<INuGetResourceProvider> possible;
-
-            if (_providerCache.TryGetValue(resourceType, out possible))
+            if (_providerCache.TryGetValue(resourceType, out IReadOnlyList<INuGetResourceProvider>? possible)
+                && possible != null)
             {
                 for (int i = 0; i < possible.Count; i++)
                 {
@@ -161,7 +159,7 @@ namespace NuGet.Protocol.Core.Types
                     var result = await provider.TryCreate(this, token);
                     if (result.Item1)
                     {
-                        return (T)result.Item2;
+                        return (T?)result.Item2;
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Protocol/SourceRepositoryProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/SourceRepositoryProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using NuGet.Configuration;
@@ -30,6 +28,16 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         public SourceRepositoryProvider(IPackageSourceProvider packageSourceProvider, IEnumerable<Lazy<INuGetResourceProvider>> resourceProviders)
         {
+            if (packageSourceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(packageSourceProvider));
+            }
+
+            if (resourceProviders == null)
+            {
+                throw new ArgumentNullException(nameof(resourceProviders));
+            }
+
             _packageSourceProvider = packageSourceProvider;
             _resourceProviders = resourceProviders;
             _repositories = new List<SourceRepository>();

--- a/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/GlobalPackagesFolderUtility.cs
@@ -3,7 +3,6 @@
 
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -127,11 +126,9 @@ namespace NuGet.Protocol
                 extractionContext,
                 token,
                 parentId);
-
-            var package = GetPackage(packageIdentity, globalPackagesFolder);
-
-            Debug.Assert(package!.PackageStream.CanSeek);
-            Debug.Assert(package.PackageReader != null);
+            // It is hard for to enforce this via the compiler, but at this point we are guaranteed to have the package. 
+            // If there were installation failured, PackageExtractor.InstallFromSourceAsync would have thrown.
+            var package = GetPackage(packageIdentity, globalPackagesFolder)!;
 
             return package;
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/AuthenticationHandlerTests.cs
@@ -49,7 +49,8 @@ namespace NuGet.Protocol.FuncTest
                     packageSource.Credentials = new PackageSourceCredential(packageSource.Name, "user", "pass", true, "basic");
                     var repository = Repository.Factory.GetCoreV3(packageSource);
 
-                    var httpSourceResource = await repository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
+                    HttpSourceResource httpSourceResource = await repository.GetResourceAsync<HttpSourceResource>(CancellationToken.None)
+                        ?? throw new InvalidOperationException();
                     var source = httpSourceResource.HttpSource;
 
                     using (var sourceCacheContext = new SourceCacheContext()
@@ -119,7 +120,8 @@ namespace NuGet.Protocol.FuncTest
                     SetupCredentialServiceMock(mockedCredentialService, expectedCredentials, packageSource);
                     HttpHandlerResourceV3.CredentialService = new Lazy<ICredentialService>(() => mockedCredentialService.Object);
 
-                    var httpSourceResource = await repository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
+                    HttpSourceResource httpSourceResource = await repository.GetResourceAsync<HttpSourceResource>(CancellationToken.None)
+                        ?? throw new InvalidOperationException();
                     var source = httpSourceResource.HttpSource;
 
                     using var sourceCacheContext = new SourceCacheContext()

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -22,7 +22,8 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(TestSources.NuGetV2Uri);
 
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None);
+            DownloadResource downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
 
             var package = new SourcePackageDependencyInfo("WindowsAzure.Storage", new NuGetVersion("6.2.0"), Enumerable.Empty<PackageDependency>(), true, repo, new Uri($@"{TestSources.NuGetV2Uri}/package/WindowsAzure.Storage/6.2.0"), "");
 
@@ -36,7 +37,8 @@ namespace NuGet.Protocol.FuncTest
                 NullLogger.Instance,
                 CancellationToken.None))
             {
-                var packageReader = downloadResult.PackageReader;
+                var packageReader = downloadResult.PackageReader
+                    ?? throw new InvalidOperationException();
                 var files = packageReader.GetFiles();
 
                 Assert.Equal(13, files.Count());
@@ -49,7 +51,8 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(TestSources.NuGetV2Uri);
 
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None);
+            DownloadResource downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
 
             var package = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0"));
 
@@ -63,7 +66,8 @@ namespace NuGet.Protocol.FuncTest
                 NullLogger.Instance,
                 CancellationToken.None))
             {
-                var packageReader = downloadResult.PackageReader;
+                var packageReader = downloadResult.PackageReader
+                    ?? throw new InvalidOperationException();
                 var files = packageReader.GetFiles();
 
                 Assert.Equal(13, files.Count());
@@ -76,7 +80,8 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(TestSources.NuGetV2Uri);
 
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None);
+            DownloadResource downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
 
             var package = new SourcePackageDependencyInfo("not-found", new NuGetVersion("6.2.0"), Enumerable.Empty<PackageDependency>(), true, repo, new Uri($@"{TestSources.NuGetV2Uri}/package/not-found/6.2.0"), "");
 
@@ -116,7 +121,8 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(TestSources.NuGetV2Uri);
 
-            var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+            PackageMetadataResource packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
 
             var package = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0"));
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/FindPackageByIdResourceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -26,7 +27,8 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
+            FindPackageByIdResource findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -52,7 +54,8 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
+            FindPackageByIdResource findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -78,7 +81,8 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
+            FindPackageByIdResource findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -104,7 +108,8 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV2(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
+            FindPackageByIdResource findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -130,7 +135,8 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV2(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
+            FindPackageByIdResource findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -156,7 +162,8 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV2(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
+            FindPackageByIdResource findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
             var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
@@ -196,7 +203,8 @@ namespace NuGet.Protocol.FuncTest
             var source = MockSourceRepository.Create(timeoutHandler);
 
             // Now arrange the NuGet Client SDK experience
-            var protocolResource = await source.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
+            FindPackageByIdResource protocolResource = await source.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
 
             using (var destination = new MemoryStream())
             {
@@ -223,7 +231,8 @@ namespace NuGet.Protocol.FuncTest
         {
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
-            var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
+            FindPackageByIdResource findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None)
+                ?? throw new InvalidOperationException();
             var logger = new TestLogger();
             string invalidPackageId = "../contoso";
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/Scenarios/ServerReturnsWrongPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/Scenarios/ServerReturnsWrongPackageTests.cs
@@ -53,7 +53,8 @@ public class ServerReturnsWrongPackageTests(ServerReturnsWrongPackageTests.Fixtu
         };
 
         SourceRepository testSource = StaticHttpHandler.CreateSource(url, Repository.Provider.GetCoreV3(), _fixture.Responses);
-        var findPackageByIdResource = await testSource.GetResourceAsync<FindPackageByIdResource>();
+        FindPackageByIdResource findPackageByIdResource = await testSource.GetResourceAsync<FindPackageByIdResource>()
+            ?? throw new InvalidOperationException();
 
         using var destination1 = new MemoryStream();
         using var destination2 = new MemoryStream();
@@ -139,7 +140,8 @@ public class ServerReturnsWrongPackageTests(ServerReturnsWrongPackageTests.Fixtu
         };
 
         SourceRepository testSource = StaticHttpHandler.CreateSource(url, Repository.Provider.GetCoreV3(), _fixture.Responses);
-        var downloadResource = await testSource.GetResourceAsync<DownloadResource>();
+        DownloadResource downloadResource = await testSource.GetResourceAsync<DownloadResource>()
+            ?? throw new InvalidOperationException();
 
         using var testDirectory = TestDirectory.Create();
         using var sourceCacheContext = new SourceCacheContext() { NoCache = noHttpCache };
@@ -214,9 +216,11 @@ public class ServerReturnsWrongPackageTests(ServerReturnsWrongPackageTests.Fixtu
                 ClientPolicyContext.GetClientPolicy(NullSettings.Instance, NullLogger.Instance),
                 NullLogger.Instance);
             var packagesConfigPathResolver = new PackagePathResolver(LocalPackagesConfigPath);
+            Stream packageStream = result.PackageStream
+                ?? throw new InvalidOperationException();
             await PackageExtractor.ExtractPackageAsync(
                 "local",
-                result.PackageStream,
+                packageStream,
                 packagesConfigPathResolver,
                 packageExtractionContext,
                 CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -27,7 +27,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
+            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected AutoCompleteResource.");
 
             // Act
             var result = await autoCompleteResource.IdStartsWith("Azure", false, NullLogger.Instance, CancellationToken.None);
@@ -49,7 +50,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
+            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected AutoCompleteResource.");
 
             // Act
             var result = await autoCompleteResource.VersionStartsWith("xunit", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -70,7 +72,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
+            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected AutoCompleteResource.");
 
             // Act
             var result = await autoCompleteResource.VersionStartsWith("azure", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
@@ -29,7 +29,8 @@ namespace NuGet.Protocol.Tests
                 JsonData.AutoCompleteEndpointNewtResult);
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.test/v3/index.json", Repository.Provider.GetCoreV3(), responses);
-            var resource = (AutoCompleteResourceV3)await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None);
+            var resource = (AutoCompleteResourceV3)(await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected AutoCompleteResource."));
 
             var envReader = new Mock<IEnvironmentVariableReader>();
             envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar)).Returns(useStj);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV2FeedTests.cs
@@ -31,7 +31,8 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses,
                  ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None);
+            var downloadResource = await repo.GetResourceAsync<DownloadResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected DownloadResource.");
 
             // Act
             using (var packagesFolder = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
@@ -23,7 +23,8 @@ namespace NuGet.Protocol.Tests
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
 
             // Act
-            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
+            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected HttpSourceResource.");
 
             // Assert
             Assert.NotNull(httpSourceResource);
@@ -38,7 +39,8 @@ namespace NuGet.Protocol.Tests
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
 
             // Act
-            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
+            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected HttpSourceResource.");
 
             // Assert
             Assert.NotNull(httpSourceResource);
@@ -56,7 +58,8 @@ namespace NuGet.Protocol.Tests
             var sourceRepository = new SourceRepository(packageSource, new[] { new HttpSourceResourceProvider() });
 
             // Act
-            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
+            HttpSourceResource httpSourceResource = await sourceRepository.GetResourceAsync<HttpSourceResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected HttpSourceResource.");
 
             // Assert
             Assert.NotNull(httpSourceResource);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV2FeedTests.cs
@@ -30,7 +30,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected MetadataResource.");
 
             // Act
             var latestVersion = await metadataResource.GetLatestVersion("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -52,7 +53,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected MetadataResource.");
 
             // Act
             var latestVersion = await metadataResource.GetLatestVersion("WindowsAzure.Storage", false, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -74,7 +76,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected MetadataResource.");
 
             // Act
             var versions = await metadataResource.GetVersions("WindowsAzure.Storage", false, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -96,7 +99,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected MetadataResource.");
 
             // Act
             var versions = await metadataResource.GetVersions("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -118,7 +122,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected MetadataResource.");
 
             // Act
             var exist = await metadataResource.Exists("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -141,7 +146,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected MetadataResource.");
 
             var package = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("4.3.2-preview"));
 
@@ -169,7 +175,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected MetadataResource.");
 
             var packageIdList = new List<string>() { "WindowsAzure.Storage", "xunit" };
 
@@ -197,7 +204,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected MetadataResource.");
 
             // Act
             var latestVersion = await metadataResource.GetLatestVersion("not-found", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -220,7 +228,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected MetadataResource.");
 
             // Act
             var versions = await metadataResource.GetVersions("not-found", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -244,7 +253,8 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses,
                  ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected MetadataResource.");
 
             var package = new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound"));
 
@@ -269,7 +279,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None);
+            var metadataResource = await repo.GetResourceAsync<MetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected MetadataResource.");
 
             // Act
             var exist = await metadataResource.Exists("not-found", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ODataServiceDocumentV2Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ODataServiceDocumentV2Tests.cs
@@ -23,7 +23,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected ODataServiceDocumentResourceV2.");
 
             // Act
             var baseAddress = oDataServiceDocumentResource.BaseAddress;
@@ -43,7 +44,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected ODataServiceDocumentResourceV2.");
 
             // Act
             var baseAddress = oDataServiceDocumentResource.BaseAddress;
@@ -65,7 +67,8 @@ namespace NuGet.Protocol.Tests
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             // Act
-            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
+            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected ODataServiceDocumentResourceV2.");
 
             // Assert
             Assert.Equal(serviceAddress.Trim('/'), resource.BaseAddress);
@@ -82,7 +85,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected ODataServiceDocumentResourceV2.");
 
             // Act
             var baseAddress = oDataServiceDocumentResource.BaseAddress;
@@ -102,7 +106,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected ODataServiceDocumentResourceV2.");
 
             // Act
             var baseAddress = oDataServiceDocumentResource.BaseAddress;
@@ -122,7 +127,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None);
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected ODataServiceDocumentResourceV2.");
 
             // Act
             var baseAddress = oDataServiceDocumentResource.BaseAddress;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -31,14 +31,16 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected PackageMetadataResource.");
 
             var package = new PackageIdentity("deepequal", NuGetVersion.Parse("0.9.0"));
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
             {
-                var result = (PackageSearchMetadataRegistration)await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
+                var result = (PackageSearchMetadataRegistration)(await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None)
+                    ?? throw new Xunit.Sdk.XunitException("Expected package metadata."));
 
                 // Assert
                 Assert.Equal("deepequal", result.Identity.Id, StringComparer.OrdinalIgnoreCase);
@@ -68,14 +70,16 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected PackageMetadataResource.");
 
             var package = new PackageIdentity("unlistedpackagea", NuGetVersion.Parse("1.0.0"));
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
             {
-                var result = (PackageSearchMetadataRegistration)await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
+                var result = (PackageSearchMetadataRegistration)(await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None)
+                    ?? throw new Xunit.Sdk.XunitException("Expected package metadata."));
 
                 // Assert
                 Assert.False(result.IsListed);
@@ -92,12 +96,14 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected PackageMetadataResource.");
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
             {
-                var result = (IEnumerable<PackageSearchMetadataRegistration>)await resource.GetMetadataAsync("afine", true, true, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
+                var result = (IEnumerable<PackageSearchMetadataRegistration>)(await resource.GetMetadataAsync("afine", true, true, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None)
+                    ?? throw new Xunit.Sdk.XunitException("Expected package metadata list."));
 
                 var first = result.ElementAt(0);
                 var second = result.ElementAt(1);
@@ -117,7 +123,8 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected PackageMetadataResource.");
 
             var package = new PackageIdentity("deepequal", NuGetVersion.Parse("0.0.0"));
 
@@ -153,14 +160,16 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(sourceName, Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected PackageMetadataResource.");
 
             var package = new PackageIdentity("PackageA", NuGetVersion.Parse("1.0.0"));
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
             {
-                var result = await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
+                var result = await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None)
+                    ?? throw new Xunit.Sdk.XunitException("Expected package metadata.");
 
                 // Assert
                 Assert.NotNull(result);
@@ -202,14 +211,16 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(sourceName, Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected PackageMetadataResource.");
 
             var package = new PackageIdentity("PackageA", NuGetVersion.Parse("1.0.0"));
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
             {
-                var result = await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
+                var result = await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None)
+                    ?? throw new Xunit.Sdk.XunitException("Expected package metadata.");
 
                 // Assert
                 Assert.NotNull(result);
@@ -256,7 +267,8 @@ namespace NuGet.Protocol.Tests
             };
 
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected PackageMetadataResource.");
 
             //Act
             using (var sourceCacheContext = new SourceCacheContext())
@@ -292,7 +304,8 @@ namespace NuGet.Protocol.Tests
             };
 
             var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected PackageMetadataResource.");
 
             //Act
             using (var sourceCacheContext = new SourceCacheContext())
@@ -314,14 +327,16 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+            var resource = await repo.GetResourceAsync<PackageMetadataResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected PackageMetadataResource.");
 
             var package = new PackageIdentity("dependencyedgecases", NuGetVersion.Parse("0.1.0"));
 
             // Act
             using (var sourceCacheContext = new SourceCacheContext())
             {
-                var result = await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
+                var result = await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None)
+                    ?? throw new Xunit.Sdk.XunitException("Expected package metadata.");
 
                 // Assert
                 result.Should().NotBeNull();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RepositoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RepositoryTests.cs
@@ -32,7 +32,7 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public void Provider_WhenSettingNull_Throws()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => Repository.Provider = null);
+            var exception = Assert.Throws<ArgumentNullException>(() => Repository.Provider = null!);
 
             Assert.Equal("value", exception.ParamName);
         }

--- a/tools-local/ensure-nupkg-dependencies-on-source/NuGetFeed.cs
+++ b/tools-local/ensure-nupkg-dependencies-on-source/NuGetFeed.cs
@@ -22,7 +22,8 @@ namespace ensure_nupkg_dependencies_on_source
                 _findPackageByIdResource = await _sourceRepository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
             }
 
-            return _findPackageByIdResource;
+            return _findPackageByIdResource
+                ?? throw new System.InvalidOperationException($"Source '{_sourceRepository.PackageSource.Source}' does not provide {nameof(FindPackageByIdResource)}.");
         }
     }
 }


### PR DESCRIPTION
# Bug

Progress: https://github.com/NuGet/Home/issues/14851

## Description

Enable nullable annotations for the Phase 12 NuGet.Protocol repository-abstraction batch.

- SourceRepository.GetResource and GetResourceAsync now return nullable resources, matching the existing XML docs and the INuGetResourceProvider.TryCreate contract when a provider cannot produce a resource.
- Annotate the repository/provider primitives (Repository, SourceRepository, ISourceRepositoryProvider, SourceRepositoryProvider, CachingSourceProvider, ProviderComparer, FeedTypePackageSource, HttpResponseMessageExtensions) and make the immediate callers/tests handle required resources explicitly.
- DownloadResourceResult now reflects its existing optional stream/source/reader state in the public annotations.
- PackageUpdateIO now treats a missing PackageMetadataResource as "no version candidate found" in both the latest-version and non-vulnerable-version lookup paths, rather than throwing.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
