### PR TITLE
Switch to STJ deserialization for PluginCacheEntry

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
@@ -6,11 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using NuGet.Common;
-using NuGet.Shared;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -20,8 +16,6 @@ namespace NuGet.Protocol.Plugins
     /// </summary>
     public sealed class PluginCacheEntry
     {
-        private readonly IEnvironmentVariableReader _environmentVariableReader;
-
         /// <summary>
         /// Create a plugin cache entry.
         /// </summary>
@@ -29,16 +23,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="pluginFilePath">The full plugin file path, which will be used to create a key for the folder created in the root folder itself </param>
         /// <param name="requestKey">A unique request key for the operation claims. Ideally the packageSourceRepository value of the PluginRequestKey. Example https://protected.package.feed/index.json, or Source-Agnostic</param>
         public PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey)
-            : this(rootCacheFolder, pluginFilePath, requestKey, environmentVariableReader: null)
-        {
-        }
-
-        internal PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey, IEnvironmentVariableReader environmentVariableReader)
         {
             RootFolder = Path.Combine(rootCacheFolder, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash(pluginFilePath, addIdentifiableCharacters: false)));
             CacheFileName = Path.Combine(RootFolder, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash(requestKey, addIdentifiableCharacters: false)) + ".dat");
             NewCacheFileName = CacheFileName + "-new";
-            _environmentVariableReader = environmentVariableReader;
         }
 
         internal TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(30);
@@ -60,30 +48,12 @@ namespace NuGet.Protocol.Plugins
                 content = CachingUtility.ReadCacheFile(MaxAge, CacheFileName);
                 if (content != null)
                 {
-                    ProcessContent(content);
+                    OperationClaims = System.Text.Json.JsonSerializer.Deserialize(content, PluginCacheJsonContext.Default.IReadOnlyListOperationClaim);
                 }
             }
             finally
             {
                 content?.Dispose();
-            }
-        }
-
-        private void ProcessContent(Stream content)
-        {
-            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
-            {
-                OperationClaims = System.Text.Json.JsonSerializer.Deserialize(content, PluginCacheJsonContext.Default.IReadOnlyListOperationClaim);
-            }
-            else
-            {
-                var serializer = new Newtonsoft.Json.JsonSerializer();
-                using (var sr = new StreamReader(content))
-                using (var jsonTextReader = new JsonTextReader(sr))
-                {
-                    OperationClaims = serializer.Deserialize<IReadOnlyList<OperationClaim>>(jsonTextReader);
-                }
             }
         }
 
@@ -108,17 +78,7 @@ namespace NuGet.Protocol.Plugins
                     FileShare.None,
                     CachingUtility.BufferSize))
                 {
-                    byte[] json;
-                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                        || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
-                    {
-                        json = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(OperationClaims, PluginCacheJsonContext.Default.IReadOnlyListOperationClaim);
-                    }
-                    else
-                    {
-                        json = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(OperationClaims, Formatting.Indented));
-                    }
-
+                    byte[] json = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(OperationClaims, PluginCacheJsonContext.Default.IReadOnlyListOperationClaim);
                     await fileStream.WriteAsync(json, 0, json.Length);
                 }
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
@@ -29,7 +29,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="pluginFilePath">The full plugin file path, which will be used to create a key for the folder created in the root folder itself </param>
         /// <param name="requestKey">A unique request key for the operation claims. Ideally the packageSourceRepository value of the PluginRequestKey. Example https://protected.package.feed/index.json, or Source-Agnostic</param>
         public PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey)
-            : this(rootCacheFolder, pluginFilePath, requestKey, EnvironmentVariableWrapper.Instance)
+            : this(rootCacheFolder, pluginFilePath, requestKey, environmentVariableReader: null)
         {
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
@@ -9,6 +9,8 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using NuGet.Common;
+using NuGet.Shared;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -18,6 +20,8 @@ namespace NuGet.Protocol.Plugins
     /// </summary>
     public sealed class PluginCacheEntry
     {
+        private readonly IEnvironmentVariableReader _environmentVariableReader;
+
         /// <summary>
         /// Create a plugin cache entry.
         /// </summary>
@@ -25,10 +29,16 @@ namespace NuGet.Protocol.Plugins
         /// <param name="pluginFilePath">The full plugin file path, which will be used to create a key for the folder created in the root folder itself </param>
         /// <param name="requestKey">A unique request key for the operation claims. Ideally the packageSourceRepository value of the PluginRequestKey. Example https://protected.package.feed/index.json, or Source-Agnostic</param>
         public PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey)
+            : this(rootCacheFolder, pluginFilePath, requestKey, EnvironmentVariableWrapper.Instance)
+        {
+        }
+
+        internal PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey, IEnvironmentVariableReader environmentVariableReader)
         {
             RootFolder = Path.Combine(rootCacheFolder, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash(pluginFilePath, addIdentifiableCharacters: false)));
             CacheFileName = Path.Combine(RootFolder, CachingUtility.RemoveInvalidFileNameChars(CachingUtility.ComputeHash(requestKey, addIdentifiableCharacters: false)) + ".dat");
             NewCacheFileName = CacheFileName + "-new";
+            _environmentVariableReader = environmentVariableReader;
         }
 
         internal TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(30);
@@ -61,11 +71,19 @@ namespace NuGet.Protocol.Plugins
 
         private void ProcessContent(Stream content)
         {
-            var serializer = new JsonSerializer();
-            using (var sr = new StreamReader(content))
-            using (var jsonTextReader = new JsonTextReader(sr))
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
+                || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
             {
-                OperationClaims = serializer.Deserialize<IReadOnlyList<OperationClaim>>(jsonTextReader);
+                OperationClaims = System.Text.Json.JsonSerializer.Deserialize(content, PluginCacheJsonContext.Default.IReadOnlyListOperationClaim);
+            }
+            else
+            {
+                var serializer = new Newtonsoft.Json.JsonSerializer();
+                using (var sr = new StreamReader(content))
+                using (var jsonTextReader = new JsonTextReader(sr))
+                {
+                    OperationClaims = serializer.Deserialize<IReadOnlyList<OperationClaim>>(jsonTextReader);
+                }
             }
         }
 
@@ -90,7 +108,17 @@ namespace NuGet.Protocol.Plugins
                     FileShare.None,
                     CachingUtility.BufferSize))
                 {
-                    var json = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(OperationClaims, Formatting.Indented));
+                    byte[] json;
+                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
+                        || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+                    {
+                        json = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(OperationClaims, PluginCacheJsonContext.Default.IReadOnlyListOperationClaim);
+                    }
+                    else
+                    {
+                        json = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(OperationClaims, Formatting.Indented));
+                    }
+
                     await fileStream.WriteAsync(json, 0, json.Length);
                 }
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheJsonContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheJsonContext.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace NuGet.Protocol.Plugins
+{
+    [JsonSerializable(typeof(IReadOnlyList<OperationClaim>))]
+    [JsonSourceGenerationOptions(WriteIndented = true)]
+    internal partial class PluginCacheJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
@@ -20,13 +20,8 @@ namespace NuGet.Protocol.Tests.Plugins
         {
             using (var testDirectory = TestDirectory.Create())
             {
-                // Arrange
                 var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
-
-                // Act
                 entry.LoadFromFile();
-
-                // Assert
                 Assert.Null(entry.OperationClaims);
             }
         }
@@ -54,7 +49,6 @@ namespace NuGet.Protocol.Tests.Plugins
         [MemberData(nameof(GetsRoundTripsValuesData))]
         public async Task PluginCacheEntry_RoundTripsValuesAsync(string[] values)
         {
-            // Arrange
             var list = new List<OperationClaim>();
             foreach (var val in values)
             {
@@ -65,14 +59,13 @@ namespace NuGet.Protocol.Tests.Plugins
             using (var testDirectory = TestDirectory.Create())
             {
                 var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
+                entry.LoadFromFile();
                 entry.OperationClaims = list;
-
-                // Act
                 await entry.UpdateCacheFileAsync();
+
                 var newEntry = new PluginCacheEntry(testDirectory.Path, "a", "b");
                 newEntry.LoadFromFile();
 
-                // Assert
                 Assert.True(EqualityUtility.SequenceEqualWithNullCheck(entry.OperationClaims, newEntry.OperationClaims));
             }
         }
@@ -80,12 +73,12 @@ namespace NuGet.Protocol.Tests.Plugins
         [Fact]
         public async Task PluginCacheEntry_DoesNotDeleteAnOpenedFile()
         {
-            // Arrange
             var list = new List<OperationClaim>() { OperationClaim.Authentication };
 
             using (var testDirectory = TestDirectory.Create())
             {
                 var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
+                entry.LoadFromFile();
                 entry.OperationClaims = list;
                 await entry.UpdateCacheFileAsync();
 
@@ -95,7 +88,6 @@ namespace NuGet.Protocol.Tests.Plugins
 
                 Assert.True(File.Exists(CacheFileName));
 
-                // Act
                 using (var fileStream = new FileStream(
                    CacheFileName,
                    FileMode.Open,
@@ -109,7 +101,6 @@ namespace NuGet.Protocol.Tests.Plugins
                     await entry.UpdateCacheFileAsync(); // this should not update
                 }
 
-                // Assert
                 entry.LoadFromFile();
                 Assert.True(EqualityUtility.SequenceEqualWithNullCheck(entry.OperationClaims, new List<OperationClaim>() { OperationClaim.Authentication }));
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
@@ -162,7 +162,7 @@ namespace NuGet.Protocol.Tests.Plugins
         private static PluginCacheEntry CreateEntry(string rootCacheFolder, string pluginFilePath, string requestKey, bool useStj)
         {
             var envReader = new Mock<IEnvironmentVariableReader>();
-            envReader.Setup(e => e.GetEnvironmentVariable("NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION"))
+            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar))
                 .Returns(useStj ? "true" : "false");
             return new PluginCacheEntry(rootCacheFolder, pluginFilePath, requestKey, envReader.Object);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Moq;
-using NuGet.Common;
 using NuGet.Protocol.Plugins;
 using NuGet.Shared;
 using NuGet.Test.Utility;
@@ -17,15 +15,13 @@ namespace NuGet.Protocol.Tests.Plugins
     [Collection(nameof(NotThreadSafeResourceCollection))]
     public class PluginCacheEntryTests
     {
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void PluginCacheEntry_DoesNotThrowWithNoFile(bool useStj)
+        [Fact]
+        public void PluginCacheEntry_DoesNotThrowWithNoFile()
         {
             using (var testDirectory = TestDirectory.Create())
             {
                 // Arrange
-                var entry = CreateEntry(testDirectory.Path, "a", "b", useStj);
+                var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
 
                 // Act
                 entry.LoadFromFile();
@@ -56,7 +52,7 @@ namespace NuGet.Protocol.Tests.Plugins
 
         [Theory]
         [MemberData(nameof(GetsRoundTripsValuesData))]
-        public async Task PluginCacheEntry_RoundTripsValuesAsync(string[] values, bool useStj)
+        public async Task PluginCacheEntry_RoundTripsValuesAsync(string[] values)
         {
             // Arrange
             var list = new List<OperationClaim>();
@@ -68,12 +64,12 @@ namespace NuGet.Protocol.Tests.Plugins
 
             using (var testDirectory = TestDirectory.Create())
             {
-                var entry = CreateEntry(testDirectory.Path, "a", "b", useStj);
+                var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
                 entry.OperationClaims = list;
 
                 // Act
                 await entry.UpdateCacheFileAsync();
-                var newEntry = CreateEntry(testDirectory.Path, "a", "b", useStj);
+                var newEntry = new PluginCacheEntry(testDirectory.Path, "a", "b");
                 newEntry.LoadFromFile();
 
                 // Assert
@@ -81,44 +77,15 @@ namespace NuGet.Protocol.Tests.Plugins
             }
         }
 
-        [Theory]
-        [MemberData(nameof(GetsRoundTripsValuesData))]
-        public async Task PluginCacheEntry_CrossDeserializationCompatibility(string[] values, bool writeWithStj)
-        {
-            // Arrange
-            var list = new List<OperationClaim>();
-            foreach (var val in values)
-            {
-                Enum.TryParse(val, out OperationClaim result);
-                list.Add(result);
-            }
-
-            using (var testDirectory = TestDirectory.Create())
-            {
-                var writeEntry = CreateEntry(testDirectory.Path, "a", "b", writeWithStj);
-                writeEntry.OperationClaims = list;
-                await writeEntry.UpdateCacheFileAsync();
-
-                // Act
-                var readEntry = CreateEntry(testDirectory.Path, "a", "b", !writeWithStj);
-                readEntry.LoadFromFile();
-
-                // Assert
-                Assert.True(EqualityUtility.SequenceEqualWithNullCheck(writeEntry.OperationClaims, readEntry.OperationClaims));
-            }
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task PluginCacheEntry_DoesNotDeleteAnOpenedFile(bool useStj)
+        [Fact]
+        public async Task PluginCacheEntry_DoesNotDeleteAnOpenedFile()
         {
             // Arrange
             var list = new List<OperationClaim>() { OperationClaim.Authentication };
 
             using (var testDirectory = TestDirectory.Create())
             {
-                var entry = CreateEntry(testDirectory.Path, "a", "b", useStj);
+                var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
                 entry.OperationClaims = list;
                 await entry.UpdateCacheFileAsync();
 
@@ -150,21 +117,10 @@ namespace NuGet.Protocol.Tests.Plugins
 
         public static IEnumerable<object[]> GetsRoundTripsValuesData()
         {
-            foreach (bool useStj in new[] { true, false })
-            {
-                yield return new object[] { new string[] { "Authentication", "DownloadPackage" }, useStj };
-                yield return new object[] { new string[] { "Authentication" }, useStj };
-                yield return new object[] { new string[] { "DownloadPackage" }, useStj };
-                yield return new object[] { new string[] { }, useStj };
-            }
-        }
-
-        private static PluginCacheEntry CreateEntry(string rootCacheFolder, string pluginFilePath, string requestKey, bool useStj)
-        {
-            var envReader = new Mock<IEnvironmentVariableReader>();
-            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar))
-                .Returns(useStj ? "true" : "false");
-            return new PluginCacheEntry(rootCacheFolder, pluginFilePath, requestKey, envReader.Object);
+            yield return new object[] { new string[] { "Authentication", "DownloadPackage" } };
+            yield return new object[] { new string[] { "Authentication" } };
+            yield return new object[] { new string[] { "DownloadPackage" } };
+            yield return new object[] { new string[] { } };
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCacheEntryTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Moq;
+using NuGet.Common;
 using NuGet.Protocol.Plugins;
 using NuGet.Shared;
 using NuGet.Test.Utility;
@@ -15,13 +17,20 @@ namespace NuGet.Protocol.Tests.Plugins
     [Collection(nameof(NotThreadSafeResourceCollection))]
     public class PluginCacheEntryTests
     {
-        [Fact]
-        public void PluginCacheEntry_DoesNotThrowWithNoFile()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void PluginCacheEntry_DoesNotThrowWithNoFile(bool useStj)
         {
             using (var testDirectory = TestDirectory.Create())
             {
-                var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
+                // Arrange
+                var entry = CreateEntry(testDirectory.Path, "a", "b", useStj);
+
+                // Act
                 entry.LoadFromFile();
+
+                // Assert
                 Assert.Null(entry.OperationClaims);
             }
         }
@@ -47,8 +56,9 @@ namespace NuGet.Protocol.Tests.Plugins
 
         [Theory]
         [MemberData(nameof(GetsRoundTripsValuesData))]
-        public async Task PluginCacheEntry_RoundTripsValuesAsync(string[] values)
+        public async Task PluginCacheEntry_RoundTripsValuesAsync(string[] values, bool useStj)
         {
+            // Arrange
             var list = new List<OperationClaim>();
             foreach (var val in values)
             {
@@ -58,27 +68,57 @@ namespace NuGet.Protocol.Tests.Plugins
 
             using (var testDirectory = TestDirectory.Create())
             {
-                var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
-                entry.LoadFromFile();
+                var entry = CreateEntry(testDirectory.Path, "a", "b", useStj);
                 entry.OperationClaims = list;
-                await entry.UpdateCacheFileAsync();
 
-                var newEntry = new PluginCacheEntry(testDirectory.Path, "a", "b");
+                // Act
+                await entry.UpdateCacheFileAsync();
+                var newEntry = CreateEntry(testDirectory.Path, "a", "b", useStj);
                 newEntry.LoadFromFile();
 
+                // Assert
                 Assert.True(EqualityUtility.SequenceEqualWithNullCheck(entry.OperationClaims, newEntry.OperationClaims));
             }
         }
 
-        [Fact]
-        public async Task PluginCacheEntry_DoesNotDeleteAnOpenedFile()
+        [Theory]
+        [MemberData(nameof(GetsRoundTripsValuesData))]
+        public async Task PluginCacheEntry_CrossDeserializationCompatibility(string[] values, bool writeWithStj)
         {
+            // Arrange
+            var list = new List<OperationClaim>();
+            foreach (var val in values)
+            {
+                Enum.TryParse(val, out OperationClaim result);
+                list.Add(result);
+            }
+
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var writeEntry = CreateEntry(testDirectory.Path, "a", "b", writeWithStj);
+                writeEntry.OperationClaims = list;
+                await writeEntry.UpdateCacheFileAsync();
+
+                // Act
+                var readEntry = CreateEntry(testDirectory.Path, "a", "b", !writeWithStj);
+                readEntry.LoadFromFile();
+
+                // Assert
+                Assert.True(EqualityUtility.SequenceEqualWithNullCheck(writeEntry.OperationClaims, readEntry.OperationClaims));
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task PluginCacheEntry_DoesNotDeleteAnOpenedFile(bool useStj)
+        {
+            // Arrange
             var list = new List<OperationClaim>() { OperationClaim.Authentication };
 
             using (var testDirectory = TestDirectory.Create())
             {
-                var entry = new PluginCacheEntry(testDirectory.Path, "a", "b");
-                entry.LoadFromFile();
+                var entry = CreateEntry(testDirectory.Path, "a", "b", useStj);
                 entry.OperationClaims = list;
                 await entry.UpdateCacheFileAsync();
 
@@ -88,6 +128,7 @@ namespace NuGet.Protocol.Tests.Plugins
 
                 Assert.True(File.Exists(CacheFileName));
 
+                // Act
                 using (var fileStream = new FileStream(
                    CacheFileName,
                    FileMode.Open,
@@ -101,6 +142,7 @@ namespace NuGet.Protocol.Tests.Plugins
                     await entry.UpdateCacheFileAsync(); // this should not update
                 }
 
+                // Assert
                 entry.LoadFromFile();
                 Assert.True(EqualityUtility.SequenceEqualWithNullCheck(entry.OperationClaims, new List<OperationClaim>() { OperationClaim.Authentication }));
             }
@@ -108,10 +150,21 @@ namespace NuGet.Protocol.Tests.Plugins
 
         public static IEnumerable<object[]> GetsRoundTripsValuesData()
         {
-            yield return new object[] { new string[] { "Authentication", "DownloadPackage" } };
-            yield return new object[] { new string[] { "Authentication" } };
-            yield return new object[] { new string[] { "DownloadPackage" } };
-            yield return new object[] { new string[] { } };
+            foreach (bool useStj in new[] { true, false })
+            {
+                yield return new object[] { new string[] { "Authentication", "DownloadPackage" }, useStj };
+                yield return new object[] { new string[] { "Authentication" }, useStj };
+                yield return new object[] { new string[] { "DownloadPackage" }, useStj };
+                yield return new object[] { new string[] { }, useStj };
+            }
+        }
+
+        private static PluginCacheEntry CreateEntry(string rootCacheFolder, string pluginFilePath, string requestKey, bool useStj)
+        {
+            var envReader = new Mock<IEnvironmentVariableReader>();
+            envReader.Setup(e => e.GetEnvironmentVariable("NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION"))
+                .Returns(useStj ? "true" : "false");
+            return new PluginCacheEntry(rootCacheFolder, pluginFilePath, requestKey, envReader.Object);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: 

## Description

 Add STJ deserialization path for `PluginCacheEntry`

remove existing NSJ path is unchanged.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
