### PR TITLE
Add STJ path in AutoCompleteResourceV2Feed

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -87,35 +87,26 @@ namespace NuGet.Protocol
             Common.ILogger logger,
             CancellationToken token)
         {
-            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
-            {
-                return await _httpSource.ProcessStreamAsync(
-                    new HttpSourceRequest(apiEndpointUri, logger),
-                    async stream =>
+            return await _httpSource.ProcessStreamAsync(
+                new HttpSourceRequest(apiEndpointUri, logger),
+                async stream =>
+                {
+                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
+                        || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
                     {
                         var seekableStream = await stream.AsSeekableStreamAsync(token);
                         return await System.Text.Json.JsonSerializer.DeserializeAsync(seekableStream, JsonContext.Default.StringArray, token);
-                    },
-                    logger,
-                    token);
-            }
-            else
-            {
-                return await _httpSource.ProcessStreamAsync(
-                    new HttpSourceRequest(apiEndpointUri, logger),
-                    async stream =>
+                    }
+                    else
                     {
-                        using (var reader = new StreamReader(await stream.AsSeekableStreamAsync(token)))
-                        using (var jsonReader = new JsonTextReader(reader))
-                        {
-                            var serializer = Newtonsoft.Json.JsonSerializer.Create();
-                            return serializer.Deserialize<string[]>(jsonReader);
-                        }
-                    },
-                    logger,
-                    token);
-            }
+                        using var reader = new StreamReader(await stream.AsSeekableStreamAsync(token));
+                        using var jsonReader = new JsonTextReader(reader);
+                        var serializer = Newtonsoft.Json.JsonSerializer.Create();
+                        return serializer.Deserialize<string[]>(jsonReader);
+                    }
+                },
+                logger,
+                token);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -12,6 +12,8 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Utility;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol
@@ -20,8 +22,14 @@ namespace NuGet.Protocol
     {
         private readonly HttpSource _httpSource;
         private readonly Uri _baseUri;
+        private readonly IEnvironmentVariableReader _environmentVariableReader;
 
         public AutoCompleteResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource)
+            : this(httpSourceResource, baseAddress, packageSource, environmentVariableReader: null)
+        {
+        }
+
+        internal AutoCompleteResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource, IEnvironmentVariableReader environmentVariableReader)
         {
             if (httpSourceResource == null)
             {
@@ -34,8 +42,8 @@ namespace NuGet.Protocol
             }
 
             _httpSource = httpSourceResource.HttpSource;
-
             _baseUri = UriUtility.CreateSourceUri($"{baseAddress}/");
+            _environmentVariableReader = environmentVariableReader;
         }
 
         public override async Task<IEnumerable<string>> IdStartsWith(
@@ -79,20 +87,35 @@ namespace NuGet.Protocol
             Common.ILogger logger,
             CancellationToken token)
         {
-            return await _httpSource.ProcessStreamAsync(
-                   new HttpSourceRequest(apiEndpointUri, logger),
-                   async stream =>
-                   {
-                       using (var reader = new StreamReader(await stream.AsSeekableStreamAsync(token)))
-                       using (var jsonReader = new JsonTextReader(reader))
-                       {
-                           var serializer = JsonSerializer.Create();
-                           var json = serializer.Deserialize<string[]>(jsonReader);
-                           return json;
-                       }
-                   },
-                   logger,
-                   token);
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
+                || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+            {
+                return await _httpSource.ProcessStreamAsync(
+                    new HttpSourceRequest(apiEndpointUri, logger),
+                    async stream =>
+                    {
+                        var seekableStream = await stream.AsSeekableStreamAsync(token);
+                        return await System.Text.Json.JsonSerializer.DeserializeAsync(seekableStream, JsonContext.Default.StringArray, token);
+                    },
+                    logger,
+                    token);
+            }
+            else
+            {
+                return await _httpSource.ProcessStreamAsync(
+                    new HttpSourceRequest(apiEndpointUri, logger),
+                    async stream =>
+                    {
+                        using (var reader = new StreamReader(await stream.AsSeekableStreamAsync(token)))
+                        using (var jsonReader = new JsonTextReader(reader))
+                        {
+                            var serializer = Newtonsoft.Json.JsonSerializer.Create();
+                            return serializer.Deserialize<string[]>(jsonReader);
+                        }
+                    },
+                    logger,
+                    token);
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/JsonContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/JsonContext.cs
@@ -18,6 +18,7 @@ namespace NuGet.Protocol.Utility
     [JsonSerializable(typeof(CaseInsensitiveDictionary<IReadOnlyList<PackageVulnerabilityInfo>>), TypeInfoPropertyName = "VulnerabilityPage")]
     [JsonSerializable(typeof(AutoCompleteModel))]
     [JsonSerializable(typeof(ServiceIndexModel))]
+    [JsonSerializable(typeof(string[]))]
     internal partial class JsonContext : JsonSerializerContext
     {
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using Test.Utility;
@@ -14,8 +15,10 @@ namespace NuGet.Protocol.Tests
 {
     public class AutoCompleteResourceV2FeedTests
     {
-        [Fact]
-        public async Task AutoCompleteResourceV2Feed_IdStartsWith()
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public async Task AutoCompleteResourceV2Feed_IdStartsWith(string useStj)
         {
             // Arrange
             var serviceAddress = ProtocolUtility.CreateServiceAddress();
@@ -26,9 +29,11 @@ namespace NuGet.Protocol.Tests
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+            var httpSourceResource = await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
 
-            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None)
-                ?? throw new Xunit.Sdk.XunitException("Expected AutoCompleteResource.");
+            var envReader = new Mock<IEnvironmentVariableReader>();
+            envReader.Setup(e => e.GetEnvironmentVariable("NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION")).Returns(useStj);
+            var autoCompleteResource = new AutoCompleteResourceV2Feed(httpSourceResource, serviceAddress.TrimEnd('/'), repo.PackageSource, envReader.Object);
 
             // Act
             var result = await autoCompleteResource.IdStartsWith("Azure", false, NullLogger.Instance, CancellationToken.None);
@@ -37,8 +42,10 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(30, result.Count());
         }
 
-        [Fact]
-        public async Task AutoCompleteResourceV2Feed_VersionStartsWith()
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public async Task AutoCompleteResourceV2Feed_VersionStartsWith(string useStj)
         {
             // Arrange
             var serviceAddress = ProtocolUtility.CreateServiceAddress();
@@ -49,9 +56,11 @@ namespace NuGet.Protocol.Tests
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+            var httpSourceResource = await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
 
-            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None)
-                ?? throw new Xunit.Sdk.XunitException("Expected AutoCompleteResource.");
+            var envReader = new Mock<IEnvironmentVariableReader>();
+            envReader.Setup(e => e.GetEnvironmentVariable("NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION")).Returns(useStj);
+            var autoCompleteResource = new AutoCompleteResourceV2Feed(httpSourceResource, serviceAddress.TrimEnd('/'), repo.PackageSource, envReader.Object);
 
             // Act
             var result = await autoCompleteResource.VersionStartsWith("xunit", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -60,8 +69,10 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(6, result.Count());
         }
 
-        [Fact]
-        public async Task AutoCompleteResourceV2Feed_VersionStartsWithInvalidId()
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public async Task AutoCompleteResourceV2Feed_VersionStartsWithInvalidId(string useStj)
         {
             // Arrange
             var serviceAddress = ProtocolUtility.CreateServiceAddress();
@@ -71,9 +82,11 @@ namespace NuGet.Protocol.Tests
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+            var httpSourceResource = await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
 
-            var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None)
-                ?? throw new Xunit.Sdk.XunitException("Expected AutoCompleteResource.");
+            var envReader = new Mock<IEnvironmentVariableReader>();
+            envReader.Setup(e => e.GetEnvironmentVariable("NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION")).Returns(useStj);
+            var autoCompleteResource = new AutoCompleteResourceV2Feed(httpSourceResource, serviceAddress.TrimEnd('/'), repo.PackageSource, envReader.Object);
 
             // Act
             var result = await autoCompleteResource.VersionStartsWith("azure", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Moq;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
 using Test.Utility;
 using Xunit;
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -32,7 +32,7 @@ namespace NuGet.Protocol.Tests
             var httpSourceResource = await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
 
             var envReader = new Mock<IEnvironmentVariableReader>();
-            envReader.Setup(e => e.GetEnvironmentVariable("NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION")).Returns(useStj);
+            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar)).Returns(useStj);
             var autoCompleteResource = new AutoCompleteResourceV2Feed(httpSourceResource, serviceAddress.TrimEnd('/'), repo.PackageSource, envReader.Object);
 
             // Act

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -42,7 +42,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
             var httpSourceResource = await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
-            var autoCompleteResource = CreateAutoCompleteResource(httpSourceResource, serviceAddress, repo.PackageSource, useStj);
+            var autoCompleteResource = CreateAutoCompleteResource(httpSourceResource!, serviceAddress, repo.PackageSource, useStj);
 
             // Act
             var result = await autoCompleteResource.IdStartsWith("Azure", false, NullLogger.Instance, CancellationToken.None);
@@ -66,7 +66,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
             var httpSourceResource = await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
-            var autoCompleteResource = CreateAutoCompleteResource(httpSourceResource, serviceAddress, repo.PackageSource, useStj);
+            var autoCompleteResource = CreateAutoCompleteResource(httpSourceResource!, serviceAddress, repo.PackageSource, useStj);
 
             // Act
             var result = await autoCompleteResource.VersionStartsWith("xunit", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -89,7 +89,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
             var httpSourceResource = await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
-            var autoCompleteResource = CreateAutoCompleteResource(httpSourceResource, serviceAddress, repo.PackageSource, useStj);
+            var autoCompleteResource = CreateAutoCompleteResource(httpSourceResource!, serviceAddress, repo.PackageSource, useStj);
 
             // Act
             var result = await autoCompleteResource.VersionStartsWith("azure", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -16,6 +16,17 @@ namespace NuGet.Protocol.Tests
 {
     public class AutoCompleteResourceV2FeedTests
     {
+        private static AutoCompleteResourceV2Feed CreateAutoCompleteResource(
+            HttpSourceResource httpSourceResource,
+            string serviceAddress,
+            Configuration.PackageSource packageSource,
+            string useStj)
+        {
+            var envReader = new Mock<IEnvironmentVariableReader>();
+            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar)).Returns(useStj);
+            return new AutoCompleteResourceV2Feed(httpSourceResource, serviceAddress.TrimEnd('/'), packageSource, envReader.Object);
+        }
+
         [Theory]
         [InlineData("true")]
         [InlineData("false")]
@@ -31,10 +42,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
             var httpSourceResource = await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
-
-            var envReader = new Mock<IEnvironmentVariableReader>();
-            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar)).Returns(useStj);
-            var autoCompleteResource = new AutoCompleteResourceV2Feed(httpSourceResource, serviceAddress.TrimEnd('/'), repo.PackageSource, envReader.Object);
+            var autoCompleteResource = CreateAutoCompleteResource(httpSourceResource, serviceAddress, repo.PackageSource, useStj);
 
             // Act
             var result = await autoCompleteResource.IdStartsWith("Azure", false, NullLogger.Instance, CancellationToken.None);
@@ -58,10 +66,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
             var httpSourceResource = await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
-
-            var envReader = new Mock<IEnvironmentVariableReader>();
-            envReader.Setup(e => e.GetEnvironmentVariable("NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION")).Returns(useStj);
-            var autoCompleteResource = new AutoCompleteResourceV2Feed(httpSourceResource, serviceAddress.TrimEnd('/'), repo.PackageSource, envReader.Object);
+            var autoCompleteResource = CreateAutoCompleteResource(httpSourceResource, serviceAddress, repo.PackageSource, useStj);
 
             // Act
             var result = await autoCompleteResource.VersionStartsWith("xunit", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
@@ -84,10 +89,7 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
             var httpSourceResource = await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None);
-
-            var envReader = new Mock<IEnvironmentVariableReader>();
-            envReader.Setup(e => e.GetEnvironmentVariable("NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION")).Returns(useStj);
-            var autoCompleteResource = new AutoCompleteResourceV2Feed(httpSourceResource, serviceAddress.TrimEnd('/'), repo.PackageSource, envReader.Object);
+            var autoCompleteResource = CreateAutoCompleteResource(httpSourceResource, serviceAddress, repo.PackageSource, useStj);
 
             // Act
             var result = await autoCompleteResource.VersionStartsWith("azure", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14895

## Description

Adds a feature-flagged System.Text.Json deserialization path for V2 feed autocomplete results in `AutoCompleteResourceV2Feed`. The existing NSJ path is unchanged.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
