### PR TITLE
Fix nullable annotation on LoadSpecificSettings

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Shipped.txt
@@ -434,7 +434,7 @@ static NuGet.Configuration.Settings.LoadDefaultSettings(string? root, string? co
 static NuGet.Configuration.Settings.LoadImmutableSettingsGivenConfigPaths(System.Collections.Generic.IList<string!>? configFilePaths, NuGet.Configuration.SettingsLoadingContext! settingsLoadingContext) -> NuGet.Configuration.ISettings!
 static NuGet.Configuration.Settings.LoadMachineWideSettings(string! root, params string![]! paths) -> NuGet.Configuration.ISettings!
 static NuGet.Configuration.Settings.LoadSettingsGivenConfigPaths(System.Collections.Generic.IList<string!>! configFilePaths) -> NuGet.Configuration.ISettings!
-static NuGet.Configuration.Settings.LoadSpecificSettings(string! root, string! configFileName) -> NuGet.Configuration.ISettings!
+static NuGet.Configuration.Settings.LoadSpecificSettings(string? root, string! configFileName) -> NuGet.Configuration.ISettings!
 static NuGet.Configuration.SettingsUtility.DeleteConfigValue(NuGet.Configuration.ISettings! settings, string! key) -> bool
 static NuGet.Configuration.SettingsUtility.DeleteValue(NuGet.Configuration.ISettings! settings, string! section, string! attributeKey, string! attributeValue) -> bool
 static NuGet.Configuration.SettingsUtility.GetConfigValue(NuGet.Configuration.ISettings! settings, string! key, bool decrypt = false, bool isPath = false) -> string?

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -352,7 +352,7 @@ namespace NuGet.Configuration
         /// Loads Specific NuGet.Config file. The method only loads specific config file 
         /// which is file <paramref name="configFileName"/>from <paramref name="root"/>.
         /// </summary>
-        public static ISettings LoadSpecificSettings(string root, string configFileName)
+        public static ISettings LoadSpecificSettings(string? root, string configFileName)
         {
             if (string.IsNullOrEmpty(configFileName))
             {


### PR DESCRIPTION
The annotation on this method is incorrect: `root` is allowed to be `null` and `null` is correctly handled throughout the rest of the call chain.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: I did not create an issue because of how simple the fix is; if you really need me to, I can do so.

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
