### PR TITLE
Refresh Package Manager UI when it becomes visible again (2nd try)

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -64,6 +64,9 @@ namespace NuGet.PackageManagement.UI
         // This tells the operation execution part that it needs to trigger a refresh when done.
         private bool _isRefreshRequired;
         private bool _isExecutingAction; // Signifies where an action is being executed. Should be updated in a coordinated fashion with IsEnabled
+        // Set when a relevant change occurs while the control is not visible, so that the
+        // pending refresh can be applied when the control becomes visible again.
+        private bool _refreshOnActivated;
         private RestartRequestBar _restartBar;
         private bool _missingPackageStatus;
         private bool _loadedAndInitialized = false;
@@ -192,6 +195,7 @@ namespace NuGet.PackageManagement.UI
             _packageList.IsSolution = Model.IsSolution;
 
             Loaded += PackageManagerLoaded;
+            IsVisibleChanged += OnIsVisibleChanged;
 
             // register with the UI controller
             var controller = model.UIController as NuGetUI;
@@ -321,7 +325,7 @@ namespace NuGet.PackageManagement.UI
         {
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
 
-            // Do not refresh if the UI is not visible. It will be refreshed later when the loaded event is called.
+            // Do not refresh if the UI is not visible. A pending refresh is recorded and applied when the control becomes visible again.
             if (IsVisible && Model.IsSolution)
             {
                 var solutionModel = _detailModel as PackageSolutionDetailControlModel;
@@ -341,6 +345,11 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
+                if (Model.IsSolution)
+                {
+                    _refreshOnActivated = true;
+                }
+
                 EmitRefreshEvent(timeSpan, RefreshOperationSource.ProjectsChanged, RefreshOperationStatus.NoOp, isUIFiltering: false, duration: 0);
             }
         }
@@ -348,7 +357,7 @@ namespace NuGet.PackageManagement.UI
         private void OnProjectActionsExecuted(object sender, IReadOnlyCollection<string> projectIds)
         {
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
-            // Do not refresh if the UI is not visible. It will be refreshed later when the loaded event is called.
+            // Do not refresh if the UI is not visible. A pending refresh is recorded and applied when the control becomes visible again.
             if (IsVisible)
             {
                 NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
@@ -365,6 +374,11 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
+                if (Model.IsSolution || projectIds.Contains(Model.Context.Projects.First().ProjectId, StringComparer.OrdinalIgnoreCase))
+                {
+                    _refreshOnActivated = true;
+                }
+
                 EmitRefreshEvent(timeSpan, RefreshOperationSource.ActionsExecuted, RefreshOperationStatus.NoOp);
             }
         }
@@ -409,7 +423,7 @@ namespace NuGet.PackageManagement.UI
         private void OnNuGetCacheUpdated(object sender, string e)
         {
             var timeSpan = GetTimeSinceLastRefreshAndRestart();
-            // Do not refresh if the UI is not visible. It will be refreshed later when the loaded event is called.
+            // Do not refresh if the UI is not visible. A pending refresh is recorded and applied when the control becomes visible again.
             if (IsVisible)
             {
                 NuGetUIThreadHelper.JoinableTaskFactory
@@ -418,7 +432,23 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
+                _refreshOnActivated = true;
                 EmitRefreshEvent(timeSpan, RefreshOperationSource.CacheUpdated, RefreshOperationStatus.NoOp);
+            }
+        }
+
+        private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            // When the control is hidden (e.g. another document is opened on top of it), refreshes
+            // triggered by external changes are skipped and recorded via _refreshOnActivated.
+            // Apply the pending refresh now that the control is visible again.
+            if (e.NewValue is true && _loadedAndInitialized && _refreshOnActivated)
+            {
+                _refreshOnActivated = false;
+                var timeSpan = GetTimeSinceLastRefreshAndRestart();
+                NuGetUIThreadHelper.JoinableTaskFactory
+                    .RunAsync(async () => await RefreshWhenNotExecutingActionAsync(RefreshOperationSource.WindowActivated, timeSpan))
+                    .PostOnFailure(nameof(PackageManagerControl), nameof(OnIsVisibleChanged));
             }
         }
 
@@ -538,6 +568,7 @@ namespace NuGet.PackageManagement.UI
                 await RunAndEmitRefreshAsync(async () =>
                 {
                     _loadedAndInitialized = true;
+                    _refreshOnActivated = false;
                     await SearchPackagesAndRefreshUpdateCountAsync(useCacheForUpdates: false);
                 },
                 RefreshOperationSource.PackageManagerLoaded, timeSpan, sw);
@@ -1604,6 +1635,7 @@ namespace NuGet.PackageManagement.UI
             solutionManager.ProjectUpdated -= OnProjectUpdated;
             solutionManager.ProjectRenamed -= OnProjectRenamed;
             solutionManager.AfterNuGetCacheUpdated -= OnNuGetCacheUpdated;
+            IsVisibleChanged -= OnIsVisibleChanged;
 
             Model.Context.ProjectActionsExecuted -= OnProjectActionsExecuted;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -66,7 +66,7 @@ namespace NuGet.PackageManagement.UI
         private bool _isExecutingAction; // Signifies where an action is being executed. Should be updated in a coordinated fashion with IsEnabled
         // Set when a relevant change occurs while the control is not visible, so that the
         // pending refresh can be applied when the control becomes visible again.
-        private bool _refreshOnActivated;
+        private bool _refreshOnVisibleChange;
         private RestartRequestBar _restartBar;
         private bool _missingPackageStatus;
         private bool _loadedAndInitialized = false;
@@ -347,7 +347,7 @@ namespace NuGet.PackageManagement.UI
             {
                 if (Model.IsSolution)
                 {
-                    _refreshOnActivated = true;
+                    _refreshOnVisibleChange = true;
                 }
 
                 EmitRefreshEvent(timeSpan, RefreshOperationSource.ProjectsChanged, RefreshOperationStatus.NoOp, isUIFiltering: false, duration: 0);
@@ -376,7 +376,7 @@ namespace NuGet.PackageManagement.UI
             {
                 if (Model.IsSolution || projectIds.Contains(Model.Context.Projects.First().ProjectId, StringComparer.OrdinalIgnoreCase))
                 {
-                    _refreshOnActivated = true;
+                    _refreshOnVisibleChange = true;
                 }
 
                 EmitRefreshEvent(timeSpan, RefreshOperationSource.ActionsExecuted, RefreshOperationStatus.NoOp);
@@ -432,7 +432,7 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
-                _refreshOnActivated = true;
+                _refreshOnVisibleChange = true;
                 EmitRefreshEvent(timeSpan, RefreshOperationSource.CacheUpdated, RefreshOperationStatus.NoOp);
             }
         }
@@ -440,11 +440,11 @@ namespace NuGet.PackageManagement.UI
         private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             // When the control is hidden (e.g. another document is opened on top of it), refreshes
-            // triggered by external changes are skipped and recorded via _refreshOnActivated.
+            // triggered by external changes are skipped and recorded via _refreshOnVisibleChange.
             // Apply the pending refresh now that the control is visible again.
-            if (e.NewValue is true && _loadedAndInitialized && _refreshOnActivated)
+            if (e.NewValue is true && _loadedAndInitialized && _refreshOnVisibleChange)
             {
-                _refreshOnActivated = false;
+                _refreshOnVisibleChange = false;
                 var timeSpan = GetTimeSinceLastRefreshAndRestart();
                 NuGetUIThreadHelper.JoinableTaskFactory
                     .RunAsync(async () => await RefreshWhenNotExecutingActionAsync(RefreshOperationSource.WindowActivated, timeSpan))
@@ -568,7 +568,7 @@ namespace NuGet.PackageManagement.UI
                 await RunAndEmitRefreshAsync(async () =>
                 {
                     _loadedAndInitialized = true;
-                    _refreshOnActivated = false;
+                    _refreshOnVisibleChange = false;
                     await SearchPackagesAndRefreshUpdateCountAsync(useCacheForUpdates: false);
                 },
                 RefreshOperationSource.PackageManagerLoaded, timeSpan, sw);
@@ -1936,3 +1936,4 @@ namespace NuGet.PackageManagement.UI
         }
     }
 }
+

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/PackageManagerUIRefreshEvent.cs
@@ -114,6 +114,7 @@ namespace NuGet.PackageManagement.Telemetry
         RestartSearchCommand,
         SourceSelectionChanged,
         PackagesMissingStatusChanged,
+        WindowActivated,
     }
 
     public enum RefreshOperationStatus

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
@@ -93,6 +93,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         [InlineData(RefreshOperationSource.ProjectsChanged, RefreshOperationStatus.Failed)]
         [InlineData(RefreshOperationSource.RestartSearchCommand, RefreshOperationStatus.Success)]
         [InlineData(RefreshOperationSource.SourceSelectionChanged, RefreshOperationStatus.Success)]
+        [InlineData(RefreshOperationSource.WindowActivated, RefreshOperationStatus.Success)]
+        [InlineData(RefreshOperationSource.WindowActivated, RefreshOperationStatus.NoOp)]
         public void NuGetTelemetryService_EmitsPMUIRefreshEvent(RefreshOperationSource expectedRefreshSource, RefreshOperationStatus expectedRefreshStatus, bool expectedUiFiltering = false)
         {
             // Arrange


### PR DESCRIPTION
 # Bug
 
 Fixes: https://github.com/NuGet/Home/issues/14761
 
 ## Description
 
 The Package Manager UI only refreshes its package lists while the control is visible. When it is hidden, change notifications (NuGet cache updates, project changes, and executed project actions) were dropped — the handlers emitted a no-op and relied on the WPF `Loaded` event to refresh on return. `Loaded` only fires on the first load and does not re-fire when a hidden document window is re-activated, so the deferred refresh never happened and the UI stayed stale.
 
This is hit by the "Fix with GitHub Copilot" flow: Copilot opens the `.csproj` on top of the Package Manager UI (hiding it) and edits it to remediate the vulnerability. The restore that updates the project completes while the UI is hidden, so when the user switches back the Installed/Browse/Updates tabs still show the old state.
 
This change makes the "refresh when the control becomes visible again" behavior actually work: when a relevant change is observed while the control is hidden, a pending refresh is recorded, and it is applied when the control becomes visible again (deferring as usual if a package action is in progress). The pending refresh preserves the existing per-project applicability filtering so a hidden project-level UI does not refresh for unrelated projects.
 
This deliberately avoids subscribing to restore-finished events (the approach in #7209, reverted in #7294), which fired in addition to the existing action-completion refresh and caused a double refresh on every install/uninstall.
 
 ## PR Checklist
 
 - [x] Meaningful title, helpful description and a linked NuGet/Home issue
 - [x] Added tests
 - [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.