### PR TITLE
Enable nullable for NuGet.Protocol plugin messages, logging, and contracts

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ConnectionOptions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ConnectionOptions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using NuGet.Common;
@@ -131,7 +129,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="reader">An environment variable reader.</param>
         /// <returns>A <see cref="ConnectionOptions" />.</returns>
-        public static ConnectionOptions CreateDefault(IEnvironmentVariableReader reader = null)
+        public static ConnectionOptions CreateDefault(IEnvironmentVariableReader? reader = null)
         {
             reader = reader ?? EnvironmentVariableWrapper.Instance;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/FaultedPluginEventArgs.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/FaultedPluginEventArgs.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IConnection.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IConnection.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,7 +36,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the negotiated protocol version, or <see langword="null" /> if not yet connected.
         /// </summary>
-        SemanticVersion ProtocolVersion { get; }
+        SemanticVersion? ProtocolVersion { get; }
 
         /// <summary>
         /// Closes the connection.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IIdGenerator.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IIdGenerator.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 namespace NuGet.Protocol.Plugins
 {
     /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IMessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IMessageDispatcher.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -104,6 +102,6 @@ namespace NuGet.Protocol.Plugins
         /// Sets the connection to be used for dispatching messages.
         /// </summary>
         /// <param name="connection">A connection instance.  Can be <see langword="null" />.</param>
-        void SetConnection(IConnection connection);
+        void SetConnection(IConnection? connection);
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPlugin.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPlugin.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginDiscoverer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginManager.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginMulticlientUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginMulticlientUtilities.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginProcess.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginProcess.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IReceiver.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IRequestHandler.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IRequestHandlers.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IRequestHandlers.cs
@@ -1,9 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -42,7 +41,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="method">A message method.</param>
         /// <param name="handler">A request handler.</param>
         /// <returns><see langword="true" /> if the request handler exists; otherwise, <see langword="false" />.</returns>
-        bool TryGet(MessageMethod method, out IRequestHandler handler);
+        bool TryGet(MessageMethod method, [NotNullWhen(true)] out IRequestHandler? handler);
 
         /// <summary>
         /// Attempts to remove a request handler for the specified message method.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IResponseHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IResponseHandler.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ISender.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ISender.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/LineReadEventArgs.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/LineReadEventArgs.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins
@@ -15,13 +13,13 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// The output line read.
         /// </summary>
-        public string Line { get; }
+        public string? Line { get; }
 
         /// <summary>
         /// Instantiates a new <see cref="LineReadEventArgs" /> class.
         /// </summary>
         /// <param name="line">The output line read.</param>
-        public LineReadEventArgs(string line)
+        public LineReadEventArgs(string? line)
         {
             Line = line;
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/AssemblyLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/AssemblyLogMessage.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Reflection;
 using Newtonsoft.Json.Linq;
@@ -11,10 +9,10 @@ namespace NuGet.Protocol.Plugins
 {
     internal sealed class AssemblyLogMessage : PluginLogMessage
     {
-        private readonly string _fileVersion;
-        private readonly string _fullName;
-        private readonly string _informationalVersion;
-        private readonly string _entryAssemblyFullName;
+        private readonly string? _fileVersion;
+        private readonly string? _fullName;
+        private readonly string? _informationalVersion;
+        private readonly string? _entryAssemblyFullName;
 
         internal AssemblyLogMessage(DateTimeOffset now)
             : base(now)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/EnvironmentVariablesLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/EnvironmentVariablesLogMessage.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
@@ -15,7 +13,7 @@ namespace NuGet.Protocol.Plugins
         private readonly int? _idleTimeout;
         private readonly int? _requestTimeout;
 
-        internal EnvironmentVariablesLogMessage(DateTimeOffset now, IEnvironmentVariableReader environmentVariableReader = null)
+        internal EnvironmentVariablesLogMessage(DateTimeOffset now, IEnvironmentVariableReader? environmentVariableReader = null)
             : base(now)
         {
             var reader = environmentVariableReader ?? EnvironmentVariableWrapper.Instance;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogger.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -14,7 +12,7 @@ namespace NuGet.Protocol.Plugins
     {
         private bool _isDisposed;
         private readonly Lazy<StreamWriter> _streamWriter;
-        private readonly string _logDirectoryPath;
+        private readonly string? _logDirectoryPath;
         private readonly DateTimeOffset _startTime;
         private readonly Stopwatch _stopwatch;
         private readonly object _streamWriterLock;
@@ -97,17 +95,21 @@ namespace NuGet.Protocol.Plugins
         {
             if (IsEnabled)
             {
+                string logDirectoryPath = _logDirectoryPath
+                    ?? throw new InvalidOperationException("Log directory must be set when plugin logging is enabled.");
                 FileInfo file;
                 int processId;
 
                 using (var process = Process.GetCurrentProcess())
                 {
-                    file = new FileInfo(process.MainModule.FileName);
+                    string processFileName = process.MainModule?.FileName
+                        ?? throw new InvalidOperationException("The current process must have a main module file name for plugin logging.");
+                    file = new FileInfo(processFileName);
                     processId = process.Id;
                 }
 
                 var fileName = $"NuGet_PluginLogFor_{Path.GetFileNameWithoutExtension(file.Name)}_{DateTime.UtcNow.Ticks:x}_{processId}.log";
-                var filePath = Path.Combine(_logDirectoryPath, fileName);
+                var filePath = Path.Combine(logDirectoryPath, fileName);
                 var stream = File.Open(filePath, FileMode.Create, FileAccess.Write, FileShare.Read);
 
                 try

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageConverter.cs
@@ -164,7 +164,7 @@ namespace NuGet.Protocol.Plugins
                 }
             }
 
-            return new Message(requestId, messageType, messageMethod, payload);
+            return new Message(requestId!, messageType, messageMethod, payload);
         }
 
         public override void Write(Utf8JsonWriter writer, Message value, JsonSerializerOptions options)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageEventArgs.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageEventArgs.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageUtilities.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json.Linq;
 
@@ -32,7 +30,7 @@ namespace NuGet.Protocol.Plugins
                 throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(requestId));
             }
 
-            return new Message(requestId, type, method, (object)null);
+            return new Message(requestId, type, method, (object?)null);
         }
 
         /// <summary>
@@ -74,7 +72,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="message">The message.</param>
         /// <returns>A JSON string, or <see langword="null" /> if no payload exists.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <see langword="null" />.</exception>
-        public static string SerializePayload(Message message)
+        public static string? SerializePayload(Message message)
         {
             if (message == null)
             {
@@ -107,7 +105,7 @@ namespace NuGet.Protocol.Plugins
         /// <returns>The deserialized message payload of type <typeparamref name="TPayload" />
         /// or <see langword="null" /> if no payload exists.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <see langword="null" />.</exception>
-        public static TPayload DeserializePayload<TPayload>(Message message)
+        public static TPayload? DeserializePayload<TPayload>(Message message)
         {
             if (message == null)
             {
@@ -116,7 +114,7 @@ namespace NuGet.Protocol.Plugins
 
             if (message.PayloadObject == null)
             {
-                return default(TPayload);
+                return default;
             }
 
             if (message.PayloadObject is Newtonsoft.Json.Linq.JObject jobj)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyFilesInPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyFilesInPackageRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyFilesInPackageResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyFilesInPackageResponse.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -19,7 +17,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the paths of files copies.
         /// </summary>
-        public IEnumerable<string> CopiedFiles { get; }
+        public IEnumerable<string>? CopiedFiles { get; }
 
         /// <summary>
         /// Gets the response code.
@@ -38,7 +36,7 @@ namespace NuGet.Protocol.Plugins
         /// is <see cref="MessageResponseCode.Success" /> and <paramref name="copiedFiles" />
         /// is either <see langword="null" /> or empty.</exception>
         [JsonConstructor]
-        public CopyFilesInPackageResponse(MessageResponseCode responseCode, IEnumerable<string> copiedFiles)
+        public CopyFilesInPackageResponse(MessageResponseCode responseCode, IEnumerable<string>? copiedFiles)
         {
             if (!Enum.IsDefined(typeof(MessageResponseCode), responseCode))
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyNupkgFileRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/CopyNupkgFileRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/Fault.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/Fault.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetAuthenticationCredentialsResponse.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-#nullable disable
 
 using System;
 using System.Collections.Generic;
@@ -18,23 +17,23 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Username
         /// </summary>
-        public string Username { get; }
+        public string? Username { get; }
 
         /// <summary>
         /// password token
         /// </summary>
-        public string Password { get; }
+        public string? Password { get; }
 
         /// <summary>
         /// message - optional, can be used as a way to communicate to NuGet why the authentication failed.
         /// </summary>
-        public string Message { get; }
+        public string? Message { get; }
 
         /// <summary>
         /// Gets or sets the list of authentication types this credential is applicable to. Useful values include
         /// <c>basic</c>, <c>digest</c>, <c>negotiate</c>, and <c>ntlm</c>
         /// </summary>
-        public IList<string> AuthenticationTypes { get; }
+        public IList<string>? AuthenticationTypes { get; }
 
         /// <summary>
         /// ResponseCode - status of the credentials
@@ -52,7 +51,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="responseCode"></param>
         /// <exception cref="ArgumentException">If MessageResponseCode is not defined on this runtime</exception>
         [JsonConstructor]
-        public GetAuthenticationCredentialsResponse(string username, string password, string message, IList<string> authenticationTypes, MessageResponseCode responseCode)
+        public GetAuthenticationCredentialsResponse(string? username, string? password, string? message, IList<string>? authenticationTypes, MessageResponseCode responseCode)
         {
 
             if (!Enum.IsDefined(typeof(MessageResponseCode), responseCode))

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetCredentialsRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetCredentialsRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using System.Net;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetCredentialsResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetCredentialsResponse.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -18,7 +16,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the password.
         /// </summary>
-        public string Password { get; }
+        public string? Password { get; }
 
         /// <summary>
         /// Gets the response code.
@@ -29,9 +27,9 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the username.
         /// </summary>
-        public string Username { get; }
+        public string? Username { get; }
 
-        public IReadOnlyList<string> AuthenticationTypes { get; }
+        public IReadOnlyList<string>? AuthenticationTypes { get; }
 
 
         /// <summary>
@@ -43,9 +41,9 @@ namespace NuGet.Protocol.Plugins
         [JsonConstructor]
         public GetCredentialsResponse(
             MessageResponseCode responseCode,
-            string username,
-            string password,
-            IReadOnlyList<string> authenticationTypes = null)
+            string? username,
+            string? password,
+            IReadOnlyList<string>? authenticationTypes = null)
         {
             if (!Enum.IsDefined(typeof(MessageResponseCode), responseCode))
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetFilesInPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetFilesInPackageRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetFilesInPackageResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetFilesInPackageResponse.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -19,7 +17,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the paths of files in the package.
         /// </summary>
-        public IEnumerable<string> Files { get; }
+        public IEnumerable<string>? Files { get; }
 
         /// <summary>
         /// Gets the response code.
@@ -38,7 +36,7 @@ namespace NuGet.Protocol.Plugins
         /// is <see cref="MessageResponseCode.Success" /> and <paramref name="files" />
         /// is either <see langword="null" /> or empty.</exception>
         [JsonConstructor]
-        public GetFilesInPackageResponse(MessageResponseCode responseCode, IEnumerable<string> files)
+        public GetFilesInPackageResponse(MessageResponseCode responseCode, IEnumerable<string>? files)
         {
             if (!Enum.IsDefined(typeof(MessageResponseCode), responseCode))
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetOperationClaimsRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetOperationClaimsRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -18,9 +16,8 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the package source repository location for the <see cref="ServiceIndexJson" />.
         /// </summary>
-        public string PackageSourceRepository { get; }
+        public string? PackageSourceRepository { get; }
 
-#nullable enable
         /// <summary>
         /// Gets the service index (index.json) for the <see cref="PackageSourceRepository" /> as a raw JSON string.
         /// </summary>
@@ -29,7 +26,6 @@ namespace NuGet.Protocol.Plugins
         [System.Text.Json.Serialization.JsonPropertyName("ServiceIndex")]
         [System.Text.Json.Serialization.JsonConverter(typeof(RawJsonStringConverter))]
         public string? ServiceIndexJson { get; }
-#nullable disable
 
         /// <summary>
         /// Gets the service index (index.json) for the <see cref="PackageSourceRepository" />.
@@ -37,7 +33,7 @@ namespace NuGet.Protocol.Plugins
         [Obsolete("Use ServiceIndexJson instead. This property always returns null.")]
         [JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
-        public JObject ServiceIndex => null;
+        public JObject? ServiceIndex => null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GetOperationClaimsRequest" /> class.
@@ -45,7 +41,6 @@ namespace NuGet.Protocol.Plugins
         /// <param name="packageSourceRepository">The package source location.</param>
         /// <param name="serviceIndexJson">The service index (index.json) as a raw JSON string.</param>
         /// <remarks>Both packageSourceRepository and service index can be null. If they are, the operation claims request is considered as source agnostic</remarks>
-#nullable enable
         [JsonConstructor]
         [System.Text.Json.Serialization.JsonConstructor]
         public GetOperationClaimsRequest(string? packageSourceRepository, string? serviceIndexJson)
@@ -53,7 +48,6 @@ namespace NuGet.Protocol.Plugins
             PackageSourceRepository = packageSourceRepository;
             ServiceIndexJson = serviceIndexJson;
         }
-#nullable disable
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GetOperationClaimsRequest" /> class.
@@ -61,7 +55,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="packageSourceRepository">The package source location.</param>
         /// <param name="serviceIndex">The service index (index.json).</param>
         [Obsolete("Use GetOperationClaimsRequest(string, string) instead.")]
-        public GetOperationClaimsRequest(string packageSourceRepository, JObject serviceIndex)
+        public GetOperationClaimsRequest(string? packageSourceRepository, JObject? serviceIndex)
             : this(packageSourceRepository, serviceIndex?.ToString(Formatting.None))
         {
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageHashRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageHashRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageHashResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageHashResponse.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using Newtonsoft.Json;
@@ -17,7 +15,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the package hash.
         /// </summary>
-        public string Hash { get; }
+        public string? Hash { get; }
 
         /// <summary>
         /// Gets the response code.
@@ -35,7 +33,7 @@ namespace NuGet.Protocol.Plugins
         /// is <see cref="MessageResponseCode.Success" /> and <paramref name="hash" />
         /// is either <see langword="null" /> or empty.</exception>
         [JsonConstructor]
-        public GetPackageHashResponse(MessageResponseCode responseCode, string hash)
+        public GetPackageHashResponse(MessageResponseCode responseCode, string? hash)
         {
             if (!Enum.IsDefined(typeof(MessageResponseCode), responseCode))
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageVersionsRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageVersionsRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageVersionsResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetPackageVersionsResponse.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -25,7 +23,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the package versions.
         /// </summary>
-        public IEnumerable<string> Versions { get; }
+        public IEnumerable<string>? Versions { get; }
 
         /// <summary>
         /// Initializes a new <see cref="GetPackageVersionsResponse" /> class.
@@ -38,7 +36,7 @@ namespace NuGet.Protocol.Plugins
         /// is <see cref="MessageResponseCode.Success" /> and <paramref name="versions" />
         /// is either <see langword="null" /> or empty.</exception>
         [JsonConstructor]
-        public GetPackageVersionsResponse(MessageResponseCode responseCode, IEnumerable<string> versions)
+        public GetPackageVersionsResponse(MessageResponseCode responseCode, IEnumerable<string>? versions)
         {
             if (!Enum.IsDefined(typeof(MessageResponseCode), responseCode))
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetServiceIndexRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetServiceIndexRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetServiceIndexResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetServiceIndexResponse.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using Newtonsoft.Json;
@@ -21,7 +19,6 @@ namespace NuGet.Protocol.Plugins
         [JsonRequired]
         public MessageResponseCode ResponseCode { get; }
 
-#nullable enable
         /// <summary>
         /// Gets the service index (index.json) for the package source repository as a raw JSON string.
         /// </summary>
@@ -30,7 +27,6 @@ namespace NuGet.Protocol.Plugins
         [System.Text.Json.Serialization.JsonPropertyName("ServiceIndex")]
         [System.Text.Json.Serialization.JsonConverter(typeof(RawJsonStringConverter))]
         public string? ServiceIndexJson { get; }
-#nullable disable
 
         /// <summary>
         /// Gets the service index (index.json) for the package source repository.
@@ -38,7 +34,7 @@ namespace NuGet.Protocol.Plugins
         [Obsolete("Use ServiceIndexJson instead. This property always returns null.")]
         [JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
-        public JObject ServiceIndex => null;
+        public JObject? ServiceIndex => null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GetServiceIndexResponse" /> class.
@@ -50,7 +46,6 @@ namespace NuGet.Protocol.Plugins
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseCode" />
         /// is <see cref="MessageResponseCode.Success" /> and <paramref name="serviceIndexJson" />
         /// is <see langword="null" />.</exception>
-#nullable enable
         [JsonConstructor]
         [System.Text.Json.Serialization.JsonConstructor]
         public GetServiceIndexResponse(MessageResponseCode responseCode, string? serviceIndexJson)
@@ -73,7 +68,6 @@ namespace NuGet.Protocol.Plugins
             ResponseCode = responseCode;
             ServiceIndexJson = serviceIndexJson;
         }
-#nullable disable
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GetServiceIndexResponse" /> class.
@@ -81,7 +75,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="responseCode">The response code.</param>
         /// <param name="serviceIndex">The service index (index.json) for the package source repository.</param>
         [Obsolete("Use GetServiceIndexResponse(MessageResponseCode, string) instead.")]
-        public GetServiceIndexResponse(MessageResponseCode responseCode, JObject serviceIndex)
+        public GetServiceIndexResponse(MessageResponseCode responseCode, JObject? serviceIndex)
             : this(responseCode, serviceIndex?.ToString(Formatting.None))
         {
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/HandshakeResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/HandshakeResponse.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using Newtonsoft.Json;
@@ -26,7 +24,7 @@ namespace NuGet.Protocol.Plugins
         /// otherwise, <see langword="null" />.
         /// </summary>
         [System.Text.Json.Serialization.JsonConverter(typeof(StjSemanticVersionConverter))]
-        public SemanticVersion ProtocolVersion { get; }
+        public SemanticVersion? ProtocolVersion { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HandshakeResponse" /> class.
@@ -43,7 +41,7 @@ namespace NuGet.Protocol.Plugins
         /// is not <see cref="MessageResponseCode.Success" /> and <paramref name="protocolVersion" />
         /// is not <see langword="null" />.</exception>
         [JsonConstructor]
-        public HandshakeResponse(MessageResponseCode responseCode, SemanticVersion protocolVersion)
+        public HandshakeResponse(MessageResponseCode responseCode, SemanticVersion? protocolVersion)
         {
             if (!Enum.IsDefined(typeof(MessageResponseCode), responseCode))
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/InitializeRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/InitializeRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/LogRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/LogRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using Newtonsoft.Json;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/Message.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/Message.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using Newtonsoft.Json;
@@ -39,11 +37,11 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         [Obsolete("Use MessageUtilities.DeserializePayload<T>() to access the payload.")]
         [JsonIgnore]
-        public JObject Payload => null;
+        public JObject? Payload => null;
 
         [JsonProperty("Payload")]
         [JsonConverter(typeof(ObjectPayloadConverter))]
-        internal object PayloadObject { get; }
+        internal object? PayloadObject { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Message" /> class.
@@ -59,12 +57,13 @@ namespace NuGet.Protocol.Plugins
         /// <exception cref="ArgumentException">Thrown if <paramref name="method" />
         /// is an undefined <see cref="MessageMethod" /> value.</exception>
         [Obsolete("Use MessageUtilities.Create<T>() to create messages.")]
-        public Message(string requestId, MessageType type, MessageMethod method, JObject payload = null)
+        public Message(string requestId, MessageType type, MessageMethod method, JObject? payload = null)
+            : this(requestId, type, method, (object?)payload)
         {
         }
 
         [JsonConstructor]
-        internal Message(string requestId, MessageType type, MessageMethod method, object payload = null)
+        internal Message(string requestId, MessageType type, MessageMethod method, object? payload = null)
         {
             if (string.IsNullOrEmpty(requestId))
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/PrefetchPackageRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/PrefetchPackageRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/SetCredentialsRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/SetCredentialsRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 
@@ -22,22 +20,22 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the package source repository password.
         /// </summary>
-        public string Password { get; }
+        public string? Password { get; }
 
         /// <summary>
         /// Gets the proxy password.
         /// </summary>
-        public string ProxyPassword { get; }
+        public string? ProxyPassword { get; }
 
         /// <summary>
         /// Gets the proxy username.
         /// </summary>
-        public string ProxyUsername { get; }
+        public string? ProxyUsername { get; }
 
         /// <summary>
         /// Gets the package source repository username.
         /// </summary>
-        public string Username { get; }
+        public string? Username { get; }
 
         /// <summary>
         /// Initializes a new <see cref="SetCredentialsRequest" /> class.
@@ -49,10 +47,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="password">The package source repository password.</param>
         public SetCredentialsRequest(
             string packageSourceRepository,
-            string proxyUsername,
-            string proxyPassword,
-            string username,
-            string password)
+            string? proxyUsername,
+            string? proxyPassword,
+            string? username,
+            string? password)
         {
             if (string.IsNullOrEmpty(packageSourceRepository))
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCacheEntry.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -34,7 +32,7 @@ namespace NuGet.Protocol.Plugins
         private string RootFolder { get; }
         private string NewCacheFileName { get; }
 
-        public IReadOnlyList<OperationClaim> OperationClaims { get; set; }
+        public IReadOnlyList<OperationClaim>? OperationClaims { get; set; }
 
         /// <summary>
         /// Loads and processes the contet from the generated file if it exists.
@@ -42,7 +40,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         public void LoadFromFile()
         {
-            Stream content = null;
+            Stream? content = null;
             try
             {
                 content = CachingUtility.ReadCacheFile(MaxAge, CacheFileName);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginConstants.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCreationResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginCreationResult.cs
@@ -1,10 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -16,27 +15,39 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the plugin's operation claims.
         /// </summary>
-        public IReadOnlyList<OperationClaim> Claims { get; }
+        public IReadOnlyList<OperationClaim>? Claims { get; }
 
         /// <summary>
         /// Gets a message if <see cref="Plugin" /> is <see langword="null" />; otherwise, <see langword="null" />.
         /// </summary>
-        public string Message { get; }
+        public string? Message { get; }
 
         /// <summary>
         /// Gets the exception caught.  May be <see langword="null" />.
         /// </summary>
-        public Exception Exception { get; }
+        public Exception? Exception { get; }
 
         /// <summary>
         /// Gets a plugin.
         /// </summary>
-        public IPlugin Plugin { get; }
+        public IPlugin? Plugin { get; }
 
         /// <summary>
         /// Gets a plugin multiclient utilities.
         /// </summary>
-        public IPluginMulticlientUtilities PluginMulticlientUtilities { get; }
+        public IPluginMulticlientUtilities? PluginMulticlientUtilities { get; }
+
+        /// <summary>
+        /// Gets whether the plugin was created successfully.
+        /// When <see langword="true" />, <see cref="Plugin" />, <see cref="PluginMulticlientUtilities" />,
+        /// and <see cref="Claims" /> are guaranteed to be non-<see langword="null" />.
+        /// When <see langword="false" />, <see cref="Message" /> is guaranteed to be non-<see langword="null" />.
+        /// </summary>
+        [MemberNotNullWhen(true, nameof(Plugin))]
+        [MemberNotNullWhen(true, nameof(PluginMulticlientUtilities))]
+        [MemberNotNullWhen(true, nameof(Claims))]
+        [MemberNotNullWhen(false, nameof(Message))]
+        internal bool IsSuccess => Plugin is not null;
 
         /// <summary>
         /// Instantiates a new <see cref="PluginCreationResult" /> class.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryResult.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 
@@ -18,13 +16,13 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         public PluginFile PluginFile { get; }
 
-        private string _message;
+        private string? _message;
 
         /// <summary>
         /// Gets a message if <see cref="PluginFile.State" /> is not <see cref="PluginFileState.Valid" />;
         /// otherwise, <see langword="null" />.
         /// </summary>
-        public string Message
+        public string? Message
         {
             get
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginEventArgs.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginEventArgs.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginException.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Runtime.Serialization;
 
@@ -18,7 +16,7 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new <see cref="PluginException" /> class.
         /// </summary>
         /// <param name="message">The exception message.</param>
-        public PluginException(string message)
+        public PluginException(string? message)
             : base(message)
         {
         }
@@ -28,7 +26,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="message">The exception message.</param>
         /// <param name="innerException">The inner exception.</param>
-        public PluginException(string message, Exception innerException)
+        public PluginException(string? message, Exception? innerException)
             : base(message, innerException)
         {
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFile.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFile.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolConstants.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using NuGet.Versioning;
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolErrorEventArgs.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolErrorEventArgs.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins
@@ -20,7 +18,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the message.
         /// </summary>
-        public Message Message { get; }
+        public Message? Message { get; }
 
         /// <summary>
         /// Instantiates a new <see cref="ProtocolErrorEventArgs" /> class.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolException.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolException.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Runtime.Serialization;
 
@@ -18,7 +16,7 @@ namespace NuGet.Protocol.Plugins
         /// Instantiates a new <see cref="ProtocolException" /> class.
         /// </summary>
         /// <param name="message">The exception message.</param>
-        public ProtocolException(string message)
+        public ProtocolException(string? message)
             : base(message)
         {
         }
@@ -28,7 +26,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="message">The exception message.</param>
         /// <param name="innerException">The inner exception.</param>
-        public ProtocolException(string message, Exception innerException)
+        public ProtocolException(string? message, Exception? innerException)
             : base(message, innerException)
         {
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/TimeoutUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/TimeoutUtilities.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins
@@ -20,7 +18,7 @@ namespace NuGet.Protocol.Plugins
         /// <returns>A <see cref="TimeSpan" /> object that represents a timeout interval.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="fallbackTimeout" /> is an invalid
         /// timeout.</exception>
-        public static TimeSpan GetTimeout(string timeoutInSeconds, TimeSpan fallbackTimeout)
+        public static TimeSpan GetTimeout(string? timeoutInSeconds, TimeSpan fallbackTimeout)
         {
             if (!IsValid(fallbackTimeout))
             {

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -881,38 +881,38 @@ NuGet.Protocol.Plugins.ConnectionState.FailedToHandshake = 0 -> NuGet.Protocol.P
 NuGet.Protocol.Plugins.ConnectionState.Handshaking = 5 -> NuGet.Protocol.Plugins.ConnectionState
 NuGet.Protocol.Plugins.ConnectionState.ReadyToConnect = 3 -> NuGet.Protocol.Plugins.ConnectionState
 NuGet.Protocol.Plugins.CopyFilesInPackageRequest
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.CopyFilesInPackageRequest(string packageSourceRepository, string packageId, string packageVersion, System.Collections.Generic.IEnumerable<string> filesInPackage, string destinationFolderPath) -> void
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.DestinationFolderPath.get -> string
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.FilesInPackage.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageVersion.get -> string
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.CopyFilesInPackageRequest(string! packageSourceRepository, string! packageId, string! packageVersion, System.Collections.Generic.IEnumerable<string!>! filesInPackage, string! destinationFolderPath) -> void
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.DestinationFolderPath.get -> string!
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.FilesInPackage.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageVersion.get -> string!
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopiedFiles.get -> System.Collections.Generic.IEnumerable<string!>?
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopyFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? copiedFiles) -> void
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.CopyNupkgFileRequest
-~NuGet.Protocol.Plugins.CopyNupkgFileRequest.CopyNupkgFileRequest(string packageSourceRepository, string packageId, string packageVersion, string destinationFilePath) -> void
-~NuGet.Protocol.Plugins.CopyNupkgFileRequest.DestinationFilePath.get -> string
-~NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageVersion.get -> string
+NuGet.Protocol.Plugins.CopyNupkgFileRequest.CopyNupkgFileRequest(string! packageSourceRepository, string! packageId, string! packageVersion, string! destinationFilePath) -> void
+NuGet.Protocol.Plugins.CopyNupkgFileRequest.DestinationFilePath.get -> string!
+NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageVersion.get -> string!
 NuGet.Protocol.Plugins.CopyNupkgFileResponse
 NuGet.Protocol.Plugins.CopyNupkgFileResponse.CopyNupkgFileResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.CopyNupkgFileResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.Fault
-~NuGet.Protocol.Plugins.Fault.Fault(string message) -> void
-~NuGet.Protocol.Plugins.Fault.Message.get -> string
+NuGet.Protocol.Plugins.Fault.Fault(string! message) -> void
+NuGet.Protocol.Plugins.Fault.Message.get -> string!
 NuGet.Protocol.Plugins.FaultedPluginEventArgs
 NuGet.Protocol.Plugins.FaultedPluginEventArgs.Exception.get -> System.Exception!
 NuGet.Protocol.Plugins.FaultedPluginEventArgs.FaultedPluginEventArgs(NuGet.Protocol.Plugins.IPlugin! plugin, System.Exception! exception) -> void
 NuGet.Protocol.Plugins.FaultedPluginEventArgs.Plugin.get -> NuGet.Protocol.Plugins.IPlugin!
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.CanShowDialog.get -> bool
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.GetAuthenticationCredentialsRequest(System.Uri uri, bool isRetry, bool isNonInteractive, bool canShowDialog) -> void
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.GetAuthenticationCredentialsRequest(System.Uri! uri, bool isRetry, bool isNonInteractive, bool canShowDialog) -> void
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.IsNonInteractive.get -> bool
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.IsRetry.get -> bool
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.Uri.get -> System.Uri
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.Uri.get -> System.Uri!
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IList<string!>?
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.GetAuthenticationCredentialsResponse(string? username, string? password, string? message, System.Collections.Generic.IList<string!>? authenticationTypes, NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
@@ -922,8 +922,8 @@ NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Password.get -> stri
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Username.get -> string?
 NuGet.Protocol.Plugins.GetCredentialsRequest
-~NuGet.Protocol.Plugins.GetCredentialsRequest.GetCredentialsRequest(string packageSourceRepository, System.Net.HttpStatusCode statusCode) -> void
-~NuGet.Protocol.Plugins.GetCredentialsRequest.PackageSourceRepository.get -> string
+NuGet.Protocol.Plugins.GetCredentialsRequest.GetCredentialsRequest(string! packageSourceRepository, System.Net.HttpStatusCode statusCode) -> void
+NuGet.Protocol.Plugins.GetCredentialsRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.GetCredentialsRequest.StatusCode.get -> System.Net.HttpStatusCode
 NuGet.Protocol.Plugins.GetCredentialsRequestHandler
 ~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository sourceRepository) -> void
@@ -938,10 +938,10 @@ NuGet.Protocol.Plugins.GetCredentialsResponse.Password.get -> string?
 NuGet.Protocol.Plugins.GetCredentialsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetCredentialsResponse.Username.get -> string?
 NuGet.Protocol.Plugins.GetFilesInPackageRequest
-~NuGet.Protocol.Plugins.GetFilesInPackageRequest.GetFilesInPackageRequest(string packageSourceRepository, string packageId, string packageVersion) -> void
-~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageVersion.get -> string
+NuGet.Protocol.Plugins.GetFilesInPackageRequest.GetFilesInPackageRequest(string! packageSourceRepository, string! packageId, string! packageVersion) -> void
+NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageVersion.get -> string!
 NuGet.Protocol.Plugins.GetFilesInPackageResponse
 NuGet.Protocol.Plugins.GetFilesInPackageResponse.Files.get -> System.Collections.Generic.IEnumerable<string!>?
 NuGet.Protocol.Plugins.GetFilesInPackageResponse.GetFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? files) -> void
@@ -954,26 +954,26 @@ NuGet.Protocol.Plugins.GetOperationClaimsResponse
 ~NuGet.Protocol.Plugins.GetOperationClaimsResponse.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>
 ~NuGet.Protocol.Plugins.GetOperationClaimsResponse.GetOperationClaimsResponse(System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.OperationClaim> claims) -> void
 NuGet.Protocol.Plugins.GetPackageHashRequest
-~NuGet.Protocol.Plugins.GetPackageHashRequest.GetPackageHashRequest(string packageSourceRepository, string packageId, string packageVersion, string hashAlgorithm) -> void
-~NuGet.Protocol.Plugins.GetPackageHashRequest.HashAlgorithm.get -> string
-~NuGet.Protocol.Plugins.GetPackageHashRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.GetPackageHashRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.GetPackageHashRequest.PackageVersion.get -> string
+NuGet.Protocol.Plugins.GetPackageHashRequest.GetPackageHashRequest(string! packageSourceRepository, string! packageId, string! packageVersion, string! hashAlgorithm) -> void
+NuGet.Protocol.Plugins.GetPackageHashRequest.HashAlgorithm.get -> string!
+NuGet.Protocol.Plugins.GetPackageHashRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.GetPackageHashRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.GetPackageHashRequest.PackageVersion.get -> string!
 NuGet.Protocol.Plugins.GetPackageHashResponse
 NuGet.Protocol.Plugins.GetPackageHashResponse.GetPackageHashResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string? hash) -> void
 NuGet.Protocol.Plugins.GetPackageHashResponse.Hash.get -> string?
 NuGet.Protocol.Plugins.GetPackageHashResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetPackageVersionsRequest
-~NuGet.Protocol.Plugins.GetPackageVersionsRequest.GetPackageVersionsRequest(string packageSourceRepository, string packageId) -> void
-~NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageSourceRepository.get -> string
+NuGet.Protocol.Plugins.GetPackageVersionsRequest.GetPackageVersionsRequest(string! packageSourceRepository, string! packageId) -> void
+NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.GetPackageVersionsResponse
 NuGet.Protocol.Plugins.GetPackageVersionsResponse.GetPackageVersionsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? versions) -> void
 NuGet.Protocol.Plugins.GetPackageVersionsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetPackageVersionsResponse.Versions.get -> System.Collections.Generic.IEnumerable<string!>?
 NuGet.Protocol.Plugins.GetServiceIndexRequest
-~NuGet.Protocol.Plugins.GetServiceIndexRequest.GetServiceIndexRequest(string packageSourceRepository) -> void
-~NuGet.Protocol.Plugins.GetServiceIndexRequest.PackageSourceRepository.get -> string
+NuGet.Protocol.Plugins.GetServiceIndexRequest.GetServiceIndexRequest(string! packageSourceRepository) -> void
+NuGet.Protocol.Plugins.GetServiceIndexRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.GetServiceIndexRequestHandler
 ~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository sourceRepository) -> void
 NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
@@ -1065,9 +1065,9 @@ NuGet.Protocol.Plugins.InboundRequestContext.Dispose() -> void
 ~NuGet.Protocol.Plugins.InboundRequestContext.InboundRequestContext(NuGet.Protocol.Plugins.IConnection connection, string requestId, System.Threading.CancellationToken cancellationToken) -> void
 ~NuGet.Protocol.Plugins.InboundRequestContext.RequestId.get -> string
 NuGet.Protocol.Plugins.InitializeRequest
-~NuGet.Protocol.Plugins.InitializeRequest.ClientVersion.get -> string
-~NuGet.Protocol.Plugins.InitializeRequest.Culture.get -> string
-~NuGet.Protocol.Plugins.InitializeRequest.InitializeRequest(string clientVersion, string culture, System.TimeSpan requestTimeout) -> void
+NuGet.Protocol.Plugins.InitializeRequest.ClientVersion.get -> string!
+NuGet.Protocol.Plugins.InitializeRequest.Culture.get -> string!
+NuGet.Protocol.Plugins.InitializeRequest.InitializeRequest(string! clientVersion, string! culture, System.TimeSpan requestTimeout) -> void
 NuGet.Protocol.Plugins.InitializeRequest.RequestTimeout.get -> System.TimeSpan
 NuGet.Protocol.Plugins.InitializeResponse
 NuGet.Protocol.Plugins.InitializeResponse.InitializeResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
@@ -1078,8 +1078,8 @@ NuGet.Protocol.Plugins.LineReadEventArgs.Line.get -> string?
 NuGet.Protocol.Plugins.LineReadEventArgs.LineReadEventArgs(string? line) -> void
 NuGet.Protocol.Plugins.LogRequest
 NuGet.Protocol.Plugins.LogRequest.LogLevel.get -> NuGet.Common.LogLevel
-~NuGet.Protocol.Plugins.LogRequest.LogRequest(NuGet.Common.LogLevel logLevel, string message) -> void
-~NuGet.Protocol.Plugins.LogRequest.Message.get -> string
+NuGet.Protocol.Plugins.LogRequest.LogRequest(NuGet.Common.LogLevel logLevel, string! message) -> void
+NuGet.Protocol.Plugins.LogRequest.Message.get -> string!
 NuGet.Protocol.Plugins.LogRequestHandler
 NuGet.Protocol.Plugins.LogRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
 ~NuGet.Protocol.Plugins.LogRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
@@ -1266,10 +1266,10 @@ NuGet.Protocol.Plugins.PluginProcess.PluginProcess() -> void
 ~NuGet.Protocol.Plugins.PluginProcess.PluginProcess(System.Diagnostics.ProcessStartInfo startInfo) -> void
 NuGet.Protocol.Plugins.PluginProcess.Start() -> void
 NuGet.Protocol.Plugins.PrefetchPackageRequest
-~NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageVersion.get -> string
-~NuGet.Protocol.Plugins.PrefetchPackageRequest.PrefetchPackageRequest(string packageSourceRepository, string packageId, string packageVersion) -> void
+NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageVersion.get -> string!
+NuGet.Protocol.Plugins.PrefetchPackageRequest.PrefetchPackageRequest(string! packageSourceRepository, string! packageId, string! packageVersion) -> void
 NuGet.Protocol.Plugins.PrefetchPackageResponse
 NuGet.Protocol.Plugins.PrefetchPackageResponse.PrefetchPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.PrefetchPackageResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -888,8 +888,8 @@ NuGet.Protocol.Plugins.CopyFilesInPackageRequest
 ~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageSourceRepository.get -> string
 ~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageVersion.get -> string
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse
-~NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopiedFiles.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopyFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> copiedFiles) -> void
+NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopiedFiles.get -> System.Collections.Generic.IEnumerable<string!>?
+NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopyFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? copiedFiles) -> void
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.CopyNupkgFileRequest
 ~NuGet.Protocol.Plugins.CopyNupkgFileRequest.CopyNupkgFileRequest(string packageSourceRepository, string packageId, string packageVersion, string destinationFilePath) -> void
@@ -914,13 +914,13 @@ NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.IsNonInteractive.get 
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.IsRetry.get -> bool
 ~NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.Uri.get -> System.Uri
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IList<string>
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.GetAuthenticationCredentialsResponse(string username, string password, string message, System.Collections.Generic.IList<string> authenticationTypes, NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IList<string!>?
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.GetAuthenticationCredentialsResponse(string? username, string? password, string? message, System.Collections.Generic.IList<string!>? authenticationTypes, NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.IsValid() -> bool
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Message.get -> string
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Password.get -> string
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Message.get -> string?
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Password.get -> string?
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Username.get -> string
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Username.get -> string?
 NuGet.Protocol.Plugins.GetCredentialsRequest
 ~NuGet.Protocol.Plugins.GetCredentialsRequest.GetCredentialsRequest(string packageSourceRepository, System.Net.HttpStatusCode statusCode) -> void
 ~NuGet.Protocol.Plugins.GetCredentialsRequest.PackageSourceRepository.get -> string
@@ -932,24 +932,24 @@ NuGet.Protocol.Plugins.GetCredentialsRequestHandler.Dispose() -> void
 ~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.GetCredentialsRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin, System.Net.IWebProxy proxy, NuGet.Configuration.ICredentialService credentialService) -> void
 ~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 NuGet.Protocol.Plugins.GetCredentialsResponse
-~NuGet.Protocol.Plugins.GetCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.Plugins.GetCredentialsResponse.GetCredentialsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string username, string password, System.Collections.Generic.IReadOnlyList<string> authenticationTypes = null) -> void
-~NuGet.Protocol.Plugins.GetCredentialsResponse.Password.get -> string
+NuGet.Protocol.Plugins.GetCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.Plugins.GetCredentialsResponse.GetCredentialsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string? username, string? password, System.Collections.Generic.IReadOnlyList<string!>? authenticationTypes = null) -> void
+NuGet.Protocol.Plugins.GetCredentialsResponse.Password.get -> string?
 NuGet.Protocol.Plugins.GetCredentialsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
-~NuGet.Protocol.Plugins.GetCredentialsResponse.Username.get -> string
+NuGet.Protocol.Plugins.GetCredentialsResponse.Username.get -> string?
 NuGet.Protocol.Plugins.GetFilesInPackageRequest
 ~NuGet.Protocol.Plugins.GetFilesInPackageRequest.GetFilesInPackageRequest(string packageSourceRepository, string packageId, string packageVersion) -> void
 ~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageId.get -> string
 ~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageSourceRepository.get -> string
 ~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageVersion.get -> string
 NuGet.Protocol.Plugins.GetFilesInPackageResponse
-~NuGet.Protocol.Plugins.GetFilesInPackageResponse.Files.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Plugins.GetFilesInPackageResponse.GetFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> files) -> void
+NuGet.Protocol.Plugins.GetFilesInPackageResponse.Files.get -> System.Collections.Generic.IEnumerable<string!>?
+NuGet.Protocol.Plugins.GetFilesInPackageResponse.GetFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? files) -> void
 NuGet.Protocol.Plugins.GetFilesInPackageResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetOperationClaimsRequest
-~NuGet.Protocol.Plugins.GetOperationClaimsRequest.GetOperationClaimsRequest(string packageSourceRepository, Newtonsoft.Json.Linq.JObject serviceIndex) -> void
-~NuGet.Protocol.Plugins.GetOperationClaimsRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.GetOperationClaimsRequest.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject
+NuGet.Protocol.Plugins.GetOperationClaimsRequest.GetOperationClaimsRequest(string? packageSourceRepository, Newtonsoft.Json.Linq.JObject? serviceIndex) -> void
+NuGet.Protocol.Plugins.GetOperationClaimsRequest.PackageSourceRepository.get -> string?
+NuGet.Protocol.Plugins.GetOperationClaimsRequest.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject?
 NuGet.Protocol.Plugins.GetOperationClaimsResponse
 ~NuGet.Protocol.Plugins.GetOperationClaimsResponse.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>
 ~NuGet.Protocol.Plugins.GetOperationClaimsResponse.GetOperationClaimsResponse(System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.OperationClaim> claims) -> void
@@ -960,17 +960,17 @@ NuGet.Protocol.Plugins.GetPackageHashRequest
 ~NuGet.Protocol.Plugins.GetPackageHashRequest.PackageSourceRepository.get -> string
 ~NuGet.Protocol.Plugins.GetPackageHashRequest.PackageVersion.get -> string
 NuGet.Protocol.Plugins.GetPackageHashResponse
-~NuGet.Protocol.Plugins.GetPackageHashResponse.GetPackageHashResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string hash) -> void
-~NuGet.Protocol.Plugins.GetPackageHashResponse.Hash.get -> string
+NuGet.Protocol.Plugins.GetPackageHashResponse.GetPackageHashResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string? hash) -> void
+NuGet.Protocol.Plugins.GetPackageHashResponse.Hash.get -> string?
 NuGet.Protocol.Plugins.GetPackageHashResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetPackageVersionsRequest
 ~NuGet.Protocol.Plugins.GetPackageVersionsRequest.GetPackageVersionsRequest(string packageSourceRepository, string packageId) -> void
 ~NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageId.get -> string
 ~NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageSourceRepository.get -> string
 NuGet.Protocol.Plugins.GetPackageVersionsResponse
-~NuGet.Protocol.Plugins.GetPackageVersionsResponse.GetPackageVersionsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> versions) -> void
+NuGet.Protocol.Plugins.GetPackageVersionsResponse.GetPackageVersionsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? versions) -> void
 NuGet.Protocol.Plugins.GetPackageVersionsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
-~NuGet.Protocol.Plugins.GetPackageVersionsResponse.Versions.get -> System.Collections.Generic.IEnumerable<string>
+NuGet.Protocol.Plugins.GetPackageVersionsResponse.Versions.get -> System.Collections.Generic.IEnumerable<string!>?
 NuGet.Protocol.Plugins.GetServiceIndexRequest
 ~NuGet.Protocol.Plugins.GetServiceIndexRequest.GetServiceIndexRequest(string packageSourceRepository) -> void
 ~NuGet.Protocol.Plugins.GetServiceIndexRequest.PackageSourceRepository.get -> string
@@ -981,16 +981,16 @@ NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.Dispose() -> void
 ~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.GetServiceIndexRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin) -> void
 ~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 NuGet.Protocol.Plugins.GetServiceIndexResponse
-~NuGet.Protocol.Plugins.GetServiceIndexResponse.GetServiceIndexResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, Newtonsoft.Json.Linq.JObject serviceIndex) -> void
+NuGet.Protocol.Plugins.GetServiceIndexResponse.GetServiceIndexResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, Newtonsoft.Json.Linq.JObject? serviceIndex) -> void
 NuGet.Protocol.Plugins.GetServiceIndexResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
-~NuGet.Protocol.Plugins.GetServiceIndexResponse.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject
+NuGet.Protocol.Plugins.GetServiceIndexResponse.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject?
 NuGet.Protocol.Plugins.HandshakeRequest
 ~NuGet.Protocol.Plugins.HandshakeRequest.HandshakeRequest(NuGet.Versioning.SemanticVersion protocolVersion, NuGet.Versioning.SemanticVersion minimumProtocolVersion) -> void
 ~NuGet.Protocol.Plugins.HandshakeRequest.MinimumProtocolVersion.get -> NuGet.Versioning.SemanticVersion
 ~NuGet.Protocol.Plugins.HandshakeRequest.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
 NuGet.Protocol.Plugins.HandshakeResponse
-~NuGet.Protocol.Plugins.HandshakeResponse.HandshakeResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, NuGet.Versioning.SemanticVersion protocolVersion) -> void
-~NuGet.Protocol.Plugins.HandshakeResponse.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
+NuGet.Protocol.Plugins.HandshakeResponse.HandshakeResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, NuGet.Versioning.SemanticVersion? protocolVersion) -> void
+NuGet.Protocol.Plugins.HandshakeResponse.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion?
 NuGet.Protocol.Plugins.HandshakeResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.IConnection
 NuGet.Protocol.Plugins.IConnection.Close() -> void
@@ -1089,10 +1089,10 @@ NuGet.Protocol.Plugins.LogResponse
 NuGet.Protocol.Plugins.LogResponse.LogResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.LogResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.Message.Message(string requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, Newtonsoft.Json.Linq.JObject payload = null) -> void
+NuGet.Protocol.Plugins.Message.Message(string! requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, Newtonsoft.Json.Linq.JObject? payload = null) -> void
 NuGet.Protocol.Plugins.Message.Method.get -> NuGet.Protocol.Plugins.MessageMethod
-~NuGet.Protocol.Plugins.Message.Payload.get -> Newtonsoft.Json.Linq.JObject
-~NuGet.Protocol.Plugins.Message.RequestId.get -> string
+NuGet.Protocol.Plugins.Message.Payload.get -> Newtonsoft.Json.Linq.JObject?
+NuGet.Protocol.Plugins.Message.RequestId.get -> string!
 NuGet.Protocol.Plugins.Message.Type.get -> NuGet.Protocol.Plugins.MessageType
 NuGet.Protocol.Plugins.MessageDispatcher
 NuGet.Protocol.Plugins.MessageDispatcher.Close() -> void
@@ -1313,12 +1313,12 @@ NuGet.Protocol.Plugins.Sender.Dispose() -> void
 ~NuGet.Protocol.Plugins.Sender.SendAsync(NuGet.Protocol.Plugins.Message message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 ~NuGet.Protocol.Plugins.Sender.Sender(System.IO.TextWriter writer) -> void
 NuGet.Protocol.Plugins.SetCredentialsRequest
-~NuGet.Protocol.Plugins.SetCredentialsRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.SetCredentialsRequest.Password.get -> string
-~NuGet.Protocol.Plugins.SetCredentialsRequest.ProxyPassword.get -> string
-~NuGet.Protocol.Plugins.SetCredentialsRequest.ProxyUsername.get -> string
-~NuGet.Protocol.Plugins.SetCredentialsRequest.SetCredentialsRequest(string packageSourceRepository, string proxyUsername, string proxyPassword, string username, string password) -> void
-~NuGet.Protocol.Plugins.SetCredentialsRequest.Username.get -> string
+NuGet.Protocol.Plugins.SetCredentialsRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.SetCredentialsRequest.Password.get -> string?
+NuGet.Protocol.Plugins.SetCredentialsRequest.ProxyPassword.get -> string?
+NuGet.Protocol.Plugins.SetCredentialsRequest.ProxyUsername.get -> string?
+NuGet.Protocol.Plugins.SetCredentialsRequest.SetCredentialsRequest(string! packageSourceRepository, string? proxyUsername, string? proxyPassword, string? username, string? password) -> void
+NuGet.Protocol.Plugins.SetCredentialsRequest.Username.get -> string?
 NuGet.Protocol.Plugins.SetCredentialsResponse
 NuGet.Protocol.Plugins.SetCredentialsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.SetCredentialsResponse.SetCredentialsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
@@ -2010,9 +2010,9 @@ static NuGet.Protocol.NullThrottle.Instance.get -> NuGet.Protocol.NullThrottle!
 ~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serializer.get -> Newtonsoft.Json.JsonSerializer
 ~static NuGet.Protocol.Plugins.JsonSerializationUtilities.ToObject<T>(Newtonsoft.Json.Linq.JObject jObject) -> T
 ~static NuGet.Protocol.Plugins.LogRequestHandler.GetLogLevel(NuGet.Common.ILogger logger) -> NuGet.Common.LogLevel
-~static NuGet.Protocol.Plugins.MessageUtilities.Create(string requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message
-~static NuGet.Protocol.Plugins.MessageUtilities.Create<TPayload>(string requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload payload) -> NuGet.Protocol.Plugins.Message
-~static NuGet.Protocol.Plugins.MessageUtilities.DeserializePayload<TPayload>(NuGet.Protocol.Plugins.Message message) -> TPayload
+static NuGet.Protocol.Plugins.MessageUtilities.Create(string! requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message!
+static NuGet.Protocol.Plugins.MessageUtilities.Create<TPayload>(string! requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload! payload) -> NuGet.Protocol.Plugins.Message!
+static NuGet.Protocol.Plugins.MessageUtilities.DeserializePayload<TPayload>(NuGet.Protocol.Plugins.Message! message) -> TPayload?
 ~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetConventionBasedPlugins(System.Collections.Generic.IEnumerable<string> directories) -> System.Collections.Generic.IEnumerable<string>
 ~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildDirectory(string msbuildDirectoryPath) -> string
 ~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetInternalPlugins() -> string

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -866,10 +866,10 @@ NuGet.Protocol.Plugins.Connection.MessageReceived -> System.EventHandler<NuGet.P
 ~NuGet.Protocol.Plugins.Connection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound>
 NuGet.Protocol.Plugins.Connection.State.get -> NuGet.Protocol.Plugins.ConnectionState
 NuGet.Protocol.Plugins.ConnectionOptions
-~NuGet.Protocol.Plugins.ConnectionOptions.ConnectionOptions(NuGet.Versioning.SemanticVersion protocolVersion, NuGet.Versioning.SemanticVersion minimumProtocolVersion, System.TimeSpan handshakeTimeout, System.TimeSpan requestTimeout) -> void
+NuGet.Protocol.Plugins.ConnectionOptions.ConnectionOptions(NuGet.Versioning.SemanticVersion! protocolVersion, NuGet.Versioning.SemanticVersion! minimumProtocolVersion, System.TimeSpan handshakeTimeout, System.TimeSpan requestTimeout) -> void
 NuGet.Protocol.Plugins.ConnectionOptions.HandshakeTimeout.get -> System.TimeSpan
-~NuGet.Protocol.Plugins.ConnectionOptions.MinimumProtocolVersion.get -> NuGet.Versioning.SemanticVersion
-~NuGet.Protocol.Plugins.ConnectionOptions.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
+NuGet.Protocol.Plugins.ConnectionOptions.MinimumProtocolVersion.get -> NuGet.Versioning.SemanticVersion!
+NuGet.Protocol.Plugins.ConnectionOptions.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion!
 NuGet.Protocol.Plugins.ConnectionOptions.RequestTimeout.get -> System.TimeSpan
 NuGet.Protocol.Plugins.ConnectionOptions.SetRequestTimeout(System.TimeSpan requestTimeout) -> void
 NuGet.Protocol.Plugins.ConnectionState
@@ -904,9 +904,9 @@ NuGet.Protocol.Plugins.Fault
 ~NuGet.Protocol.Plugins.Fault.Fault(string message) -> void
 ~NuGet.Protocol.Plugins.Fault.Message.get -> string
 NuGet.Protocol.Plugins.FaultedPluginEventArgs
-~NuGet.Protocol.Plugins.FaultedPluginEventArgs.Exception.get -> System.Exception
-~NuGet.Protocol.Plugins.FaultedPluginEventArgs.FaultedPluginEventArgs(NuGet.Protocol.Plugins.IPlugin plugin, System.Exception exception) -> void
-~NuGet.Protocol.Plugins.FaultedPluginEventArgs.Plugin.get -> NuGet.Protocol.Plugins.IPlugin
+NuGet.Protocol.Plugins.FaultedPluginEventArgs.Exception.get -> System.Exception!
+NuGet.Protocol.Plugins.FaultedPluginEventArgs.FaultedPluginEventArgs(NuGet.Protocol.Plugins.IPlugin! plugin, System.Exception! exception) -> void
+NuGet.Protocol.Plugins.FaultedPluginEventArgs.Plugin.get -> NuGet.Protocol.Plugins.IPlugin!
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.CanShowDialog.get -> bool
 ~NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.GetAuthenticationCredentialsRequest(System.Uri uri, bool isRetry, bool isNonInteractive, bool canShowDialog) -> void
@@ -994,69 +994,69 @@ NuGet.Protocol.Plugins.HandshakeResponse.ProtocolVersion.get -> NuGet.Versioning
 NuGet.Protocol.Plugins.HandshakeResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.IConnection
 NuGet.Protocol.Plugins.IConnection.Close() -> void
-NuGet.Protocol.Plugins.IConnection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs>
-~NuGet.Protocol.Plugins.IConnection.MessageDispatcher.get -> NuGet.Protocol.Plugins.IMessageDispatcher
-NuGet.Protocol.Plugins.IConnection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs>
-~NuGet.Protocol.Plugins.IConnection.Options.get -> NuGet.Protocol.Plugins.ConnectionOptions
-~NuGet.Protocol.Plugins.IConnection.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
-~NuGet.Protocol.Plugins.IConnection.SendAsync(NuGet.Protocol.Plugins.Message message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.IConnection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound>
+NuGet.Protocol.Plugins.IConnection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>!
+NuGet.Protocol.Plugins.IConnection.MessageDispatcher.get -> NuGet.Protocol.Plugins.IMessageDispatcher!
+NuGet.Protocol.Plugins.IConnection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>!
+NuGet.Protocol.Plugins.IConnection.Options.get -> NuGet.Protocol.Plugins.ConnectionOptions!
+NuGet.Protocol.Plugins.IConnection.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion?
+NuGet.Protocol.Plugins.IConnection.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.IConnection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound!>!
 NuGet.Protocol.Plugins.IIdGenerator
-~NuGet.Protocol.Plugins.IIdGenerator.GenerateUniqueId() -> string
+NuGet.Protocol.Plugins.IIdGenerator.GenerateUniqueId() -> string!
 NuGet.Protocol.Plugins.IMessageDispatcher
 NuGet.Protocol.Plugins.IMessageDispatcher.Close() -> void
-~NuGet.Protocol.Plugins.IMessageDispatcher.CreateMessage(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.IMessageDispatcher.CreateMessage<TPayload>(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload payload) -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.IMessageDispatcher.DispatchCancelAsync(NuGet.Protocol.Plugins.Message request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.IMessageDispatcher.DispatchFaultAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.Fault fault, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.IMessageDispatcher.DispatchProgressAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.Progress progress, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.IMessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound>
-~NuGet.Protocol.Plugins.IMessageDispatcher.DispatchResponseAsync<TOutbound>(NuGet.Protocol.Plugins.Message request, TOutbound responsePayload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.IMessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers
-~NuGet.Protocol.Plugins.IMessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection connection) -> void
+NuGet.Protocol.Plugins.IMessageDispatcher.CreateMessage(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message!
+NuGet.Protocol.Plugins.IMessageDispatcher.CreateMessage<TPayload>(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload! payload) -> NuGet.Protocol.Plugins.Message!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchCancelAsync(NuGet.Protocol.Plugins.Message! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchFaultAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Fault! fault, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchProgressAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Progress! progress, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound!>!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchResponseAsync<TOutbound>(NuGet.Protocol.Plugins.Message! request, TOutbound! responsePayload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.IMessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers!
+NuGet.Protocol.Plugins.IMessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection? connection) -> void
 NuGet.Protocol.Plugins.IPlugin
-NuGet.Protocol.Plugins.IPlugin.BeforeClose -> System.EventHandler
+NuGet.Protocol.Plugins.IPlugin.BeforeClose -> System.EventHandler!
 NuGet.Protocol.Plugins.IPlugin.Close() -> void
-NuGet.Protocol.Plugins.IPlugin.Closed -> System.EventHandler
-~NuGet.Protocol.Plugins.IPlugin.Connection.get -> NuGet.Protocol.Plugins.IConnection
-~NuGet.Protocol.Plugins.IPlugin.FilePath.get -> string
-~NuGet.Protocol.Plugins.IPlugin.Id.get -> string
-~NuGet.Protocol.Plugins.IPlugin.Name.get -> string
+NuGet.Protocol.Plugins.IPlugin.Closed -> System.EventHandler!
+NuGet.Protocol.Plugins.IPlugin.Connection.get -> NuGet.Protocol.Plugins.IConnection!
+NuGet.Protocol.Plugins.IPlugin.FilePath.get -> string!
+NuGet.Protocol.Plugins.IPlugin.Id.get -> string!
+NuGet.Protocol.Plugins.IPlugin.Name.get -> string!
 NuGet.Protocol.Plugins.IPluginDiscoverer
-~NuGet.Protocol.Plugins.IPluginDiscoverer.DiscoverAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult>>
+NuGet.Protocol.Plugins.IPluginDiscoverer.DiscoverAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult!>!>!
 NuGet.Protocol.Plugins.IPluginManager
-~NuGet.Protocol.Plugins.IPluginManager.CreatePluginsAsync(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginCreationResult>>
-~NuGet.Protocol.Plugins.IPluginManager.FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult>>
-~NuGet.Protocol.Plugins.IPluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult>>
+NuGet.Protocol.Plugins.IPluginManager.CreatePluginsAsync(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginCreationResult!>!>!
+NuGet.Protocol.Plugins.IPluginManager.FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult!>!>!
+NuGet.Protocol.Plugins.IPluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult! pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult!>!>!
 NuGet.Protocol.Plugins.IPluginMulticlientUtilities
-~NuGet.Protocol.Plugins.IPluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(string key, System.Func<System.Threading.Tasks.Task> taskFunc, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.IPluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(string! key, System.Func<System.Threading.Tasks.Task!>! taskFunc, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IPluginProcess
 NuGet.Protocol.Plugins.IPluginProcess.BeginReadLine() -> void
 NuGet.Protocol.Plugins.IPluginProcess.CancelRead() -> void
 NuGet.Protocol.Plugins.IPluginProcess.ExitCode.get -> int?
-NuGet.Protocol.Plugins.IPluginProcess.Exited -> System.EventHandler<NuGet.Protocol.Plugins.IPluginProcess>
+NuGet.Protocol.Plugins.IPluginProcess.Exited -> System.EventHandler<NuGet.Protocol.Plugins.IPluginProcess!>!
 NuGet.Protocol.Plugins.IPluginProcess.Id.get -> int?
 NuGet.Protocol.Plugins.IPluginProcess.Kill() -> void
-NuGet.Protocol.Plugins.IPluginProcess.LineRead -> System.EventHandler<NuGet.Protocol.Plugins.LineReadEventArgs>
+NuGet.Protocol.Plugins.IPluginProcess.LineRead -> System.EventHandler<NuGet.Protocol.Plugins.LineReadEventArgs!>!
 NuGet.Protocol.Plugins.IReceiver
 NuGet.Protocol.Plugins.IReceiver.Close() -> void
 NuGet.Protocol.Plugins.IReceiver.Connect() -> void
-NuGet.Protocol.Plugins.IReceiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs>
-NuGet.Protocol.Plugins.IReceiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs>
+NuGet.Protocol.Plugins.IReceiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>!
+NuGet.Protocol.Plugins.IReceiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>!
 NuGet.Protocol.Plugins.IRequestHandler
 NuGet.Protocol.Plugins.IRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
-~NuGet.Protocol.Plugins.IRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.IRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IRequestHandlers
-~NuGet.Protocol.Plugins.IRequestHandlers.AddOrUpdate(NuGet.Protocol.Plugins.MessageMethod method, System.Func<NuGet.Protocol.Plugins.IRequestHandler> addHandlerFunc, System.Func<NuGet.Protocol.Plugins.IRequestHandler, NuGet.Protocol.Plugins.IRequestHandler> updateHandlerFunc) -> void
-~NuGet.Protocol.Plugins.IRequestHandlers.TryAdd(NuGet.Protocol.Plugins.MessageMethod method, NuGet.Protocol.Plugins.IRequestHandler handler) -> bool
-~NuGet.Protocol.Plugins.IRequestHandlers.TryGet(NuGet.Protocol.Plugins.MessageMethod method, out NuGet.Protocol.Plugins.IRequestHandler handler) -> bool
+NuGet.Protocol.Plugins.IRequestHandlers.AddOrUpdate(NuGet.Protocol.Plugins.MessageMethod method, System.Func<NuGet.Protocol.Plugins.IRequestHandler!>! addHandlerFunc, System.Func<NuGet.Protocol.Plugins.IRequestHandler!, NuGet.Protocol.Plugins.IRequestHandler!>! updateHandlerFunc) -> void
+NuGet.Protocol.Plugins.IRequestHandlers.TryAdd(NuGet.Protocol.Plugins.MessageMethod method, NuGet.Protocol.Plugins.IRequestHandler! handler) -> bool
+NuGet.Protocol.Plugins.IRequestHandlers.TryGet(NuGet.Protocol.Plugins.MessageMethod method, out NuGet.Protocol.Plugins.IRequestHandler? handler) -> bool
 NuGet.Protocol.Plugins.IRequestHandlers.TryRemove(NuGet.Protocol.Plugins.MessageMethod method) -> bool
 NuGet.Protocol.Plugins.IResponseHandler
-~NuGet.Protocol.Plugins.IResponseHandler.SendResponseAsync<TPayload>(NuGet.Protocol.Plugins.Message request, TPayload payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.IResponseHandler.SendResponseAsync<TPayload>(NuGet.Protocol.Plugins.Message! request, TPayload! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.ISender
 NuGet.Protocol.Plugins.ISender.Close() -> void
 NuGet.Protocol.Plugins.ISender.Connect() -> void
-~NuGet.Protocol.Plugins.ISender.SendAsync(NuGet.Protocol.Plugins.Message message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.ISender.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.InboundRequestContext
 ~NuGet.Protocol.Plugins.InboundRequestContext.BeginFaultAsync(NuGet.Protocol.Plugins.Message request, System.Exception exception) -> void
 ~NuGet.Protocol.Plugins.InboundRequestContext.BeginResponseAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IRequestHandler requestHandler, NuGet.Protocol.Plugins.IResponseHandler responseHandler) -> void
@@ -1074,8 +1074,8 @@ NuGet.Protocol.Plugins.InitializeResponse.InitializeResponse(NuGet.Protocol.Plug
 NuGet.Protocol.Plugins.InitializeResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.JsonSerializationUtilities
 NuGet.Protocol.Plugins.LineReadEventArgs
-~NuGet.Protocol.Plugins.LineReadEventArgs.Line.get -> string
-~NuGet.Protocol.Plugins.LineReadEventArgs.LineReadEventArgs(string line) -> void
+NuGet.Protocol.Plugins.LineReadEventArgs.Line.get -> string?
+NuGet.Protocol.Plugins.LineReadEventArgs.LineReadEventArgs(string? line) -> void
 NuGet.Protocol.Plugins.LogRequest
 NuGet.Protocol.Plugins.LogRequest.LogLevel.get -> NuGet.Common.LogLevel
 ~NuGet.Protocol.Plugins.LogRequest.LogRequest(NuGet.Common.LogLevel logLevel, string message) -> void
@@ -1108,8 +1108,8 @@ NuGet.Protocol.Plugins.MessageDispatcher.Dispose() -> void
 ~NuGet.Protocol.Plugins.MessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers
 ~NuGet.Protocol.Plugins.MessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection connection) -> void
 NuGet.Protocol.Plugins.MessageEventArgs
-~NuGet.Protocol.Plugins.MessageEventArgs.Message.get -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.MessageEventArgs.MessageEventArgs(NuGet.Protocol.Plugins.Message message) -> void
+NuGet.Protocol.Plugins.MessageEventArgs.Message.get -> NuGet.Protocol.Plugins.Message!
+NuGet.Protocol.Plugins.MessageEventArgs.MessageEventArgs(NuGet.Protocol.Plugins.Message! message) -> void
 NuGet.Protocol.Plugins.MessageMethod
 NuGet.Protocol.Plugins.MessageMethod.Close = 1 -> NuGet.Protocol.Plugins.MessageMethod
 NuGet.Protocol.Plugins.MessageMethod.CopyFilesInPackage = 2 -> NuGet.Protocol.Plugins.MessageMethod
@@ -1189,42 +1189,42 @@ NuGet.Protocol.Plugins.Plugin.Idle -> System.EventHandler<NuGet.Protocol.Plugins
 ~NuGet.Protocol.Plugins.Plugin.Plugin(string filePath, NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.IPluginProcess process, bool isOwnProcess, System.TimeSpan idleTimeout) -> void
 NuGet.Protocol.Plugins.PluginCacheEntry
 NuGet.Protocol.Plugins.PluginCacheEntry.LoadFromFile() -> void
-~NuGet.Protocol.Plugins.PluginCacheEntry.OperationClaims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>
-~NuGet.Protocol.Plugins.PluginCacheEntry.OperationClaims.set -> void
-~NuGet.Protocol.Plugins.PluginCacheEntry.PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey) -> void
-~NuGet.Protocol.Plugins.PluginCacheEntry.UpdateCacheFileAsync() -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.PluginCacheEntry.OperationClaims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>?
+NuGet.Protocol.Plugins.PluginCacheEntry.OperationClaims.set -> void
+NuGet.Protocol.Plugins.PluginCacheEntry.PluginCacheEntry(string! rootCacheFolder, string! pluginFilePath, string! requestKey) -> void
+NuGet.Protocol.Plugins.PluginCacheEntry.UpdateCacheFileAsync() -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.PluginConstants
 NuGet.Protocol.Plugins.PluginCreationResult
-~NuGet.Protocol.Plugins.PluginCreationResult.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>
-~NuGet.Protocol.Plugins.PluginCreationResult.Exception.get -> System.Exception
-~NuGet.Protocol.Plugins.PluginCreationResult.Message.get -> string
-~NuGet.Protocol.Plugins.PluginCreationResult.Plugin.get -> NuGet.Protocol.Plugins.IPlugin
-~NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(NuGet.Protocol.Plugins.IPlugin plugin, NuGet.Protocol.Plugins.IPluginMulticlientUtilities utilities, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim> claims) -> void
-~NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string message) -> void
-~NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string message, System.Exception exception) -> void
-~NuGet.Protocol.Plugins.PluginCreationResult.PluginMulticlientUtilities.get -> NuGet.Protocol.Plugins.IPluginMulticlientUtilities
+NuGet.Protocol.Plugins.PluginCreationResult.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>?
+NuGet.Protocol.Plugins.PluginCreationResult.Exception.get -> System.Exception?
+NuGet.Protocol.Plugins.PluginCreationResult.Message.get -> string?
+NuGet.Protocol.Plugins.PluginCreationResult.Plugin.get -> NuGet.Protocol.Plugins.IPlugin?
+NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(NuGet.Protocol.Plugins.IPlugin! plugin, NuGet.Protocol.Plugins.IPluginMulticlientUtilities! utilities, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>! claims) -> void
+NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string! message) -> void
+NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string! message, System.Exception! exception) -> void
+NuGet.Protocol.Plugins.PluginCreationResult.PluginMulticlientUtilities.get -> NuGet.Protocol.Plugins.IPluginMulticlientUtilities?
 NuGet.Protocol.Plugins.PluginDiscoverer
 ~NuGet.Protocol.Plugins.PluginDiscoverer.DiscoverAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult>>
 NuGet.Protocol.Plugins.PluginDiscoverer.Dispose() -> void
 NuGet.Protocol.Plugins.PluginDiscoverer.PluginDiscoverer() -> void
 NuGet.Protocol.Plugins.PluginDiscoveryResult
-~NuGet.Protocol.Plugins.PluginDiscoveryResult.Message.get -> string
-~NuGet.Protocol.Plugins.PluginDiscoveryResult.PluginDiscoveryResult(NuGet.Protocol.Plugins.PluginFile pluginFile) -> void
-~NuGet.Protocol.Plugins.PluginDiscoveryResult.PluginFile.get -> NuGet.Protocol.Plugins.PluginFile
+NuGet.Protocol.Plugins.PluginDiscoveryResult.Message.get -> string?
+NuGet.Protocol.Plugins.PluginDiscoveryResult.PluginDiscoveryResult(NuGet.Protocol.Plugins.PluginFile! pluginFile) -> void
+NuGet.Protocol.Plugins.PluginDiscoveryResult.PluginFile.get -> NuGet.Protocol.Plugins.PluginFile!
 NuGet.Protocol.Plugins.PluginDiscoveryUtility
 NuGet.Protocol.Plugins.PluginEventArgs
-~NuGet.Protocol.Plugins.PluginEventArgs.Plugin.get -> NuGet.Protocol.Plugins.IPlugin
-~NuGet.Protocol.Plugins.PluginEventArgs.PluginEventArgs(NuGet.Protocol.Plugins.IPlugin plugin) -> void
+NuGet.Protocol.Plugins.PluginEventArgs.Plugin.get -> NuGet.Protocol.Plugins.IPlugin!
+NuGet.Protocol.Plugins.PluginEventArgs.PluginEventArgs(NuGet.Protocol.Plugins.IPlugin! plugin) -> void
 NuGet.Protocol.Plugins.PluginException
-~NuGet.Protocol.Plugins.PluginException.PluginException(string message) -> void
-~NuGet.Protocol.Plugins.PluginException.PluginException(string message, System.Exception innerException) -> void
+NuGet.Protocol.Plugins.PluginException.PluginException(string? message) -> void
+NuGet.Protocol.Plugins.PluginException.PluginException(string? message, System.Exception? innerException) -> void
 NuGet.Protocol.Plugins.PluginFactory
 NuGet.Protocol.Plugins.PluginFactory.PluginFactory(System.TimeSpan pluginIdleTimeout) -> void
 NuGet.Protocol.Plugins.PluginFile
-~NuGet.Protocol.Plugins.PluginFile.Path.get -> string
-~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state) -> void
-~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state, bool requiresDotnetHost) -> void
-~NuGet.Protocol.Plugins.PluginFile.State.get -> System.Lazy<NuGet.Protocol.Plugins.PluginFileState>
+NuGet.Protocol.Plugins.PluginFile.Path.get -> string!
+NuGet.Protocol.Plugins.PluginFile.PluginFile(string! filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState>! state) -> void
+NuGet.Protocol.Plugins.PluginFile.PluginFile(string! filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState>! state, bool requiresDotnetHost) -> void
+NuGet.Protocol.Plugins.PluginFile.State.get -> System.Lazy<NuGet.Protocol.Plugins.PluginFileState>!
 NuGet.Protocol.Plugins.PluginFileState
 NuGet.Protocol.Plugins.PluginFileState.InvalidEmbeddedSignature = 3 -> NuGet.Protocol.Plugins.PluginFileState
 NuGet.Protocol.Plugins.PluginFileState.InvalidFilePath = 2 -> NuGet.Protocol.Plugins.PluginFileState
@@ -1278,13 +1278,13 @@ NuGet.Protocol.Plugins.Progress.Percentage.get -> double?
 NuGet.Protocol.Plugins.Progress.Progress(double? percentage = null) -> void
 NuGet.Protocol.Plugins.ProtocolConstants
 NuGet.Protocol.Plugins.ProtocolErrorEventArgs
-~NuGet.Protocol.Plugins.ProtocolErrorEventArgs.Exception.get -> System.Exception
-~NuGet.Protocol.Plugins.ProtocolErrorEventArgs.Message.get -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.ProtocolErrorEventArgs.ProtocolErrorEventArgs(System.Exception exception) -> void
-~NuGet.Protocol.Plugins.ProtocolErrorEventArgs.ProtocolErrorEventArgs(System.Exception exception, NuGet.Protocol.Plugins.Message message) -> void
+NuGet.Protocol.Plugins.ProtocolErrorEventArgs.Exception.get -> System.Exception!
+NuGet.Protocol.Plugins.ProtocolErrorEventArgs.Message.get -> NuGet.Protocol.Plugins.Message?
+NuGet.Protocol.Plugins.ProtocolErrorEventArgs.ProtocolErrorEventArgs(System.Exception! exception) -> void
+NuGet.Protocol.Plugins.ProtocolErrorEventArgs.ProtocolErrorEventArgs(System.Exception! exception, NuGet.Protocol.Plugins.Message! message) -> void
 NuGet.Protocol.Plugins.ProtocolException
-~NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string message) -> void
-~NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string message, System.Exception innerException) -> void
+NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string? message) -> void
+NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string? message, System.Exception? innerException) -> void
 NuGet.Protocol.Plugins.Receiver
 NuGet.Protocol.Plugins.Receiver.Dispose() -> void
 NuGet.Protocol.Plugins.Receiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs>
@@ -1789,7 +1789,7 @@ override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleCancelResp
 ~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleFault(NuGet.Protocol.Plugins.Message fault) -> void
 ~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleProgress(NuGet.Protocol.Plugins.Message progress) -> void
 ~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleResponse(NuGet.Protocol.Plugins.Message response) -> void
-~override NuGet.Protocol.Plugins.PluginFile.ToString() -> string
+override NuGet.Protocol.Plugins.PluginFile.ToString() -> string!
 ~override NuGet.Protocol.Plugins.PluginPackageReader.CanVerifySignedPackages(NuGet.Packaging.Signing.SignedPackageVerifierSettings verifierSettings) -> bool
 ~override NuGet.Protocol.Plugins.PluginPackageReader.CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate extractFile, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<string>
 ~override NuGet.Protocol.Plugins.PluginPackageReader.CopyFilesAsync(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate extractFile, NuGet.Common.ILogger logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
@@ -2003,7 +2003,7 @@ static NuGet.Protocol.LocalFolderUtility.ResolvePackageFromPath(string! packageP
 static NuGet.Protocol.NullThrottle.Instance.get -> NuGet.Protocol.NullThrottle!
 ~static NuGet.Protocol.PackageDetailsUriResourceV3.CreateOrNull(string uriTemplate) -> NuGet.Protocol.PackageDetailsUriResourceV3
 ~static NuGet.Protocol.Plugins.AutomaticProgressReporter.Create(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Plugins.AutomaticProgressReporter
-~static NuGet.Protocol.Plugins.ConnectionOptions.CreateDefault(NuGet.Common.IEnvironmentVariableReader reader = null) -> NuGet.Protocol.Plugins.ConnectionOptions
+static NuGet.Protocol.Plugins.ConnectionOptions.CreateDefault(NuGet.Common.IEnvironmentVariableReader? reader = null) -> NuGet.Protocol.Plugins.ConnectionOptions!
 ~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Deserialize<T>(string json) -> T
 ~static NuGet.Protocol.Plugins.JsonSerializationUtilities.FromObject(object value) -> Newtonsoft.Json.Linq.JObject
 ~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serialize(Newtonsoft.Json.JsonWriter writer, object value) -> void
@@ -2022,7 +2022,7 @@ static NuGet.Protocol.Plugins.MessageUtilities.DeserializePayload<TPayload>(NuGe
 ~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot.set -> void
 ~static NuGet.Protocol.Plugins.PluginFactory.CreateFromCurrentProcessAsync(NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>
 ~static NuGet.Protocol.Plugins.PluginManager.Instance.get -> NuGet.Protocol.Plugins.IPluginManager
-~static NuGet.Protocol.Plugins.TimeoutUtilities.GetTimeout(string timeoutInSeconds, System.TimeSpan fallbackTimeout) -> System.TimeSpan
+static NuGet.Protocol.Plugins.TimeoutUtilities.GetTimeout(string? timeoutInSeconds, System.TimeSpan fallbackTimeout) -> System.TimeSpan
 static NuGet.Protocol.Plugins.TimeoutUtilities.IsValid(System.TimeSpan timeout) -> bool
 static NuGet.Protocol.RegistrationUtility.CreateVersionRange(string! stringToParse) -> NuGet.Versioning.VersionRange!
 static NuGet.Protocol.RegistrationUtility.LoadRanges(NuGet.Protocol.HttpSource! httpSource, System.Uri! registrationUri, string! packageId, NuGet.Versioning.VersionRange! range, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject?>!>!
@@ -2047,15 +2047,15 @@ static readonly NuGet.Protocol.HttpSourceRequest.DefaultRequestTimeout -> System
 static readonly NuGet.Protocol.JsonExtensions.ObjectSerializationSettings -> Newtonsoft.Json.JsonSerializerSettings!
 static readonly NuGet.Protocol.Plugins.PluginConstants.CloseTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.PluginConstants.IdleTimeout -> System.TimeSpan
-~static readonly NuGet.Protocol.Plugins.PluginConstants.PluginArguments -> System.Collections.Generic.IEnumerable<string>
+static readonly NuGet.Protocol.Plugins.PluginConstants.PluginArguments -> System.Collections.Generic.IEnumerable<string!>!
 static readonly NuGet.Protocol.Plugins.PluginConstants.ProgressInterval -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.PluginConstants.RequestTimeout -> System.TimeSpan
-~static readonly NuGet.Protocol.Plugins.ProtocolConstants.CurrentVersion -> NuGet.Versioning.SemanticVersion
+static readonly NuGet.Protocol.Plugins.ProtocolConstants.CurrentVersion -> NuGet.Versioning.SemanticVersion!
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.HandshakeTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.MaxTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.MinTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.RequestTimeout -> System.TimeSpan
-~static readonly NuGet.Protocol.Plugins.ProtocolConstants.Version100 -> NuGet.Versioning.SemanticVersion
+static readonly NuGet.Protocol.Plugins.ProtocolConstants.Version100 -> NuGet.Versioning.SemanticVersion!
 static readonly NuGet.Protocol.ProtocolConstants.ApiKeyHeader -> string!
 static readonly NuGet.Protocol.ProtocolConstants.ServerWarningHeader -> string!
 static readonly NuGet.Protocol.ProtocolConstants.SessionId -> string!

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -7,4 +7,4 @@ NuGet.Protocol.Plugins.GetOperationClaimsRequest.GetOperationClaimsRequest(strin
 NuGet.Protocol.Plugins.GetOperationClaimsRequest.ServiceIndexJson.get -> string?
 NuGet.Protocol.Plugins.GetServiceIndexResponse.GetServiceIndexResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string? serviceIndexJson) -> void
 NuGet.Protocol.Plugins.GetServiceIndexResponse.ServiceIndexJson.get -> string?
-~static NuGet.Protocol.Plugins.MessageUtilities.SerializePayload(NuGet.Protocol.Plugins.Message message) -> string
+static NuGet.Protocol.Plugins.MessageUtilities.SerializePayload(NuGet.Protocol.Plugins.Message! message) -> string?

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -881,38 +881,38 @@ NuGet.Protocol.Plugins.ConnectionState.FailedToHandshake = 0 -> NuGet.Protocol.P
 NuGet.Protocol.Plugins.ConnectionState.Handshaking = 5 -> NuGet.Protocol.Plugins.ConnectionState
 NuGet.Protocol.Plugins.ConnectionState.ReadyToConnect = 3 -> NuGet.Protocol.Plugins.ConnectionState
 NuGet.Protocol.Plugins.CopyFilesInPackageRequest
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.CopyFilesInPackageRequest(string packageSourceRepository, string packageId, string packageVersion, System.Collections.Generic.IEnumerable<string> filesInPackage, string destinationFolderPath) -> void
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.DestinationFolderPath.get -> string
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.FilesInPackage.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageVersion.get -> string
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.CopyFilesInPackageRequest(string! packageSourceRepository, string! packageId, string! packageVersion, System.Collections.Generic.IEnumerable<string!>! filesInPackage, string! destinationFolderPath) -> void
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.DestinationFolderPath.get -> string!
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.FilesInPackage.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageVersion.get -> string!
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopiedFiles.get -> System.Collections.Generic.IEnumerable<string!>?
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopyFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? copiedFiles) -> void
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.CopyNupkgFileRequest
-~NuGet.Protocol.Plugins.CopyNupkgFileRequest.CopyNupkgFileRequest(string packageSourceRepository, string packageId, string packageVersion, string destinationFilePath) -> void
-~NuGet.Protocol.Plugins.CopyNupkgFileRequest.DestinationFilePath.get -> string
-~NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageVersion.get -> string
+NuGet.Protocol.Plugins.CopyNupkgFileRequest.CopyNupkgFileRequest(string! packageSourceRepository, string! packageId, string! packageVersion, string! destinationFilePath) -> void
+NuGet.Protocol.Plugins.CopyNupkgFileRequest.DestinationFilePath.get -> string!
+NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.CopyNupkgFileRequest.PackageVersion.get -> string!
 NuGet.Protocol.Plugins.CopyNupkgFileResponse
 NuGet.Protocol.Plugins.CopyNupkgFileResponse.CopyNupkgFileResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.CopyNupkgFileResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.Fault
-~NuGet.Protocol.Plugins.Fault.Fault(string message) -> void
-~NuGet.Protocol.Plugins.Fault.Message.get -> string
+NuGet.Protocol.Plugins.Fault.Fault(string! message) -> void
+NuGet.Protocol.Plugins.Fault.Message.get -> string!
 NuGet.Protocol.Plugins.FaultedPluginEventArgs
 NuGet.Protocol.Plugins.FaultedPluginEventArgs.Exception.get -> System.Exception!
 NuGet.Protocol.Plugins.FaultedPluginEventArgs.FaultedPluginEventArgs(NuGet.Protocol.Plugins.IPlugin! plugin, System.Exception! exception) -> void
 NuGet.Protocol.Plugins.FaultedPluginEventArgs.Plugin.get -> NuGet.Protocol.Plugins.IPlugin!
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.CanShowDialog.get -> bool
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.GetAuthenticationCredentialsRequest(System.Uri uri, bool isRetry, bool isNonInteractive, bool canShowDialog) -> void
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.GetAuthenticationCredentialsRequest(System.Uri! uri, bool isRetry, bool isNonInteractive, bool canShowDialog) -> void
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.IsNonInteractive.get -> bool
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.IsRetry.get -> bool
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.Uri.get -> System.Uri
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.Uri.get -> System.Uri!
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IList<string!>?
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.GetAuthenticationCredentialsResponse(string? username, string? password, string? message, System.Collections.Generic.IList<string!>? authenticationTypes, NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
@@ -922,8 +922,8 @@ NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Password.get -> stri
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Username.get -> string?
 NuGet.Protocol.Plugins.GetCredentialsRequest
-~NuGet.Protocol.Plugins.GetCredentialsRequest.GetCredentialsRequest(string packageSourceRepository, System.Net.HttpStatusCode statusCode) -> void
-~NuGet.Protocol.Plugins.GetCredentialsRequest.PackageSourceRepository.get -> string
+NuGet.Protocol.Plugins.GetCredentialsRequest.GetCredentialsRequest(string! packageSourceRepository, System.Net.HttpStatusCode statusCode) -> void
+NuGet.Protocol.Plugins.GetCredentialsRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.GetCredentialsRequest.StatusCode.get -> System.Net.HttpStatusCode
 NuGet.Protocol.Plugins.GetCredentialsRequestHandler
 ~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository sourceRepository) -> void
@@ -938,10 +938,10 @@ NuGet.Protocol.Plugins.GetCredentialsResponse.Password.get -> string?
 NuGet.Protocol.Plugins.GetCredentialsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetCredentialsResponse.Username.get -> string?
 NuGet.Protocol.Plugins.GetFilesInPackageRequest
-~NuGet.Protocol.Plugins.GetFilesInPackageRequest.GetFilesInPackageRequest(string packageSourceRepository, string packageId, string packageVersion) -> void
-~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageVersion.get -> string
+NuGet.Protocol.Plugins.GetFilesInPackageRequest.GetFilesInPackageRequest(string! packageSourceRepository, string! packageId, string! packageVersion) -> void
+NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageVersion.get -> string!
 NuGet.Protocol.Plugins.GetFilesInPackageResponse
 NuGet.Protocol.Plugins.GetFilesInPackageResponse.Files.get -> System.Collections.Generic.IEnumerable<string!>?
 NuGet.Protocol.Plugins.GetFilesInPackageResponse.GetFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? files) -> void
@@ -954,26 +954,26 @@ NuGet.Protocol.Plugins.GetOperationClaimsResponse
 ~NuGet.Protocol.Plugins.GetOperationClaimsResponse.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>
 ~NuGet.Protocol.Plugins.GetOperationClaimsResponse.GetOperationClaimsResponse(System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.OperationClaim> claims) -> void
 NuGet.Protocol.Plugins.GetPackageHashRequest
-~NuGet.Protocol.Plugins.GetPackageHashRequest.GetPackageHashRequest(string packageSourceRepository, string packageId, string packageVersion, string hashAlgorithm) -> void
-~NuGet.Protocol.Plugins.GetPackageHashRequest.HashAlgorithm.get -> string
-~NuGet.Protocol.Plugins.GetPackageHashRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.GetPackageHashRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.GetPackageHashRequest.PackageVersion.get -> string
+NuGet.Protocol.Plugins.GetPackageHashRequest.GetPackageHashRequest(string! packageSourceRepository, string! packageId, string! packageVersion, string! hashAlgorithm) -> void
+NuGet.Protocol.Plugins.GetPackageHashRequest.HashAlgorithm.get -> string!
+NuGet.Protocol.Plugins.GetPackageHashRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.GetPackageHashRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.GetPackageHashRequest.PackageVersion.get -> string!
 NuGet.Protocol.Plugins.GetPackageHashResponse
 NuGet.Protocol.Plugins.GetPackageHashResponse.GetPackageHashResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string? hash) -> void
 NuGet.Protocol.Plugins.GetPackageHashResponse.Hash.get -> string?
 NuGet.Protocol.Plugins.GetPackageHashResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetPackageVersionsRequest
-~NuGet.Protocol.Plugins.GetPackageVersionsRequest.GetPackageVersionsRequest(string packageSourceRepository, string packageId) -> void
-~NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageSourceRepository.get -> string
+NuGet.Protocol.Plugins.GetPackageVersionsRequest.GetPackageVersionsRequest(string! packageSourceRepository, string! packageId) -> void
+NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.GetPackageVersionsResponse
 NuGet.Protocol.Plugins.GetPackageVersionsResponse.GetPackageVersionsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? versions) -> void
 NuGet.Protocol.Plugins.GetPackageVersionsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetPackageVersionsResponse.Versions.get -> System.Collections.Generic.IEnumerable<string!>?
 NuGet.Protocol.Plugins.GetServiceIndexRequest
-~NuGet.Protocol.Plugins.GetServiceIndexRequest.GetServiceIndexRequest(string packageSourceRepository) -> void
-~NuGet.Protocol.Plugins.GetServiceIndexRequest.PackageSourceRepository.get -> string
+NuGet.Protocol.Plugins.GetServiceIndexRequest.GetServiceIndexRequest(string! packageSourceRepository) -> void
+NuGet.Protocol.Plugins.GetServiceIndexRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.GetServiceIndexRequestHandler
 ~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository sourceRepository) -> void
 NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
@@ -1065,9 +1065,9 @@ NuGet.Protocol.Plugins.InboundRequestContext.Dispose() -> void
 ~NuGet.Protocol.Plugins.InboundRequestContext.InboundRequestContext(NuGet.Protocol.Plugins.IConnection connection, string requestId, System.Threading.CancellationToken cancellationToken) -> void
 ~NuGet.Protocol.Plugins.InboundRequestContext.RequestId.get -> string
 NuGet.Protocol.Plugins.InitializeRequest
-~NuGet.Protocol.Plugins.InitializeRequest.ClientVersion.get -> string
-~NuGet.Protocol.Plugins.InitializeRequest.Culture.get -> string
-~NuGet.Protocol.Plugins.InitializeRequest.InitializeRequest(string clientVersion, string culture, System.TimeSpan requestTimeout) -> void
+NuGet.Protocol.Plugins.InitializeRequest.ClientVersion.get -> string!
+NuGet.Protocol.Plugins.InitializeRequest.Culture.get -> string!
+NuGet.Protocol.Plugins.InitializeRequest.InitializeRequest(string! clientVersion, string! culture, System.TimeSpan requestTimeout) -> void
 NuGet.Protocol.Plugins.InitializeRequest.RequestTimeout.get -> System.TimeSpan
 NuGet.Protocol.Plugins.InitializeResponse
 NuGet.Protocol.Plugins.InitializeResponse.InitializeResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
@@ -1078,8 +1078,8 @@ NuGet.Protocol.Plugins.LineReadEventArgs.Line.get -> string?
 NuGet.Protocol.Plugins.LineReadEventArgs.LineReadEventArgs(string? line) -> void
 NuGet.Protocol.Plugins.LogRequest
 NuGet.Protocol.Plugins.LogRequest.LogLevel.get -> NuGet.Common.LogLevel
-~NuGet.Protocol.Plugins.LogRequest.LogRequest(NuGet.Common.LogLevel logLevel, string message) -> void
-~NuGet.Protocol.Plugins.LogRequest.Message.get -> string
+NuGet.Protocol.Plugins.LogRequest.LogRequest(NuGet.Common.LogLevel logLevel, string! message) -> void
+NuGet.Protocol.Plugins.LogRequest.Message.get -> string!
 NuGet.Protocol.Plugins.LogRequestHandler
 NuGet.Protocol.Plugins.LogRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
 ~NuGet.Protocol.Plugins.LogRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
@@ -1266,10 +1266,10 @@ NuGet.Protocol.Plugins.PluginProcess.PluginProcess() -> void
 ~NuGet.Protocol.Plugins.PluginProcess.PluginProcess(System.Diagnostics.ProcessStartInfo startInfo) -> void
 NuGet.Protocol.Plugins.PluginProcess.Start() -> void
 NuGet.Protocol.Plugins.PrefetchPackageRequest
-~NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageId.get -> string
-~NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageVersion.get -> string
-~NuGet.Protocol.Plugins.PrefetchPackageRequest.PrefetchPackageRequest(string packageSourceRepository, string packageId, string packageVersion) -> void
+NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageId.get -> string!
+NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageVersion.get -> string!
+NuGet.Protocol.Plugins.PrefetchPackageRequest.PrefetchPackageRequest(string! packageSourceRepository, string! packageId, string! packageVersion) -> void
 NuGet.Protocol.Plugins.PrefetchPackageResponse
 NuGet.Protocol.Plugins.PrefetchPackageResponse.PrefetchPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.PrefetchPackageResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -866,10 +866,10 @@ NuGet.Protocol.Plugins.Connection.MessageReceived -> System.EventHandler<NuGet.P
 ~NuGet.Protocol.Plugins.Connection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound>
 NuGet.Protocol.Plugins.Connection.State.get -> NuGet.Protocol.Plugins.ConnectionState
 NuGet.Protocol.Plugins.ConnectionOptions
-~NuGet.Protocol.Plugins.ConnectionOptions.ConnectionOptions(NuGet.Versioning.SemanticVersion protocolVersion, NuGet.Versioning.SemanticVersion minimumProtocolVersion, System.TimeSpan handshakeTimeout, System.TimeSpan requestTimeout) -> void
+NuGet.Protocol.Plugins.ConnectionOptions.ConnectionOptions(NuGet.Versioning.SemanticVersion! protocolVersion, NuGet.Versioning.SemanticVersion! minimumProtocolVersion, System.TimeSpan handshakeTimeout, System.TimeSpan requestTimeout) -> void
 NuGet.Protocol.Plugins.ConnectionOptions.HandshakeTimeout.get -> System.TimeSpan
-~NuGet.Protocol.Plugins.ConnectionOptions.MinimumProtocolVersion.get -> NuGet.Versioning.SemanticVersion
-~NuGet.Protocol.Plugins.ConnectionOptions.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
+NuGet.Protocol.Plugins.ConnectionOptions.MinimumProtocolVersion.get -> NuGet.Versioning.SemanticVersion!
+NuGet.Protocol.Plugins.ConnectionOptions.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion!
 NuGet.Protocol.Plugins.ConnectionOptions.RequestTimeout.get -> System.TimeSpan
 NuGet.Protocol.Plugins.ConnectionOptions.SetRequestTimeout(System.TimeSpan requestTimeout) -> void
 NuGet.Protocol.Plugins.ConnectionState
@@ -904,9 +904,9 @@ NuGet.Protocol.Plugins.Fault
 ~NuGet.Protocol.Plugins.Fault.Fault(string message) -> void
 ~NuGet.Protocol.Plugins.Fault.Message.get -> string
 NuGet.Protocol.Plugins.FaultedPluginEventArgs
-~NuGet.Protocol.Plugins.FaultedPluginEventArgs.Exception.get -> System.Exception
-~NuGet.Protocol.Plugins.FaultedPluginEventArgs.FaultedPluginEventArgs(NuGet.Protocol.Plugins.IPlugin plugin, System.Exception exception) -> void
-~NuGet.Protocol.Plugins.FaultedPluginEventArgs.Plugin.get -> NuGet.Protocol.Plugins.IPlugin
+NuGet.Protocol.Plugins.FaultedPluginEventArgs.Exception.get -> System.Exception!
+NuGet.Protocol.Plugins.FaultedPluginEventArgs.FaultedPluginEventArgs(NuGet.Protocol.Plugins.IPlugin! plugin, System.Exception! exception) -> void
+NuGet.Protocol.Plugins.FaultedPluginEventArgs.Plugin.get -> NuGet.Protocol.Plugins.IPlugin!
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.CanShowDialog.get -> bool
 ~NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.GetAuthenticationCredentialsRequest(System.Uri uri, bool isRetry, bool isNonInteractive, bool canShowDialog) -> void
@@ -994,69 +994,69 @@ NuGet.Protocol.Plugins.HandshakeResponse.ProtocolVersion.get -> NuGet.Versioning
 NuGet.Protocol.Plugins.HandshakeResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.IConnection
 NuGet.Protocol.Plugins.IConnection.Close() -> void
-NuGet.Protocol.Plugins.IConnection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs>
-~NuGet.Protocol.Plugins.IConnection.MessageDispatcher.get -> NuGet.Protocol.Plugins.IMessageDispatcher
-NuGet.Protocol.Plugins.IConnection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs>
-~NuGet.Protocol.Plugins.IConnection.Options.get -> NuGet.Protocol.Plugins.ConnectionOptions
-~NuGet.Protocol.Plugins.IConnection.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
-~NuGet.Protocol.Plugins.IConnection.SendAsync(NuGet.Protocol.Plugins.Message message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.IConnection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound>
+NuGet.Protocol.Plugins.IConnection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>!
+NuGet.Protocol.Plugins.IConnection.MessageDispatcher.get -> NuGet.Protocol.Plugins.IMessageDispatcher!
+NuGet.Protocol.Plugins.IConnection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>!
+NuGet.Protocol.Plugins.IConnection.Options.get -> NuGet.Protocol.Plugins.ConnectionOptions!
+NuGet.Protocol.Plugins.IConnection.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion?
+NuGet.Protocol.Plugins.IConnection.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.IConnection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound!>!
 NuGet.Protocol.Plugins.IIdGenerator
-~NuGet.Protocol.Plugins.IIdGenerator.GenerateUniqueId() -> string
+NuGet.Protocol.Plugins.IIdGenerator.GenerateUniqueId() -> string!
 NuGet.Protocol.Plugins.IMessageDispatcher
 NuGet.Protocol.Plugins.IMessageDispatcher.Close() -> void
-~NuGet.Protocol.Plugins.IMessageDispatcher.CreateMessage(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.IMessageDispatcher.CreateMessage<TPayload>(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload payload) -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.IMessageDispatcher.DispatchCancelAsync(NuGet.Protocol.Plugins.Message request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.IMessageDispatcher.DispatchFaultAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.Fault fault, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.IMessageDispatcher.DispatchProgressAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.Progress progress, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.IMessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound>
-~NuGet.Protocol.Plugins.IMessageDispatcher.DispatchResponseAsync<TOutbound>(NuGet.Protocol.Plugins.Message request, TOutbound responsePayload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.IMessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers
-~NuGet.Protocol.Plugins.IMessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection connection) -> void
+NuGet.Protocol.Plugins.IMessageDispatcher.CreateMessage(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message!
+NuGet.Protocol.Plugins.IMessageDispatcher.CreateMessage<TPayload>(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload! payload) -> NuGet.Protocol.Plugins.Message!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchCancelAsync(NuGet.Protocol.Plugins.Message! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchFaultAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Fault! fault, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchProgressAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Progress! progress, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound!>!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchResponseAsync<TOutbound>(NuGet.Protocol.Plugins.Message! request, TOutbound! responsePayload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.IMessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers!
+NuGet.Protocol.Plugins.IMessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection? connection) -> void
 NuGet.Protocol.Plugins.IPlugin
-NuGet.Protocol.Plugins.IPlugin.BeforeClose -> System.EventHandler
+NuGet.Protocol.Plugins.IPlugin.BeforeClose -> System.EventHandler!
 NuGet.Protocol.Plugins.IPlugin.Close() -> void
-NuGet.Protocol.Plugins.IPlugin.Closed -> System.EventHandler
-~NuGet.Protocol.Plugins.IPlugin.Connection.get -> NuGet.Protocol.Plugins.IConnection
-~NuGet.Protocol.Plugins.IPlugin.FilePath.get -> string
-~NuGet.Protocol.Plugins.IPlugin.Id.get -> string
-~NuGet.Protocol.Plugins.IPlugin.Name.get -> string
+NuGet.Protocol.Plugins.IPlugin.Closed -> System.EventHandler!
+NuGet.Protocol.Plugins.IPlugin.Connection.get -> NuGet.Protocol.Plugins.IConnection!
+NuGet.Protocol.Plugins.IPlugin.FilePath.get -> string!
+NuGet.Protocol.Plugins.IPlugin.Id.get -> string!
+NuGet.Protocol.Plugins.IPlugin.Name.get -> string!
 NuGet.Protocol.Plugins.IPluginDiscoverer
-~NuGet.Protocol.Plugins.IPluginDiscoverer.DiscoverAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult>>
+NuGet.Protocol.Plugins.IPluginDiscoverer.DiscoverAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult!>!>!
 NuGet.Protocol.Plugins.IPluginManager
-~NuGet.Protocol.Plugins.IPluginManager.CreatePluginsAsync(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginCreationResult>>
-~NuGet.Protocol.Plugins.IPluginManager.FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult>>
-~NuGet.Protocol.Plugins.IPluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult>>
+NuGet.Protocol.Plugins.IPluginManager.CreatePluginsAsync(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginCreationResult!>!>!
+NuGet.Protocol.Plugins.IPluginManager.FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult!>!>!
+NuGet.Protocol.Plugins.IPluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult! pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult!>!>!
 NuGet.Protocol.Plugins.IPluginMulticlientUtilities
-~NuGet.Protocol.Plugins.IPluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(string key, System.Func<System.Threading.Tasks.Task> taskFunc, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.IPluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(string! key, System.Func<System.Threading.Tasks.Task!>! taskFunc, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IPluginProcess
 NuGet.Protocol.Plugins.IPluginProcess.BeginReadLine() -> void
 NuGet.Protocol.Plugins.IPluginProcess.CancelRead() -> void
 NuGet.Protocol.Plugins.IPluginProcess.ExitCode.get -> int?
-NuGet.Protocol.Plugins.IPluginProcess.Exited -> System.EventHandler<NuGet.Protocol.Plugins.IPluginProcess>
+NuGet.Protocol.Plugins.IPluginProcess.Exited -> System.EventHandler<NuGet.Protocol.Plugins.IPluginProcess!>!
 NuGet.Protocol.Plugins.IPluginProcess.Id.get -> int?
 NuGet.Protocol.Plugins.IPluginProcess.Kill() -> void
-NuGet.Protocol.Plugins.IPluginProcess.LineRead -> System.EventHandler<NuGet.Protocol.Plugins.LineReadEventArgs>
+NuGet.Protocol.Plugins.IPluginProcess.LineRead -> System.EventHandler<NuGet.Protocol.Plugins.LineReadEventArgs!>!
 NuGet.Protocol.Plugins.IReceiver
 NuGet.Protocol.Plugins.IReceiver.Close() -> void
 NuGet.Protocol.Plugins.IReceiver.Connect() -> void
-NuGet.Protocol.Plugins.IReceiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs>
-NuGet.Protocol.Plugins.IReceiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs>
+NuGet.Protocol.Plugins.IReceiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>!
+NuGet.Protocol.Plugins.IReceiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>!
 NuGet.Protocol.Plugins.IRequestHandler
 NuGet.Protocol.Plugins.IRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
-~NuGet.Protocol.Plugins.IRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.IRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IRequestHandlers
-~NuGet.Protocol.Plugins.IRequestHandlers.AddOrUpdate(NuGet.Protocol.Plugins.MessageMethod method, System.Func<NuGet.Protocol.Plugins.IRequestHandler> addHandlerFunc, System.Func<NuGet.Protocol.Plugins.IRequestHandler, NuGet.Protocol.Plugins.IRequestHandler> updateHandlerFunc) -> void
-~NuGet.Protocol.Plugins.IRequestHandlers.TryAdd(NuGet.Protocol.Plugins.MessageMethod method, NuGet.Protocol.Plugins.IRequestHandler handler) -> bool
-~NuGet.Protocol.Plugins.IRequestHandlers.TryGet(NuGet.Protocol.Plugins.MessageMethod method, out NuGet.Protocol.Plugins.IRequestHandler handler) -> bool
+NuGet.Protocol.Plugins.IRequestHandlers.AddOrUpdate(NuGet.Protocol.Plugins.MessageMethod method, System.Func<NuGet.Protocol.Plugins.IRequestHandler!>! addHandlerFunc, System.Func<NuGet.Protocol.Plugins.IRequestHandler!, NuGet.Protocol.Plugins.IRequestHandler!>! updateHandlerFunc) -> void
+NuGet.Protocol.Plugins.IRequestHandlers.TryAdd(NuGet.Protocol.Plugins.MessageMethod method, NuGet.Protocol.Plugins.IRequestHandler! handler) -> bool
+NuGet.Protocol.Plugins.IRequestHandlers.TryGet(NuGet.Protocol.Plugins.MessageMethod method, out NuGet.Protocol.Plugins.IRequestHandler? handler) -> bool
 NuGet.Protocol.Plugins.IRequestHandlers.TryRemove(NuGet.Protocol.Plugins.MessageMethod method) -> bool
 NuGet.Protocol.Plugins.IResponseHandler
-~NuGet.Protocol.Plugins.IResponseHandler.SendResponseAsync<TPayload>(NuGet.Protocol.Plugins.Message request, TPayload payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.IResponseHandler.SendResponseAsync<TPayload>(NuGet.Protocol.Plugins.Message! request, TPayload! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.ISender
 NuGet.Protocol.Plugins.ISender.Close() -> void
 NuGet.Protocol.Plugins.ISender.Connect() -> void
-~NuGet.Protocol.Plugins.ISender.SendAsync(NuGet.Protocol.Plugins.Message message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.ISender.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.InboundRequestContext
 ~NuGet.Protocol.Plugins.InboundRequestContext.BeginFaultAsync(NuGet.Protocol.Plugins.Message request, System.Exception exception) -> void
 ~NuGet.Protocol.Plugins.InboundRequestContext.BeginResponseAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IRequestHandler requestHandler, NuGet.Protocol.Plugins.IResponseHandler responseHandler) -> void
@@ -1074,8 +1074,8 @@ NuGet.Protocol.Plugins.InitializeResponse.InitializeResponse(NuGet.Protocol.Plug
 NuGet.Protocol.Plugins.InitializeResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.JsonSerializationUtilities
 NuGet.Protocol.Plugins.LineReadEventArgs
-~NuGet.Protocol.Plugins.LineReadEventArgs.Line.get -> string
-~NuGet.Protocol.Plugins.LineReadEventArgs.LineReadEventArgs(string line) -> void
+NuGet.Protocol.Plugins.LineReadEventArgs.Line.get -> string?
+NuGet.Protocol.Plugins.LineReadEventArgs.LineReadEventArgs(string? line) -> void
 NuGet.Protocol.Plugins.LogRequest
 NuGet.Protocol.Plugins.LogRequest.LogLevel.get -> NuGet.Common.LogLevel
 ~NuGet.Protocol.Plugins.LogRequest.LogRequest(NuGet.Common.LogLevel logLevel, string message) -> void
@@ -1108,8 +1108,8 @@ NuGet.Protocol.Plugins.MessageDispatcher.Dispose() -> void
 ~NuGet.Protocol.Plugins.MessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers
 ~NuGet.Protocol.Plugins.MessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection connection) -> void
 NuGet.Protocol.Plugins.MessageEventArgs
-~NuGet.Protocol.Plugins.MessageEventArgs.Message.get -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.MessageEventArgs.MessageEventArgs(NuGet.Protocol.Plugins.Message message) -> void
+NuGet.Protocol.Plugins.MessageEventArgs.Message.get -> NuGet.Protocol.Plugins.Message!
+NuGet.Protocol.Plugins.MessageEventArgs.MessageEventArgs(NuGet.Protocol.Plugins.Message! message) -> void
 NuGet.Protocol.Plugins.MessageMethod
 NuGet.Protocol.Plugins.MessageMethod.Close = 1 -> NuGet.Protocol.Plugins.MessageMethod
 NuGet.Protocol.Plugins.MessageMethod.CopyFilesInPackage = 2 -> NuGet.Protocol.Plugins.MessageMethod
@@ -1189,42 +1189,42 @@ NuGet.Protocol.Plugins.Plugin.Idle -> System.EventHandler<NuGet.Protocol.Plugins
 ~NuGet.Protocol.Plugins.Plugin.Plugin(string filePath, NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.IPluginProcess process, bool isOwnProcess, System.TimeSpan idleTimeout) -> void
 NuGet.Protocol.Plugins.PluginCacheEntry
 NuGet.Protocol.Plugins.PluginCacheEntry.LoadFromFile() -> void
-~NuGet.Protocol.Plugins.PluginCacheEntry.OperationClaims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>
-~NuGet.Protocol.Plugins.PluginCacheEntry.OperationClaims.set -> void
-~NuGet.Protocol.Plugins.PluginCacheEntry.PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey) -> void
-~NuGet.Protocol.Plugins.PluginCacheEntry.UpdateCacheFileAsync() -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.PluginCacheEntry.OperationClaims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>?
+NuGet.Protocol.Plugins.PluginCacheEntry.OperationClaims.set -> void
+NuGet.Protocol.Plugins.PluginCacheEntry.PluginCacheEntry(string! rootCacheFolder, string! pluginFilePath, string! requestKey) -> void
+NuGet.Protocol.Plugins.PluginCacheEntry.UpdateCacheFileAsync() -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.PluginConstants
 NuGet.Protocol.Plugins.PluginCreationResult
-~NuGet.Protocol.Plugins.PluginCreationResult.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>
-~NuGet.Protocol.Plugins.PluginCreationResult.Exception.get -> System.Exception
-~NuGet.Protocol.Plugins.PluginCreationResult.Message.get -> string
-~NuGet.Protocol.Plugins.PluginCreationResult.Plugin.get -> NuGet.Protocol.Plugins.IPlugin
-~NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(NuGet.Protocol.Plugins.IPlugin plugin, NuGet.Protocol.Plugins.IPluginMulticlientUtilities utilities, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim> claims) -> void
-~NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string message) -> void
-~NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string message, System.Exception exception) -> void
-~NuGet.Protocol.Plugins.PluginCreationResult.PluginMulticlientUtilities.get -> NuGet.Protocol.Plugins.IPluginMulticlientUtilities
+NuGet.Protocol.Plugins.PluginCreationResult.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>?
+NuGet.Protocol.Plugins.PluginCreationResult.Exception.get -> System.Exception?
+NuGet.Protocol.Plugins.PluginCreationResult.Message.get -> string?
+NuGet.Protocol.Plugins.PluginCreationResult.Plugin.get -> NuGet.Protocol.Plugins.IPlugin?
+NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(NuGet.Protocol.Plugins.IPlugin! plugin, NuGet.Protocol.Plugins.IPluginMulticlientUtilities! utilities, System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>! claims) -> void
+NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string! message) -> void
+NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string! message, System.Exception! exception) -> void
+NuGet.Protocol.Plugins.PluginCreationResult.PluginMulticlientUtilities.get -> NuGet.Protocol.Plugins.IPluginMulticlientUtilities?
 NuGet.Protocol.Plugins.PluginDiscoverer
 ~NuGet.Protocol.Plugins.PluginDiscoverer.DiscoverAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult>>
 NuGet.Protocol.Plugins.PluginDiscoverer.Dispose() -> void
 NuGet.Protocol.Plugins.PluginDiscoverer.PluginDiscoverer() -> void
 NuGet.Protocol.Plugins.PluginDiscoveryResult
-~NuGet.Protocol.Plugins.PluginDiscoveryResult.Message.get -> string
-~NuGet.Protocol.Plugins.PluginDiscoveryResult.PluginDiscoveryResult(NuGet.Protocol.Plugins.PluginFile pluginFile) -> void
-~NuGet.Protocol.Plugins.PluginDiscoveryResult.PluginFile.get -> NuGet.Protocol.Plugins.PluginFile
+NuGet.Protocol.Plugins.PluginDiscoveryResult.Message.get -> string?
+NuGet.Protocol.Plugins.PluginDiscoveryResult.PluginDiscoveryResult(NuGet.Protocol.Plugins.PluginFile! pluginFile) -> void
+NuGet.Protocol.Plugins.PluginDiscoveryResult.PluginFile.get -> NuGet.Protocol.Plugins.PluginFile!
 NuGet.Protocol.Plugins.PluginDiscoveryUtility
 NuGet.Protocol.Plugins.PluginEventArgs
-~NuGet.Protocol.Plugins.PluginEventArgs.Plugin.get -> NuGet.Protocol.Plugins.IPlugin
-~NuGet.Protocol.Plugins.PluginEventArgs.PluginEventArgs(NuGet.Protocol.Plugins.IPlugin plugin) -> void
+NuGet.Protocol.Plugins.PluginEventArgs.Plugin.get -> NuGet.Protocol.Plugins.IPlugin!
+NuGet.Protocol.Plugins.PluginEventArgs.PluginEventArgs(NuGet.Protocol.Plugins.IPlugin! plugin) -> void
 NuGet.Protocol.Plugins.PluginException
-~NuGet.Protocol.Plugins.PluginException.PluginException(string message) -> void
-~NuGet.Protocol.Plugins.PluginException.PluginException(string message, System.Exception innerException) -> void
+NuGet.Protocol.Plugins.PluginException.PluginException(string? message) -> void
+NuGet.Protocol.Plugins.PluginException.PluginException(string? message, System.Exception? innerException) -> void
 NuGet.Protocol.Plugins.PluginFactory
 NuGet.Protocol.Plugins.PluginFactory.PluginFactory(System.TimeSpan pluginIdleTimeout) -> void
 NuGet.Protocol.Plugins.PluginFile
-~NuGet.Protocol.Plugins.PluginFile.Path.get -> string
-~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state) -> void
-~NuGet.Protocol.Plugins.PluginFile.PluginFile(string filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState> state, bool requiresDotnetHost) -> void
-~NuGet.Protocol.Plugins.PluginFile.State.get -> System.Lazy<NuGet.Protocol.Plugins.PluginFileState>
+NuGet.Protocol.Plugins.PluginFile.Path.get -> string!
+NuGet.Protocol.Plugins.PluginFile.PluginFile(string! filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState>! state) -> void
+NuGet.Protocol.Plugins.PluginFile.PluginFile(string! filePath, System.Lazy<NuGet.Protocol.Plugins.PluginFileState>! state, bool requiresDotnetHost) -> void
+NuGet.Protocol.Plugins.PluginFile.State.get -> System.Lazy<NuGet.Protocol.Plugins.PluginFileState>!
 NuGet.Protocol.Plugins.PluginFileState
 NuGet.Protocol.Plugins.PluginFileState.InvalidEmbeddedSignature = 3 -> NuGet.Protocol.Plugins.PluginFileState
 NuGet.Protocol.Plugins.PluginFileState.InvalidFilePath = 2 -> NuGet.Protocol.Plugins.PluginFileState
@@ -1278,13 +1278,13 @@ NuGet.Protocol.Plugins.Progress.Percentage.get -> double?
 NuGet.Protocol.Plugins.Progress.Progress(double? percentage = null) -> void
 NuGet.Protocol.Plugins.ProtocolConstants
 NuGet.Protocol.Plugins.ProtocolErrorEventArgs
-~NuGet.Protocol.Plugins.ProtocolErrorEventArgs.Exception.get -> System.Exception
-~NuGet.Protocol.Plugins.ProtocolErrorEventArgs.Message.get -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.ProtocolErrorEventArgs.ProtocolErrorEventArgs(System.Exception exception) -> void
-~NuGet.Protocol.Plugins.ProtocolErrorEventArgs.ProtocolErrorEventArgs(System.Exception exception, NuGet.Protocol.Plugins.Message message) -> void
+NuGet.Protocol.Plugins.ProtocolErrorEventArgs.Exception.get -> System.Exception!
+NuGet.Protocol.Plugins.ProtocolErrorEventArgs.Message.get -> NuGet.Protocol.Plugins.Message?
+NuGet.Protocol.Plugins.ProtocolErrorEventArgs.ProtocolErrorEventArgs(System.Exception! exception) -> void
+NuGet.Protocol.Plugins.ProtocolErrorEventArgs.ProtocolErrorEventArgs(System.Exception! exception, NuGet.Protocol.Plugins.Message! message) -> void
 NuGet.Protocol.Plugins.ProtocolException
-~NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string message) -> void
-~NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string message, System.Exception innerException) -> void
+NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string? message) -> void
+NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string? message, System.Exception? innerException) -> void
 NuGet.Protocol.Plugins.Receiver
 NuGet.Protocol.Plugins.Receiver.Dispose() -> void
 NuGet.Protocol.Plugins.Receiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs>
@@ -1780,7 +1780,7 @@ override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleCancelResp
 ~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleFault(NuGet.Protocol.Plugins.Message fault) -> void
 ~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleProgress(NuGet.Protocol.Plugins.Message progress) -> void
 ~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleResponse(NuGet.Protocol.Plugins.Message response) -> void
-~override NuGet.Protocol.Plugins.PluginFile.ToString() -> string
+override NuGet.Protocol.Plugins.PluginFile.ToString() -> string!
 ~override NuGet.Protocol.Plugins.PluginPackageReader.CanVerifySignedPackages(NuGet.Packaging.Signing.SignedPackageVerifierSettings verifierSettings) -> bool
 ~override NuGet.Protocol.Plugins.PluginPackageReader.CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate extractFile, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<string>
 ~override NuGet.Protocol.Plugins.PluginPackageReader.CopyFilesAsync(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate extractFile, NuGet.Common.ILogger logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
@@ -1993,7 +1993,7 @@ static NuGet.Protocol.LocalFolderUtility.ResolvePackageFromPath(string! packageP
 static NuGet.Protocol.NullThrottle.Instance.get -> NuGet.Protocol.NullThrottle!
 ~static NuGet.Protocol.PackageDetailsUriResourceV3.CreateOrNull(string uriTemplate) -> NuGet.Protocol.PackageDetailsUriResourceV3
 ~static NuGet.Protocol.Plugins.AutomaticProgressReporter.Create(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Plugins.AutomaticProgressReporter
-~static NuGet.Protocol.Plugins.ConnectionOptions.CreateDefault(NuGet.Common.IEnvironmentVariableReader reader = null) -> NuGet.Protocol.Plugins.ConnectionOptions
+static NuGet.Protocol.Plugins.ConnectionOptions.CreateDefault(NuGet.Common.IEnvironmentVariableReader? reader = null) -> NuGet.Protocol.Plugins.ConnectionOptions!
 ~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Deserialize<T>(string json) -> T
 ~static NuGet.Protocol.Plugins.JsonSerializationUtilities.FromObject(object value) -> Newtonsoft.Json.Linq.JObject
 ~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serialize(Newtonsoft.Json.JsonWriter writer, object value) -> void
@@ -2010,7 +2010,7 @@ static NuGet.Protocol.Plugins.MessageUtilities.DeserializePayload<TPayload>(NuGe
 ~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot.set -> void
 ~static NuGet.Protocol.Plugins.PluginFactory.CreateFromCurrentProcessAsync(NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>
 ~static NuGet.Protocol.Plugins.PluginManager.Instance.get -> NuGet.Protocol.Plugins.IPluginManager
-~static NuGet.Protocol.Plugins.TimeoutUtilities.GetTimeout(string timeoutInSeconds, System.TimeSpan fallbackTimeout) -> System.TimeSpan
+static NuGet.Protocol.Plugins.TimeoutUtilities.GetTimeout(string? timeoutInSeconds, System.TimeSpan fallbackTimeout) -> System.TimeSpan
 static NuGet.Protocol.Plugins.TimeoutUtilities.IsValid(System.TimeSpan timeout) -> bool
 static NuGet.Protocol.RegistrationUtility.CreateVersionRange(string! stringToParse) -> NuGet.Versioning.VersionRange!
 static NuGet.Protocol.RegistrationUtility.LoadRanges(NuGet.Protocol.HttpSource! httpSource, System.Uri! registrationUri, string! packageId, NuGet.Versioning.VersionRange! range, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject?>!>!
@@ -2035,15 +2035,15 @@ static readonly NuGet.Protocol.HttpSourceRequest.DefaultRequestTimeout -> System
 static readonly NuGet.Protocol.JsonExtensions.ObjectSerializationSettings -> Newtonsoft.Json.JsonSerializerSettings!
 static readonly NuGet.Protocol.Plugins.PluginConstants.CloseTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.PluginConstants.IdleTimeout -> System.TimeSpan
-~static readonly NuGet.Protocol.Plugins.PluginConstants.PluginArguments -> System.Collections.Generic.IEnumerable<string>
+static readonly NuGet.Protocol.Plugins.PluginConstants.PluginArguments -> System.Collections.Generic.IEnumerable<string!>!
 static readonly NuGet.Protocol.Plugins.PluginConstants.ProgressInterval -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.PluginConstants.RequestTimeout -> System.TimeSpan
-~static readonly NuGet.Protocol.Plugins.ProtocolConstants.CurrentVersion -> NuGet.Versioning.SemanticVersion
+static readonly NuGet.Protocol.Plugins.ProtocolConstants.CurrentVersion -> NuGet.Versioning.SemanticVersion!
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.HandshakeTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.MaxTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.MinTimeout -> System.TimeSpan
 static readonly NuGet.Protocol.Plugins.ProtocolConstants.RequestTimeout -> System.TimeSpan
-~static readonly NuGet.Protocol.Plugins.ProtocolConstants.Version100 -> NuGet.Versioning.SemanticVersion
+static readonly NuGet.Protocol.Plugins.ProtocolConstants.Version100 -> NuGet.Versioning.SemanticVersion!
 static readonly NuGet.Protocol.ProtocolConstants.ApiKeyHeader -> string!
 static readonly NuGet.Protocol.ProtocolConstants.ServerWarningHeader -> string!
 static readonly NuGet.Protocol.ProtocolConstants.SessionId -> string!

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -888,8 +888,8 @@ NuGet.Protocol.Plugins.CopyFilesInPackageRequest
 ~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageSourceRepository.get -> string
 ~NuGet.Protocol.Plugins.CopyFilesInPackageRequest.PackageVersion.get -> string
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse
-~NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopiedFiles.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopyFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> copiedFiles) -> void
+NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopiedFiles.get -> System.Collections.Generic.IEnumerable<string!>?
+NuGet.Protocol.Plugins.CopyFilesInPackageResponse.CopyFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? copiedFiles) -> void
 NuGet.Protocol.Plugins.CopyFilesInPackageResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.CopyNupkgFileRequest
 ~NuGet.Protocol.Plugins.CopyNupkgFileRequest.CopyNupkgFileRequest(string packageSourceRepository, string packageId, string packageVersion, string destinationFilePath) -> void
@@ -914,13 +914,13 @@ NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.IsNonInteractive.get 
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.IsRetry.get -> bool
 ~NuGet.Protocol.Plugins.GetAuthenticationCredentialsRequest.Uri.get -> System.Uri
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IList<string>
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.GetAuthenticationCredentialsResponse(string username, string password, string message, System.Collections.Generic.IList<string> authenticationTypes, NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IList<string!>?
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.GetAuthenticationCredentialsResponse(string? username, string? password, string? message, System.Collections.Generic.IList<string!>? authenticationTypes, NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.IsValid() -> bool
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Message.get -> string
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Password.get -> string
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Message.get -> string?
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Password.get -> string?
 NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
-~NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Username.get -> string
+NuGet.Protocol.Plugins.GetAuthenticationCredentialsResponse.Username.get -> string?
 NuGet.Protocol.Plugins.GetCredentialsRequest
 ~NuGet.Protocol.Plugins.GetCredentialsRequest.GetCredentialsRequest(string packageSourceRepository, System.Net.HttpStatusCode statusCode) -> void
 ~NuGet.Protocol.Plugins.GetCredentialsRequest.PackageSourceRepository.get -> string
@@ -932,24 +932,24 @@ NuGet.Protocol.Plugins.GetCredentialsRequestHandler.Dispose() -> void
 ~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.GetCredentialsRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin, System.Net.IWebProxy proxy, NuGet.Configuration.ICredentialService credentialService) -> void
 ~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 NuGet.Protocol.Plugins.GetCredentialsResponse
-~NuGet.Protocol.Plugins.GetCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.Plugins.GetCredentialsResponse.GetCredentialsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string username, string password, System.Collections.Generic.IReadOnlyList<string> authenticationTypes = null) -> void
-~NuGet.Protocol.Plugins.GetCredentialsResponse.Password.get -> string
+NuGet.Protocol.Plugins.GetCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.Plugins.GetCredentialsResponse.GetCredentialsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string? username, string? password, System.Collections.Generic.IReadOnlyList<string!>? authenticationTypes = null) -> void
+NuGet.Protocol.Plugins.GetCredentialsResponse.Password.get -> string?
 NuGet.Protocol.Plugins.GetCredentialsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
-~NuGet.Protocol.Plugins.GetCredentialsResponse.Username.get -> string
+NuGet.Protocol.Plugins.GetCredentialsResponse.Username.get -> string?
 NuGet.Protocol.Plugins.GetFilesInPackageRequest
 ~NuGet.Protocol.Plugins.GetFilesInPackageRequest.GetFilesInPackageRequest(string packageSourceRepository, string packageId, string packageVersion) -> void
 ~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageId.get -> string
 ~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageSourceRepository.get -> string
 ~NuGet.Protocol.Plugins.GetFilesInPackageRequest.PackageVersion.get -> string
 NuGet.Protocol.Plugins.GetFilesInPackageResponse
-~NuGet.Protocol.Plugins.GetFilesInPackageResponse.Files.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.Plugins.GetFilesInPackageResponse.GetFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> files) -> void
+NuGet.Protocol.Plugins.GetFilesInPackageResponse.Files.get -> System.Collections.Generic.IEnumerable<string!>?
+NuGet.Protocol.Plugins.GetFilesInPackageResponse.GetFilesInPackageResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? files) -> void
 NuGet.Protocol.Plugins.GetFilesInPackageResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetOperationClaimsRequest
-~NuGet.Protocol.Plugins.GetOperationClaimsRequest.GetOperationClaimsRequest(string packageSourceRepository, Newtonsoft.Json.Linq.JObject serviceIndex) -> void
-~NuGet.Protocol.Plugins.GetOperationClaimsRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.GetOperationClaimsRequest.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject
+NuGet.Protocol.Plugins.GetOperationClaimsRequest.GetOperationClaimsRequest(string? packageSourceRepository, Newtonsoft.Json.Linq.JObject? serviceIndex) -> void
+NuGet.Protocol.Plugins.GetOperationClaimsRequest.PackageSourceRepository.get -> string?
+NuGet.Protocol.Plugins.GetOperationClaimsRequest.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject?
 NuGet.Protocol.Plugins.GetOperationClaimsResponse
 ~NuGet.Protocol.Plugins.GetOperationClaimsResponse.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>
 ~NuGet.Protocol.Plugins.GetOperationClaimsResponse.GetOperationClaimsResponse(System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.OperationClaim> claims) -> void
@@ -960,17 +960,17 @@ NuGet.Protocol.Plugins.GetPackageHashRequest
 ~NuGet.Protocol.Plugins.GetPackageHashRequest.PackageSourceRepository.get -> string
 ~NuGet.Protocol.Plugins.GetPackageHashRequest.PackageVersion.get -> string
 NuGet.Protocol.Plugins.GetPackageHashResponse
-~NuGet.Protocol.Plugins.GetPackageHashResponse.GetPackageHashResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string hash) -> void
-~NuGet.Protocol.Plugins.GetPackageHashResponse.Hash.get -> string
+NuGet.Protocol.Plugins.GetPackageHashResponse.GetPackageHashResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string? hash) -> void
+NuGet.Protocol.Plugins.GetPackageHashResponse.Hash.get -> string?
 NuGet.Protocol.Plugins.GetPackageHashResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetPackageVersionsRequest
 ~NuGet.Protocol.Plugins.GetPackageVersionsRequest.GetPackageVersionsRequest(string packageSourceRepository, string packageId) -> void
 ~NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageId.get -> string
 ~NuGet.Protocol.Plugins.GetPackageVersionsRequest.PackageSourceRepository.get -> string
 NuGet.Protocol.Plugins.GetPackageVersionsResponse
-~NuGet.Protocol.Plugins.GetPackageVersionsResponse.GetPackageVersionsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> versions) -> void
+NuGet.Protocol.Plugins.GetPackageVersionsResponse.GetPackageVersionsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string!>? versions) -> void
 NuGet.Protocol.Plugins.GetPackageVersionsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
-~NuGet.Protocol.Plugins.GetPackageVersionsResponse.Versions.get -> System.Collections.Generic.IEnumerable<string>
+NuGet.Protocol.Plugins.GetPackageVersionsResponse.Versions.get -> System.Collections.Generic.IEnumerable<string!>?
 NuGet.Protocol.Plugins.GetServiceIndexRequest
 ~NuGet.Protocol.Plugins.GetServiceIndexRequest.GetServiceIndexRequest(string packageSourceRepository) -> void
 ~NuGet.Protocol.Plugins.GetServiceIndexRequest.PackageSourceRepository.get -> string
@@ -981,16 +981,16 @@ NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.Dispose() -> void
 ~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.GetServiceIndexRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin) -> void
 ~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 NuGet.Protocol.Plugins.GetServiceIndexResponse
-~NuGet.Protocol.Plugins.GetServiceIndexResponse.GetServiceIndexResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, Newtonsoft.Json.Linq.JObject serviceIndex) -> void
+NuGet.Protocol.Plugins.GetServiceIndexResponse.GetServiceIndexResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, Newtonsoft.Json.Linq.JObject? serviceIndex) -> void
 NuGet.Protocol.Plugins.GetServiceIndexResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
-~NuGet.Protocol.Plugins.GetServiceIndexResponse.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject
+NuGet.Protocol.Plugins.GetServiceIndexResponse.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject?
 NuGet.Protocol.Plugins.HandshakeRequest
 ~NuGet.Protocol.Plugins.HandshakeRequest.HandshakeRequest(NuGet.Versioning.SemanticVersion protocolVersion, NuGet.Versioning.SemanticVersion minimumProtocolVersion) -> void
 ~NuGet.Protocol.Plugins.HandshakeRequest.MinimumProtocolVersion.get -> NuGet.Versioning.SemanticVersion
 ~NuGet.Protocol.Plugins.HandshakeRequest.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
 NuGet.Protocol.Plugins.HandshakeResponse
-~NuGet.Protocol.Plugins.HandshakeResponse.HandshakeResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, NuGet.Versioning.SemanticVersion protocolVersion) -> void
-~NuGet.Protocol.Plugins.HandshakeResponse.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
+NuGet.Protocol.Plugins.HandshakeResponse.HandshakeResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, NuGet.Versioning.SemanticVersion? protocolVersion) -> void
+NuGet.Protocol.Plugins.HandshakeResponse.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion?
 NuGet.Protocol.Plugins.HandshakeResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.IConnection
 NuGet.Protocol.Plugins.IConnection.Close() -> void
@@ -1089,10 +1089,10 @@ NuGet.Protocol.Plugins.LogResponse
 NuGet.Protocol.Plugins.LogResponse.LogResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.LogResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.Message.Message(string requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, Newtonsoft.Json.Linq.JObject payload = null) -> void
+NuGet.Protocol.Plugins.Message.Message(string! requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, Newtonsoft.Json.Linq.JObject? payload = null) -> void
 NuGet.Protocol.Plugins.Message.Method.get -> NuGet.Protocol.Plugins.MessageMethod
-~NuGet.Protocol.Plugins.Message.Payload.get -> Newtonsoft.Json.Linq.JObject
-~NuGet.Protocol.Plugins.Message.RequestId.get -> string
+NuGet.Protocol.Plugins.Message.Payload.get -> Newtonsoft.Json.Linq.JObject?
+NuGet.Protocol.Plugins.Message.RequestId.get -> string!
 NuGet.Protocol.Plugins.Message.Type.get -> NuGet.Protocol.Plugins.MessageType
 NuGet.Protocol.Plugins.MessageDispatcher
 NuGet.Protocol.Plugins.MessageDispatcher.Close() -> void
@@ -1313,12 +1313,12 @@ NuGet.Protocol.Plugins.Sender.Dispose() -> void
 ~NuGet.Protocol.Plugins.Sender.SendAsync(NuGet.Protocol.Plugins.Message message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 ~NuGet.Protocol.Plugins.Sender.Sender(System.IO.TextWriter writer) -> void
 NuGet.Protocol.Plugins.SetCredentialsRequest
-~NuGet.Protocol.Plugins.SetCredentialsRequest.PackageSourceRepository.get -> string
-~NuGet.Protocol.Plugins.SetCredentialsRequest.Password.get -> string
-~NuGet.Protocol.Plugins.SetCredentialsRequest.ProxyPassword.get -> string
-~NuGet.Protocol.Plugins.SetCredentialsRequest.ProxyUsername.get -> string
-~NuGet.Protocol.Plugins.SetCredentialsRequest.SetCredentialsRequest(string packageSourceRepository, string proxyUsername, string proxyPassword, string username, string password) -> void
-~NuGet.Protocol.Plugins.SetCredentialsRequest.Username.get -> string
+NuGet.Protocol.Plugins.SetCredentialsRequest.PackageSourceRepository.get -> string!
+NuGet.Protocol.Plugins.SetCredentialsRequest.Password.get -> string?
+NuGet.Protocol.Plugins.SetCredentialsRequest.ProxyPassword.get -> string?
+NuGet.Protocol.Plugins.SetCredentialsRequest.ProxyUsername.get -> string?
+NuGet.Protocol.Plugins.SetCredentialsRequest.SetCredentialsRequest(string! packageSourceRepository, string? proxyUsername, string? proxyPassword, string? username, string? password) -> void
+NuGet.Protocol.Plugins.SetCredentialsRequest.Username.get -> string?
 NuGet.Protocol.Plugins.SetCredentialsResponse
 NuGet.Protocol.Plugins.SetCredentialsResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.SetCredentialsResponse.SetCredentialsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
@@ -2000,9 +2000,9 @@ static NuGet.Protocol.NullThrottle.Instance.get -> NuGet.Protocol.NullThrottle!
 ~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serializer.get -> Newtonsoft.Json.JsonSerializer
 ~static NuGet.Protocol.Plugins.JsonSerializationUtilities.ToObject<T>(Newtonsoft.Json.Linq.JObject jObject) -> T
 ~static NuGet.Protocol.Plugins.LogRequestHandler.GetLogLevel(NuGet.Common.ILogger logger) -> NuGet.Common.LogLevel
-~static NuGet.Protocol.Plugins.MessageUtilities.Create(string requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message
-~static NuGet.Protocol.Plugins.MessageUtilities.Create<TPayload>(string requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload payload) -> NuGet.Protocol.Plugins.Message
-~static NuGet.Protocol.Plugins.MessageUtilities.DeserializePayload<TPayload>(NuGet.Protocol.Plugins.Message message) -> TPayload
+static NuGet.Protocol.Plugins.MessageUtilities.Create(string! requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message!
+static NuGet.Protocol.Plugins.MessageUtilities.Create<TPayload>(string! requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload! payload) -> NuGet.Protocol.Plugins.Message!
+static NuGet.Protocol.Plugins.MessageUtilities.DeserializePayload<TPayload>(NuGet.Protocol.Plugins.Message! message) -> TPayload?
 ~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetConventionBasedPlugins(System.Collections.Generic.IEnumerable<string> directories) -> System.Collections.Generic.IEnumerable<string>
 ~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetNuGetHomePluginsPath() -> string
 ~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string nugetAssemblyPath) -> string

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -7,4 +7,4 @@ NuGet.Protocol.Plugins.GetOperationClaimsRequest.GetOperationClaimsRequest(strin
 NuGet.Protocol.Plugins.GetOperationClaimsRequest.ServiceIndexJson.get -> string?
 NuGet.Protocol.Plugins.GetServiceIndexResponse.GetServiceIndexResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string? serviceIndexJson) -> void
 NuGet.Protocol.Plugins.GetServiceIndexResponse.ServiceIndexJson.get -> string?
-~static NuGet.Protocol.Plugins.MessageUtilities.SerializePayload(NuGet.Protocol.Plugins.Message message) -> string
+static NuGet.Protocol.Plugins.MessageUtilities.SerializePayload(NuGet.Protocol.Plugins.Message! message) -> string?

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/FaultedPluginEventArgsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/FaultedPluginEventArgsTests.cs
@@ -13,7 +13,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_ThrowsForNullPlugin()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new FaultedPluginEventArgs(plugin: null, exception: new Exception()));
+                () => new FaultedPluginEventArgs(plugin: null!, exception: new Exception()));
 
             Assert.Equal("plugin", exception.ParamName);
         }
@@ -22,7 +22,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_ThrowsForNullException()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new FaultedPluginEventArgs(Mock.Of<IPlugin>(), exception: null));
+                () => new FaultedPluginEventArgs(Mock.Of<IPlugin>(), exception: null!));
 
             Assert.Equal("exception", exception.ParamName);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageEventArgsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageEventArgsTests.cs
@@ -11,7 +11,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [Fact]
         public void Constructor_ThrowsForNullException()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => new MessageEventArgs(message: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => new MessageEventArgs(message: null!));
 
             Assert.Equal("message", exception.ParamName);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/CopyFilesInPackageRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/CopyFilesInPackageRequestTests.cs
@@ -65,7 +65,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     packageSourceRepository: "a",
                     packageId: "b",
                     packageVersion: "c",
-                    filesInPackage: null,
+                    filesInPackage: null!,
                     destinationFolderPath: "d"));
 
             Assert.Equal("filesInPackage", exception.ParamName);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/MessageConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/MessageConverterTests.cs
@@ -909,7 +909,7 @@ namespace NuGet.Protocol.Plugins.Tests
             useStj ? DeserializeWithStj(json) : DeserializeWithNsj(json);
 
         private static T GetPayload<T>(Message message) where T : class =>
-            MessageUtilities.DeserializePayload<T>(message);
+            MessageUtilities.DeserializePayload<T>(message)!;
 
         private static T RoundtripPayload<T>(Message message, bool useStj) where T : class
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCreationResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginCreationResultTests.cs
@@ -15,7 +15,7 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new PluginCreationResult(
-                    plugin: null,
+                    plugin: null!,
                     utilities: Mock.Of<IPluginMulticlientUtilities>(),
                     claims: new List<OperationClaim>()));
 
@@ -28,7 +28,7 @@ namespace NuGet.Protocol.Plugins.Tests
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new PluginCreationResult(
                     Mock.Of<IPlugin>(),
-                    utilities: null,
+                    utilities: null!,
                     claims: new List<OperationClaim>()));
 
             Assert.Equal("utilities", exception.ParamName);
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 () => new PluginCreationResult(
                     Mock.Of<IPlugin>(),
                     Mock.Of<IPluginMulticlientUtilities>(),
-                    claims: null));
+                    claims: null!));
 
             Assert.Equal("claims", exception.ParamName);
         }
@@ -72,7 +72,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_Message_Exception_ThrowsForNullException()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new PluginCreationResult("a", exception: null));
+                () => new PluginCreationResult("a", exception: null!));
 
             Assert.Equal("exception", exception.ParamName);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginDiscoveryResultTests.cs
@@ -12,7 +12,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_ThrowsForNullPluginFile()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new PluginDiscoveryResult(pluginFile: null));
+                () => new PluginDiscoveryResult(pluginFile: null!));
 
             Assert.Equal("pluginFile", exception.ParamName);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginEventArgsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginEventArgsTests.cs
@@ -12,7 +12,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [Fact]
         public void Constructor_ThrowsForNullPlugin()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => new PluginEventArgs(plugin: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => new PluginEventArgs(plugin: null!));
 
             Assert.Equal("plugin", exception.ParamName);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/ProtocolErrorEventArgsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/ProtocolErrorEventArgsTests.cs
@@ -11,7 +11,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [Fact]
         public void Constructor_ThrowsForNullException()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => new ProtocolErrorEventArgs(exception: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => new ProtocolErrorEventArgs(exception: null!));
 
             Assert.Equal("exception", exception.ParamName);
         }


### PR DESCRIPTION
# Bug

Progress: https://github.com/NuGet/Home/issues/14851

## Description

Completes the nullable enablement of the `NuGet.Protocol` plugin layer: every type under `NuGet.Protocol.Plugins/Messages/` and `NuGet.Protocol.Plugins/Logging/`, plus `MessageUtilities` and the surrounding plugin contracts (interfaces, exceptions, event args, constants, and small value objects), is now annotated. The plugin runtime (`Connection`, `Sender`, `Receiver`, `MessageDispatcher`, request handlers, lifecycle, discovery, package operations) is intentionally left for a follow-up PR.

Non-mechanical changes worth calling out:

- `PluginLogger.CreateStreamWriter` now throws an explicit `InvalidOperationException` if `_logDirectoryPath` is missing or if `Process.MainModule?.FileName` is null, instead of relying on an implicit `NullReferenceException`.
- The obsolete public `Message(string, MessageType, MessageMethod, JObject)` constructor previously had an empty body, leaving `RequestId`, `Type`, `Method`, and `PayloadObject` uninitialized. It now delegates to the internal constructor so the documented validation actually runs.
- `PluginCreationResult` had five reference-type properties that are mutually exclusive depending on whether the creation succeeded. Added an `internal bool IsSuccess` discriminator with `[MemberNotNullWhen]` attributes so the compiler enforces the documented contract: when `Message` is non-null `Plugin`/`PluginMulticlientUtilities`/`Claims` are null, and vice versa.
- `LineReadEventArgs.Line` and `ProtocolErrorEventArgs.Message` are now nullable to match the call sites that already produced null values (StandardOutputReceiver null-guards lines; the single-argument `ProtocolErrorEventArgs` constructor never sets `Message`).
- `IConnection.ProtocolVersion` and `IMessageDispatcher.SetConnection`'s parameter are now nullable, matching what the XML docs already said.
- `IRequestHandlers.TryGet` is annotated with `[NotNullWhen(true)]` on the `out` parameter so callers don't need a redundant null check after a successful lookup.
- Plugin exception constructors accept nullable `message`/`innerException` parameters to match the `System.Exception` base contract.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
