### PR TITLE
Revert CI trigger change from d2396e1f

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -41,9 +41,16 @@ variables:
 trigger:
   branches:
     include:
-    - '*'
+    - dev
 
-pr: none
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - '*'
+  paths:
+    include:
+    - '**'
 
 stages:
 - ${{ if eq(parameters.RunUnitTestsOnWindows, true) }}:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -44,13 +44,9 @@ trigger:
     - dev
 
 pr:
-  autoCancel: true
   branches:
     include:
     - '*'
-  paths:
-    include:
-    - '**'
 
 stages:
 - ${{ if eq(parameters.RunUnitTestsOnWindows, true) }}:


### PR DESCRIPTION
## Problem

The change in d2396e1f ("Use branch-push CI for pr.yml") disabled the `pr` trigger entirely, causing external fork PRs to never run CI:

```yaml
trigger:
  branches:
    include:
    - '*'
pr: none
```

The attempted fix using `paths` filtering did not work as expected.

## Solution

Revert `eng/pipelines/pr.yml` to the state before d2396e1f, restoring the original configuration:

```yaml
trigger:
  branches:
    include:
    - dev

pr:
  branches:
    include:
    - '*'
```

## Result

✅ External fork PRs trigger CI  
✅ Direct pushes to `dev` branch trigger CI  
✅ No unnecessary rebuilds on other internal branches