### PR TITLE
Add first on-build restore coordination

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -423,13 +423,19 @@ namespace NuGet.SolutionRestoreManager
                     using (var restoreOperation = new BackgroundRestoreOperation())
                     {
                         await PromoteTaskToActiveAsync(restoreOperation, token);
+                        RestoreReadinessResult restoreReadiness = new();
+                        if (ShouldWaitForOnBuildRestoreReadiness(request))
+                        {
+                            restoreReadiness = await WaitForOnBuildRestoreReadinessAsync(token);
+                        }
+
                         var restoreTrackingData = GetRestoreTrackingData(
-                            restoreReason: ImplicitRestoreReason.None,
+                            restoreReason: restoreReadiness.RestoreReason,
                             requestCount: 1,
-                            projectRestoreInfoSourcesCount: -1,
-                            bulkRestoreCoordinationCheckStartTime: default,
-                            projectsReadyCheckCount: 0,
-                            projectReadyTimings: new List<TimeSpan>(),
+                            projectRestoreInfoSourcesCount: restoreReadiness.ProjectRestoreInfoSourcesCount,
+                            bulkRestoreCoordinationCheckStartTime: restoreReadiness.BulkRestoreCoordinationCheckStartTime,
+                            projectsReadyCheckCount: restoreReadiness.ProjectsReadyCheckCount,
+                            projectReadyTimings: restoreReadiness.ProjectReadyTimings,
                             request.ExplicitRestoreReason);
                         var result = await ProcessRestoreRequestAsync(restoreOperation, request, restoreTrackingData, token);
 
@@ -454,30 +460,77 @@ namespace NuGet.SolutionRestoreManager
             Interlocked.Exchange(ref _restoreJobContext, new SolutionRestoreJobContext());
         }
 
+        private bool ShouldWaitForOnBuildRestoreReadiness(SolutionRestoreRequest request)
+        {
+            return request.RestoreSource == RestoreOperationSource.OnBuild && _isFirstRestore;
+        }
+
+        internal async Task<RestoreReadinessResult> WaitForOnBuildRestoreReadinessAsync(CancellationToken token)
+        {
+            return await WaitForOnBuildRestoreReadinessCoreAsync(
+                waitForSolutionLoadedAsync: WaitForSolutionLoadedAsync,
+                isAllProjectsNominatedAsync: () => _solutionManager.Value.IsAllProjectsNominatedAsync(),
+                checkProjectsReadyAsync: CheckProjectsReadyAsync,
+                token: token);
+        }
+
+        internal static async Task<RestoreReadinessResult> WaitForOnBuildRestoreReadinessCoreAsync(
+            Func<CancellationToken, Task> waitForSolutionLoadedAsync,
+            Func<Task<bool>> isAllProjectsNominatedAsync,
+            Func<DateTime, CancellationToken, Task<(bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, TimeSpan projectReadyCheckTime)>> checkProjectsReadyAsync,
+            CancellationToken token)
+        {
+            RestoreReadinessResult restoreReadiness = new();
+
+            await waitForSolutionLoadedAsync(token);
+
+            while (!token.IsCancellationRequested)
+            {
+                var isAllProjectsNominated = await isAllProjectsNominatedAsync();
+                if (!isAllProjectsNominated)
+                {
+                    await Task.Delay(IdleTimeoutMs, token);
+                    continue;
+                }
+
+                if (restoreReadiness.BulkRestoreCoordinationCheckStartTime == default)
+                {
+                    restoreReadiness.BulkRestoreCoordinationCheckStartTime = DateTime.UtcNow;
+                }
+
+                restoreReadiness.ProjectsReadyCheckCount++;
+                (bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, TimeSpan projectReadyTiming) =
+                    await checkProjectsReadyAsync(
+                        restoreReadiness.BulkRestoreCoordinationCheckStartTime.Value,
+                        token);
+                restoreReadiness.ProjectRestoreInfoSourcesCount = projectRestoreInfoSourcesCount;
+                restoreReadiness.ProjectReadyTimings.Add(projectReadyTiming);
+
+                if (allProjectsReady)
+                {
+                    restoreReadiness.RestoreReason = ImplicitRestoreReason.ProjectsReady;
+                    break;
+                }
+
+                if (bulkCheckTimeout)
+                {
+                    restoreReadiness.RestoreReason = ImplicitRestoreReason.ProjectsReadyCheckTimeout;
+                    break;
+                }
+            }
+
+            token.ThrowIfCancellationRequested();
+
+            return restoreReadiness;
+        }
+
         private async Task<bool> StartBackgroundJobRunnerAsync(CancellationToken token)
         {
             // Hops onto a background pool thread
             await TaskScheduler.Default;
 
             var status = false;
-            // Check if the solution is fully loaded
-            while (!_solutionLoadedEvent.IsSet)
-            {
-                // Needed when OnAfterBackgroundSolutionLoadComplete fires before
-                // Advise has been called.
-                if (await IsSolutionFullyLoadedAsync())
-                {
-                    _solutionLoadedEvent.Set();
-                    break;
-                }
-                else
-                {
-                    // Waits for 100ms to let solution fully load or canceled
-                    await _solutionLoadedEvent.WaitAsync()
-                        .WithTimeout(TimeSpan.FromMilliseconds(DelaySolutionLoadRetry))
-                        .WithCancellation(token);
-                }
-            }
+            await WaitForSolutionLoadedAsync(token);
 
             ImplicitRestoreReason restoreReason = ImplicitRestoreReason.None;
             DateTime? bulkRestoreCoordinationCheckStartTime = default;
@@ -529,41 +582,22 @@ namespace NuGet.SolutionRestoreManager
                             {
                                 if (isAllProjectsNominated)
                                 {
-                                    var projectReadyCheckMeasurement = Stopwatch.StartNew();
                                     if (bulkRestoreCoordinationCheckStartTime == default)
                                     {
                                         bulkRestoreCoordinationCheckStartTime = DateTime.UtcNow;
                                     }
+
                                     projectsReadyCheckCount++;
-                                    // If we are about to start restore, we should run through all the projects to ensure there isn't a pending nomination.
-                                    IReadOnlyList<object> restoreProjectInfoSources = _solutionManager.Value.GetAllProjectRestoreInfoSources();
-                                    projectRestoreInfoSourcesCount = restoreProjectInfoSources.Count;
-                                    var allProjectsReady = true;
-                                    var bulkCheckTimeout = false;
-                                    for (int i = 0; i < restoreProjectInfoSources.Count && !bulkCheckTimeout; i++)
-                                    {
-                                        var restoreInfoSource = (IVsProjectRestoreInfoSource)restoreProjectInfoSources[i];
-                                        if (restoreInfoSource.HasPendingNomination)
-                                        {
-                                            allProjectsReady = false;
-                                            TimeSpan timeoutTime = CalculateTimeoutTime(bulkRestoreCoordinationCheckStartTime.Value, DateTime.UtcNow, BulkRestoreCoordinationTimeout);
-                                            var timeoutTask = Task.Delay(timeoutTime, token);
-                                            var whenNominatedTask = restoreInfoSource.WhenNominated(token);
-
-                                            var result = await Task.WhenAny(whenNominatedTask, timeoutTask);
-                                            if (result == timeoutTask)
-                                            {
-                                                bulkCheckTimeout = true;
-                                            }
-                                        }
-                                    }
-
-                                    projectReadyCheckMeasurement.Stop();
+                                    (bool allProjectsReady, bool bulkCheckTimeout, int updatedProjectRestoreInfoSourcesCount, TimeSpan projectReadyCheckTime) =
+                                        await CheckProjectsReadyAsync(
+                                            bulkRestoreCoordinationCheckStartTime.Value,
+                                            token);
+                                    projectRestoreInfoSourcesCount = updatedProjectRestoreInfoSourcesCount;
                                     if (projectReadyTimings == null)
                                     {
                                         projectReadyTimings = new();
                                     }
-                                    projectReadyTimings.Add(projectReadyCheckMeasurement.Elapsed);
+                                    projectReadyTimings.Add(projectReadyCheckTime);
 
                                     if (allProjectsReady)
                                     {
@@ -639,6 +673,65 @@ namespace NuGet.SolutionRestoreManager
             }
 
             return status;
+        }
+
+        private async Task WaitForSolutionLoadedAsync(CancellationToken token)
+        {
+            while (!_solutionLoadedEvent.IsSet)
+            {
+                // Needed when OnAfterBackgroundSolutionLoadComplete fires before
+                // Advise has been called.
+                if (await IsSolutionFullyLoadedAsync())
+                {
+                    _solutionLoadedEvent.Set();
+                    break;
+                }
+
+                // Waits for 100ms to let solution fully load or canceled
+                await _solutionLoadedEvent.WaitAsync(token)
+                    .WithTimeout(TimeSpan.FromMilliseconds(DelaySolutionLoadRetry));
+            }
+        }
+
+        private async Task<(bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, TimeSpan projectReadyCheckTime)> CheckProjectsReadyAsync(
+            DateTime bulkRestoreCoordinationCheckStartTime,
+            CancellationToken token)
+        {
+            var projectReadyCheckMeasurement = Stopwatch.StartNew();
+
+            // If we are about to start restore, we should run through all the projects to ensure there isn't a pending nomination.
+            IReadOnlyList<object> restoreProjectInfoSources = _solutionManager.Value.GetAllProjectRestoreInfoSources();
+            int projectRestoreInfoSourcesCount = restoreProjectInfoSources.Count;
+            var allProjectsReady = true;
+            var bulkCheckTimeout = false;
+            for (int i = 0; i < restoreProjectInfoSources.Count && !bulkCheckTimeout; i++)
+            {
+                var restoreInfoSource = (IVsProjectRestoreInfoSource)restoreProjectInfoSources[i];
+                if (restoreInfoSource.HasPendingNomination)
+                {
+                    allProjectsReady = false;
+                    TimeSpan timeoutTime = CalculateTimeoutTime(
+                        bulkRestoreCoordinationCheckStartTime,
+                        DateTime.UtcNow,
+                        BulkRestoreCoordinationTimeout);
+                    var timeoutTask = Task.Delay(timeoutTime, token);
+                    var whenNominatedTask = restoreInfoSource.WhenNominated(token);
+
+                    var result = await Task.WhenAny(whenNominatedTask, timeoutTask);
+                    if (result == timeoutTask)
+                    {
+                        bulkCheckTimeout = true;
+                    }
+                }
+            }
+
+            projectReadyCheckMeasurement.Stop();
+
+            return (
+                allProjectsReady,
+                bulkCheckTimeout,
+                projectRestoreInfoSourcesCount,
+                projectReadyCheckMeasurement.Elapsed);
         }
 
         /// <summary>
@@ -785,6 +878,26 @@ namespace NuGet.SolutionRestoreManager
             _solutionLoadedEvent.Set();
 
             return VSConstants.S_OK;
+        }
+
+        internal sealed class RestoreReadinessResult
+        {
+            public RestoreReadinessResult()
+            {
+                RestoreReason = ImplicitRestoreReason.None;
+                ProjectRestoreInfoSourcesCount = -1;
+                ProjectReadyTimings = new List<TimeSpan>();
+            }
+
+            public ImplicitRestoreReason RestoreReason { get; set; }
+
+            public DateTime? BulkRestoreCoordinationCheckStartTime { get; set; }
+
+            public int ProjectsReadyCheckCount { get; set; }
+
+            public int ProjectRestoreInfoSourcesCount { get; set; }
+
+            public List<TimeSpan> ProjectReadyTimings { get; }
         }
 
         private class BackgroundRestoreOperation

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -426,7 +426,13 @@ namespace NuGet.SolutionRestoreManager
                         RestoreReadinessResult restoreReadiness = new();
                         if (ShouldWaitForOnBuildRestoreReadiness(request))
                         {
-                            restoreReadiness = await WaitForOnBuildRestoreReadinessAsync(token);
+                            restoreReadiness = await WaitForOnBuildRestoreReadinessCoreAsync(
+                                waitForSolutionLoadedAsync: WaitForSolutionLoadedAsync,
+                                isAllProjectsNominatedAsync: () => _solutionManager.Value.IsAllProjectsNominatedAsync(),
+                                checkProjectsReadyAsync: CheckProjectsReadyAsync,
+                                delayAsync: Task.Delay,
+                                getUtcNow: () => DateTime.UtcNow,
+                                token: token);
                         }
 
                         var restoreTrackingData = GetRestoreTrackingData(
@@ -463,17 +469,6 @@ namespace NuGet.SolutionRestoreManager
         private bool ShouldWaitForOnBuildRestoreReadiness(SolutionRestoreRequest request)
         {
             return request.RestoreSource == RestoreOperationSource.OnBuild && _isFirstRestore;
-        }
-
-        internal async Task<RestoreReadinessResult> WaitForOnBuildRestoreReadinessAsync(CancellationToken token)
-        {
-            return await WaitForOnBuildRestoreReadinessCoreAsync(
-                waitForSolutionLoadedAsync: WaitForSolutionLoadedAsync,
-                isAllProjectsNominatedAsync: () => _solutionManager.Value.IsAllProjectsNominatedAsync(),
-                checkProjectsReadyAsync: CheckProjectsReadyAsync,
-                delayAsync: (delay, cancellationToken) => Task.Delay(delay, cancellationToken),
-                getUtcNow: () => DateTime.UtcNow,
-                token: token);
         }
 
         internal static async Task<RestoreReadinessResult> WaitForOnBuildRestoreReadinessCoreAsync(

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -905,17 +905,13 @@ namespace NuGet.SolutionRestoreManager
             {
                 RestoreReason = ImplicitRestoreReason.None;
                 ProjectRestoreInfoSourcesCount = -1;
-                ProjectReadyTimings = new List<TimeSpan>();
+                ProjectReadyTimings = [];
             }
 
             public ImplicitRestoreReason RestoreReason { get; set; }
-
             public DateTime? BulkRestoreCoordinationCheckStartTime { get; set; }
-
             public int ProjectsReadyCheckCount { get; set; }
-
             public int ProjectRestoreInfoSourcesCount { get; set; }
-
             public List<TimeSpan> ProjectReadyTimings { get; }
         }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -471,6 +471,8 @@ namespace NuGet.SolutionRestoreManager
                 waitForSolutionLoadedAsync: WaitForSolutionLoadedAsync,
                 isAllProjectsNominatedAsync: () => _solutionManager.Value.IsAllProjectsNominatedAsync(),
                 checkProjectsReadyAsync: CheckProjectsReadyAsync,
+                delayAsync: (delay, cancellationToken) => Task.Delay(delay, cancellationToken),
+                getUtcNow: () => DateTime.UtcNow,
                 token: token);
         }
 
@@ -478,30 +480,39 @@ namespace NuGet.SolutionRestoreManager
             Func<CancellationToken, Task> waitForSolutionLoadedAsync,
             Func<Task<bool>> isAllProjectsNominatedAsync,
             Func<DateTime, CancellationToken, Task<(bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, TimeSpan projectReadyCheckTime)>> checkProjectsReadyAsync,
+            Func<TimeSpan, CancellationToken, Task> delayAsync,
+            Func<DateTime> getUtcNow,
             CancellationToken token)
         {
             RestoreReadinessResult restoreReadiness = new();
 
             await waitForSolutionLoadedAsync(token);
 
+            restoreReadiness.BulkRestoreCoordinationCheckStartTime = getUtcNow();
+            DateTime lastProgressTime = restoreReadiness.BulkRestoreCoordinationCheckStartTime.Value;
             while (!token.IsCancellationRequested)
             {
                 var isAllProjectsNominated = await isAllProjectsNominatedAsync();
                 if (!isAllProjectsNominated)
                 {
-                    await Task.Delay(IdleTimeoutMs, token);
-                    continue;
-                }
+                    TimeSpan timeoutTime = CalculateTimeoutTime(
+                        lastProgressTime,
+                        getUtcNow(),
+                        BulkRestoreCoordinationTimeout);
+                    if (timeoutTime == TimeSpan.Zero)
+                    {
+                        restoreReadiness.RestoreReason = ImplicitRestoreReason.ProjectsReadyCheckTimeout;
+                        break;
+                    }
 
-                if (restoreReadiness.BulkRestoreCoordinationCheckStartTime == default)
-                {
-                    restoreReadiness.BulkRestoreCoordinationCheckStartTime = DateTime.UtcNow;
+                    await delayAsync(TimeSpan.FromMilliseconds(IdleTimeoutMs), token);
+                    continue;
                 }
 
                 restoreReadiness.ProjectsReadyCheckCount++;
                 (bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, TimeSpan projectReadyTiming) =
                     await checkProjectsReadyAsync(
-                        restoreReadiness.BulkRestoreCoordinationCheckStartTime.Value,
+                        lastProgressTime,
                         token);
                 restoreReadiness.ProjectRestoreInfoSourcesCount = projectRestoreInfoSourcesCount;
                 restoreReadiness.ProjectReadyTimings.Add(projectReadyTiming);
@@ -517,6 +528,8 @@ namespace NuGet.SolutionRestoreManager
                     restoreReadiness.RestoreReason = ImplicitRestoreReason.ProjectsReadyCheckTimeout;
                     break;
                 }
+
+                lastProgressTime = getUtcNow();
             }
 
             token.ThrowIfCancellationRequested();
@@ -534,6 +547,7 @@ namespace NuGet.SolutionRestoreManager
 
             ImplicitRestoreReason restoreReason = ImplicitRestoreReason.None;
             DateTime? bulkRestoreCoordinationCheckStartTime = default;
+            DateTime lastBulkRestoreCoordinationProgressTime = default;
             // Loops until there are pending restore requests or it's get cancelled
             while (!token.IsCancellationRequested)
             {
@@ -554,6 +568,7 @@ namespace NuGet.SolutionRestoreManager
                         // Blocks the execution until first request is scheduled
                         // Monitors the cancelllation token as well.
                         var request = _pendingRequests.Value.Take(token);
+                        lastBulkRestoreCoordinationProgressTime = DateTime.UtcNow;
 
                         token.ThrowIfCancellationRequested();
 
@@ -585,12 +600,13 @@ namespace NuGet.SolutionRestoreManager
                                     if (bulkRestoreCoordinationCheckStartTime == default)
                                     {
                                         bulkRestoreCoordinationCheckStartTime = DateTime.UtcNow;
+                                        lastBulkRestoreCoordinationProgressTime = bulkRestoreCoordinationCheckStartTime.Value;
                                     }
 
                                     projectsReadyCheckCount++;
                                     (bool allProjectsReady, bool bulkCheckTimeout, int updatedProjectRestoreInfoSourcesCount, TimeSpan projectReadyCheckTime) =
                                         await CheckProjectsReadyAsync(
-                                            bulkRestoreCoordinationCheckStartTime.Value,
+                                            lastBulkRestoreCoordinationProgressTime,
                                             token);
                                     projectRestoreInfoSourcesCount = updatedProjectRestoreInfoSourcesCount;
                                     if (projectReadyTimings == null)
@@ -609,6 +625,8 @@ namespace NuGet.SolutionRestoreManager
                                         restoreReason = ImplicitRestoreReason.ProjectsReadyCheckTimeout;
                                         break;
                                     }
+
+                                    lastBulkRestoreCoordinationProgressTime = DateTime.UtcNow;
                                 }
                                 else
                                 {
@@ -619,6 +637,7 @@ namespace NuGet.SolutionRestoreManager
                             {
                                 requestCount++;
                                 lastNominationReceived = DateTime.UtcNow;
+                                lastBulkRestoreCoordinationProgressTime = lastNominationReceived;
                                 // Upgrade request if necessary
                                 if (next != null && next.RestoreSource != request.RestoreSource)
                                 {
@@ -694,7 +713,7 @@ namespace NuGet.SolutionRestoreManager
         }
 
         private async Task<(bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, TimeSpan projectReadyCheckTime)> CheckProjectsReadyAsync(
-            DateTime bulkRestoreCoordinationCheckStartTime,
+            DateTime lastProgressTime,
             CancellationToken token)
         {
             var projectReadyCheckMeasurement = Stopwatch.StartNew();
@@ -711,7 +730,7 @@ namespace NuGet.SolutionRestoreManager
                 {
                     allProjectsReady = false;
                     TimeSpan timeoutTime = CalculateTimeoutTime(
-                        bulkRestoreCoordinationCheckStartTime,
+                        lastProgressTime,
                         DateTime.UtcNow,
                         BulkRestoreCoordinationTimeout);
                     var timeoutTask = Task.Delay(timeoutTime, token);
@@ -721,6 +740,11 @@ namespace NuGet.SolutionRestoreManager
                     if (result == timeoutTask)
                     {
                         bulkCheckTimeout = true;
+                    }
+                    else
+                    {
+                        await whenNominatedTask;
+                        lastProgressTime = DateTime.UtcNow;
                     }
                 }
             }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreWorkerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreWorkerTests.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
+using NuGet.VisualStudio.Telemetry;
 using Xunit;
 
 namespace NuGet.SolutionRestoreManager.Test
@@ -29,6 +32,70 @@ namespace NuGet.SolutionRestoreManager.Test
 
             var timeout = SolutionRestoreWorker.CalculateTimeoutTime(startTime: startTime, currentTime: currentTime, timeoutTime: timeoutSpan);
             timeout.TotalMilliseconds.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task WaitForOnBuildRestoreReadinessCoreAsync_WhenProjectHasPendingNomination_WaitsUntilNominated()
+        {
+            var whenNominatedStarted = new TaskCompletionSource<bool>();
+            var whenNominatedCompleted = new TaskCompletionSource<bool>();
+            var checkProjectsReadyCallCount = 0;
+
+            Task<SolutionRestoreWorker.RestoreReadinessResult> coordinationTask = SolutionRestoreWorker.WaitForOnBuildRestoreReadinessCoreAsync(
+                waitForSolutionLoadedAsync: _ => Task.CompletedTask,
+                isAllProjectsNominatedAsync: () => Task.FromResult(true),
+                checkProjectsReadyAsync: async (bulkRestoreCoordinationCheckStartTime, cancellationToken) =>
+                {
+                    checkProjectsReadyCallCount++;
+                    if (checkProjectsReadyCallCount == 1)
+                    {
+                        whenNominatedStarted.TrySetResult(true);
+                        await whenNominatedCompleted.Task;
+                        return (false, false, 1, TimeSpan.FromMilliseconds(10));
+                    }
+
+                    return (true, false, 1, TimeSpan.FromMilliseconds(5));
+                },
+                token: CancellationToken.None);
+
+            await whenNominatedStarted.Task;
+            coordinationTask.IsCompleted.Should().BeFalse();
+
+            whenNominatedCompleted.SetResult(true);
+
+            SolutionRestoreWorker.RestoreReadinessResult readiness = await coordinationTask;
+            readiness.RestoreReason.Should().Be(ImplicitRestoreReason.ProjectsReady);
+            readiness.ProjectsReadyCheckCount.Should().Be(2);
+            readiness.ProjectRestoreInfoSourcesCount.Should().Be(1);
+            readiness.ProjectReadyTimings.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public async Task WaitForOnBuildRestoreReadinessCoreAsync_WhenSolutionLoadCompletes_ThenChecksNomination()
+        {
+            var solutionLoadCompleted = new TaskCompletionSource<bool>();
+            int isAllProjectsNominatedCallCount = 0;
+
+            Task<SolutionRestoreWorker.RestoreReadinessResult> coordinationTask = SolutionRestoreWorker.WaitForOnBuildRestoreReadinessCoreAsync(
+                waitForSolutionLoadedAsync: _ => solutionLoadCompleted.Task,
+                isAllProjectsNominatedAsync: () =>
+                {
+                    Interlocked.Increment(ref isAllProjectsNominatedCallCount);
+                    return Task.FromResult(true);
+                },
+                checkProjectsReadyAsync: (bulkRestoreCoordinationCheckStartTime, cancellationToken) =>
+                    Task.FromResult((true, false, 0, TimeSpan.Zero)),
+                token: CancellationToken.None);
+
+            await Task.Delay(50);
+            isAllProjectsNominatedCallCount.Should().Be(0);
+
+            solutionLoadCompleted.SetResult(true);
+
+            SolutionRestoreWorker.RestoreReadinessResult readiness = await coordinationTask;
+            readiness.RestoreReason.Should().Be(ImplicitRestoreReason.ProjectsReady);
+            readiness.ProjectsReadyCheckCount.Should().Be(1);
+            isAllProjectsNominatedCallCount.Should().Be(1);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreWorkerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreWorkerTests.cs
@@ -56,6 +56,8 @@ namespace NuGet.SolutionRestoreManager.Test
 
                     return (true, false, 1, TimeSpan.FromMilliseconds(5));
                 },
+                delayAsync: (delay, cancellationToken) => Task.Delay(delay, cancellationToken),
+                getUtcNow: () => DateTime.UtcNow,
                 token: CancellationToken.None);
 
             await whenNominatedStarted.Task;
@@ -85,9 +87,10 @@ namespace NuGet.SolutionRestoreManager.Test
                 },
                 checkProjectsReadyAsync: (bulkRestoreCoordinationCheckStartTime, cancellationToken) =>
                     Task.FromResult((true, false, 0, TimeSpan.Zero)),
+                delayAsync: (delay, cancellationToken) => Task.Delay(delay, cancellationToken),
+                getUtcNow: () => DateTime.UtcNow,
                 token: CancellationToken.None);
 
-            await Task.Delay(50);
             isAllProjectsNominatedCallCount.Should().Be(0);
 
             solutionLoadCompleted.SetResult(true);
@@ -96,6 +99,63 @@ namespace NuGet.SolutionRestoreManager.Test
             readiness.RestoreReason.Should().Be(ImplicitRestoreReason.ProjectsReady);
             readiness.ProjectsReadyCheckCount.Should().Be(1);
             isAllProjectsNominatedCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task WaitForOnBuildRestoreReadinessCoreAsync_WhenNominationsDoNotComplete_TimesOut()
+        {
+            var utcNow = new DateTime(year: 2026, month: 9, day: 11);
+
+            SolutionRestoreWorker.RestoreReadinessResult readiness = await SolutionRestoreWorker.WaitForOnBuildRestoreReadinessCoreAsync(
+                waitForSolutionLoadedAsync: _ => Task.CompletedTask,
+                isAllProjectsNominatedAsync: () => Task.FromResult(false),
+                checkProjectsReadyAsync: (lastProgressTime, cancellationToken) =>
+                    throw new InvalidOperationException("Projects cannot be ready before all projects are nominated."),
+                delayAsync: (delay, cancellationToken) =>
+                {
+                    utcNow += TimeSpan.FromMinutes(6);
+                    return Task.CompletedTask;
+                },
+                getUtcNow: () => utcNow,
+                token: CancellationToken.None);
+
+            readiness.RestoreReason.Should().Be(ImplicitRestoreReason.ProjectsReadyCheckTimeout);
+            readiness.BulkRestoreCoordinationCheckStartTime.Should().Be(new DateTime(year: 2026, month: 9, day: 11));
+            readiness.ProjectsReadyCheckCount.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task WaitForOnBuildRestoreReadinessCoreAsync_WhenBulkCoordinationMakesProgress_DoesNotTimeOut()
+        {
+            var utcNow = new DateTime(year: 2026, month: 9, day: 11);
+            DateTime firstCheckStartTime = default;
+            int checkProjectsReadyCallCount = 0;
+
+            SolutionRestoreWorker.RestoreReadinessResult readiness = await SolutionRestoreWorker.WaitForOnBuildRestoreReadinessCoreAsync(
+                waitForSolutionLoadedAsync: _ => Task.CompletedTask,
+                isAllProjectsNominatedAsync: () => Task.FromResult(true),
+                checkProjectsReadyAsync: (lastProgressTime, cancellationToken) =>
+                {
+                    checkProjectsReadyCallCount++;
+                    utcNow += TimeSpan.FromMinutes(4);
+
+                    if (checkProjectsReadyCallCount == 1)
+                    {
+                        firstCheckStartTime = lastProgressTime;
+                        return Task.FromResult((false, false, 2, TimeSpan.FromMinutes(4)));
+                    }
+
+                    lastProgressTime.Should().Be(utcNow - TimeSpan.FromMinutes(4));
+                    lastProgressTime.Should().BeAfter(firstCheckStartTime);
+                    return Task.FromResult((true, false, 2, TimeSpan.FromMinutes(4)));
+                },
+                delayAsync: (delay, cancellationToken) => Task.Delay(delay, cancellationToken),
+                getUtcNow: () => utcNow,
+                token: CancellationToken.None);
+
+            readiness.RestoreReason.Should().Be(ImplicitRestoreReason.ProjectsReady);
+            readiness.ProjectsReadyCheckCount.Should().Be(2);
+            readiness.ProjectReadyTimings.Should().HaveCount(2);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14927

## Description

Visual Studio can start its first on-build restore before solution loading and project nomination have finished. Because on-build restore executes directly rather than through the background restore queue, it could run with incomplete restore inputs and fail when a solution is built immediately after opening.

This change coordinates the first on-build restore with the existing restore-readiness signals. It waits for solution loading, all projects to be nominated, and pending project restore-info sources to finish nomination before starting restore.

The readiness wait uses the existing five-minute bulk coordination timeout as an inactivity fallback. The timeout now starts while waiting for initial project nominations, preventing a project that never nominates from delaying build indefinitely. It resets when nomination work makes progress, allowing large solutions to continue beyond five minutes as long as projects are still advancing. The original coordination start time remains fixed for total-duration telemetry.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
