### PR TITLE
Update DartLab1ES pipelines to reference templates in DartLab instead of DartLab.Templates

### DIFF
--- a/eng/pipelines/dailytests.yml
+++ b/eng/pipelines/dailytests.yml
@@ -20,12 +20,14 @@ resources:
   pipelines:
   - pipeline: DartLab
     source: DartLab
-    branch: main
+    branch: refs/heads/main
+    tags:
+    - Production
   repositories:
   - repository: DartLabTemplates
     type: git
-    name: DartLab.Templates
-    ref: refs/heads/main
+    name: DevDiv/DartLab
+    ref: refs/tags/Production
 
 variables:
   DOTNET_NOLOGO: 1

--- a/eng/pipelines/vs-test/apex.yml
+++ b/eng/pipelines/vs-test/apex.yml
@@ -22,7 +22,7 @@ parameters:
       - OnSuccess
 
 stages:
-  - template: stages/cloudtest/visual-studio/single-runsettings.yml@DartLabTemplates
+  - template: /templates/stages/visual-studio/single-runsettings.yml@DartLabTemplates
     parameters:
       name: VS_Apex_Tests
       displayName: Apex Tests On Windows

--- a/eng/pipelines/vs-test/end_to_end.yml
+++ b/eng/pipelines/vs-test/end_to_end.yml
@@ -31,7 +31,7 @@ parameters:
   type: string
 
 stages:
-- template: stages\visual-studio\build-to-build-upgrade\agent.yml@DartLabTemplates
+- template: stages\visual-studio\build-to-build-upgrade\agent.yml@LegacyDartLabTemplates
   parameters:
     name: ${{parameters.stageName}}
     displayName: 'E2E Tests ${{parameters.stageDisplayName}}'
@@ -66,14 +66,14 @@ stages:
 ## preTestMachineConfigurationStepList
 ##############################
     preTestMachineConfigurationStepList:
-    - template: '\steps\powershell\execute-script.yml@DartLabTemplates'
+    - template: '\steps\powershell\execute-script.yml@LegacyDartLabTemplates'
       parameters:
         displayName: Set 'VisualStudio.InstallationUnderTest.SetupParameters'
         filePath: $(DartLab.Path)\Scripts\VisualStudio\Installation\Get-VisualStudioSetupParameters.ps1
         arguments: -RunSettingsURI '$(runSettingsURI)' -InstallPath 'C:\Test\VisualStudio' -NoRestart -Quiet -Wait -OutVariableName 'VisualStudio.InstallationUnderTest.SetupParameters' -ServiceConnectionTenantID $env:AZURESUBSCRIPTION_TENANT_ID -ServiceConnectionClientID $env:AZURESUBSCRIPTION_CLIENT_ID -ServiceConnectionID $env:AZURESUBSCRIPTION_SERVICE_CONNECTION_ID
         serviceConnectionName: DartLab-TestMachine
 
-    - template: '\steps\powershell\execute-script.yml@DartLabTemplates'
+    - template: '\steps\powershell\execute-script.yml@LegacyDartLabTemplates'
       parameters:
         displayName: Get Baseline Build ID using CloudBuild Session ID
         continueOnError: true

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -54,10 +54,16 @@ resources:
     source: DartLab
     branch: main
   repositories:
-  - repository: DartLabTemplates
+  # Legacy DTL DartLab templates repository
+  - repository: LegacyDartLabTemplates
     type: git
     name: DartLab.Templates
     ref: refs/heads/main
+  # DartLab1ES/CloudTest templates repository
+  - repository: DartLabTemplates
+    type: git
+    name: DevDiv/DartLab
+    ref: refs/tags/Production
 
 variables:
   DOTNET_NOLOGO: 1


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description
Update paths to reference CloudTest templates in DartLab instead of DartLab.Templates
Associated user stories
- [User Story 2943790 Introduce Explicit Deployment Pipeline for DartLab (Decouple Build from Deploy)](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2943790)
- [User Story 2943792 Merge DartLab 1ES Templates into DartLab Repository](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2943792)
- Validation run https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14175499&view=results
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] N/A Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
