### PR TITLE
DteMiscProject now returns null instead of throwing ArgumentException

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,6 +17,7 @@
 ## Project-Specific Rules
 
 - All files in the repository are nullable by default (project-level nullable enable). No need to add `#nullable enable` directives to individual files.
+- Do not add `#nullable disable` to new files. Project-level nullable is enabled, so new files should opt in to nullable annotations and handle any warnings honestly (return `?` types, guard nulls, etc.) rather than disabling the feature. Existing files that still have `#nullable disable` will be migrated incrementally — do not propagate the directive into newly created files alongside them.
 
 ## Benchmarking
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/EnvDteProjectExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/EnvDteProjectExtensions.cs
@@ -311,10 +311,9 @@ namespace NuGet.VisualStudio
             }
             catch (ArgumentException)
             {
-                // Some VS project types (notably the "Miscellaneous Files" pseudo-project,
-                // Microsoft.VisualStudio.CommonIDE.Solutions.Dte.DteMiscProject) throw
-                // ArgumentException from the ParentProjectItem getter instead of returning
-                // null. Treat that case as "no parent" so callers don't fault.
+                // DteMiscProject.ParentProjectItem can throw ArgumentException from its
+                // ProjectItems.Item(name) lookup. Treat as "no parent".
+                // https://devdiv.visualstudio.com/DevDiv/_git/VS?path=/src/env/vscore/package/Solutions/Dte/DteMiscProject.cs&version=GC01fad60843e7b3b97d52e6a6a602b0eace04a509&line=419&lineEnd=420&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
                 return null;
             }
         }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/EnvDteProjectExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/EnvDteProjectExtensions.cs
@@ -290,14 +290,33 @@ namespace NuGet.VisualStudio
             nameParts.Push(GetName(cursor));
 
             // walk up till the solution root
-            while (cursor.ParentProjectItem != null
-                   && cursor.ParentProjectItem.ContainingProject != null)
+            ProjectItem parent;
+            while ((parent = GetParentProjectItemOrNull(cursor)) != null
+                   && parent.ContainingProject != null)
             {
-                cursor = cursor.ParentProjectItem.ContainingProject;
+                cursor = parent.ContainingProject;
                 nameParts.Push(GetName(cursor));
             }
 
             return string.Join("\\", nameParts);
+        }
+
+        private static ProjectItem GetParentProjectItemOrNull(EnvDTE.Project project)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            try
+            {
+                return project.ParentProjectItem;
+            }
+            catch (ArgumentException)
+            {
+                // Some VS project types (notably the "Miscellaneous Files" pseudo-project,
+                // Microsoft.VisualStudio.CommonIDE.Solutions.Dte.DteMiscProject) throw
+                // ArgumentException from the ParentProjectItem getter instead of returning
+                // null. Treat that case as "no parent" so callers don't fault.
+                return null;
+            }
         }
 
         /// <summary>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/IDE/EnvDteProjectExtensionsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/IDE/EnvDteProjectExtensionsTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Threading.Tasks;
+using EnvDTE;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Microsoft.VisualStudio.Shell;
+using Moq;
+using Xunit;
+
+namespace NuGet.VisualStudio.Common.Test.IDE
+{
+    [Collection(MockedVS.Collection)]
+    public class EnvDteProjectExtensionsTests
+    {
+        public EnvDteProjectExtensionsTests(GlobalServiceProvider sp)
+        {
+            sp.Reset();
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(ThreadHelper.JoinableTaskFactory);
+        }
+
+        [Fact]
+        public async Task GetCustomUniqueNameAsync_ParentProjectItemThrowsArgumentException_ReturnsProjectName()
+        {
+            // Arrange
+            // Regression test for the "Miscellaneous Files" pseudo-project
+            // (Microsoft.VisualStudio.CommonIDE.Solutions.Dte.DteMiscProject), whose
+            // ParentProjectItem getter throws ArgumentException rather than returning null.
+            const string projectName = "MiscellaneousFiles";
+
+            var project = new Mock<Project>();
+            project.SetupGet(p => p.Name).Returns(projectName);
+            project.SetupGet(p => p.Kind).Returns(VsProjectTypes.VsProjectKindMisc);
+            project.SetupGet(p => p.ParentProjectItem).Throws(new ArgumentException("Item was not found."));
+
+            // Act
+            string customUniqueName = await project.Object.GetCustomUniqueNameAsync();
+
+            // Assert
+            Assert.Equal(projectName, customUniqueName);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/IDE/EnvDteProjectExtensionsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/IDE/EnvDteProjectExtensionsTests.cs
@@ -26,9 +26,8 @@ namespace NuGet.VisualStudio.Common.Test.IDE
         public async Task GetCustomUniqueNameAsync_ParentProjectItemThrowsArgumentException_ReturnsProjectName()
         {
             // Arrange
-            // Regression test for the "Miscellaneous Files" pseudo-project
-            // (Microsoft.VisualStudio.CommonIDE.Solutions.Dte.DteMiscProject), whose
-            // ParentProjectItem getter throws ArgumentException rather than returning null.
+            // Regression: DteMiscProject.ParentProjectItem can throw ArgumentException.
+            // https://devdiv.visualstudio.com/DevDiv/_git/VS?path=/src/env/vscore/package/Solutions/Dte/DteMiscProject.cs&version=GC01fad60843e7b3b97d52e6a6a602b0eace04a509&line=419&lineEnd=420&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
             const string projectName = "MiscellaneousFiles";
 
             var project = new Mock<Project>();

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/IDE/EnvDteProjectExtensionsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/IDE/EnvDteProjectExtensionsTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading.Tasks;
 using EnvDTE;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3664

## Description

 DteMiscProject is the Visual Studio "Miscellaneous Files" pseudo-project (the bucket that holds files opened outside any real project).

 Its DTE implementation of ParentProjectItem ends up calling `DteMiscProjectItems.Item(Object)`, which throws `ArgumentException` instead of returning null like real project types do.

 The test correctly reproduces the production fault from the bug (the stack trace ends in NuGet.VisualStudio.EnvDteProjectExtensions.<GetCustomUniqueNameAsync>d__13.MoveNext()


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
