### PR TITLE
Make PackageBuilder.CalcPsmdcpName deterministic

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -369,13 +369,13 @@ namespace NuGet.Packaging
             }
         }
 
-        private string CalcPsmdcpName()
+        internal string CalcPsmdcpName()
         {
             if (_deterministic)
             {
                 using (var hashFunc = new Sha512HashFunction())
                 {
-                    foreach (var file in Files)
+                    foreach (var file in Files.OrderBy(f => f, new NormalizedPathComparer()))
                     {
                         var data = ReadAllBytes(file.GetStream());
                         hashFunc.Update(data, 0, data.Length);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -5010,6 +5010,105 @@ namespace ClassLibrary
             }
         }
 
+        [Fact]
+        public void PackCommand_Deterministic_MultiplePackInvocationsAgainstNuspecWithGlobs_CreateIdenticalPackages()
+        {
+            var deterministicTimestamp = new DateTimeOffset(year: 2020, month: 1, day: 1,
+                                                            hour: 0, minute: 0, second: 0,
+                                                            offset: TimeSpan.Zero);
+
+            using (var testDirectory = _dotnetFixture.CreateTestDirectory())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                _dotnetFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib", testOutputHelper: _testOutputHelper);
+
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.AddProperty(xml, "Deterministic", "true");
+                    ProjectFileUtils.AddProperty(xml, "DeterministicTimestamp", deterministicTimestamp.ToString("o"));
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                var nuspecXml = @"
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+    <metadata>
+        <id>ClassLibrary1</id>
+        <version>1.0.0</version>
+        <description>Foo Bar</description>
+        <authors>Foo Bar Baz</authors>
+    </metadata>
+    <files>
+      <file src=""content/**/file1"" target=""content/"" />
+      <file src=""content/**/file2"" target=""content/"" />
+      <file src=""content/**/file3"" target=""content/"" />
+    </files>
+</package>";
+                var nuspecFile = Path.Combine(workingDirectory, $"{projectName}.nuspec");
+                File.WriteAllText(nuspecFile, nuspecXml);
+
+                var contentDirectory = Path.Combine(workingDirectory, "content");
+                Directory.CreateDirectory(contentDirectory);
+                foreach (var directory in new[] { "dir1", "dir2", "dir3" })
+                {
+                    var subcontentDirectory = Path.Combine(contentDirectory, directory);
+                    Directory.CreateDirectory(subcontentDirectory);
+                    foreach (var file in new[] { "file1", "file2", "file3" })
+                    {
+                        // Write deterministic contents
+                        File.WriteAllText(Path.Combine(subcontentDirectory, $"{file}"), $"{directory},{file}");
+                    }
+                }
+
+                _dotnetFixture.RestoreProjectExpectSuccess(workingDirectory, projectName, testOutputHelper: _testOutputHelper);
+
+                var iterations = 5;
+                byte[][] packageBytes = new byte[iterations][];
+
+                for (var i = 0; i < iterations; i++)
+                {
+                    var packageOutputPath = Path.Combine(workingDirectory, i.ToString());
+                    var nupkgPath = Path.Combine(packageOutputPath, $"{projectName}.1.0.0.nupkg");
+
+                    // Every iteration, recreate everything in a random order
+
+                    Directory.Delete(contentDirectory, recursive: true);
+                    Directory.CreateDirectory(contentDirectory);
+
+                    foreach (var directory in new[] { "dir1", "dir2", "dir3" }.OrderBy(_ => Random.Shared.Next()))
+                    {
+                        var subcontentDirectory = Path.Combine(contentDirectory, directory);
+                        Directory.CreateDirectory(subcontentDirectory);
+                        foreach (var file in new[] { "file1", "file2", "file3" }.OrderBy(_ => Random.Shared.Next()))
+                        {
+                            // Write deterministic contents
+                            File.WriteAllText(Path.Combine(subcontentDirectory, $"{file}"), $"{directory},{file}");
+                        }
+                    }
+
+                    // Act
+                    _dotnetFixture.PackProjectExpectSuccess(workingDirectory, projectName, $"-p:NuspecFile={nuspecFile} -p:NuspecBasePath={workingDirectory} -o {packageOutputPath}", testOutputHelper: _testOutputHelper);
+
+                    Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+
+                    using (var reader = new FileStream(nupkgPath, FileMode.Open))
+                    using (var ms = new MemoryStream())
+                    {
+                        reader.CopyTo(ms);
+                        packageBytes[i] = ms.ToArray();
+                    }
+                }
+
+                // Assert
+                for (var i = 1; i < iterations; i++)
+                {
+                    Assert.Equal(packageBytes[0], packageBytes[i]);
+                }
+            }
+        }
+
         [PlatformFact(Platform.Windows)]
         public void PackCommand_PackageIcon_HappyPath_Warns_Succeeds()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -223,6 +223,48 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
+        public void CreatePackageWithChangingOrderOfFilesIsDeterministic()
+        {
+            var sep = Path.DirectorySeparatorChar;
+            string[] hashes = new string[2];
+
+            for (var i = 0; i < 2; i++)
+            {
+                // Arrange
+                PackageBuilder builder = new PackageBuilder(deterministic: true)
+                {
+                    Id = "A",
+                    Version = NuGetVersion.Parse("1.0"),
+                    Description = "Descriptions",
+                    DeterministicTimestamp = "2009-02-13T23:31:30+00:00",
+                };
+
+                // With globs like <file src="**" >, the order of files can be
+                // random. Simulate that by using different order different
+                // times.
+                List<IPackageFile> files = new List<IPackageFile>
+                {
+                    CreatePackageFile(@"content" + sep + "file1.txt", new byte[] { 0x01 }),
+                    CreatePackageFile(@"content" + sep + "file2.txt", new byte[] { 0x02 }),
+                    CreatePackageFile(@"data" + sep + "file1.txt", new byte[] { 0x03 }),
+                    CreatePackageFile(@"data" + sep + "file2.txt", new byte[] { 0x04 }),
+                    CreatePackageFile(@"content" + sep + "file3.txt", new byte[] { 0x05 }),
+                };
+
+                if (i % 2 != 0)
+                {
+                    files.Reverse();
+                }
+
+                builder.Files.AddRange(files);
+
+                hashes[i] = builder.CalcPsmdcpName();
+            }
+
+            Assert.Equal(hashes[0], hashes[1]);
+        }
+
+        [Fact]
         public void CreatePackage_IncludesAStableOrderOfContentTypesXml()
         {
             // Arrange
@@ -3358,11 +3400,11 @@ Enabling license acceptance requires a license or a licenseUrl to be specified. 
             return testDir;
         }
 
-        private static IPackageFile CreatePackageFile(string name)
+        private static IPackageFile CreatePackageFile(string name, byte[] buffer = null)
         {
             var file = new Mock<IPackageFile>();
             file.SetupGet(f => f.Path).Returns(name);
-            file.Setup(f => f.GetStream()).Returns(new MemoryStream());
+            file.Setup(f => f.GetStream()).Returns(() => buffer == null ? new MemoryStream() : new MemoryStream(buffer));
             file.Setup(f => f.LastWriteTime).Returns(DateTimeOffset.UtcNow);
 
             string effectivePath;


### PR DESCRIPTION
# Bug

Fixes: https://github.com/NuGet/Home/issues/14916

## Description

The order of input files can vary between nuget pack runs, specially if nuspec files use the `**` glob when specifying `<file>` elements.

A simple workaround is to sort files before computing the hash of the file contents in nuget package for the psmdcp file name. This keeps the hash stable across nuget pack runs.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
