### PR TITLE
Fix nomination hang during project rename

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -648,7 +648,6 @@ namespace NuGet.PackageManagement.VisualStudio
                     if (await EnvDTEProjectUtility.IsSupportedAsync(envDTEProject))
                     {
                         _projectSystemCache.TryGetProjectRestoreInfoSource(oldName, out object restoreInfoSource);
-
                         RemoveVsProjectAdapterFromCache(oldName);
 
                         var vsProjectAdapter = await _vsProjectAdapterProvider.CreateAdapterForFullyLoadedProjectAsync(envDTEProject);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -647,10 +647,17 @@ namespace NuGet.PackageManagement.VisualStudio
 
                     if (await EnvDTEProjectUtility.IsSupportedAsync(envDTEProject))
                     {
+                        _projectSystemCache.TryGetProjectRestoreInfoSource(oldName, out object restoreInfoSource);
+
                         RemoveVsProjectAdapterFromCache(oldName);
 
                         var vsProjectAdapter = await _vsProjectAdapterProvider.CreateAdapterForFullyLoadedProjectAsync(envDTEProject);
                         await AddVsProjectAdapterToCacheAsync(vsProjectAdapter);
+
+                        if (restoreInfoSource != null)
+                        {
+                            _projectSystemCache.AddProjectRestoreInfoSource(vsProjectAdapter.ProjectNames, restoreInfoSource);
+                        }
 
                         _projectSystemCache.TryGetNuGetProject(envDTEProject.Name, out var nuGetProject);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectSystemCache.cs
@@ -623,5 +623,22 @@ namespace NuGet.PackageManagement.VisualStudio
                 _readerWriterLock.ExitReadLock();
             }
         }
+
+        public bool TryGetProjectRestoreInfoSource(string name, out object restoreInfoSource)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException(CommonResources.Argument_Cannot_Be_Null_Or_Empty, nameof(name));
+            }
+
+            restoreInfoSource = null;
+
+            if (TryGetCacheEntry(name, out CacheEntry cacheEntry))
+            {
+                restoreInfoSource = cacheEntry.ProjectRestoreInfoSource;
+            }
+
+            return restoreInfoSource != null;
+        }
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -578,6 +578,12 @@ namespace NuGet.SolutionRestoreManager
                                 }
                                 else
                                 {
+                                    if (DateTime.UtcNow - lastNominationReceived > BulkRestoreCoordinationTimeout)
+                                    {
+                                        restoreReason = ImplicitRestoreReason.NominationsIdleTimeout;
+                                        break;
+                                    }
+
                                     await Task.Delay(IdleTimeoutMs, token);
                                 }
                             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/IProjectSystemCache.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/ProjectSystems/IProjectSystemCache.cs
@@ -138,6 +138,14 @@ namespace NuGet.VisualStudio
         bool AddProjectRestoreInfoSource(ProjectNames projectNames, object restoreInfoSource);
 
         /// <summary>
+        /// Retrieves the project restore info source associated with project name.
+        /// </summary>
+        /// <param name="name">Project name, full path, unique name, or project id (guid).</param>
+        /// <param name="restoreInfoSource">The restore info source object, or null if not found.</param>
+        /// <returns>True if found, false otherwise.</returns>
+        bool TryGetProjectRestoreInfoSource(string name, out object restoreInfoSource);
+
+        /// <summary>
         /// Retrieves collection of all project info sources stored in the cache.
         /// </summary>
         /// <returns>Collection of project restore info sources.</returns>


### PR DESCRIPTION
# Bug

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1618509

## Description

A project rename in Visual Studio causes a permanent hang because NuGet's `ProjectSystemCache` loses a project's `ProjectRestoreInfo` during the rename, and no recovery path exists. The `SolutionRestoreWorker` drain loop polls indefinitely at 400ms intervals because `IsAllProjectsNominatedAsync()` can never return `true` again.

### Changes

1. **Timeout in the `!isAllProjectsNominated` branch** (`SolutionRestoreWorker.cs`): If no nominations arrive within `BulkRestoreCoordinationTimeout` (5 minutes) since the last received nomination, break the drain loop and proceed with restore. This prevents permanent hangs when a project's cache entry is wiped and no recovery nomination can arrive. Uses the existing `ImplicitRestoreReason.NominationsIdleTimeout` telemetry reason.

2. **Preserve `ProjectRestoreInfoSource` across renames** (`VSSolutionManager.cs`, `ProjectSystemCache.cs`, `IProjectSystemCache.cs`): Before removing a project from the cache during rename, retrieve its `ProjectRestoreInfoSource` and re-register it on the new cache entry. This ensures future restore cycles can properly coordinate via `HasPendingNomination`. Added `TryGetProjectRestoreInfoSource` to `IProjectSystemCache`.

## PR Checklist

- [x] PR has a meaningful title
- [x] PR has a linked work item
- [ ] Tested changes locally
