### PR TITLE
Test dotnet integration with current and next SDKs

### DIFF
--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -2,4 +2,5 @@
 # To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
 -Channel 8.0 -Runtime dotnet
 -Channel 9.0 -Runtime dotnet
--Version 10.0.301-servicing.26227.122
+-Channel 10.0.4xx -Quality daily
+-Channel 11.0.1xx -Quality daily

--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,2 +1,2 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 10.0.1xx
+-Channel 10.0.3xx

--- a/configure.ps1
+++ b/configure.ps1
@@ -26,9 +26,10 @@ Param (
     [switch]$CleanCache,
     [Alias('f')]
     [switch]$Force,
-    [switch]$RunTest,
     [switch]$SkipDotnetInfo,
-    [switch]$ProcDump
+    [switch]$ProcDump,
+    [switch]$SkipDotnetForBuildInstallation,
+    [switch]$SkipDotnetForTestInstallation
 )
 
 $ErrorActionPreference = 'Stop'
@@ -49,11 +50,11 @@ if ($ProcDump -eq $true -Or $env:CI -eq "true")
 
 Invoke-BuildStep 'Installing .NET CLI' {
     Install-DotnetCLI -Force:$Force -SkipDotnetInfo:$SkipDotnetInfo
-} -ev +BuildErrors
+} -skip:(-not $SkipDotnetForBuildInstallation) -ev +BuildErrors
 
 Invoke-BuildStep 'Installing .NET SDKs for functional tests' {
     Install-DotNetSdksForTesting -Force:$Force
-} -ev +BuildErrors
+} -skip:(-not $SkipDotnetForTestInstallation) -ev +BuildErrors
 
 Invoke-BuildStep 'Cleaning package cache' {
     Clear-PackageCache

--- a/configure.ps1
+++ b/configure.ps1
@@ -50,11 +50,11 @@ if ($ProcDump -eq $true -Or $env:CI -eq "true")
 
 Invoke-BuildStep 'Installing .NET CLI' {
     Install-DotnetCLI -Force:$Force -SkipDotnetInfo:$SkipDotnetInfo
-} -skip:(-not $SkipDotnetForBuildInstallation) -ev +BuildErrors
+} -skip:($SkipDotnetForBuildInstallation) -ev +BuildErrors
 
 Invoke-BuildStep 'Installing .NET SDKs for functional tests' {
     Install-DotNetSdksForTesting -Force:$Force
-} -skip:(-not $SkipDotnetForTestInstallation) -ev +BuildErrors
+} -skip:($SkipDotnetForTestInstallation) -ev +BuildErrors
 
 Invoke-BuildStep 'Cleaning package cache' {
     Clear-PackageCache

--- a/eng/pipelines/pr.job.yml
+++ b/eng/pipelines/pr.job.yml
@@ -23,6 +23,10 @@ parameters:
   displayName: Optional verbosity to use when running tests.
   type: string
   default: 'minimal'
+- name: useDotNetBuild
+  displayName: Use dotnet build instead of MSBuild on Windows.
+  type: boolean
+  default: false
 
 jobs:
 - job:
@@ -70,7 +74,7 @@ jobs:
     - script: env | sort -f
       displayName: Log Environment Variables
 
-  - ${{ if eq(parameters.osName, 'Windows') }}:
+  - ${{ if and(eq(parameters.osName, 'Windows'), not(parameters.useDotNetBuild)) }}:
     - task: MSBuild@1
       displayName: Restore and Build $(TestType) Test Projects
       inputs:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -60,7 +60,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Unit
@@ -77,7 +77,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Unit
@@ -94,7 +94,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -112,7 +112,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -131,7 +131,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -151,7 +151,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -169,7 +169,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -188,7 +188,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -60,7 +60,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Unit
@@ -77,7 +77,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Unit
@@ -94,7 +94,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -112,7 +112,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -151,7 +151,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -207,7 +207,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -64,7 +64,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Unit
@@ -81,7 +81,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Unit
@@ -98,7 +98,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -116,7 +116,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -135,7 +135,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -155,7 +155,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -211,7 +211,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -31,6 +31,10 @@ parameters:
   displayName: Run a static analysis
   type: boolean
   default: true
+- name: IsEscrow
+  displayName: Is this an escrow/release branch build
+  type: boolean
+  default: false
 variables:
   DOTNET_NOLOGO: 1
   NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY: 3,1000
@@ -177,7 +181,7 @@ stages:
         testProjectName: Dotnet.Integration.Test
         timeoutInMinutes: 60
 
-- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
+- ${{ if and(eq(parameters.RunFunctionalTestsOnWindows, true), eq(parameters.IsEscrow, false)) }}:
   - stage:
     displayName: Dotnet.Integration.Test on Windows (SDK Next)
     dependsOn: []
@@ -241,7 +245,7 @@ stages:
         testTargetFramework: net10.0
         timeoutInMinutes: 30
 
-- ${{ if eq(parameters.RunFunctionalTestsOnLinux, true) }}:
+- ${{ if and(eq(parameters.RunFunctionalTestsOnLinux, true), eq(parameters.IsEscrow, false)) }}:
   - stage:
     displayName: Dotnet.Integration.Test on Linux (SDK Next)
     dependsOn: []
@@ -283,7 +287,7 @@ stages:
         testTargetFramework: net10.0
         timeoutInMinutes: 30
 
-- ${{ if eq(parameters.RunFunctionalTestsOnMacOS, true) }}:
+- ${{ if and(eq(parameters.RunFunctionalTestsOnMacOS, true), eq(parameters.IsEscrow, false)) }}:
   - stage:
     displayName: Dotnet.Integration.Test on MacOS (SDK Next)
     dependsOn: []

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -31,10 +31,6 @@ parameters:
   displayName: Run a static analysis
   type: boolean
   default: true
-- name: IsEscrow
-  displayName: Is this an escrow/release branch build
-  type: boolean
-  default: false
 variables:
   DOTNET_NOLOGO: 1
   NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY: 3,1000
@@ -181,7 +177,7 @@ stages:
         testProjectName: Dotnet.Integration.Test
         timeoutInMinutes: 60
 
-- ${{ if and(eq(parameters.RunFunctionalTestsOnWindows, true), eq(parameters.IsEscrow, false)) }}:
+- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
     displayName: Dotnet.Integration.Test on Windows (SDK Next)
     dependsOn: []
@@ -245,7 +241,7 @@ stages:
         testTargetFramework: net10.0
         timeoutInMinutes: 30
 
-- ${{ if and(eq(parameters.RunFunctionalTestsOnLinux, true), eq(parameters.IsEscrow, false)) }}:
+- ${{ if eq(parameters.RunFunctionalTestsOnLinux, true) }}:
   - stage:
     displayName: Dotnet.Integration.Test on Linux (SDK Next)
     dependsOn: []
@@ -287,7 +283,7 @@ stages:
         testTargetFramework: net10.0
         timeoutInMinutes: 30
 
-- ${{ if and(eq(parameters.RunFunctionalTestsOnMacOS, true), eq(parameters.IsEscrow, false)) }}:
+- ${{ if eq(parameters.RunFunctionalTestsOnMacOS, true) }}:
   - stage:
     displayName: Dotnet.Integration.Test on MacOS (SDK Next)
     dependsOn: []

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -323,7 +323,8 @@ stages:
         displayName: Run Static Analysis
         timeoutInMinutes: 30
         pool:
-          vmImage: windows-latest
+          name: NetCore-Public
+          demands: ImageOverride -equals Windows.VS2026.Amd64.Open
         steps:
         - task: PowerShell@2
           displayName: Run configure.ps1

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -179,6 +179,25 @@ stages:
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
   - stage:
+    displayName: Dotnet.Integration.Test on Windows (SDK Next)
+    dependsOn: []
+    jobs:
+    - template: pr.job.yml
+      parameters:
+        displayName: Dotnet.Integration.Test on Windows (SDK Next)
+        osName: Windows
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          agentPool: NetCore-Public
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
+        ${{ else }}:
+          agentPool: VSEng-MicroBuildVSStable
+        testType: Functional
+        testTargetFramework: sdkNext
+        testProjectName: Dotnet.Integration.Test
+        timeoutInMinutes: 60
+
+- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
+  - stage:
     displayName: NuGet.Packaging.FuncTest on Windows (.NET 10.0)
     dependsOn: []
     jobs:
@@ -222,6 +241,21 @@ stages:
         testTargetFramework: net10.0
         timeoutInMinutes: 30
 
+- ${{ if eq(parameters.RunFunctionalTestsOnLinux, true) }}:
+  - stage:
+    displayName: Dotnet.Integration.Test on Linux (SDK Next)
+    dependsOn: []
+    jobs:
+    - template: pr.job.yml
+      parameters:
+        displayName: Dotnet.Integration.Test on Linux (SDK Next)
+        osName: Linux
+        vmImage: ubuntu-latest
+        testType: Functional
+        testTargetFramework: sdkNext
+        testProjectName: Dotnet.Integration.Test
+        timeoutInMinutes: 60
+
 - ${{ if eq(parameters.RunUnitTestsOnMacOS, true) }}:
   - stage:
     displayName: Unit Tests on MacOS (.NET 10.0)
@@ -248,6 +282,21 @@ stages:
         testType: Functional
         testTargetFramework: net10.0
         timeoutInMinutes: 30
+
+- ${{ if eq(parameters.RunFunctionalTestsOnMacOS, true) }}:
+  - stage:
+    displayName: Dotnet.Integration.Test on MacOS (SDK Next)
+    dependsOn: []
+    jobs:
+    - template: pr.job.yml
+      parameters:
+        displayName: Dotnet.Integration.Test on MacOS (SDK Next)
+        osName: MacOS
+        vmImage: macos-14
+        testType: Functional
+        testTargetFramework: sdkNext
+        testProjectName: Dotnet.Integration.Test
+        timeoutInMinutes: 60
 
 - ${{ if or(eq(parameters.RunSourceBuild, true), eq(parameters.RunStaticAnalysis, true)) }}:
   - stage:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -194,6 +194,7 @@ stages:
         testType: Functional
         testTargetFramework: sdkNext
         testProjectName: Dotnet.Integration.Test
+        useDotNetBuild: true
         timeoutInMinutes: 60
 
 - ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -112,7 +112,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional
@@ -131,7 +131,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -112,7 +112,7 @@ stages:
         osName: Windows
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           agentPool: NetCore-Public
-          agentDemands: ImageOverride -equals Windows.VS2026.Amd64.Open
+          agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
           agentPool: VSEng-MicroBuildVSStable
         testType: Functional

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9727,7 +9727,7 @@ namespace NuGet.CommandLine.Test
                 var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
                     "proj",
                     pathContext.SolutionRoot,
-                    $"{TestConstants.ProjectTargetFramework}-windows");
+                    $"net10.0-windows");
 
                 project.AddPackageToAllFrameworks(packageX);
                 solution.Projects.Add(project);
@@ -9746,7 +9746,7 @@ namespace NuGet.CommandLine.Test
 
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ItemGroup").ToList();
 
-                Assert.Contains($"'$(TargetFramework)' == '{TestConstants.ProjectTargetFramework}-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Contains($"'$(TargetFramework)' == 'net10.0-windows' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -24,7 +24,6 @@ using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
-using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Release/escrow branches and source-build/VMR builds ship against a single SDK, so only the current SDK is exercised there. -->
-    <TargetFramework Condition="'$(DotNetBuildSourceOnly)' == 'true' Or '$(DotNetBuildFromVMR)' == 'true'">$(LatestNETCoreTargetFramework)</TargetFramework>
+    <TargetFrameworks Condition="'$(DotNetBuildSourceOnly)' == 'true' Or '$(DotNetBuildFromVMR)' == 'true'">$(LatestNETCoreTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(DotNetBuildSourceOnly)' != 'true' And '$(DotNetBuildFromVMR)' != 'true'">$(LatestNETCoreTargetFramework);sdkNext</TargetFrameworks>
     <Description>Integration tests for NuGet-powered dotnet CLI commands such as pack/restore/list package and dotnet nuget.</Description>
     <LatestNETCoreTargetFrameworkMajorVersion>$([System.Version]::Parse('$([MSBuild]::GetTargetFrameworkVersion('$(LatestNETCoreTargetFramework)', 2))').Major)</LatestNETCoreTargetFrameworkMajorVersion>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -1,7 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(LatestNETCoreTargetFramework)</TargetFramework>
+    <TargetFramework>sdkCurrent;sdkNext</TargetFramework>
     <Description>Integration tests for NuGet-powered dotnet CLI commands such as pack/restore/list package and dotnet nuget.</Description>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkMoniker>.NETCoreApp,Version=v10.0</TargetFrameworkMoniker>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LatestNETCoreTargetFramework);sdkNext</TargetFrameworks>
+    <!-- Release/escrow branches and source-build/VMR builds ship against a single SDK, so only the current SDK is exercised there. -->
+    <TargetFramework Condition="'$(IsEscrow)' == 'true' Or '$(DotNetBuildSourceOnly)' == 'true' Or '$(DotNetBuildFromVMR)' == 'true'">$(LatestNETCoreTargetFramework)</TargetFramework>
+    <TargetFrameworks Condition="'$(IsEscrow)' != 'true' And '$(DotNetBuildSourceOnly)' != 'true' And '$(DotNetBuildFromVMR)' != 'true'">$(LatestNETCoreTargetFramework);sdkNext</TargetFrameworks>
     <Description>Integration tests for NuGet-powered dotnet CLI commands such as pack/restore/list package and dotnet nuget.</Description>
     <LatestNETCoreTargetFrameworkMajorVersion>$([System.Version]::Parse('$([MSBuild]::GetTargetFrameworkVersion('$(LatestNETCoreTargetFramework)', 2))').Major)</LatestNETCoreTargetFrameworkMajorVersion>
     <NextNETCoreTargetFrameworkMajorVersion>$([MSBuild]::Add($(LatestNETCoreTargetFrameworkMajorVersion), 1))</NextNETCoreTargetFrameworkMajorVersion>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -1,18 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>sdkCurrent;sdkNext</TargetFrameworks>
+    <TargetFrameworks>$(LatestNETCoreTargetFramework);sdkNext</TargetFrameworks>
     <Description>Integration tests for NuGet-powered dotnet CLI commands such as pack/restore/list package and dotnet nuget.</Description>
-    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
-    <TargetFrameworkMoniker>.NETCoreApp,Version=v10.0</TargetFrameworkMoniker>
+    <LatestNETCoreTargetFrameworkMajorVersion>$([System.Version]::Parse('$([MSBuild]::GetTargetFrameworkVersion('$(LatestNETCoreTargetFramework)', 2))').Major)</LatestNETCoreTargetFrameworkMajorVersion>
+    <NextNETCoreTargetFrameworkMajorVersion>$([MSBuild]::Add($(LatestNETCoreTargetFrameworkMajorVersion), 1))</NextNETCoreTargetFrameworkMajorVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'sdkCurrent'">
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(LatestNETCoreTargetFramework)'">
     <DefineConstants>$(DefineConstants);SDK_CURRENT</DefineConstants>
+    <PreferredSdkMajorVersion>$(LatestNETCoreTargetFrameworkMajorVersion)</PreferredSdkMajorVersion>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'sdkNext'">
     <DefineConstants>$(DefineConstants);SDK_NEXT</DefineConstants>
+    <PreferredSdkMajorVersion>$(NextNETCoreTargetFrameworkMajorVersion)</PreferredSdkMajorVersion>
+    <TargetFrameworkIdentifier>$([MSBuild]::GetTargetFrameworkIdentifier('$(LatestNETCoreTargetFramework)'))</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v$([MSBuild]::GetTargetFrameworkVersion('$(LatestNETCoreTargetFramework)', 2))</TargetFrameworkVersion>
+    <TargetFrameworkMoniker>$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)</TargetFrameworkMoniker>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(PreferredSdkMajorVersion)' != ''">
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>PreferredSdkMajorVersion</_Parameter1>
+      <_Parameter2>$(PreferredSdkMajorVersion)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="compiler\resources\*" />

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -1,10 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>sdkCurrent;sdkNext</TargetFramework>
+    <TargetFrameworks>sdkCurrent;sdkNext</TargetFrameworks>
     <Description>Integration tests for NuGet-powered dotnet CLI commands such as pack/restore/list package and dotnet nuget.</Description>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <TargetFrameworkMoniker>.NETCoreApp,Version=v10.0</TargetFrameworkMoniker>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'sdkCurrent'">
+    <DefineConstants>$(DefineConstants);SDK_CURRENT</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'sdkNext'">
+    <DefineConstants>$(DefineConstants);SDK_NEXT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- Release/escrow branches and source-build/VMR builds ship against a single SDK, so only the current SDK is exercised there. -->
-    <TargetFramework Condition="'$(IsEscrow)' == 'true' Or '$(DotNetBuildSourceOnly)' == 'true' Or '$(DotNetBuildFromVMR)' == 'true'">$(LatestNETCoreTargetFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(IsEscrow)' != 'true' And '$(DotNetBuildSourceOnly)' != 'true' And '$(DotNetBuildFromVMR)' != 'true'">$(LatestNETCoreTargetFramework);sdkNext</TargetFrameworks>
+    <TargetFramework Condition="'$(DotNetBuildSourceOnly)' == 'true' Or '$(DotNetBuildFromVMR)' == 'true'">$(LatestNETCoreTargetFramework)</TargetFramework>
+    <TargetFrameworks Condition="'$(DotNetBuildSourceOnly)' != 'true' And '$(DotNetBuildFromVMR)' != 'true'">$(LatestNETCoreTargetFramework);sdkNext</TargetFrameworks>
     <Description>Integration tests for NuGet-powered dotnet CLI commands such as pack/restore/list package and dotnet nuget.</Description>
     <LatestNETCoreTargetFrameworkMajorVersion>$([System.Version]::Parse('$([MSBuild]::GetTargetFrameworkVersion('$(LatestNETCoreTargetFramework)', 2))').Major)</LatestNETCoreTargetFrameworkMajorVersion>
     <NextNETCoreTargetFrameworkMajorVersion>$([MSBuild]::Add($(LatestNETCoreTargetFrameworkMajorVersion), 1))</NextNETCoreTargetFrameworkMajorVersion>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -44,7 +44,11 @@ namespace Dotnet.Integration.Test
         public DotnetIntegrationTestFixture()
         {
             string testAssemblyPath = Path.GetFullPath(Assembly.GetExecutingAssembly().Location);
-            _cliDirectory = TestDotnetCLiUtility.CopyAndPatchLatestDotnetCli(testAssemblyPath);
+#if SDK_CURRENT
+            _cliDirectory = TestDotnetCLiUtility.CopyAndPatchLatestDotnetCli(testAssemblyPath, preferredMajorVersion: 10);
+#elif SDK_NEXT
+            _cliDirectory = TestDotnetCLiUtility.CopyAndPatchLatestDotnetCli(testAssemblyPath, preferredMajorVersion: 11);
+#endif
             var dotnetExecutableName = RuntimeEnvironmentHelper.IsWindows ? "dotnet.exe" : "dotnet";
             TestDotnetCli = Path.Combine(_cliDirectory, dotnetExecutableName);
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -23,6 +23,8 @@ namespace Dotnet.Integration.Test
 {
     public class DotnetIntegrationTestFixture : IDisposable
     {
+        private const string PreferredSdkMajorVersionMetadataKey = "PreferredSdkMajorVersion";
+
         /// <summary>
         /// A value indicating if the test is running on a hosted agent with diagnostics enabled.
         /// </summary>
@@ -43,12 +45,8 @@ namespace Dotnet.Integration.Test
 
         public DotnetIntegrationTestFixture()
         {
-            string testAssemblyPath = Path.GetFullPath(Assembly.GetExecutingAssembly().Location);
-#if SDK_CURRENT
-            _cliDirectory = TestDotnetCLiUtility.CopyAndPatchLatestDotnetCli(testAssemblyPath, preferredMajorVersion: 10);
-#elif SDK_NEXT
-            _cliDirectory = TestDotnetCLiUtility.CopyAndPatchLatestDotnetCli(testAssemblyPath, preferredMajorVersion: 11);
-#endif
+            int preferredMajorVersion = GetPreferredSdkMajorVersion();
+            _cliDirectory = TestDotnetCLiUtility.CopyAndPatchLatestDotnetCli(preferredMajorVersion);
             var dotnetExecutableName = RuntimeEnvironmentHelper.IsWindows ? "dotnet.exe" : "dotnet";
             TestDotnetCli = Path.Combine(_cliDirectory, dotnetExecutableName);
 
@@ -70,6 +68,23 @@ namespace Dotnet.Integration.Test
 
             // This is for pre-release packages.
             AddPackageSource("dotnet", Constants.DotNetPackageSource.AbsoluteUri);
+        }
+
+        private static int GetPreferredSdkMajorVersion()
+        {
+            string preferredSdkMajorVersion = Assembly.GetExecutingAssembly()
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Where(attribute => StringComparer.Ordinal.Equals(attribute.Key, PreferredSdkMajorVersionMetadataKey))
+                .Select(attribute => attribute.Value)
+                .SingleOrDefault();
+
+            if (!int.TryParse(preferredSdkMajorVersion, out int preferredMajorVersion))
+            {
+                throw new InvalidOperationException(
+                    $"Could not determine {PreferredSdkMajorVersionMetadataKey} from assembly metadata.");
+            }
+
+            return preferredMajorVersion;
         }
 
         private void AddPackageSource(string name, string source)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -566,7 +566,7 @@ namespace Dotnet.Integration.Test
                     $"add {projectA.ProjectPath} package packageX --no-restore",
                     testOutputHelper: _testOutputHelper);
 
-                // Disable implicit reference assembly packages to avoid needing Microsoft.NETFramework.ReferenceAssemblies from NuGet
+                // Disable implicit reference assembly packages to avoid needing Microsoft.NETFramework.ReferenceAssemblies
                 var doc = XDocument.Load(projectA.ProjectPath);
                 doc.Root.Element(XName.Get("PropertyGroup")).Add(new XElement(XName.Get("AutomaticallyUseReferenceAssemblyPackages"), "false"));
                 doc.Save(projectA.ProjectPath);
@@ -641,7 +641,6 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-
                 var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net461");
 
                 projectA.Properties.Add("RuntimeIdentifiers", "win;win-x86;win-x64");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -624,7 +624,7 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
                 var listResult = _fixture.RunDotnetExpectFailure(Directory.GetParent(projectA.ProjectPath).FullName,
                     $"list {projectA.ProjectPath} package --deprecated --outdated",

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -513,7 +513,7 @@ namespace Dotnet.Integration.Test
 	<AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include=""PackageX"" Version=""2.0.0""/>   
+		<PackageReference Include=""PackageX"" Version=""2.0.0""/>
      </ItemGroup>
      <ItemGroup Condition = ""'$(TargetFramework)' == 'net46'"">
          <PackageReference Include=""PackageY"" Version=""3.0.0""/>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -645,7 +645,6 @@ namespace Dotnet.Integration.Test
                 var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net461");
 
                 projectA.Properties.Add("RuntimeIdentifiers", "win;win-x86;win-x64");
-                projectA.Properties.Add("AutomaticallyUseReferenceAssemblyPackages", bool.FalseString);
 
                 var packageX = XPlatTestUtils.CreatePackage();
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -51,7 +51,7 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
                 var packageX = XPlatTestUtils.CreatePackage();
 
@@ -196,7 +196,7 @@ namespace Dotnet.Integration.Test
                 string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
 <PropertyGroup>
-	<TargetFramework>net46</TargetFramework>
+	<TargetFramework>{TestConstants.ProjectTargetFramework}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
         <PackageReference Include=""X""/>
@@ -250,7 +250,7 @@ namespace Dotnet.Integration.Test
                 string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
 <PropertyGroup>
-	<TargetFramework>net46</TargetFramework>
+	<TargetFramework>{TestConstants.ProjectTargetFramework}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
         <PackageReference Include=""X"" VersionOverride=""1.0.0""/>
@@ -302,7 +302,7 @@ namespace Dotnet.Integration.Test
                 string projectContent =
 @$"<Project  Sdk=""Microsoft.NET.Sdk"">
 <PropertyGroup>
-	<TargetFramework>net46</TargetFramework>
+	<TargetFramework>{TestConstants.ProjectTargetFramework}</TargetFramework>
 	</PropertyGroup>
     <ItemGroup>
         <PackageReference Include=""X""/>
@@ -332,7 +332,7 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
                 var packageX = XPlatTestUtils.CreatePackage();
                 var packageY = XPlatTestUtils.CreatePackage(packageId: "packageY");
@@ -380,9 +380,9 @@ namespace Dotnet.Integration.Test
             {
                 string directDependencyProjectName = $"{ProjectName}Dependency";
                 string transitiveDependencyProjectName = $"{ProjectName}TransitiveDependency";
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
-                var projectB = XPlatTestUtils.CreateProject(directDependencyProjectName, pathContext, "net46");
-                var projectC = XPlatTestUtils.CreateProject(transitiveDependencyProjectName, pathContext, "net46");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
+                var projectB = XPlatTestUtils.CreateProject(directDependencyProjectName, pathContext, TestConstants.ProjectTargetFramework);
+                var projectC = XPlatTestUtils.CreateProject(transitiveDependencyProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
                 var packageX = XPlatTestUtils.CreatePackage(packageId: "packageX");
                 var packageY = XPlatTestUtils.CreatePackage(packageId: "packageY");
@@ -510,9 +510,10 @@ namespace Dotnet.Integration.Test
 @$"<Project Sdk=""Microsoft.NET.Sdk"">
 <PropertyGroup>
 	<TargetFrameworks>net46;net48</TargetFrameworks>
+	<AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
 	</PropertyGroup>
-	 <ItemGroup>
-		 <PackageReference Include=""PackageX"" Version=""2.0.0""/>   
+	<ItemGroup>
+		<PackageReference Include=""PackageX"" Version=""2.0.0""/>   
      </ItemGroup>
      <ItemGroup Condition = ""'$(TargetFramework)' == 'net46'"">
          <PackageReference Include=""PackageY"" Version=""3.0.0""/>
@@ -565,6 +566,11 @@ namespace Dotnet.Integration.Test
                     $"add {projectA.ProjectPath} package packageX --no-restore",
                     testOutputHelper: _testOutputHelper);
 
+                // Disable implicit reference assembly packages to avoid needing Microsoft.NETFramework.ReferenceAssemblies from NuGet
+                var doc = XDocument.Load(projectA.ProjectPath);
+                doc.Root.Element(XName.Get("PropertyGroup")).Add(new XElement(XName.Get("AutomaticallyUseReferenceAssemblyPackages"), "false"));
+                doc.Save(projectA.ProjectPath);
+
                 _fixture.RunDotnetExpectSuccess(Directory.GetParent(projectA.ProjectPath).FullName,
                     $"restore {projectA.ProjectName}.csproj",
                     testOutputHelper: _testOutputHelper);
@@ -588,7 +594,7 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
                 var packageX = XPlatTestUtils.CreatePackage();
 
@@ -608,7 +614,7 @@ namespace Dotnet.Integration.Test
                     testOutputHelper: _testOutputHelper);
 
                 _fixture.RunDotnetExpectFailure(Directory.GetParent(projectA.ProjectPath).FullName,
-                    $"list {projectA.ProjectPath} package --framework net46 --framework invalidFramework",
+                    $"list {projectA.ProjectPath} package --framework {TestConstants.ProjectTargetFramework} --framework invalidFramework",
                     testOutputHelper: _testOutputHelper);
             }
         }
@@ -839,7 +845,7 @@ namespace Dotnet.Integration.Test
         {
             using (var pathContext = _fixture.CreateSimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, "net46");
+                var projectA = XPlatTestUtils.CreateProject(ProjectName, pathContext, TestConstants.ProjectTargetFramework);
 
                 var doc = XDocument.Parse(File.ReadAllText(projectA.ProjectPath));
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -208,11 +208,7 @@ namespace Dotnet.Integration.Test
 
             // Assert
             Assert.Equal(ExitCodes.InvalidArguments, result.ExitCode);
-#if SDK_CURRENT
-            Assert.Contains($"Required argument missing for command: 'why'.", result.AllOutput);
-#else
             result.AllOutput.Should().Contain("Unable to run 'dotnet nuget why'. Missing or invalid path '--package'.");
-#endif
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -19,6 +19,7 @@ using Xunit.Abstractions;
 
 namespace Dotnet.Integration.Test
 {
+    [UseCulture("en-US")] // We are asserting exception messages in English
     [Collection(DotnetIntegrationCollection.Name)]
     public class DotnetWhyTests
     {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -5,8 +5,8 @@
 
 using System;
 using System.IO;
-using System.Threading.Tasks;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 using NuGet.CommandLine.XPlat;
@@ -92,9 +92,13 @@ namespace Dotnet.Integration.Test
 
             // Run "why" command.
             var result = _testFixture.RunDotnetExpectSuccess(fbaDir, "nuget why app.cs PackageB", testOutputHelper: _testOutputHelper);
-
+#if SDK_CURRENT
             Assert.Contains("packageA (v1.0.0)", result.AllOutput);
             Assert.Contains("packageB (v1.0.1)", result.AllOutput);
+#else
+            result.AllOutput.Should().Contain("packageA@1.0.0 (>= 1.0.0)");
+            result.AllOutput.Should().Contain("packageB@1.0.1 (>= 1.0.1)");
+#endif
         }
 
         [Fact]
@@ -197,14 +201,18 @@ namespace Dotnet.Integration.Test
             // Arrange
             var pathContext = new SimpleTestPathContext();
 
-            string whyCommandArgs = $"nuget why";
+            string whyCommandArgs = $"nuget why --package package";
 
             // Act
             CommandRunnerResult result = _testFixture.RunDotnetExpectFailure(pathContext.SolutionRoot, whyCommandArgs, testOutputHelper: _testOutputHelper);
 
             // Assert
             Assert.Equal(ExitCodes.InvalidArguments, result.ExitCode);
+#if SDK_CURRENT
             Assert.Contains($"Required argument missing for command: 'why'.", result.Errors);
+#else
+            result.AllOutput.Should().Contain("Unable to run 'dotnet nuget why'. Missing or invalid path '--package'.");
+#endif
         }
 
         [Fact]
@@ -221,7 +229,11 @@ namespace Dotnet.Integration.Test
 
             // Assert
             Assert.Equal(ExitCodes.InvalidArguments, result.ExitCode);
+#if SDK_CURRENT
             Assert.Contains($"Required argument missing for command: 'why'.", result.Errors);
+#else
+            Assert.Contains($"Required argument 'PACKAGE' missing for command: 'why'.", result.Errors);
+#endif
         }
 
         [Fact]
@@ -338,6 +350,7 @@ namespace Dotnet.Integration.Test
 
             // Assert
             // project references should not have version numbers
+#if SDK_CURRENT
             string[] expected =
                 [
                 "Project 'ProjectC' has the following dependency graph(s) for 'PackageX':",
@@ -350,6 +363,20 @@ namespace Dotnet.Integration.Test
                 "",
                 ""
                 ];
+#else
+            string[] expected =
+                [
+                "Project 'ProjectC' has the following dependency graph(s) for 'PackageX':",
+                "",
+                $"  [{TestConstants.ProjectTargetFramework}]                                                                     ",
+                "  └── ProjectB                                                                  ",
+                "      └── ProjectA                                                              ",
+                "          └── PackageX@1.0.0 (>= 1.0.0)                                         ",
+                "",
+                "",
+                ""
+                ];
+#endif
             StripAnsiCodes(result.AllOutput).Should().Be(string.Join(Environment.NewLine, expected));
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -209,7 +209,7 @@ namespace Dotnet.Integration.Test
             // Assert
             Assert.Equal(ExitCodes.InvalidArguments, result.ExitCode);
 #if SDK_CURRENT
-            Assert.Contains($"Required argument missing for command: 'why'.", result.Errors);
+            Assert.Contains($"Required argument missing for command: 'why'.", result.AllOutput);
 #else
             result.AllOutput.Should().Contain("Unable to run 'dotnet nuget why'. Missing or invalid path '--package'.");
 #endif

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -201,14 +201,18 @@ namespace Dotnet.Integration.Test
             // Arrange
             var pathContext = new SimpleTestPathContext();
 
-            string whyCommandArgs = $"nuget why --package package";
+            string whyCommandArgs = $"nuget why";
 
             // Act
             CommandRunnerResult result = _testFixture.RunDotnetExpectFailure(pathContext.SolutionRoot, whyCommandArgs, testOutputHelper: _testOutputHelper);
 
             // Assert
             Assert.Equal(ExitCodes.InvalidArguments, result.ExitCode);
-            result.AllOutput.Should().Contain("Unable to run 'dotnet nuget why'. Missing or invalid path '--package'.");
+#if SDK_CURRENT
+            Assert.Contains($"Required argument missing for command: 'why'.", result.Errors);
+#else
+            Assert.Contains("Required argument 'PACKAGE' missing for command: 'why'", result.Errors);
+#endif
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/TestConstants.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/TestConstants.cs
@@ -7,7 +7,11 @@ namespace Test.Utility;
 
 public static class TestConstants
 {
-#if NET10_0 || NETFRAMEWORK
+#if SDK_NEXT
+    // Specifies a target framework for projects used during testing.  This should match the framework that the SDK being tested has.
+    public const string ProjectTargetFramework = "net11.0";
+    public static readonly NuGetFramework DefaultTargetFramework = NuGetFramework.Parse(ProjectTargetFramework);
+#elif NET10_0
     // Specifies a target framework for projects used during testing.  This should match the framework that the SDK being tested has.
     public const string ProjectTargetFramework = "net10.0";
     public static readonly NuGetFramework DefaultTargetFramework = NuGetFramework.Parse(ProjectTargetFramework);

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -448,6 +448,7 @@ namespace NuGet.Test.Utility
             context.Frameworks.AddRange(frameworks.Select(f => new SimpleTestProjectFrameworkContext(NuGetFramework.Parse(f)) { TargetAlias = f }));
             context.ToolingVersion15 = true;
             context.Properties.Add("BuildWithNetFrameworkHostedCompiler", bool.FalseString);
+            context.Properties.Add("AutomaticallyUseReferenceAssemblyPackages", bool.FalseString);
             return context;
         }
 

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -31,7 +31,7 @@ namespace NuGet.Test.Utility
 
 #if !IS_DESKTOP
         // For non fullframework code path, we could dynamically determine which SDK version to copy by checking the TFM of test project assembly and the dotnet.dll.
-        public static TestDirectory CopyAndPatchLatestDotnetCli(string testAssemblyPath)
+        public static TestDirectory CopyAndPatchLatestDotnetCli(string testAssemblyPath, int preferredMajorVersion)
         {
             CliDirSource = Path.GetDirectoryName(TestFileSystemUtility.GetDotnetCli());
             SdkDirSource = Path.Combine(CliDirSource, "sdk" + Path.DirectorySeparatorChar);

--- a/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestDotnetCLiUtility.cs
@@ -18,26 +18,20 @@ namespace NuGet.Test.Utility
 {
     public static class TestDotnetCLiUtility
     {
-#if NET9_0 // This override allows us to test the next version of the CLI without making all the projects target that version.
-        private static NuGetFramework FrameworkOverride = new NuGetFramework("net10.0");
-#elif !IS_DESKTOP
-        private static NuGetFramework FrameworkOverride = null;
-#endif
-
         internal static string SdkVersion { get; private set; }
         internal static NuGetFramework SdkTfm { get; private set; }
         internal static string CliDirSource { get; private set; }
         internal static string SdkDirSource { get; private set; }
 
 #if !IS_DESKTOP
-        // For non fullframework code path, we could dynamically determine which SDK version to copy by checking the TFM of test project assembly and the dotnet.dll.
-        public static TestDirectory CopyAndPatchLatestDotnetCli(string testAssemblyPath, int preferredMajorVersion)
+        // Prefer a specific SDK major so the same net10.0 test assembly can validate both the 10.0.4xx SDK and the 11.0 daily SDK.
+        public static TestDirectory CopyAndPatchLatestDotnetCli(int preferredMajorVersion)
         {
             CliDirSource = Path.GetDirectoryName(TestFileSystemUtility.GetDotnetCli());
             SdkDirSource = Path.Combine(CliDirSource, "sdk" + Path.DirectorySeparatorChar);
 
             // Dynamically determine which SDK version to copy
-            SdkVersion = GetSdkToTestByAssemblyPath(testAssemblyPath);
+            SdkVersion = GetSdkToTestByAssemblyPath(preferredMajorVersion);
 
             // Dynamically determine the TFM of the dotnet.dll
             SdkTfm = AssemblyReader.GetTargetFramework(Path.Combine(SdkDirSource, SdkVersion, "dotnet.dll"));
@@ -107,34 +101,45 @@ namespace NuGet.Test.Utility
         }
 
 #if !IS_DESKTOP
-        // Dynamically determine which SDK version to copy by checking the TFM of test project assembly and the dotnet.dll.
-        private static string GetSdkToTestByAssemblyPath(string testAssemblyPath)
+        // Dynamically determine which SDK version to copy.
+        private static string GetSdkToTestByAssemblyPath(int preferredMajorVersion)
         {
-            // The TFM we're testing
-            var testTfm = FrameworkOverride ?? AssemblyReader.GetTargetFramework(testAssemblyPath);
+            var installedSdkDirectories = Directory.EnumerateDirectories(SdkDirSource)
+                .Where(path => !string.Equals(Path.GetFileName(path), "NuGetFallbackFolder", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var installedSdkVersions = installedSdkDirectories
+                .Select(Path.GetFileName)
+                .ToArray();
+            string selectedVersion = null;
 
-            var selectedVersion =
-                Directory.EnumerateDirectories(SdkDirSource) // get all directories in sdk folder
-                .Where(path =>
-                { // SDK is for TFM to test
-                    if (string.Equals(Path.GetFileName(path), "NuGetFallbackFolder", StringComparison.OrdinalIgnoreCase))
-                    {
-                        return false;
-                    }
+            if (preferredMajorVersion > 0)
+            {
+                selectedVersion = installedSdkDirectories
+                    .Where(path => IsPreferredMajorVersion(path, preferredMajorVersion))
+                    .Select(Path.GetFileName)
+                    .OrderByDescending(path => NuGetVersion.Parse(path))
+                    .FirstOrDefault();
 
-                    var dotnetPath = Path.Combine(path, "dotnet.dll");
-                    var sdkTfm = AssemblyReader.GetTargetFramework(dotnetPath);
+                if (selectedVersion == null)
+                {
+                    var message = $@"Could not find suitable SDK to test in {SdkDirSource}
+preferredMajorVersion specified: {preferredMajorVersion}
+SDKs found: {string.Join(", ", installedSdkVersions)}";
 
-                    return testTfm == sdkTfm;
-                })
-                .Select(Path.GetFileName) // just the folder name (version string)
-                .OrderByDescending(path => NuGetVersion.Parse(Path.GetFileName(path))) // in case there are multiple matching SDKs, selected the highest version
+                    throw new Exception(message);
+                }
+
+                return selectedVersion;
+            }
+
+            selectedVersion = installedSdkDirectories
+                .Select(Path.GetFileName)
+                .OrderByDescending(path => NuGetVersion.Parse(path))
                 .FirstOrDefault();
 
             if (selectedVersion == null)
             {
-                selectedVersion = Directory.EnumerateDirectories(SdkDirSource)
-                    .Select(Path.GetFileName)
+                selectedVersion = installedSdkVersions
                     .OrderByDescending(directoryName => NuGetVersion.Parse(directoryName))
                     .FirstOrDefault();
             }
@@ -142,13 +147,19 @@ namespace NuGet.Test.Utility
             if (selectedVersion == null)
             {
                 var message = $@"Could not find suitable SDK to test in {SdkDirSource}
-TFM being tested: {testTfm.DotNetFrameworkName}
-SDKs found: {string.Join(", ", Directory.EnumerateDirectories(SdkDirSource).Select(Path.GetFileName).Where(d => !string.Equals(d, "NuGetFallbackFolder", StringComparison.OrdinalIgnoreCase)))}";
+SDKs found: {string.Join(", ", installedSdkVersions)}";
 
                 throw new Exception(message);
             }
 
             return selectedVersion;
+        }
+
+        private static bool IsPreferredMajorVersion(string sdkDirectory, int preferredMajorVersion)
+        {
+            var sdkVersion = Path.GetFileName(sdkDirectory);
+
+            return NuGetVersion.Parse(sdkVersion).Version.Major == preferredMajorVersion;
         }
 #else
         // Use specified sdkVersion(could be just a major version) to determine which SDK version to copy.


### PR DESCRIPTION
# Bug

Progress: https://github.com/NuGet/Home/issues/13389

## Description

Migrate PR CI machines to Windows VS 2026 images and add SDK Next test stages for Dotnet.Integration.Test.

### Changes

1. **Migrate to VS 2026 machines** — All Windows test stages now use `Windows.VS2026.Amd64.Open`, except `NuGet.CommandLine.Test` (net472) which remains on `Windows.VS2022.Amd64.Open` due to https://github.com/dotnet/roslyn/issues/82931 and our use of older MSBuild references.

2. **Add SDK Next stages** — Added `Dotnet.Integration.Test` stages for Windows, Linux, and MacOS that run against the next SDK version (`sdkNext`).

3. **Fix DotnetListPackage tests** — Tests targeting `net46` were failing with NU1101 for `Microsoft.NETFramework.ReferenceAssemblies` because of a regression in MSBuild (https://github.com/dotnet/msbuild/issues/13928) where `GetReferenceAssemblyPaths` returns empty on the new machines. Fixed by:
   - Switching single-TFM tests from `net46` to `TestConstants.ProjectTargetFramework` (net10.0)
   - Adding `AutomaticallyUseReferenceAssemblyPackages=false` for multi-TFM tests that still need `net46;net48`

4. **Static Analysis** — Moved from `windows-latest` vmImage to `NetCore-Public` pool with `Windows.VS2026.Amd64.Open`. to ensure a toolset that supports aliasing is used.

5. Dotnet NuGet Why has some needed test changes that are a consequence of the system.commandline version being used. 3.0.0-preview.6.26277.111 vs 2.0.6. 

## PR Checklist

- [x] PR has a meaningful title
- [x] Linked to an appropriate issue (if applicable)
- [x] Added/updated appropriate tests