### PR TITLE
Add STJ path in package search

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Core/PackageDependency.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Core/PackageDependency.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using NuGet.Versioning;
 
@@ -20,6 +21,7 @@ namespace NuGet.Packaging.Core
         /// <summary>
         /// Dependency package Id
         /// </summary>
+        [JsonPropertyName("id")]
         public string Id { get; }
 
         /// <summary>
@@ -36,6 +38,7 @@ namespace NuGet.Packaging.Core
         /// Range of versions allowed for the depenency
         /// </summary>
         [JsonProperty(PropertyName = "range")]
+        [JsonPropertyName("range")]
         public VersionRange VersionRange
         {
             get { return _versionRange; }
@@ -46,7 +49,8 @@ namespace NuGet.Packaging.Core
         {
         }
 
-        [JsonConstructor]
+        [Newtonsoft.Json.JsonConstructor]
+        [System.Text.Json.Serialization.JsonConstructor]
         public PackageDependency(string id, VersionRange? versionRange)
             : this(id, versionRange, include: null, exclude: null)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Converters/PackageDependencyGroupStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/PackageDependencyGroupStjConverter.cs
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+
+namespace NuGet.Protocol.Converters
+{
+    /// <remarks>
+    /// NSJ deserializes <see cref="PackageDependencyGroup"/> via a private constructor attributed with
+    /// <c>[JsonConstructor]</c>. STJ source generation cannot access private constructors, so this
+    /// converter handles deserialization explicitly.
+    /// </remarks>
+    internal sealed class PackageDependencyGroupStjConverter : JsonConverter<PackageDependencyGroup>
+    {
+        public override PackageDependencyGroup Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType));
+            }
+
+            NuGetFramework targetFramework = null;
+            var packages = new List<PackageDependency>();
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType));
+                }
+
+                var propName = reader.GetString();
+                reader.Read();
+
+                if (string.Equals(propName, JsonProperties.TargetFramework, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (reader.TokenType != JsonTokenType.Null)
+                    {
+                        var fw = reader.GetString();
+                        targetFramework = string.IsNullOrEmpty(fw) ? null : NuGetFramework.Parse(fw);
+                    }
+                }
+                else if (string.Equals(propName, JsonProperties.Dependencies, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (reader.TokenType == JsonTokenType.StartArray)
+                    {
+                        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                        {
+                            packages.Add(JsonSerializer.Deserialize(ref reader, PackageSearchJsonContext.Default.PackageDependency));
+                        }
+                    }
+                    else if (reader.TokenType != JsonTokenType.Null)
+                    {
+                        throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType));
+                    }
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            return new PackageDependencyGroup(targetFramework ?? NuGetFramework.AnyFramework, packages);
+        }
+
+        public override void Write(Utf8JsonWriter writer, PackageDependencyGroup value, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Converters/PackageDependencyGroupStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/PackageDependencyGroupStjConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -28,7 +26,7 @@ namespace NuGet.Protocol.Converters
                 throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType));
             }
 
-            NuGetFramework targetFramework = null;
+            NuGetFramework? targetFramework = null;
             var packages = new List<PackageDependency>();
 
             while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
@@ -45,8 +43,8 @@ namespace NuGet.Protocol.Converters
                 {
                     if (reader.TokenType != JsonTokenType.Null)
                     {
-                        var fw = reader.GetString();
-                        targetFramework = string.IsNullOrEmpty(fw) ? null : NuGetFramework.Parse(fw);
+                        string? fw = reader.GetString();
+                        targetFramework = string.IsNullOrEmpty(fw) ? null : NuGetFramework.Parse(fw!);
                     }
                 }
                 else if (string.Equals(propName, JsonProperties.Dependencies, StringComparison.OrdinalIgnoreCase))
@@ -55,7 +53,11 @@ namespace NuGet.Protocol.Converters
                     {
                         while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
                         {
-                            packages.Add(JsonSerializer.Deserialize(ref reader, PackageSearchJsonContext.Default.PackageDependency));
+                            PackageDependency? dependency = JsonSerializer.Deserialize(ref reader, PackageSearchJsonContext.Default.PackageDependency);
+                            if (dependency != null)
+                            {
+                                packages.Add(dependency);
+                            }
                         }
                     }
                     else if (reader.TokenType != JsonTokenType.Null)

--- a/src/NuGet.Core/NuGet.Protocol/Converters/PackageSearchJsonContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/PackageSearchJsonContext.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Model;
+
+namespace NuGet.Protocol.Converters
+{
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
+    [JsonSourceGenerationOptions(
+        PropertyNameCaseInsensitive = true,
+        GenerationMode = JsonSourceGenerationMode.Metadata,
+        Converters = new[] { typeof(PackageDependencyGroupStjConverter), typeof(SafeUriStjConverter), typeof(VersionRangeStjConverter), typeof(NuGetVersionStjConverter) })]
+#pragma warning restore CS3016
+    [JsonSerializable(typeof(V3SearchResults))]
+    [JsonSerializable(typeof(PackageDependency))]
+    internal partial class PackageSearchJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/Model/AlternatePackageMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/AlternatePackageMetadata.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using NuGet.Versioning;
 
@@ -9,9 +10,13 @@ namespace NuGet.Protocol
     public class AlternatePackageMetadata
     {
         [JsonProperty(PropertyName = JsonProperties.PackageId)]
+        [JsonPropertyName(JsonProperties.PackageId)]
+        [JsonInclude]
         public string? PackageId { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.Range, ItemConverterType = typeof(VersionRangeConverter))]
+        [JsonPropertyName(JsonProperties.Range)]
+        [JsonInclude]
         public VersionRange? Range { get; internal set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageDeprecationMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageDeprecationMetadata.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace NuGet.Protocol
@@ -10,12 +11,18 @@ namespace NuGet.Protocol
     public class PackageDeprecationMetadata
     {
         [JsonProperty(PropertyName = JsonProperties.DeprecationMessage)]
+        [JsonPropertyName(JsonProperties.DeprecationMessage)]
+        [JsonInclude]
         public string? Message { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.DeprecationReasons)]
+        [JsonPropertyName(JsonProperties.DeprecationReasons)]
+        [JsonInclude]
         public IEnumerable<string> Reasons { get; internal set; } = Array.Empty<string>();
 
         [JsonProperty(PropertyName = JsonProperties.AlternatePackage)]
+        [JsonPropertyName(JsonProperties.AlternatePackage)]
+        [JsonInclude]
         public AlternatePackageMetadata? AlternatePackage { get; internal set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -8,11 +8,13 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Licenses;
+using NuGet.Protocol.Converters;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
@@ -21,13 +23,19 @@ namespace NuGet.Protocol
     public class PackageSearchMetadata : IPackageSearchMetadata
     {
         [JsonProperty(PropertyName = JsonProperties.Authors)]
-        [JsonConverter(typeof(MetadataFieldConverter))]
-        public string Authors { get; private set; }
+        [Newtonsoft.Json.JsonConverter(typeof(MetadataFieldConverter))]
+        [JsonPropertyName(JsonProperties.Authors)]
+        [System.Text.Json.Serialization.JsonConverter(typeof(MetadataFieldStjConverter))]
+        [JsonInclude]
+        public string Authors { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.DependencyGroups)]
-        public IEnumerable<PackageDependencyGroup> DependencySetsInternal { get; private set; }
+        [JsonPropertyName(JsonProperties.DependencyGroups)]
+        [JsonInclude]
+        public IEnumerable<PackageDependencyGroup> DependencySetsInternal { get; internal set; }
 
-        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public IEnumerable<PackageDependencyGroup> DependencySets
         {
             get
@@ -37,17 +45,24 @@ namespace NuGet.Protocol
         }
 
         [JsonProperty(PropertyName = JsonProperties.Description)]
-        public string Description { get; private set; }
+        [JsonPropertyName(JsonProperties.Description)]
+        [JsonInclude]
+        public string Description { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.DownloadCount)]
-        public long? DownloadCount { get; private set; }
+        [JsonPropertyName(JsonProperties.DownloadCount)]
+        [JsonInclude]
+        public long? DownloadCount { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.IconUrl)]
-        public Uri IconUrl { get; private set; }
+        [JsonPropertyName(JsonProperties.IconUrl)]
+        [JsonInclude]
+        public Uri IconUrl { get; internal set; }
 
         private PackageIdentity _packageIdentity = null;
 
-        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public PackageIdentity Identity
         {
             get
@@ -61,17 +76,23 @@ namespace NuGet.Protocol
         }
 
         [JsonProperty(PropertyName = JsonProperties.LicenseUrl)]
-        [JsonConverter(typeof(SafeUriConverter))]
-        public Uri LicenseUrl { get; private set; }
+        [Newtonsoft.Json.JsonConverter(typeof(SafeUriConverter))]
+        [JsonPropertyName(JsonProperties.LicenseUrl)]
+        [System.Text.Json.Serialization.JsonConverter(typeof(SafeUriStjConverter))]
+        [JsonInclude]
+        public Uri LicenseUrl { get; internal set; }
 
         private IReadOnlyList<string> _ownersList;
 
         [JsonProperty(PropertyName = JsonProperties.Owners)]
-        [JsonConverter(typeof(MetadataStringOrArrayConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(MetadataStringOrArrayConverter))]
+        [JsonPropertyName(JsonProperties.Owners)]
+        [System.Text.Json.Serialization.JsonConverter(typeof(MetadataStringOrArrayStjConverter))]
+        [JsonInclude]
         public IReadOnlyList<string> OwnersList
         {
             get { return _ownersList; }
-            private set
+            internal set
             {
                 if (_ownersList != value)
                 {
@@ -82,6 +103,7 @@ namespace NuGet.Protocol
         }
 
         private string _owners;
+        [System.Text.Json.Serialization.JsonIgnore]
         public string Owners
         {
             get
@@ -95,71 +117,105 @@ namespace NuGet.Protocol
         }
 
         [JsonProperty(PropertyName = JsonProperties.PackageId)]
-        public string PackageId { get; private set; }
+        [JsonPropertyName(JsonProperties.PackageId)]
+        [JsonInclude]
+        public string PackageId { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.ProjectUrl)]
-        [JsonConverter(typeof(SafeUriConverter))]
-        public Uri ProjectUrl { get; private set; }
+        [Newtonsoft.Json.JsonConverter(typeof(SafeUriConverter))]
+        [JsonPropertyName(JsonProperties.ProjectUrl)]
+        [System.Text.Json.Serialization.JsonConverter(typeof(SafeUriStjConverter))]
+        [JsonInclude]
+        public Uri ProjectUrl { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.Published)]
-        public DateTimeOffset? Published { get; private set; }
+        [JsonPropertyName(JsonProperties.Published)]
+        [JsonInclude]
+        public DateTimeOffset? Published { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.ReadmeUrl)]
-        [JsonConverter(typeof(SafeUriConverter))]
-        public Uri ReadmeUrl { get; private set; }
+        [Newtonsoft.Json.JsonConverter(typeof(SafeUriConverter))]
+        [JsonPropertyName(JsonProperties.ReadmeUrl)]
+        [System.Text.Json.Serialization.JsonConverter(typeof(SafeUriStjConverter))]
+        [JsonInclude]
+        public Uri ReadmeUrl { get; internal set; }
 
-        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public string ReadmeFileUrl { get; internal set; }
 
-        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public Uri ReportAbuseUrl { get; set; }
 
-        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public Uri PackageDetailsUrl { get; set; }
 
         [JsonProperty(PropertyName = JsonProperties.RequireLicenseAcceptance, DefaultValueHandling = DefaultValueHandling.Populate)]
         [DefaultValue(false)]
-        [JsonConverter(typeof(SafeBoolConverter))]
-        public bool RequireLicenseAcceptance { get; private set; }
+        [Newtonsoft.Json.JsonConverter(typeof(SafeBoolConverter))]
+        [JsonPropertyName(JsonProperties.RequireLicenseAcceptance)]
+        [System.Text.Json.Serialization.JsonConverter(typeof(SafeBoolStjConverter))]
+        [JsonInclude]
+        public bool RequireLicenseAcceptance { get; internal set; }
 
         private string _summaryValue;
 
         [JsonProperty(PropertyName = JsonProperties.Summary)]
+        [JsonPropertyName(JsonProperties.Summary)]
+        [JsonInclude]
         public string Summary
         {
             get { return !string.IsNullOrEmpty(_summaryValue) ? _summaryValue : Description; }
-            private set { _summaryValue = value; }
+            internal set { _summaryValue = value; }
         }
 
         [JsonProperty(PropertyName = JsonProperties.Tags)]
-        [JsonConverter(typeof(MetadataFieldConverter))]
-        public string Tags { get; private set; }
+        [Newtonsoft.Json.JsonConverter(typeof(MetadataFieldConverter))]
+        [JsonPropertyName(JsonProperties.Tags)]
+        [System.Text.Json.Serialization.JsonConverter(typeof(MetadataFieldStjConverter))]
+        [JsonInclude]
+        public string Tags { get; internal set; }
 
         private string _titleValue;
 
         [JsonProperty(PropertyName = JsonProperties.Title)]
+        [JsonPropertyName(JsonProperties.Title)]
+        [JsonInclude]
         public string Title
         {
             get { return !string.IsNullOrEmpty(_titleValue) ? _titleValue : PackageId; }
-            private set { _titleValue = value; }
+            internal set { _titleValue = value; }
         }
 
         [JsonProperty(PropertyName = JsonProperties.Version)]
-        public NuGetVersion Version { get; private set; }
+        [JsonPropertyName(JsonProperties.Version)]
+        [JsonInclude]
+        public NuGetVersion Version { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.Versions)]
-        public VersionInfo[] ParsedVersions { get; private set; }
+        [JsonPropertyName(JsonProperties.Versions)]
+        [JsonInclude]
+        public VersionInfo[] ParsedVersions { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.PrefixReserved)]
-        public bool PrefixReserved { get; private set; }
+        [JsonPropertyName(JsonProperties.PrefixReserved)]
+        [JsonInclude]
+        public bool PrefixReserved { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.LicenseExpression)]
-        public string LicenseExpression { get; private set; }
+        [JsonPropertyName(JsonProperties.LicenseExpression)]
+        [JsonInclude]
+        public string LicenseExpression { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.LicenseExpressionVersion)]
-        public string LicenseExpressionVersion { get; private set; }
+        [JsonPropertyName(JsonProperties.LicenseExpressionVersion)]
+        [JsonInclude]
+        public string LicenseExpressionVersion { get; internal set; }
 
-        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public LicenseMetadata LicenseMetadata
         {
             get
@@ -245,17 +301,23 @@ namespace NuGet.Protocol
         public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => Task.FromResult<IEnumerable<VersionInfo>>(ParsedVersions);
 
         [JsonProperty(PropertyName = JsonProperties.Listed)]
-        public bool IsListed { get; private set; } = true;
+        [JsonPropertyName(JsonProperties.Listed)]
+        [JsonInclude]
+        public bool IsListed { get; internal set; } = true;
 
         [JsonProperty(PropertyName = JsonProperties.Deprecation)]
-        public PackageDeprecationMetadata DeprecationMetadata { get; private set; }
+        [JsonPropertyName(JsonProperties.Deprecation)]
+        [JsonInclude]
+        public PackageDeprecationMetadata DeprecationMetadata { get; internal set; }
 
         /// <inheritdoc cref="IPackageSearchMetadata.GetDeprecationMetadataAsync" />
         public Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() => Task.FromResult(DeprecationMetadata);
 
         /// <inheritdoc cref="IPackageSearchMetadata.Vulnerabilities" />
         [JsonProperty(PropertyName = JsonProperties.Vulnerabilities)]
-        public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; private set; }
+        [JsonPropertyName(JsonProperties.Vulnerabilities)]
+        [JsonInclude]
+        public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; internal set; }
 
         internal void CacheStrings(MetadataReferenceCache cache)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityMetadata.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace NuGet.Protocol
@@ -11,9 +12,13 @@ namespace NuGet.Protocol
     public class PackageVulnerabilityMetadata
     {
         [JsonProperty(PropertyName = JsonProperties.AdvisoryUrl, ItemConverterType = typeof(SafeUriConverter))]
+        [JsonPropertyName(JsonProperties.AdvisoryUrl)]
+        [JsonInclude]
         public Uri AdvisoryUrl { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.Severity)]
+        [JsonPropertyName(JsonProperties.Severity)]
+        [JsonInclude]
         public int Severity { get; internal set; }
 
         public PackageVulnerabilityMetadata(Uri advisoryUrl, int severity)

--- a/src/NuGet.Core/NuGet.Protocol/Model/V3SearchResults.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/V3SearchResults.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace NuGet.Protocol.Model
@@ -9,9 +10,11 @@ namespace NuGet.Protocol.Model
     internal class V3SearchResults
     {
         [JsonProperty("totalHits")]
+        [JsonPropertyName("totalHits")]
         public long TotalHits { get; set; }
 
         [JsonProperty("data")]
-        public List<PackageSearchMetadata> Data { get; private set; } = new List<PackageSearchMetadata>();
+        [JsonPropertyName("data")]
+        public List<PackageSearchMetadata> Data { get; set; } = new List<PackageSearchMetadata>();
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/VersionInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/VersionInfo.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text.Json.Serialization;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol.Core.Types
@@ -23,14 +24,17 @@ namespace NuGet.Protocol.Core.Types
             }
         }
 
+        [JsonConstructor]
         public VersionInfo(NuGetVersion version, long? downloadCount)
         {
             Version = version;
             DownloadCount = downloadCount;
         }
 
+        [JsonPropertyName(JsonProperties.Version)]
         public NuGetVersion Version { get; private set; }
 
+        [JsonPropertyName("downloads")]
         public long? DownloadCount { get; private set; }
 
         /// <summary>
@@ -39,6 +43,7 @@ namespace NuGet.Protocol.Core.Types
         /// here. For V3, the metadata property is null. Callers that receive this type need to be able to
         /// fetch this package metadata some other way if this property is null.
         /// </summary>
+        [JsonIgnore]
         public IPackageSearchMetadata? PackageSearchMetadata { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -12,8 +12,11 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using NuGet.Common;
+using NuGet.Protocol.Converters;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
+using NuGet.Shared;
 
 namespace NuGet.Protocol
 {
@@ -21,6 +24,7 @@ namespace NuGet.Protocol
     {
         private readonly HttpSource _client;
         private readonly Uri[] _searchEndpoints;
+        private readonly IEnvironmentVariableReader _environmentVariableReader;
 
 #pragma warning disable CS0618 // Type or member is obsolete
         private readonly RawSearchResourceV3 _rawSearchResource;
@@ -34,10 +38,16 @@ namespace NuGet.Protocol
         }
 
         internal PackageSearchResourceV3(HttpSource client, IEnumerable<Uri> searchEndpoints)
+            : this(client, searchEndpoints, environmentVariableReader: null)
+        {
+        }
+
+        internal PackageSearchResourceV3(HttpSource client, IEnumerable<Uri> searchEndpoints, IEnvironmentVariableReader environmentVariableReader)
             : base()
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _searchEndpoints = searchEndpoints?.ToArray() ?? throw new ArgumentNullException(nameof(searchEndpoints));
+            _environmentVariableReader = environmentVariableReader;
         }
 
         /// <summary>
@@ -255,6 +265,36 @@ namespace NuGet.Protocol
                 return null;
             }
 
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
+                || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+            {
+                return await ProcessHttpStreamWithStjAsync(httpInitialResponse, take, token);
+            }
+            else
+            {
+                return await ProcessHttpStreamWithNsjAsync(httpInitialResponse, take, token);
+            }
+        }
+
+        private static async Task<V3SearchResults> ProcessHttpStreamWithStjAsync(HttpResponseMessage httpInitialResponse, uint take, CancellationToken token)
+        {
+#if NETCOREAPP2_0_OR_GREATER
+            using var stream = await httpInitialResponse.Content.ReadAsStreamAsync(token);
+#else
+            using var stream = await httpInitialResponse.Content.ReadAsStreamAsync();
+#endif
+            var results = await System.Text.Json.JsonSerializer.DeserializeAsync(stream, PackageSearchJsonContext.Default.V3SearchResults, token);
+
+            if (results?.Data?.Count > take)
+            {
+                results.Data = results.Data.Take((int)take).ToList();
+            }
+
+            return results;
+        }
+
+        private static async Task<V3SearchResults> ProcessHttpStreamWithNsjAsync(HttpResponseMessage httpInitialResponse, uint take, CancellationToken token)
+        {
             var _newtonsoftConvertersSerializer = JsonSerializer.Create(JsonExtensions.ObjectSerializationSettings);
             _newtonsoftConvertersSerializer.Converters.Add(new Converters.V3SearchResultsConverter(take));
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
@@ -9,9 +9,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Moq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
 using Test.Utility;
 using Xunit;
 
@@ -20,21 +22,34 @@ namespace NuGet.Protocol.Tests
     [Collection(nameof(NotThreadSafeResourceCollection))]
     public class PackageSearchResourceV3Tests
     {
+        private static PackageSearchResourceV3 CreateSearchResource(HttpSource httpSource, Uri[] searchEndpoints, string useStj)
+        {
+            var envReader = new Mock<IEnvironmentVariableReader>();
+            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar)).Returns(useStj);
+            return new PackageSearchResourceV3(httpSource, searchEndpoints, envReader.Object);
+        }
+
         [Theory]
-        [InlineData("EntityFrameworkSearch.json", true, true)]
-        [InlineData("EntityFrameworkSearchWithStringTypes.json", true, false)]
-        [InlineData("EntityFrameworkSearchWithoutOwner.json", false, false)]
-        public async Task PackageSearchResourceV3_GetMetadataAsync(string jsonFileName, bool hasOwners, bool hasOwnersArray)
+        [InlineData("true", "EntityFrameworkSearch.json", true, true)]   // STJ path
+        [InlineData("false", "EntityFrameworkSearch.json", true, true)]  // NSJ path
+        [InlineData("true", "EntityFrameworkSearchWithStringTypes.json", true, false)]
+        [InlineData("false", "EntityFrameworkSearchWithStringTypes.json", true, false)]
+        [InlineData("true", "EntityFrameworkSearchWithoutOwner.json", false, false)]
+        [InlineData("false", "EntityFrameworkSearchWithoutOwner.json", false, false)]
+        public async Task PackageSearchResourceV3_GetMetadataAsync(string useStj, string jsonFileName, bool hasOwners, bool hasOwnersArray)
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("https://api-v3search-0.nuget.org/query?q=entityframework&skip=0&take=1&prerelease=false&semVerLevel=2.0.0",
-                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources." + jsonFileName, GetType()));
-            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
+            var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
+            var searchUrl = serviceAddress + "?q=entityframework&skip=0&take=1&prerelease=false&semVerLevel=2.0.0";
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>
+            {
+                { searchUrl, ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources." + jsonFileName, GetType()) },
+                { serviceAddress, string.Empty }
+            };
 
-            var resource = await repo.GetResourceAsync<PackageSearchResource>(CancellationToken.None);
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
+            var resource = CreateSearchResource(httpSource, new[] { new Uri(serviceAddress) }, useStj);
 
             // Act
             var packages = await resource.SearchAsync(
@@ -42,8 +57,8 @@ namespace NuGet.Protocol.Tests
                 new SearchFilter(false),
                 skip: 0,
                 take: 1,
-                log: NullLogger.Instance,
-                cancellationToken: CancellationToken.None);
+                NullLogger.Instance,
+                CancellationToken.None);
 
             var package = packages.SingleOrDefault();
 
@@ -142,18 +157,23 @@ namespace NuGet.Protocol.Tests
             MetadataReferenceCacheTestUtility.AssertPackagesHaveSameReferences(first, second);
         }
 
-        [Fact]
-        public async Task PackageSearchResourceV3_GetMetadataAsync_NotFound()
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task PackageSearchResourceV3_GetMetadataAsync_NotFound(string useStj)
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("https://api-v3search-0.nuget.org/query?q=yabbadabbadoo&skip=0&take=1&prerelease=false&semVerLevel=2.0.0",
-                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.EmptySearchResponse.json", GetType()));
-            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
+            var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
+            var searchUrl = serviceAddress + "?q=yabbadabbadoo&skip=0&take=1&prerelease=false&semVerLevel=2.0.0";
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>
+            {
+                { searchUrl, ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.EmptySearchResponse.json", GetType()) },
+                { serviceAddress, string.Empty }
+            };
 
-            var resource = await repo.GetResourceAsync<PackageSearchResource>(CancellationToken.None);
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
+            var resource = CreateSearchResource(httpSource, new[] { new Uri(serviceAddress) }, useStj);
 
             // Act
             var packages = await resource.SearchAsync(
@@ -161,26 +181,31 @@ namespace NuGet.Protocol.Tests
                 new SearchFilter(false),
                 skip: 0,
                 take: 1,
-                log: NullLogger.Instance,
-                cancellationToken: CancellationToken.None);
+                NullLogger.Instance,
+                CancellationToken.None);
 
             // Assert
             Assert.Empty(packages);
         }
 
-        [Fact]
-        public async Task PackageSearchResourceV3_GetMetadataAsync_VersionsDownloadCount()
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task PackageSearchResourceV3_GetMetadataAsync_VersionsDownloadCount(string useStj)
         {
             // Arrange
             long largerThanIntMax = (long)int.MaxValue + 10;
-            var responses = new Dictionary<string, string>();
-            responses.Add("https://api-v3search-0.nuget.org/query?q=entityframework&skip=0&take=1&prerelease=false&semVerLevel=2.0.0",
-                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.EntityFrameworkSearch.json", GetType()));
-            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
+            var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
+            var searchUrl = serviceAddress + "?q=entityframework&skip=0&take=1&prerelease=false&semVerLevel=2.0.0";
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>
+            {
+                { searchUrl, ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.EntityFrameworkSearch.json", GetType()) },
+                { serviceAddress, string.Empty }
+            };
 
-            var resource = await repo.GetResourceAsync<PackageSearchResource>(CancellationToken.None);
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
+            var resource = CreateSearchResource(httpSource, new[] { new Uri(serviceAddress) }, useStj);
 
             // Act
             var packages = await resource.SearchAsync(
@@ -188,8 +213,8 @@ namespace NuGet.Protocol.Tests
                 new SearchFilter(false),
                 skip: 0,
                 take: 1,
-                log: NullLogger.Instance,
-                cancellationToken: CancellationToken.None);
+                NullLogger.Instance,
+                CancellationToken.None);
 
             var package = packages.SingleOrDefault();
 
@@ -204,22 +229,26 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(largerThanIntMax, versions[1].DownloadCount);
         }
 
-        [Fact]
-        public async Task PackageSearchResourceV3_SearchEncoding()
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task PackageSearchResourceV3_SearchEncoding(string useStj)
         {
             // Arrange
             var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
 
-            var responses = new Dictionary<string, string>();
-            responses.Add(
-                serviceAddress + "?q=azure%20b&skip=0&take=1&prerelease=false" +
-                "&supportedFramework=.NETFramework,Version=v4.5&semVerLevel=2.0.0",
-                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.V3Search.json", GetType()));
-            responses.Add(serviceAddress, string.Empty);
+            var responses = new Dictionary<string, string>
+            {
+                {
+                    serviceAddress + "?q=azure%20b&skip=0&take=1&prerelease=false" +
+                    "&supportedFramework=.NETFramework,Version=v4.5&semVerLevel=2.0.0",
+                    ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.V3Search.json", GetType())
+                },
+                { serviceAddress, string.Empty }
+            };
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
-
-            var packageSearchResourceV3 = new PackageSearchResourceV3(httpSource, new Uri[] { new Uri(serviceAddress) });
+            var resource = CreateSearchResource(httpSource, new[] { new Uri(serviceAddress) }, useStj);
 
             var searchFilter = new SearchFilter(includePrerelease: false)
             {
@@ -230,7 +259,7 @@ namespace NuGet.Protocol.Tests
             var take = 1;
 
             // Act
-            var packages = await packageSearchResourceV3.Search(
+            var packages = await resource.SearchAsync(
                         "azure b",
                         searchFilter,
                         skip,
@@ -245,8 +274,10 @@ namespace NuGet.Protocol.Tests
             Assert.True(packagesArray.Length > 0);
         }
 
-        [Fact]
-        public async Task Search_HttpResource_ThrowsAnException()
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task Search_HttpResource_ThrowsAnException(string useStj)
         {
             // Arrange
             var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
@@ -265,7 +296,7 @@ namespace NuGet.Protocol.Tests
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
-            var packageSearchResourceV3 = new PackageSearchResourceV3(httpSource, [new Uri(httpresource)]);
+            var packageSearchResourceV3 = CreateSearchResource(httpSource, [new Uri(httpresource)], useStj);
 
             var searchFilter = new SearchFilter(includePrerelease: false)
             {
@@ -276,7 +307,7 @@ namespace NuGet.Protocol.Tests
             var take = 1;
 
             // Act
-            var ex = await Assert.ThrowsAsync<HttpSourceException>(() => packageSearchResourceV3.Search(
+            var ex = await Assert.ThrowsAsync<HttpSourceException>(() => packageSearchResourceV3.SearchAsync(
                         "azure b",
                         searchFilter,
                         skip,
@@ -289,8 +320,10 @@ namespace NuGet.Protocol.Tests
             ex.Message.Should().Contain(string.Format(Protocol.Strings.Error_Insecure_HTTP, serviceAddress, requestUrl));
         }
 
-        [Fact]
-        public async Task Search_HttpResourceAndAllowInsecureConnections_Succeeds()
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task Search_HttpResourceAndAllowInsecureConnections_Succeeds(string useStj)
         {
             // Arrange
             var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
@@ -316,7 +349,7 @@ namespace NuGet.Protocol.Tests
                 },
                 responses);
 
-            var packageSearchResourceV3 = new PackageSearchResourceV3(httpSource, [new Uri(httpresource)]);
+            var packageSearchResourceV3 = CreateSearchResource(httpSource, [new Uri(httpresource)], useStj);
 
             var searchFilter = new SearchFilter(includePrerelease: false)
             {
@@ -327,7 +360,7 @@ namespace NuGet.Protocol.Tests
             var take = 1;
 
             // Act
-            var packages = await packageSearchResourceV3.Search(
+            var packages = await packageSearchResourceV3.SearchAsync(
                         "azure b",
                         searchFilter,
                         skip,
@@ -341,8 +374,10 @@ namespace NuGet.Protocol.Tests
             Assert.True(packagesArray.Length > 0);
         }
 
-        [Fact]
-        public async Task PackageSearchResourceV3_VerifyReadSyncIsNotUsed()
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task PackageSearchResourceV3_VerifyReadSyncIsNotUsed(string useStj)
         {
             // Arrange
             var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
@@ -359,7 +394,7 @@ namespace NuGet.Protocol.Tests
             // throw if sync .Read is used
             httpSource.StreamWrapper = (stream) => new NoSyncReadStream(stream);
 
-            var packageSearchResourceV3 = new PackageSearchResourceV3(httpSource, new Uri[] { new Uri(serviceAddress) });
+            var resource = CreateSearchResource(httpSource, new Uri[] { new Uri(serviceAddress) }, useStj);
 
             var searchFilter = new SearchFilter(includePrerelease: false)
             {
@@ -369,7 +404,7 @@ namespace NuGet.Protocol.Tests
             var take = 1;
 
             // Act
-            var packages = await packageSearchResourceV3.Search(
+            var packages = await resource.SearchAsync(
                         "azure b",
                         searchFilter,
                         skip,
@@ -384,8 +419,10 @@ namespace NuGet.Protocol.Tests
             Assert.True(packagesArray.Length > 0);
         }
 
-        [Fact]
-        public async Task PackageSearchResourceV3_CancelledToken_ThrowsOperationCancelledException()
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task PackageSearchResourceV3_CancelledToken_ThrowsOperationCancelledException(string useStj)
         {
             // Arrange
             var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
@@ -401,7 +438,7 @@ namespace NuGet.Protocol.Tests
 
             httpSource.StreamWrapper = (stream) => new NoSyncReadStream(stream);
 
-            var packageSearchResourceV3 = new PackageSearchResourceV3(httpSource, new Uri[] { new Uri(serviceAddress) });
+            var packageSearchResourceV3 = CreateSearchResource(httpSource, new Uri[] { new Uri(serviceAddress) }, useStj);
 
             var searchFilter = new SearchFilter(includePrerelease: false)
             {
@@ -415,7 +452,7 @@ namespace NuGet.Protocol.Tests
 
             // Act/Assert
             await Assert.ThrowsAsync<TaskCanceledException>(() =>
-               packageSearchResourceV3.Search(
+               packageSearchResourceV3.SearchAsync(
                         "Sentry",
                         searchFilter,
                         skip,
@@ -423,6 +460,86 @@ namespace NuGet.Protocol.Tests
                         NullLogger.Instance,
                         tokenSource.Token));
 
+        }
+
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task PackageSearchResourceV3_SearchAsync_AllMetadata(string useStj)
+        {
+            // Arrange
+            var serviceAddress = ProtocolUtility.CreateHttpsServiceAddress();
+            var searchUrl = serviceAddress + "?q=contoso.logging&skip=0&take=1&prerelease=false&semVerLevel=2.0.0";
+
+            var responses = new Dictionary<string, string>
+            {
+                { searchUrl, ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.SearchWithAllMetadata.json", GetType()) },
+                { serviceAddress, string.Empty }
+            };
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
+            var resource = CreateSearchResource(httpSource, new[] { new Uri(serviceAddress) }, useStj);
+
+            // Act
+            var packages = await resource.SearchAsync(
+                "contoso.logging",
+                new SearchFilter(false),
+                skip: 0,
+                take: 1,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            var package = packages.SingleOrDefault();
+
+            // Assert - basic metadata
+            package.Should().NotBeNull();
+            package.Identity.Id.Should().Be("Contoso.Logging");
+            package.Identity.Version.OriginalVersion.Should().Be("2.0.0");
+
+            // Assert - dependency groups
+            var depSets = package.DependencySets.ToList();
+            depSets.Should().HaveCount(2);
+
+            var netStandard = depSets[0];
+            netStandard.TargetFramework.GetShortFolderName().Should().Be("netstandard2.0");
+            var netStandardDeps = netStandard.Packages.ToList();
+            netStandardDeps.Should().HaveCount(2);
+            netStandardDeps[0].Id.Should().Be("Contoso.Serialization");
+            netStandardDeps[0].VersionRange.MinVersion.ToNormalizedString().Should().Be("13.0.1");
+            netStandardDeps[1].Id.Should().Be("Contoso.Buffers");
+            netStandardDeps[1].VersionRange.MinVersion.ToNormalizedString().Should().Be("4.5.4");
+
+            var net6 = depSets[1];
+            net6.TargetFramework.GetShortFolderName().Should().Be("net6.0");
+            var net6Deps = net6.Packages.ToList();
+            net6Deps.Should().HaveCount(1);
+            net6Deps[0].Id.Should().Be("Contoso.Json");
+            net6Deps[0].VersionRange.MinVersion.ToNormalizedString().Should().Be("6.0.0");
+
+            // Assert - deprecation
+            var deprecation = await package.GetDeprecationMetadataAsync();
+            deprecation.Should().NotBeNull();
+            deprecation.Message.Should().Be("This package is deprecated. Use Contoso.Logging.Modern instead.");
+            deprecation.Reasons.Should().ContainInOrder("Legacy", "Other");
+            deprecation.AlternatePackage.Should().NotBeNull();
+            deprecation.AlternatePackage.PackageId.Should().Be("Contoso.Logging.Modern");
+            deprecation.AlternatePackage.Range.MinVersion.ToNormalizedString().Should().Be("1.0.0");
+
+            // Assert - vulnerabilities
+            var vulns = package.Vulnerabilities.ToList();
+            vulns.Should().HaveCount(2);
+            vulns[0].AdvisoryUrl.AbsoluteUri.Should().Be("https://contoso.test/advisories/CTSO-2024-1234");
+            vulns[0].Severity.Should().Be(2);
+            vulns[1].AdvisoryUrl.AbsoluteUri.Should().Be("https://contoso.test/advisories/CTSO-2024-5678");
+            vulns[1].Severity.Should().Be(3);
+
+            // Assert - versions
+            var versions = (await package.GetVersionsAsync()).ToList();
+            versions.Should().HaveCount(2);
+            versions[0].Version.ToNormalizedString().Should().Be("1.0.0");
+            versions[0].DownloadCount.Should().Be(50000);
+            versions[1].Version.ToNormalizedString().Should().Be("2.0.0");
+            versions[1].DownloadCount.Should().Be(50000);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/SearchWithAllMetadata.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/SearchWithAllMetadata.json
@@ -1,0 +1,96 @@
+{
+  "@context": {
+    "@vocab": "http://schema.nuget.org/schema#",
+    "@base": "https://pkgs.contoso.test/v3/registration/"
+  },
+  "totalHits": 1,
+  "data": [
+    {
+      "@id": "https://pkgs.contoso.test/v3/registration/contoso.logging/index.json",
+      "@type": "Package",
+      "registration": "https://pkgs.contoso.test/v3/registration/contoso.logging/index.json",
+      "id": "Contoso.Logging",
+      "version": "2.0.0",
+      "description": "A test package with all metadata fields.",
+      "summary": "",
+      "title": "Contoso.Logging",
+      "iconUrl": "https://pkgs.contoso.test/v3/flatcontainer/contoso.logging/2.0.0/icon",
+      "licenseUrl": "https://pkgs.contoso.test/packages/Contoso.Logging/2.0.0/license",
+      "projectUrl": "https://contoso.test/projects/logging",
+      "tags": [
+        "Test",
+        "Package"
+      ],
+      "authors": [
+        "TestAuthor"
+      ],
+      "owners": [
+        "TestOwner"
+      ],
+      "totalDownloads": 100000,
+      "verified": true,
+      "packageTypes": [
+        {
+          "name": "Dependency"
+        }
+      ],
+      "versions": [
+        {
+          "version": "1.0.0",
+          "downloads": 50000,
+          "@id": "https://pkgs.contoso.test/v3/registration/contoso.logging/1.0.0.json"
+        },
+        {
+          "version": "2.0.0",
+          "downloads": 50000,
+          "@id": "https://pkgs.contoso.test/v3/registration/contoso.logging/2.0.0.json"
+        }
+      ],
+      "dependencyGroups": [
+        {
+          "targetFramework": ".NETStandard2.0",
+          "dependencies": [
+            {
+              "id": "Contoso.Serialization",
+              "range": "[13.0.1, )"
+            },
+            {
+              "id": "Contoso.Buffers",
+              "range": "[4.5.4, )"
+            }
+          ]
+        },
+        {
+          "targetFramework": "net6.0",
+          "dependencies": [
+            {
+              "id": "Contoso.Json",
+              "range": "[6.0.0, )"
+            }
+          ]
+        }
+      ],
+      "deprecation": {
+        "message": "This package is deprecated. Use Contoso.Logging.Modern instead.",
+        "reasons": [
+          "Legacy",
+          "Other"
+        ],
+        "alternatePackage": {
+          "id": "Contoso.Logging.Modern",
+          "range": "[1.0.0, )"
+        }
+      },
+      "vulnerabilities": [
+        {
+          "advisoryUrl": "https://contoso.test/advisories/CTSO-2024-1234",
+          "severity": 2
+        },
+        {
+          "advisoryUrl": "https://contoso.test/advisories/CTSO-2024-5678",
+          "severity": 3
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14890
Fixes: https://github.com/NuGet/Home/issues/14892

## Description

 Adds `System.Text.Json` deserialization support to `PackageSearchResourceV3`, gated behind the existing feature flag. 

  Key changes:

   - New STJ converter: `PackageDependencyGroupStjConverter` : needed because NSJ deserializes PackageDependencyGroup via a `private [JsonConstructor]`-attributed constructor, which STJ source generation cannot access.
   - Post-deserialization `take` enforcement in the STJ path - the NSJ converter stops parsing after take items mid-strea STJ deserializes the full response, then trims to take for parity. In practice, the server should respect take in the query string, so this is purely defensive.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
