### PR TITLE
Account for dual compatibility in AssetTargetFallback calculation - fix LockFileBuilderCache conflicts

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/AssetTargetFallbackFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/AssetTargetFallbackFramework.cs
@@ -78,6 +78,14 @@ namespace NuGet.Frameworks
 
                 combiner.AddObject(Comparer.GetHashCode(this));
 
+                // Include DualCompatibilityFramework's secondary framework in the hash
+                // to distinguish ATF(DCF(net6.0, native)) from ATF(net6.0).
+                if (RootFramework is DualCompatibilityFramework dualCompatibilityFramework)
+                {
+                    combiner.AddStringIgnoreCase(nameof(DualCompatibilityFramework));
+                    combiner.AddObject(Comparer.GetHashCode(dualCompatibilityFramework.SecondaryFramework));
+                }
+
                 foreach (var each in Fallback)
                 {
                     combiner.AddObject(Comparer.GetHashCode(each));
@@ -101,8 +109,26 @@ namespace NuGet.Frameworks
                 return true;
             }
 
-            return NuGetFramework.Comparer.Equals(this, other)
-                && Fallback.SequenceEqual(other.Fallback);
+            if (!NuGetFramework.Comparer.Equals(this, other))
+            {
+                return false;
+            }
+
+            // Check DualCompatibilityFramework secondary framework equality to distinguish
+            // ATF(DCF(net6.0, native)) from ATF(net6.0).
+            var thisDcf = RootFramework as DualCompatibilityFramework;
+            var otherDcf = other.RootFramework as DualCompatibilityFramework;
+            if ((thisDcf == null) != (otherDcf == null))
+            {
+                return false;
+            }
+
+            if (thisDcf != null && !Comparer.Equals(thisDcf.SecondaryFramework, otherDcf!.SecondaryFramework))
+            {
+                return false;
+            }
+
+            return Fallback.SequenceEqual(other.Fallback);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4711,7 +4711,6 @@ namespace NuGet.Commands.FuncTest
             }
         }
 
-        // https://github.com/NuGet/Home/issues/13326
         // When a managed project (B) references a C++/CLI project (A) that has a package
         // with build/native/ targets, restoring B first causes A to miss the build/native/ targets
         // due to a LockFileBuilderCache collision. When both projects use AssetTargetFallback with

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4711,6 +4711,129 @@ namespace NuGet.Commands.FuncTest
             }
         }
 
+        // https://github.com/NuGet/Home/issues/13326
+        // When a managed project (B) references a C++/CLI project (A) that has a package
+        // with build/native/ targets, restoring B first causes A to miss the build/native/ targets
+        // due to a LockFileBuilderCache collision. When both projects use AssetTargetFallback with
+        // the same imports, NuGetFrameworkFullComparer treats DualCompatibilityFramework(net6.0, native)
+        // as equal to plain net6.0, causing the criteria cache to return wrong selection criteria.
+        [Fact]
+        public async Task RestoreCommand_CppCliWithNativeBuildTargets_SharedCache_RestoreOrderDoesNotAffectBuildAssets()
+        {
+            using var pathContext = new SimpleTestPathContext();
+
+            // Package structure:
+            // MyPackage: build/native/MyPackage.targets (only matched by native framework criteria)
+            // MyPackage depends on MyPackage-binaries
+            // MyPackage-binaries: buildTransitive/MyPackage-binaries.targets
+            var binariesPackage = new SimpleTestPackageContext("MyPackage-binaries", "1.0.0");
+            binariesPackage.AddFile("buildTransitive/MyPackage-binaries.targets");
+
+            var myPackage = new SimpleTestPackageContext("MyPackage", "1.0.0");
+            myPackage.AddFile("build/native/MyPackage.targets");
+            myPackage.Dependencies.Add(binariesPackage);
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                myPackage,
+                binariesPackage);
+
+            // Project A: C++/CLI (net6.0-windows7.0 + secondaryFramework=native + ATF)
+            // Direct PackageReference to MyPackage
+            var projectAJson = @"
+                {
+                    ""frameworks"": {
+                        ""net6.0-windows7.0"": {
+                            ""targetAlias"" : ""net6.0-windows7.0"",
+                            ""assetTargetFallback"" : true,
+                            ""imports"" : [
+                                ""net461"",
+                                ""net472""
+                            ],
+                            ""secondaryFramework"" : ""native"",
+                            ""dependencies"": {
+                                ""MyPackage"": ""1.0.0""
+                            }
+                        }
+                    }
+                }";
+
+            // Project B: managed net6.0-windows7.0 with same ATF imports, references Project A
+            var projectBJson = @"
+                {
+                    ""frameworks"": {
+                        ""net6.0-windows7.0"": {
+                            ""targetAlias"" : ""net6.0-windows7.0"",
+                            ""assetTargetFallback"" : true,
+                            ""imports"" : [
+                                ""net461"",
+                                ""net472""
+                            ],
+                            ""dependencies"": {
+                            }
+                        }
+                    }
+                }";
+
+            var logger = new TestLogger();
+
+            var projectA = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec(
+                "ProjectA", pathContext.SolutionRoot, projectAJson);
+            var projectB = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec(
+                "ProjectB", pathContext.SolutionRoot, projectBJson);
+
+            // B references A (default PrivateAssets = contentfiles;analyzers;build)
+            projectB = projectB.WithTestProjectReference(projectA);
+            CreateFakeProjectFile(projectA);
+
+            // Use DependencyGraphSpecRequestProvider which naturally shares a LockFileBuilderCache
+            // across all projects in the solution restore
+            var dgSpec = ProjectTestHelpers.GetDGSpecForAllProjects(projectB, projectA);
+
+            var restoreContext = new RestoreArgs()
+            {
+                CacheContext = new SourceCacheContext(),
+                Log = logger,
+                GlobalPackagesFolder = pathContext.UserPackagesFolder,
+                Sources = new List<string>() { pathContext.PackageSource },
+            };
+
+            var dgProvider = new DependencyGraphSpecRequestProvider(
+                new RestoreCommandProvidersCache(),
+                dgSpec);
+
+            IReadOnlyList<RestoreSummaryRequest> requests = await dgProvider.CreateRequests(restoreContext);
+
+            // Restore B first, then A (the problematic order)
+            var requestB = requests.Single(r => r.Request.Project.Name.Equals("ProjectB", StringComparison.OrdinalIgnoreCase));
+            var requestA = requests.Single(r => r.Request.Project.Name.Equals("ProjectA", StringComparison.OrdinalIgnoreCase));
+
+            var resultB = await new RestoreCommand(requestB.Request).ExecuteAsync();
+            resultB.Success.Should().BeTrue();
+
+            var resultA = await new RestoreCommand(requestA.Request).ExecuteAsync();
+            resultA.Success.Should().BeTrue();
+
+            // Assert: A's lock file should include build/native/MyPackage.targets
+            resultA.LockFile.Targets.Should().HaveCount(1);
+            var targetA = resultA.LockFile.Targets[0];
+
+            var myPackageLib = targetA.Libraries.First(l => l.Name.Equals("MyPackage", StringComparison.OrdinalIgnoreCase));
+            myPackageLib.Build.Should().ContainSingle()
+                .Which.Path.Should().Be("build/native/MyPackage.targets");
+
+            var binariesLib = targetA.Libraries.First(l => l.Name.Equals("MyPackage-binaries", StringComparison.OrdinalIgnoreCase));
+            binariesLib.Build.Should().ContainSingle()
+                .Which.Path.Should().Be("buildTransitive/MyPackage-binaries.targets");
+
+            // Assert: B should not get build assets (transitive through P2P with PrivateAssets=build)
+            resultB.LockFile.Targets.Should().HaveCount(1);
+            var targetB = resultB.LockFile.Targets[0];
+            var myPackageLibB = targetB.Libraries.First(l => l.Name.Equals("MyPackage", StringComparison.OrdinalIgnoreCase));
+            myPackageLibB.Build.Should().BeEmpty();
+        }
+
         private static JObject BasicConfigWithNet46
         {
             get

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/AssetTargetFallbackTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/AssetTargetFallbackTests.cs
@@ -64,5 +64,52 @@ namespace NuGet.Frameworks.Test
             var assetTargetFallback = new AssetTargetFallbackFramework(nugetFramework, fallbackFrameworks: SampleFrameworkList);
             Assert.False(assetTargetFallback.Equals((object)nugetFramework));
         }
+
+        [Fact]
+        public void Equals_WithDualCompatibilityFramework_DifferentFromPlainFramework()
+        {
+            var net6Win = NuGetFramework.Parse("net6.0-windows7.0");
+            var native = NuGetFramework.Parse("native");
+            var fallbacks = new NuGetFramework[] { NuGetFramework.Parse("net461") };
+
+            var atfPlain = new AssetTargetFallbackFramework(net6Win, fallbacks);
+            var atfDcf = new AssetTargetFallbackFramework(
+                new DualCompatibilityFramework(net6Win, native), fallbacks);
+
+            atfPlain.Equals(atfDcf).Should().BeFalse(
+                because: "ATF wrapping DualCompatibilityFramework(net6.0, native) must differ from ATF wrapping plain net6.0");
+            atfDcf.Equals(atfPlain).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetHashCode_WithDualCompatibilityFramework_DifferentFromPlainFramework()
+        {
+            var net6Win = NuGetFramework.Parse("net6.0-windows7.0");
+            var native = NuGetFramework.Parse("native");
+            var fallbacks = new NuGetFramework[] { NuGetFramework.Parse("net461") };
+
+            var atfPlain = new AssetTargetFallbackFramework(net6Win, fallbacks);
+            var atfDcf = new AssetTargetFallbackFramework(
+                new DualCompatibilityFramework(net6Win, native), fallbacks);
+
+            atfPlain.GetHashCode().Should().NotBe(atfDcf.GetHashCode(),
+                because: "hash codes must differ to avoid cache collisions in LockFileBuilderCache");
+        }
+
+        [Fact]
+        public void Equals_TwoDualCompatibilityFrameworks_WithSameSecondary_AreEqual()
+        {
+            var net6Win = NuGetFramework.Parse("net6.0-windows7.0");
+            var native = NuGetFramework.Parse("native");
+            var fallbacks = new NuGetFramework[] { NuGetFramework.Parse("net461") };
+
+            var atf1 = new AssetTargetFallbackFramework(
+                new DualCompatibilityFramework(net6Win, native), fallbacks);
+            var atf2 = new AssetTargetFallbackFramework(
+                new DualCompatibilityFramework(net6Win, native), fallbacks);
+
+            atf1.Equals(atf2).Should().BeTrue();
+            atf1.GetHashCode().Should().Be(atf2.GetHashCode());
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13326

## Description

During solution restore, all projects share a `LockFileBuilderCache`. The selection criteria cache (`_criteriaSets`) is keyed by `CriteriaKey`, which compares `AssetTargetFallbackFramework` instances using `Equals`/`GetHashCode`.

The problem: `AssetTargetFallbackFramework.Equals/GetHashCode` only compared base framework properties and the fallback list. It did not account for the `RootFramework` being a `DualCompatibilityFramework` (used by C++/CLI projects to add `native` as a secondary framework).

This meant `ATF(DCF(net6.0-windows7.0, native), [net461])` and `ATF(net6.0-windows7.0, [net461])` hashed and compared as equal. When the managed project restored first, its criteria (without `native`) got cached, and the C++/CLI project reused those wrong criteria — so `build/native/` targets were never matched.

**Fix:** Include `DualCompatibilityFramework`'s secondary framework in `AssetTargetFallbackFramework.GetHashCode()` and `Equals()`, so the two produce distinct cache keys.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
