### PR TITLE
Migrate dotnet nuget locals, delete, push, verify commands to S.CL

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/CommandParsers.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/CommandParsers.cs
@@ -3,22 +3,22 @@
 
 #nullable enable
 
-using System;
 using Microsoft.Extensions.CommandLineUtils;
-using NuGet.Common;
 
 namespace NuGet.CommandLine.XPlat
 {
     internal static class CommandParsers
     {
-        public static void Register(CommandLineApplication app, Func<ILogger> getLogger)
+        // Registers placeholders on the legacy CommandLineApplication so that `dotnet nuget --help`
+        // still lists these verbs. They are implemented with System.CommandLine (see Verbs.cs).
+        public static void Register(CommandLineApplication app)
         {
-            AddVerbParser.Register(app, getLogger);
-            DisableVerbParser.Register(app, getLogger);
-            EnableVerbParser.Register(app, getLogger);
-            ListVerbParser.Register(app, getLogger);
-            RemoveVerbParser.Register(app, getLogger);
-            UpdateVerbParser.Register(app, getLogger);
+            AddVerbParser.Register(app);
+            DisableVerbParser.Register(app);
+            EnableVerbParser.Register(app);
+            ListVerbParser.Register(app);
+            RemoveVerbParser.Register(app);
+            UpdateVerbParser.Register(app);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/DeleteCommand.cs
@@ -1,11 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
+#nullable enable
 
 using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Help;
 using System.Globalization;
 using Microsoft.Extensions.CommandLineUtils;
+using NuGet.CommandLine.XPlat.Commands;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -15,83 +19,115 @@ namespace NuGet.CommandLine.XPlat
 {
     internal static class DeleteCommand
     {
-        public static void Register(CommandLineApplication app, Func<ILogger> getLogger)
+        // Registers a placeholder on the legacy CommandLineApplication so that `dotnet nuget --help`
+        // still lists `delete`. The command is implemented with System.CommandLine (see overload below).
+        internal static void Register(CommandLineApplication app)
         {
             app.Command("delete", delete =>
             {
                 delete.Description = Strings.Delete_Description;
-                delete.HelpOption(XPlatUtility.HelpOption);
+            });
+        }
 
-                delete.Option(
-                    CommandConstants.ForceEnglishOutputOption,
-                    Strings.ForceEnglishOutput_Description,
-                    CommandOptionType.NoValue);
+        internal static void Register(Command rootCommand, Func<ILogger> getLogger)
+        {
+            var deleteCommand = new DocumentedCommand("delete", Strings.Delete_Description, "https://aka.ms/dotnet/nuget/delete");
 
-                var source = delete.Option(
-                    "-s|--source <source>",
-                    Strings.Source_Description,
-                    CommandOptionType.SingleValue);
+            var arguments = new Argument<List<string>>("[root]")
+            {
+                Description = Strings.Delete_PackageIdAndVersion_Description,
+                Arity = ArgumentArity.ZeroOrMore,
+            };
 
-                var nonInteractive = delete.Option(
-                    "--non-interactive",
-                    Strings.NonInteractive_Description,
-                    CommandOptionType.NoValue);
+            var source = new Option<string>("--source", "-s")
+            {
+                Description = Strings.Source_Description,
+                Arity = ArgumentArity.ExactlyOne,
+            };
 
-                var apikey = delete.Option(
-                    "-k|--api-key <apiKey>",
-                    Strings.ApiKey_Description,
-                    CommandOptionType.SingleValue);
+            var nonInteractive = new Option<bool>("--non-interactive")
+            {
+                Description = Strings.NonInteractive_Description,
+                Arity = ArgumentArity.Zero,
+            };
 
-                var arguments = delete.Argument(
-                    "[root]",
-                    Strings.Delete_PackageIdAndVersion_Description,
-                    multipleValues: true);
+            var apikey = new Option<string>("--api-key", "-k")
+            {
+                Description = Strings.ApiKey_Description,
+                Arity = ArgumentArity.ExactlyOne,
+            };
 
-                var noServiceEndpointDescription = delete.Option(
-                    "--no-service-endpoint",
-                    Strings.NoServiceEndpoint_Description,
-                    CommandOptionType.NoValue);
+            var noServiceEndpoint = new Option<bool>("--no-service-endpoint")
+            {
+                Description = Strings.NoServiceEndpoint_Description,
+                Arity = ArgumentArity.Zero,
+            };
 
-                var interactive = delete.Option(
-                    "--interactive",
-                    Strings.NuGetXplatCommand_Interactive,
-                    CommandOptionType.NoValue);
+            var interactive = new Option<bool>("--interactive")
+            {
+                Description = Strings.NuGetXplatCommand_Interactive,
+                Arity = ArgumentArity.Zero,
+            };
 
-                delete.OnExecute(async () =>
+            var forceEnglishOutput = new Option<bool>(CommandConstants.ForceEnglishOutputOption)
+            {
+                Description = Strings.ForceEnglishOutput_Description,
+                Arity = ArgumentArity.Zero,
+            };
+
+            var help = new HelpOption()
+            {
+                Arity = ArgumentArity.Zero,
+            };
+
+            deleteCommand.Arguments.Add(arguments);
+            deleteCommand.Options.Add(source);
+            deleteCommand.Options.Add(nonInteractive);
+            deleteCommand.Options.Add(apikey);
+            deleteCommand.Options.Add(noServiceEndpoint);
+            deleteCommand.Options.Add(interactive);
+            deleteCommand.Options.Add(forceEnglishOutput);
+            deleteCommand.Options.Add(help);
+
+            deleteCommand.SetAction(async (parseResult, cancellationToken) =>
+            {
+                List<string>? packageArguments = parseResult.GetValue(arguments);
+
+                if (packageArguments == null || packageArguments.Count < 2)
                 {
-                    if (arguments.Values.Count < 2)
-                    {
-                        throw new ArgumentException(Strings.Delete_MissingArguments);
-                    }
+                    throw new ArgumentException(Strings.Delete_MissingArguments);
+                }
 
-                    string packageId = arguments.Values[0];
-                    string packageVersion = arguments.Values[1];
-                    string sourcePath = source.Value();
-                    string apiKeyValue = apikey.Value();
-                    bool nonInteractiveValue = nonInteractive.HasValue();
-                    bool noServiceEndpoint = noServiceEndpointDescription.HasValue();
+                string packageId = packageArguments[0];
+                string packageVersion = packageArguments[1];
+                string? sourcePath = parseResult.GetValue(source);
+                string? apiKeyValue = parseResult.GetValue(apikey);
+                bool nonInteractiveValue = parseResult.GetValue(nonInteractive);
+                bool noServiceEndpointValue = parseResult.GetValue(noServiceEndpoint);
+                bool interactiveValue = parseResult.GetValue(interactive);
 
-                    DefaultCredentialServiceUtility.SetupDefaultCredentialService(getLogger(), !interactive.HasValue());
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(getLogger(), !interactiveValue);
 
 #pragma warning disable CS0618 // Type or member is obsolete
-                    PackageSourceProvider sourceProvider = new PackageSourceProvider(XPlatUtility.GetSettingsForCurrentWorkingDirectory(), enablePackageSourcesChangedEvent: false);
+                PackageSourceProvider sourceProvider = new PackageSourceProvider(XPlatUtility.GetSettingsForCurrentWorkingDirectory(), enablePackageSourcesChangedEvent: false);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-                    await DeleteRunner.Run(
-                        sourceProvider.Settings,
-                        sourceProvider,
-                        packageId,
-                        packageVersion,
-                        sourcePath,
-                        apiKeyValue,
-                        nonInteractiveValue,
-                        noServiceEndpoint,
-                        Confirm,
-                        getLogger());
+                await DeleteRunner.Run(
+                    sourceProvider.Settings,
+                    sourceProvider,
+                    packageId,
+                    packageVersion,
+                    sourcePath,
+                    apiKeyValue,
+                    nonInteractiveValue,
+                    noServiceEndpointValue,
+                    Confirm,
+                    getLogger());
 
-                    return 0;
-                });
+                return ExitCodes.Success;
             });
+
+            rootCommand.Subcommands.Add(deleteCommand);
         }
 
         private static bool Confirm(string description)
@@ -103,7 +139,7 @@ namespace NuGet.CommandLine.XPlat
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine(string.Format(CultureInfo.CurrentCulture, Strings.ConsoleConfirmMessage, description));
                 var result = Console.ReadLine();
-                return result.StartsWith(Strings.ConsoleConfirmMessageAccept, StringComparison.OrdinalIgnoreCase);
+                return result != null && result.StartsWith(Strings.ConsoleConfirmMessageAccept, StringComparison.OrdinalIgnoreCase);
             }
             finally
             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/LocalsCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/LocalsCommand.cs
@@ -4,8 +4,13 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Help;
 using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
+using NuGet.CommandLine.XPlat.Commands;
 using NuGet.Commands;
 using NuGet.Common;
 
@@ -13,70 +18,107 @@ namespace NuGet.CommandLine.XPlat
 {
     internal static class LocalsCommand
     {
-        public static void Register(CommandLineApplication app, Func<ILogger> getLogger)
+        // Registers a placeholder on the legacy CommandLineApplication so that `dotnet nuget --help`
+        // still lists `locals`. The command is implemented with System.CommandLine (see overloads below).
+        internal static void Register(CommandLineApplication app)
         {
             app.Command("locals", locals =>
             {
                 locals.Description = Strings.LocalsCommand_Description;
-                locals.HelpOption(XPlatUtility.HelpOption);
+            });
+        }
 
-                locals.Option(
-                    CommandConstants.ForceEnglishOutputOption,
-                    Strings.ForceEnglishOutput_Description,
-                    CommandOptionType.NoValue);
+        internal static void Register(Command rootCommand, Func<ILogger> getLogger)
+        {
+            Register(rootCommand, getLogger, () => new LocalsCommandRunner());
+        }
 
-                var clear = locals.Option(
-                    "-c|--clear",
-                    Strings.LocalsCommand_ClearDescription,
-                    CommandOptionType.NoValue);
+        internal static void Register(Command rootCommand, Func<ILogger> getLogger, Func<ILocalsCommandRunner> getCommandRunner)
+        {
+            var localsCommand = new DocumentedCommand("locals", Strings.LocalsCommand_Description, "https://aka.ms/dotnet/nuget/locals");
 
-                var list = locals.Option(
-                    "-l|--list",
-                    Strings.LocalsCommand_ListDescription,
-                    CommandOptionType.NoValue);
+            var cacheLocationArgument = new Argument<string>("Cache Location(s)")
+            {
+                Description = Strings.LocalsCommand_ArgumentDescription,
+                Arity = ArgumentArity.ZeroOrOne,
+            };
 
-                var arguments = locals.Argument(
-                    "Cache Location(s)",
-                    Strings.LocalsCommand_ArgumentDescription,
-                    multipleValues: false);
+            var clearOption = new Option<bool>("--clear", "-c")
+            {
+                Description = Strings.LocalsCommand_ClearDescription,
+                Arity = ArgumentArity.Zero,
+            };
 
-                locals.OnExecute(() =>
+            var listOption = new Option<bool>("--list", "-l")
+            {
+                Description = Strings.LocalsCommand_ListDescription,
+                Arity = ArgumentArity.Zero,
+            };
+
+            var forceEnglishOutputOption = new Option<bool>(CommandConstants.ForceEnglishOutputOption)
+            {
+                Description = Strings.ForceEnglishOutput_Description,
+                Arity = ArgumentArity.Zero,
+            };
+
+            var helpOption = new HelpOption()
+            {
+                Arity = ArgumentArity.Zero,
+            };
+
+            localsCommand.Arguments.Add(cacheLocationArgument);
+            localsCommand.Options.Add(clearOption);
+            localsCommand.Options.Add(listOption);
+            localsCommand.Options.Add(forceEnglishOutputOption);
+            localsCommand.Options.Add(helpOption);
+
+            localsCommand.SetAction((parseResult, cancellationToken) =>
+            {
+                var logger = getLogger();
+
+                try
                 {
-                    var logger = getLogger();
-                    var setting = XPlatUtility.GetSettingsForCurrentWorkingDirectory();
+                    var settings = XPlatUtility.GetSettingsForCurrentWorkingDirectory();
+                    string? cacheLocation = parseResult.GetValue(cacheLocationArgument);
+                    bool clear = parseResult.GetValue(clearOption);
+                    bool list = parseResult.GetValue(listOption);
 
-                    // Using both -clear and -list command options, or neither one of them, is not supported.
-                    // We use MinArgs = 0 even though the first argument is required,
-                    // to avoid throwing a command argument validation exception and
-                    // immediately show usage help for this command instead.
-                    if ((arguments.Values.Count < 1) || string.IsNullOrWhiteSpace(arguments.Values[0]))
+                    // Using both --clear and --list, or neither one of them, is not supported.
+                    // The cache location argument is optional at parse time so we can surface a
+                    // NuGet-specific usage message instead of System.CommandLine's generic error.
+                    if (string.IsNullOrWhiteSpace(cacheLocation))
                     {
                         throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_NoArguments));
                     }
-                    else if (clear.HasValue() && list.HasValue())
+                    else if (clear && list)
                     {
                         throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_MultipleOperations));
                     }
-                    else if (!clear.HasValue() && !list.HasValue())
+                    else if (!clear && !list)
                     {
                         throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_NoOperation));
                     }
-                    else
-                    {
-                        var localsArgs = new LocalsArgs(arguments.Values,
-                            setting,
-                            logger.LogInformation,
-                            logger.LogError,
-                            clear.HasValue(),
-                            list.HasValue());
 
-                        var localsCommandRunner = new LocalsCommandRunner();
-                        localsCommandRunner.ExecuteCommand(localsArgs);
-                    }
+                    var localsArgs = new LocalsArgs(
+                        new List<string>() { cacheLocation },
+                        settings,
+                        logger.LogInformation,
+                        logger.LogError,
+                        clear,
+                        list);
 
-                    return 0;
-                });
+                    getCommandRunner().ExecuteCommand(localsArgs);
+
+                    return Task.FromResult(ExitCodes.Success);
+                }
+                catch (ArgumentException ex)
+                {
+                    logger.LogError(ex.Message);
+                    return Task.FromResult(ExitCodes.InvalidArguments);
+                }
             });
+
+            rootCommand.Subcommands.Add(localsCommand);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -5,8 +5,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Help;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
+using NuGet.CommandLine.XPlat.Commands;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -16,139 +19,185 @@ namespace NuGet.CommandLine.XPlat
 {
     internal static class PushCommand
     {
-        public static void Register(CommandLineApplication app, Func<ILogger> getLogger)
+        // Registers a placeholder on the legacy CommandLineApplication so that `dotnet nuget --help`
+        // still lists `push`. The command is implemented with System.CommandLine (see overload below).
+        internal static void Register(CommandLineApplication app)
         {
             app.Command("push", push =>
             {
                 push.Description = Strings.Push_Description;
-                push.HelpOption(XPlatUtility.HelpOption);
+            });
+        }
 
-                push.Option(
-                    CommandConstants.ForceEnglishOutputOption,
-                    Strings.ForceEnglishOutput_Description,
-                    CommandOptionType.NoValue);
+        internal static void Register(Command rootCommand, Func<ILogger> getLogger)
+        {
+            var pushCommand = new DocumentedCommand("push", Strings.Push_Description, "https://aka.ms/dotnet/nuget/push");
 
-                var source = push.Option(
-                    "-s|--source <source>",
-                    Strings.Source_Description,
-                    CommandOptionType.SingleValue);
+            var arguments = new Argument<List<string>>("[root]")
+            {
+                Description = Strings.Push_Package_ApiKey_Description,
+                Arity = ArgumentArity.ZeroOrMore,
+            };
 
-                var allowInsecureConnections = push.Option(
-                    "--allow-insecure-connections",
-                    Strings.AllowInsecureConnections_Description,
-                    CommandOptionType.NoValue);
+            var source = new Option<string>("--source", "-s")
+            {
+                Description = Strings.Source_Description,
+                Arity = ArgumentArity.ExactlyOne,
+            };
 
-                var symbolSource = push.Option(
-                    "-ss|--symbol-source <source>",
-                    Strings.SymbolSource_Description,
-                    CommandOptionType.SingleValue);
+            var allowInsecureConnections = new Option<bool>("--allow-insecure-connections")
+            {
+                Description = Strings.AllowInsecureConnections_Description,
+                Arity = ArgumentArity.Zero,
+            };
 
-                var timeout = push.Option(
-                    "-t|--timeout <timeout>",
-                    Strings.Push_Timeout_Description,
-                    CommandOptionType.SingleValue);
+            var symbolSource = new Option<string>("--symbol-source", "-ss")
+            {
+                Description = Strings.SymbolSource_Description,
+                Arity = ArgumentArity.ExactlyOne,
+            };
 
-                var apikey = push.Option(
-                    "-k|--api-key <apiKey>",
-                    Strings.ApiKey_Description,
-                    CommandOptionType.SingleValue);
+            var timeout = new Option<string>("--timeout", "-t")
+            {
+                Description = Strings.Push_Timeout_Description,
+                Arity = ArgumentArity.ExactlyOne,
+            };
 
-                var symbolApiKey = push.Option(
-                    "-sk|--symbol-api-key <apiKey>",
-                    Strings.SymbolApiKey_Description,
-                    CommandOptionType.SingleValue);
+            var apikey = new Option<string>("--api-key", "-k")
+            {
+                Description = Strings.ApiKey_Description,
+                Arity = ArgumentArity.ExactlyOne,
+            };
 
-                var disableBuffering = push.Option(
-                    "-d|--disable-buffering",
-                    Strings.DisableBuffering_Description,
-                    CommandOptionType.NoValue);
+            var symbolApiKey = new Option<string>("--symbol-api-key", "-sk")
+            {
+                Description = Strings.SymbolApiKey_Description,
+                Arity = ArgumentArity.ExactlyOne,
+            };
 
-                var noSymbols = push.Option(
-                    "-n|--no-symbols",
-                    Strings.NoSymbols_Description,
-                    CommandOptionType.NoValue);
+            var disableBuffering = new Option<bool>("--disable-buffering", "-d")
+            {
+                Description = Strings.DisableBuffering_Description,
+                Arity = ArgumentArity.Zero,
+            };
 
-                var arguments = push.Argument(
-                    "[root]",
-                    Strings.Push_Package_ApiKey_Description,
-                    multipleValues: true);
+            var noSymbols = new Option<bool>("--no-symbols", "-n")
+            {
+                Description = Strings.NoSymbols_Description,
+                Arity = ArgumentArity.Zero,
+            };
 
-                var noServiceEndpointDescription = push.Option(
-                    "--no-service-endpoint",
-                    Strings.NoServiceEndpoint_Description,
-                    CommandOptionType.NoValue);
+            var noServiceEndpoint = new Option<bool>("--no-service-endpoint")
+            {
+                Description = Strings.NoServiceEndpoint_Description,
+                Arity = ArgumentArity.Zero,
+            };
 
-                var interactive = push.Option(
-                    "--interactive",
-                    Strings.NuGetXplatCommand_Interactive,
-                    CommandOptionType.NoValue);
+            var interactive = new Option<bool>("--interactive")
+            {
+                Description = Strings.NuGetXplatCommand_Interactive,
+                Arity = ArgumentArity.Zero,
+            };
 
-                var skipDuplicate = push.Option(
-                    "--skip-duplicate",
-                    Strings.PushCommandSkipDuplicateDescription,
-                    CommandOptionType.NoValue);
+            var skipDuplicate = new Option<bool>("--skip-duplicate")
+            {
+                Description = Strings.PushCommandSkipDuplicateDescription,
+                Arity = ArgumentArity.Zero,
+            };
 
-                var configurationFile = push.Option(
-                    "--configfile",
-                    Strings.Option_ConfigFile,
-                    CommandOptionType.SingleValue);
+            var configurationFile = new Option<string>("--configfile")
+            {
+                Description = Strings.Option_ConfigFile,
+                Arity = ArgumentArity.ExactlyOne,
+            };
 
-                push.OnExecute(async () =>
+            var forceEnglishOutput = new Option<bool>(CommandConstants.ForceEnglishOutputOption)
+            {
+                Description = Strings.ForceEnglishOutput_Description,
+                Arity = ArgumentArity.Zero,
+            };
+
+            var help = new HelpOption()
+            {
+                Arity = ArgumentArity.Zero,
+            };
+
+            pushCommand.Arguments.Add(arguments);
+            pushCommand.Options.Add(source);
+            pushCommand.Options.Add(allowInsecureConnections);
+            pushCommand.Options.Add(symbolSource);
+            pushCommand.Options.Add(timeout);
+            pushCommand.Options.Add(apikey);
+            pushCommand.Options.Add(symbolApiKey);
+            pushCommand.Options.Add(disableBuffering);
+            pushCommand.Options.Add(noSymbols);
+            pushCommand.Options.Add(noServiceEndpoint);
+            pushCommand.Options.Add(interactive);
+            pushCommand.Options.Add(skipDuplicate);
+            pushCommand.Options.Add(configurationFile);
+            pushCommand.Options.Add(forceEnglishOutput);
+            pushCommand.Options.Add(help);
+
+            pushCommand.SetAction(async (parseResult, cancellationToken) =>
+            {
+                List<string>? packagePaths = parseResult.GetValue(arguments);
+
+                if (packagePaths == null || packagePaths.Count < 1)
                 {
-                    if (arguments.Values.Count < 1)
-                    {
-                        throw new ArgumentException(Strings.Push_MissingArguments);
-                    }
+                    throw new ArgumentException(Strings.Push_MissingArguments);
+                }
 
-                    IList<string> packagePaths = arguments.Values;
-                    string sourcePath = source.Value();
-                    string apiKeyValue = apikey.Value();
-                    string symbolSourcePath = symbolSource.Value();
-                    string symbolApiKeyValue = symbolApiKey.Value();
-                    bool disableBufferingValue = disableBuffering.HasValue();
-                    bool noSymbolsValue = noSymbols.HasValue();
-                    bool noServiceEndpoint = noServiceEndpointDescription.HasValue();
-                    bool skipDuplicateValue = skipDuplicate.HasValue();
-                    bool allowInsecureConnectionsValue = allowInsecureConnections.HasValue();
-                    int timeoutSeconds = 0;
+                string? sourcePath = parseResult.GetValue(source);
+                string? apiKeyValue = parseResult.GetValue(apikey);
+                string? symbolSourcePath = parseResult.GetValue(symbolSource);
+                string? symbolApiKeyValue = parseResult.GetValue(symbolApiKey);
+                bool disableBufferingValue = parseResult.GetValue(disableBuffering);
+                bool noSymbolsValue = parseResult.GetValue(noSymbols);
+                bool noServiceEndpointValue = parseResult.GetValue(noServiceEndpoint);
+                bool skipDuplicateValue = parseResult.GetValue(skipDuplicate);
+                bool allowInsecureConnectionsValue = parseResult.GetValue(allowInsecureConnections);
+                bool interactiveValue = parseResult.GetValue(interactive);
+                string? timeoutValue = parseResult.GetValue(timeout);
+                int timeoutSeconds = 0;
 
-                    if (timeout.HasValue() && !int.TryParse(timeout.Value(), out timeoutSeconds))
-                    {
-                        throw new ArgumentException(Strings.Push_InvalidTimeout);
-                    }
+                if (!string.IsNullOrEmpty(timeoutValue) && !int.TryParse(timeoutValue, out timeoutSeconds))
+                {
+                    throw new ArgumentException(Strings.Push_InvalidTimeout);
+                }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-                    var sourceProvider = new PackageSourceProvider(XPlatUtility.ProcessConfigFile(configurationFile.Value()), enablePackageSourcesChangedEvent: false);
+                var sourceProvider = new PackageSourceProvider(XPlatUtility.ProcessConfigFile(parseResult.GetValue(configurationFile)), enablePackageSourcesChangedEvent: false);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-                    try
-                    {
-                        DefaultCredentialServiceUtility.SetupDefaultCredentialService(getLogger(), !interactive.HasValue());
+                try
+                {
+                    DefaultCredentialServiceUtility.SetupDefaultCredentialService(getLogger(), !interactiveValue);
 
-                        await PushRunner.Run(
-                            sourceProvider.Settings,
-                            sourceProvider,
-                            packagePaths,
-                            sourcePath,
-                            apiKeyValue,
-                            symbolSourcePath,
-                            symbolApiKeyValue,
-                            timeoutSeconds,
-                            disableBufferingValue,
-                            noSymbolsValue,
-                            noServiceEndpoint,
-                            skipDuplicateValue,
-                            allowInsecureConnectionsValue,
-                            getLogger());
-                    }
-                    catch (TaskCanceledException ex)
-                    {
-                        throw new AggregateException(ex, new Exception(Strings.Push_Timeout_Error));
-                    }
+                    await PushRunner.Run(
+                        sourceProvider.Settings,
+                        sourceProvider,
+                        packagePaths,
+                        sourcePath,
+                        apiKeyValue,
+                        symbolSourcePath,
+                        symbolApiKeyValue,
+                        timeoutSeconds,
+                        disableBufferingValue,
+                        noSymbolsValue,
+                        noServiceEndpointValue,
+                        skipDuplicateValue,
+                        allowInsecureConnectionsValue,
+                        getLogger());
+                }
+                catch (TaskCanceledException ex)
+                {
+                    throw new AggregateException(ex, new Exception(Strings.Push_Timeout_Error));
+                }
 
-                    return 0;
-                });
+                return ExitCodes.Success;
             });
+
+            rootCommand.Subcommands.Add(pushCommand);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/VerifyCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Signing/VerifyCommand.cs
@@ -5,9 +5,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Help;
 using System.Globalization;
 using System.Linq;
 using Microsoft.Extensions.CommandLineUtils;
+using NuGet.CommandLine.XPlat.Commands;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
@@ -17,74 +20,107 @@ namespace NuGet.CommandLine.XPlat
 {
     internal static class VerifyCommand
     {
-        internal static void Register(CommandLineApplication app,
+        // Registers a placeholder on the legacy CommandLineApplication so that `dotnet nuget --help`
+        // still lists `verify`. The command is implemented with System.CommandLine (see overload below).
+        internal static void Register(CommandLineApplication app)
+        {
+            app.Command("verify", verifyCmd =>
+            {
+                verifyCmd.Description = Strings.VerifyCommandDescription;
+            });
+        }
+
+        internal static void Register(Command rootCommand,
                               Func<ILogger> getLogger,
                               Action<LogLevel> setLogLevel,
                               Func<IVerifyCommandRunner> getCommandRunner)
         {
-            app.Command("verify", verifyCmd =>
+            var verifyCommand = new DocumentedCommand("verify", Strings.VerifyCommandDescription, "https://aka.ms/dotnet/nuget/verify");
+
+            var packagePaths = new Argument<List<string>>("package-paths")
             {
-                CommandArgument packagePaths = verifyCmd.Argument(
-                    "<package-paths>",
-                    Strings.VerifyCommandPackagePathDescription,
-                    multipleValues: true);
+                Description = Strings.VerifyCommandPackagePathDescription,
+                Arity = ArgumentArity.ZeroOrMore,
+            };
 
-                CommandOption all = verifyCmd.Option(
-                    "--all",
-                    Strings.VerifyCommandAllDescription,
-                    CommandOptionType.NoValue);
+            var all = new Option<bool>("--all")
+            {
+                Description = Strings.VerifyCommandAllDescription,
+                Arity = ArgumentArity.Zero,
+            };
 
-                CommandOption fingerPrint = verifyCmd.Option(
-                    "--certificate-fingerprint",
-                    Strings.VerifyCommandCertificateFingerprintDescription,
-                    CommandOptionType.MultipleValue);
+            var fingerPrint = new Option<List<string>>("--certificate-fingerprint")
+            {
+                Description = Strings.VerifyCommandCertificateFingerprintDescription,
+                Arity = ArgumentArity.ZeroOrMore,
+                AllowMultipleArgumentsPerToken = true,
+            };
 
-                CommandOption configFile = verifyCmd.Option(
-                    "--configfile",
-                    Strings.Option_ConfigFile,
-                    CommandOptionType.SingleValue);
+            var configFile = new Option<string>("--configfile")
+            {
+                Description = Strings.Option_ConfigFile,
+                Arity = ArgumentArity.ExactlyOne,
+            };
 
-                CommandOption verbosity = verifyCmd.Option(
-                    "-v|--verbosity",
-                    Strings.Verbosity_Description,
-                    CommandOptionType.SingleValue);
+            var verbosity = new Option<string>("--verbosity", "-v")
+            {
+                Description = Strings.Verbosity_Description,
+                Arity = ArgumentArity.ExactlyOne,
+            };
 
-                verifyCmd.HelpOption(XPlatUtility.HelpOption);
-                verifyCmd.Description = Strings.VerifyCommandDescription;
+            var forceEnglishOutput = new Option<bool>(CommandConstants.ForceEnglishOutputOption)
+            {
+                Description = Strings.ForceEnglishOutput_Description,
+                Arity = ArgumentArity.Zero,
+            };
 
-                verifyCmd.OnExecute(async () =>
-                {
-                    ValidatePackagePaths(packagePaths);
+            var help = new HelpOption()
+            {
+                Arity = ArgumentArity.Zero,
+            };
 
-                    VerifyArgs args = new VerifyArgs();
-                    args.PackagePaths = packagePaths.Values;
-                    args.Verifications = all.HasValue() ?
-                        new List<Verification>() { Verification.All } :
-                        new List<Verification>() { Verification.Signatures };
-                    args.CertificateFingerprint = fingerPrint.Values;
-                    args.Logger = getLogger();
-                    args.Settings = XPlatUtility.ProcessConfigFile(configFile.Value());
-                    setLogLevel(XPlatUtility.MSBuildVerbosityToNuGetLogLevel(verbosity.Value()));
+            verifyCommand.Arguments.Add(packagePaths);
+            verifyCommand.Options.Add(all);
+            verifyCommand.Options.Add(fingerPrint);
+            verifyCommand.Options.Add(configFile);
+            verifyCommand.Options.Add(verbosity);
+            verifyCommand.Options.Add(forceEnglishOutput);
+            verifyCommand.Options.Add(help);
 
-                    X509TrustStore.InitializeForDotNetSdk(args.Logger);
+            verifyCommand.SetAction(async (parseResult, cancellationToken) =>
+            {
+                List<string>? packagePathsValue = parseResult.GetValue(packagePaths);
 
-                    var runner = getCommandRunner();
-                    var verifyTask = runner.ExecuteCommandAsync(args);
-                    await verifyTask;
+                ValidatePackagePaths(packagePathsValue, "<package-paths>");
 
-                    return verifyTask.Result;
-                });
+                VerifyArgs args = new VerifyArgs();
+                args.PackagePaths = packagePathsValue!;
+                args.Verifications = parseResult.GetValue(all) ?
+                    new List<Verification>() { Verification.All } :
+                    new List<Verification>() { Verification.Signatures };
+                args.CertificateFingerprint = parseResult.GetValue(fingerPrint);
+                args.Logger = getLogger();
+                args.Settings = XPlatUtility.ProcessConfigFile(parseResult.GetValue(configFile));
+                setLogLevel(XPlatUtility.MSBuildVerbosityToNuGetLogLevel(parseResult.GetValue(verbosity)));
+
+                X509TrustStore.InitializeForDotNetSdk(args.Logger);
+
+                var runner = getCommandRunner();
+                return await runner.ExecuteCommandAsync(args);
             });
+
+            rootCommand.Subcommands.Add(verifyCommand);
         }
 
-        private static void ValidatePackagePaths(CommandArgument argument)
+        private static void ValidatePackagePaths(List<string>? packagePaths, string argumentName)
         {
-            if (argument.Values.Count == 0 ||
-                argument.Values.Any<string>(packagePath => string.IsNullOrEmpty(packagePath)))
+            if (packagePaths == null ||
+                packagePaths.Count == 0 ||
+                packagePaths.Any<string>(packagePath => string.IsNullOrEmpty(packagePath)))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_PkgMissingArgument,
                     "verify",
-                    argument.Name));
+                    argumentName));
             }
         }
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Verbs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Verbs.cs
@@ -4,493 +4,492 @@
 #nullable enable
 
 using System;
+using System.CommandLine;
+using System.CommandLine.Help;
+using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
+using NuGet.CommandLine.XPlat.Commands;
 using NuGet.Commands;
 using NuGet.Common;
 
 namespace NuGet.CommandLine.XPlat
 {
+    /// <summary>
+    /// Shared helpers used by the source/client-cert verb parsers that have been migrated to System.CommandLine.
+    /// </summary>
+    internal static class VerbCommandHelpers
+    {
+        // The verb runners (e.g. AddSourceRunner.Run) throw on error. Exceptions propagate to Program.MainInternal's
+        // handler (System.CommandLine's default exception handler is disabled for these commands), which logs the
+        // message and returns a non-zero exit code, matching the legacy parser's behavior.
+        internal static int RunVerb(Action run)
+        {
+            run();
+            return ExitCodes.Success;
+        }
+
+        internal static Argument<string> CreateNameArgument(string name, string description)
+        {
+            return new Argument<string>(name)
+            {
+                Description = description,
+                // ZeroOrOne (not ExactlyOne) so a missing name yields null and the NuGet
+                // runner surfaces its own command-specific error instead of System.CommandLine's
+                // generic "Required argument missing" message.
+                Arity = ArgumentArity.ZeroOrOne,
+            };
+        }
+
+        internal static Option<string> CreateStringOption(string name, string description, string? alias = null)
+        {
+            Option<string> option = alias is null
+                ? new Option<string>(name)
+                : new Option<string>(name, alias);
+            option.Description = description;
+            option.Arity = ArgumentArity.ExactlyOne;
+            return option;
+        }
+
+        internal static Option<bool> CreateBoolOption(string name, string description, string? alias = null)
+        {
+            Option<bool> option = alias is null
+                ? new Option<bool>(name)
+                : new Option<bool>(name, alias);
+            option.Description = description;
+            option.Arity = ArgumentArity.Zero;
+            return option;
+        }
+
+        internal static Option<bool> CreateForceEnglishOutputOption()
+        {
+            return new Option<bool>(CommandConstants.ForceEnglishOutputOption)
+            {
+                Description = Strings.ForceEnglishOutput_Description,
+                Arity = ArgumentArity.Zero,
+            };
+        }
+
+        internal static HelpOption CreateHelpOption()
+        {
+            return new HelpOption()
+            {
+                Arity = ArgumentArity.Zero,
+            };
+        }
+    }
+
     internal partial class AddVerbParser
     {
-        internal static void Register(CommandLineApplication app,
-                                      Func<ILogger> getLogger)
+        // Registers a placeholder on the legacy CommandLineApplication so that `dotnet nuget --help`
+        // still lists `add`. The command is implemented with System.CommandLine (see overload below).
+        internal static void Register(CommandLineApplication app)
         {
-            app.Command("add", AddCmd =>
+            app.Command("add", addCmd =>
             {
-                AddCmd.Command("source", SourceCmd =>
-                {
-                    CommandArgument Source = SourceCmd.Argument(
-                        "PackageSourcePath", Strings.SourcesCommandSourceDescription);
-                    CommandOption name = SourceCmd.Option(
-                        "-n|--name",
-                        Strings.SourcesCommandNameDescription,
-                        CommandOptionType.SingleValue);
-                    CommandOption username = SourceCmd.Option(
-                        "-u|--username",
-                        Strings.SourcesCommandUsernameDescription,
-                        CommandOptionType.SingleValue);
-                    CommandOption password = SourceCmd.Option(
-                        "-p|--password",
-                        Strings.SourcesCommandPasswordDescription,
-                        CommandOptionType.SingleValue);
-                    CommandOption storePasswordInClearText = SourceCmd.Option(
-                        "--store-password-in-clear-text",
-                        Strings.SourcesCommandStorePasswordInClearTextDescription,
-                        CommandOptionType.NoValue);
-                    CommandOption validAuthenticationTypes = SourceCmd.Option(
-                        "--valid-authentication-types",
-                        Strings.SourcesCommandValidAuthenticationTypesDescription,
-                        CommandOptionType.SingleValue);
-                    CommandOption protocolVersion = SourceCmd.Option(
-                        "--protocol-version",
-                        Strings.SourcesCommandProtocolVersionDescription,
-                        CommandOptionType.SingleValue);
-                    CommandOption configfile = SourceCmd.Option(
-                        "--configfile",
-                        Strings.Option_ConfigFile,
-                        CommandOptionType.SingleValue);
-                    CommandOption allowInsecureConnections = SourceCmd.Option(
-                        "--allow-insecure-connections",
-                        Strings.SourcesCommandAllowInsecureConnectionsDescription,
-                        CommandOptionType.NoValue);
-                    SourceCmd.HelpOption("-h|--help");
-                    SourceCmd.Description = Strings.AddSourceCommandDescription;
-                    SourceCmd.OnExecute(() =>
-                    {
-                        var args = new AddSourceArgs()
-                        {
-                            Source = Source.Value,
-                            Name = name.Value(),
-                            Username = username.Value(),
-                            Password = password.Value(),
-                            StorePasswordInClearText = storePasswordInClearText.HasValue(),
-                            ValidAuthenticationTypes = validAuthenticationTypes.Value(),
-                            ProtocolVersion = protocolVersion.Value(),
-                            Configfile = configfile.Value(),
-                            AllowInsecureConnections = allowInsecureConnections.HasValue(),
-                        };
-
-                        AddSourceRunner.Run(args, getLogger);
-                        return 0;
-                    });
-                });
-                AddCmd.Command("client-cert", ClientCertCmd =>
-                {
-                    CommandOption packagesource = ClientCertCmd.Option(
-                        "-s|--package-source",
-                        Strings.Option_PackageSource,
-                        CommandOptionType.SingleValue);
-                    CommandOption path = ClientCertCmd.Option(
-                        "--path",
-                        Strings.Option_Path,
-                        CommandOptionType.SingleValue);
-                    CommandOption password = ClientCertCmd.Option(
-                        "--password",
-                        Strings.Option_Password,
-                        CommandOptionType.SingleValue);
-                    CommandOption storepasswordincleartext = ClientCertCmd.Option(
-                        "--store-password-in-clear-text",
-                        Strings.Option_StorePasswordInClearText,
-                        CommandOptionType.NoValue);
-                    CommandOption storelocation = ClientCertCmd.Option(
-                        "--store-location",
-                        Strings.Option_StoreLocation,
-                        CommandOptionType.SingleValue);
-                    CommandOption storename = ClientCertCmd.Option(
-                        "--store-name",
-                        Strings.Option_StoreName,
-                        CommandOptionType.SingleValue);
-                    CommandOption findby = ClientCertCmd.Option(
-                        "--find-by",
-                        Strings.Option_FindBy,
-                        CommandOptionType.SingleValue);
-                    CommandOption findvalue = ClientCertCmd.Option(
-                        "--find-value",
-                        Strings.Option_FindValue,
-                        CommandOptionType.SingleValue);
-                    CommandOption force = ClientCertCmd.Option(
-                        "-f|--force",
-                        Strings.Option_Force,
-                        CommandOptionType.NoValue);
-                    CommandOption configfile = ClientCertCmd.Option(
-                        "--configfile",
-                        Strings.Option_ConfigFile,
-                        CommandOptionType.SingleValue);
-                    ClientCertCmd.HelpOption("-h|--help");
-                    ClientCertCmd.Description = Strings.AddClientCertCommandDescription;
-                    ClientCertCmd.OnExecute(() =>
-                    {
-                        var args = new AddClientCertArgs()
-                        {
-                            PackageSource = packagesource.Value(),
-                            Path = path.Value(),
-                            Password = password.Value(),
-                            StorePasswordInClearText = storepasswordincleartext.HasValue(),
-                            StoreLocation = storelocation.Value(),
-                            StoreName = storename.Value(),
-                            FindBy = findby.Value(),
-                            FindValue = findvalue.Value(),
-                            Force = force.HasValue(),
-                            Configfile = configfile.Value(),
-                        };
-
-                        AddClientCertRunner.Run(args, getLogger);
-                        return 0;
-                    });
-                });
-                AddCmd.HelpOption("-h|--help");
-                AddCmd.Description = Strings.Add_Description;
-                AddCmd.OnExecute(() =>
-                {
-                    app.ShowHelp("add");
-                    return 0;
-                });
+                addCmd.Command("source", sourceCmd => sourceCmd.Description = Strings.AddSourceCommandDescription);
+                addCmd.Command("client-cert", clientCertCmd => clientCertCmd.Description = Strings.AddClientCertCommandDescription);
+                addCmd.Description = Strings.Add_Description;
             });
+        }
+
+        internal static void Register(Command app, Func<ILogger> getLogger)
+        {
+            var addCmd = new DocumentedCommand("add", Strings.Add_Description, "https://aka.ms/dotnet/nuget/add");
+
+            // add source
+            var sourceCmd = new DocumentedCommand("source", Strings.AddSourceCommandDescription, "https://aka.ms/dotnet/nuget/add/source");
+            var sourceArgument = VerbCommandHelpers.CreateNameArgument("PackageSourcePath", Strings.SourcesCommandSourceDescription);
+            var name = VerbCommandHelpers.CreateStringOption("--name", Strings.SourcesCommandNameDescription, "-n");
+            var username = VerbCommandHelpers.CreateStringOption("--username", Strings.SourcesCommandUsernameDescription, "-u");
+            var password = VerbCommandHelpers.CreateStringOption("--password", Strings.SourcesCommandPasswordDescription, "-p");
+            var storePasswordInClearText = VerbCommandHelpers.CreateBoolOption("--store-password-in-clear-text", Strings.SourcesCommandStorePasswordInClearTextDescription);
+            var validAuthenticationTypes = VerbCommandHelpers.CreateStringOption("--valid-authentication-types", Strings.SourcesCommandValidAuthenticationTypesDescription);
+            var protocolVersion = VerbCommandHelpers.CreateStringOption("--protocol-version", Strings.SourcesCommandProtocolVersionDescription);
+            var configfile = VerbCommandHelpers.CreateStringOption("--configfile", Strings.Option_ConfigFile);
+            var allowInsecureConnections = VerbCommandHelpers.CreateBoolOption("--allow-insecure-connections", Strings.SourcesCommandAllowInsecureConnectionsDescription);
+
+            sourceCmd.Arguments.Add(sourceArgument);
+            sourceCmd.Options.Add(name);
+            sourceCmd.Options.Add(username);
+            sourceCmd.Options.Add(password);
+            sourceCmd.Options.Add(storePasswordInClearText);
+            sourceCmd.Options.Add(validAuthenticationTypes);
+            sourceCmd.Options.Add(protocolVersion);
+            sourceCmd.Options.Add(configfile);
+            sourceCmd.Options.Add(allowInsecureConnections);
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateForceEnglishOutputOption());
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateHelpOption());
+            sourceCmd.SetAction((parseResult, cancellationToken) =>
+            {
+                var args = new AddSourceArgs()
+                {
+                    Source = parseResult.GetValue(sourceArgument),
+                    Name = parseResult.GetValue(name),
+                    Username = parseResult.GetValue(username),
+                    Password = parseResult.GetValue(password),
+                    StorePasswordInClearText = parseResult.GetValue(storePasswordInClearText),
+                    ValidAuthenticationTypes = parseResult.GetValue(validAuthenticationTypes),
+                    ProtocolVersion = parseResult.GetValue(protocolVersion),
+                    Configfile = parseResult.GetValue(configfile),
+                    AllowInsecureConnections = parseResult.GetValue(allowInsecureConnections),
+                };
+
+                return Task.FromResult(VerbCommandHelpers.RunVerb(() => AddSourceRunner.Run(args, getLogger)));
+            });
+            addCmd.Subcommands.Add(sourceCmd);
+
+            // add client-cert
+            var clientCertCmd = new DocumentedCommand("client-cert", Strings.AddClientCertCommandDescription, "https://aka.ms/dotnet/nuget/add/client-cert");
+            var ccPackageSource = VerbCommandHelpers.CreateStringOption("--package-source", Strings.Option_PackageSource, "-s");
+            var ccPath = VerbCommandHelpers.CreateStringOption("--path", Strings.Option_Path);
+            var ccPassword = VerbCommandHelpers.CreateStringOption("--password", Strings.Option_Password);
+            var ccStorePasswordInClearText = VerbCommandHelpers.CreateBoolOption("--store-password-in-clear-text", Strings.Option_StorePasswordInClearText);
+            var ccStoreLocation = VerbCommandHelpers.CreateStringOption("--store-location", Strings.Option_StoreLocation);
+            var ccStoreName = VerbCommandHelpers.CreateStringOption("--store-name", Strings.Option_StoreName);
+            var ccFindBy = VerbCommandHelpers.CreateStringOption("--find-by", Strings.Option_FindBy);
+            var ccFindValue = VerbCommandHelpers.CreateStringOption("--find-value", Strings.Option_FindValue);
+            var ccForce = VerbCommandHelpers.CreateBoolOption("--force", Strings.Option_Force, "-f");
+            var ccConfigfile = VerbCommandHelpers.CreateStringOption("--configfile", Strings.Option_ConfigFile);
+
+            clientCertCmd.Options.Add(ccPackageSource);
+            clientCertCmd.Options.Add(ccPath);
+            clientCertCmd.Options.Add(ccPassword);
+            clientCertCmd.Options.Add(ccStorePasswordInClearText);
+            clientCertCmd.Options.Add(ccStoreLocation);
+            clientCertCmd.Options.Add(ccStoreName);
+            clientCertCmd.Options.Add(ccFindBy);
+            clientCertCmd.Options.Add(ccFindValue);
+            clientCertCmd.Options.Add(ccForce);
+            clientCertCmd.Options.Add(ccConfigfile);
+            clientCertCmd.Options.Add(VerbCommandHelpers.CreateForceEnglishOutputOption());
+            clientCertCmd.Options.Add(VerbCommandHelpers.CreateHelpOption());
+            clientCertCmd.SetAction((parseResult, cancellationToken) =>
+            {
+                var args = new AddClientCertArgs()
+                {
+                    PackageSource = parseResult.GetValue(ccPackageSource),
+                    Path = parseResult.GetValue(ccPath),
+                    Password = parseResult.GetValue(ccPassword),
+                    StorePasswordInClearText = parseResult.GetValue(ccStorePasswordInClearText),
+                    StoreLocation = parseResult.GetValue(ccStoreLocation),
+                    StoreName = parseResult.GetValue(ccStoreName),
+                    FindBy = parseResult.GetValue(ccFindBy),
+                    FindValue = parseResult.GetValue(ccFindValue),
+                    Force = parseResult.GetValue(ccForce),
+                    Configfile = parseResult.GetValue(ccConfigfile),
+                };
+
+                return Task.FromResult(VerbCommandHelpers.RunVerb(() => AddClientCertRunner.Run(args, getLogger)));
+            });
+            addCmd.Subcommands.Add(clientCertCmd);
+
+            app.Subcommands.Add(addCmd);
         }
     }
 
     internal partial class DisableVerbParser
     {
-        internal static void Register(CommandLineApplication app,
-                                      Func<ILogger> getLogger)
+        internal static void Register(CommandLineApplication app)
         {
-            app.Command("disable", DisableCmd =>
+            app.Command("disable", disableCmd =>
             {
-                DisableCmd.Command("source", SourceCmd =>
-                {
-                    CommandArgument name = SourceCmd.Argument(
-                        "name", Strings.SourcesCommandNameDescription);
-                    CommandOption configfile = SourceCmd.Option(
-                        "--configfile",
-                        Strings.Option_ConfigFile,
-                        CommandOptionType.SingleValue);
-                    SourceCmd.HelpOption("-h|--help");
-                    SourceCmd.Description = Strings.DisableSourceCommandDescription;
-                    SourceCmd.OnExecute(() =>
-                    {
-                        var args = new DisableSourceArgs()
-                        {
-                            Name = name.Value,
-                            Configfile = configfile.Value(),
-                        };
-
-                        DisableSourceRunner.Run(args, getLogger);
-                        return 0;
-                    });
-                });
-                DisableCmd.HelpOption("-h|--help");
-                DisableCmd.Description = Strings.Disable_Description;
-                DisableCmd.OnExecute(() =>
-                {
-                    app.ShowHelp("disable");
-                    return 0;
-                });
+                disableCmd.Command("source", sourceCmd => sourceCmd.Description = Strings.DisableSourceCommandDescription);
+                disableCmd.Description = Strings.Disable_Description;
             });
+        }
+
+        internal static void Register(Command app, Func<ILogger> getLogger)
+        {
+            var disableCmd = new DocumentedCommand("disable", Strings.Disable_Description, "https://aka.ms/dotnet/nuget/disable");
+
+            var sourceCmd = new DocumentedCommand("source", Strings.DisableSourceCommandDescription, "https://aka.ms/dotnet/nuget/disable/source");
+            var nameArgument = VerbCommandHelpers.CreateNameArgument("name", Strings.SourcesCommandNameDescription);
+            var configfile = VerbCommandHelpers.CreateStringOption("--configfile", Strings.Option_ConfigFile);
+
+            sourceCmd.Arguments.Add(nameArgument);
+            sourceCmd.Options.Add(configfile);
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateForceEnglishOutputOption());
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateHelpOption());
+            sourceCmd.SetAction((parseResult, cancellationToken) =>
+            {
+                var args = new DisableSourceArgs()
+                {
+                    Name = parseResult.GetValue(nameArgument),
+                    Configfile = parseResult.GetValue(configfile),
+                };
+
+                return Task.FromResult(VerbCommandHelpers.RunVerb(() => DisableSourceRunner.Run(args, getLogger)));
+            });
+            disableCmd.Subcommands.Add(sourceCmd);
+
+            app.Subcommands.Add(disableCmd);
         }
     }
 
     internal partial class EnableVerbParser
     {
-        internal static void Register(CommandLineApplication app,
-                                      Func<ILogger> getLogger)
+        internal static void Register(CommandLineApplication app)
         {
-            app.Command("enable", EnableCmd =>
+            app.Command("enable", enableCmd =>
             {
-                EnableCmd.Command("source", SourceCmd =>
-                {
-                    CommandArgument name = SourceCmd.Argument(
-                        "name", Strings.SourcesCommandNameDescription);
-                    CommandOption configfile = SourceCmd.Option(
-                        "--configfile",
-                        Strings.Option_ConfigFile,
-                        CommandOptionType.SingleValue);
-                    SourceCmd.HelpOption("-h|--help");
-                    SourceCmd.Description = Strings.EnableSourceCommandDescription;
-                    SourceCmd.OnExecute(() =>
-                    {
-                        var args = new EnableSourceArgs()
-                        {
-                            Name = name.Value,
-                            Configfile = configfile.Value(),
-                        };
-
-                        EnableSourceRunner.Run(args, getLogger);
-                        return 0;
-                    });
-                });
-                EnableCmd.HelpOption("-h|--help");
-                EnableCmd.Description = Strings.Enable_Description;
-                EnableCmd.OnExecute(() =>
-                {
-                    app.ShowHelp("enable");
-                    return 0;
-                });
+                enableCmd.Command("source", sourceCmd => sourceCmd.Description = Strings.EnableSourceCommandDescription);
+                enableCmd.Description = Strings.Enable_Description;
             });
+        }
+
+        internal static void Register(Command app, Func<ILogger> getLogger)
+        {
+            var enableCmd = new DocumentedCommand("enable", Strings.Enable_Description, "https://aka.ms/dotnet/nuget/enable");
+
+            var sourceCmd = new DocumentedCommand("source", Strings.EnableSourceCommandDescription, "https://aka.ms/dotnet/nuget/enable/source");
+            var nameArgument = VerbCommandHelpers.CreateNameArgument("name", Strings.SourcesCommandNameDescription);
+            var configfile = VerbCommandHelpers.CreateStringOption("--configfile", Strings.Option_ConfigFile);
+
+            sourceCmd.Arguments.Add(nameArgument);
+            sourceCmd.Options.Add(configfile);
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateForceEnglishOutputOption());
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateHelpOption());
+            sourceCmd.SetAction((parseResult, cancellationToken) =>
+            {
+                var args = new EnableSourceArgs()
+                {
+                    Name = parseResult.GetValue(nameArgument),
+                    Configfile = parseResult.GetValue(configfile),
+                };
+
+                return Task.FromResult(VerbCommandHelpers.RunVerb(() => EnableSourceRunner.Run(args, getLogger)));
+            });
+            enableCmd.Subcommands.Add(sourceCmd);
+
+            app.Subcommands.Add(enableCmd);
         }
     }
 
     internal partial class ListVerbParser
     {
-        internal static void Register(CommandLineApplication app,
-                                      Func<ILogger> getLogger)
+        internal static void Register(CommandLineApplication app)
         {
-            app.Command("list", ListCmd =>
+            app.Command("list", listCmd =>
             {
-                ListCmd.Command("source", SourceCmd =>
-                {
-                    CommandOption format = SourceCmd.Option(
-                        "--format",
-                        Strings.SourcesCommandFormatDescription,
-                        CommandOptionType.SingleValue);
-                    CommandOption configfile = SourceCmd.Option(
-                        "--configfile",
-                        Strings.Option_ConfigFile,
-                        CommandOptionType.SingleValue);
-                    SourceCmd.HelpOption("-h|--help");
-                    SourceCmd.Description = Strings.ListSourceCommandDescription;
-                    SourceCmd.OnExecute(() =>
-                    {
-                        var args = new ListSourceArgs()
-                        {
-                            Format = format.Value(),
-                            Configfile = configfile.Value(),
-                        };
-
-                        ListSourceRunner.Run(args, getLogger);
-                        return 0;
-                    });
-                });
-                ListCmd.Command("client-cert", ClientCertCmd =>
-                {
-                    CommandOption configfile = ClientCertCmd.Option(
-                        "--configfile",
-                        Strings.Option_ConfigFile,
-                        CommandOptionType.SingleValue);
-                    ClientCertCmd.HelpOption("-h|--help");
-                    ClientCertCmd.Description = Strings.ListClientCertCommandDescription;
-                    ClientCertCmd.OnExecute(() =>
-                    {
-                        var args = new ListClientCertArgs()
-                        {
-                            Configfile = configfile.Value(),
-                        };
-
-                        ListClientCertRunner.Run(args, getLogger);
-                        return 0;
-                    });
-                });
-                ListCmd.HelpOption("-h|--help");
-                ListCmd.Description = Strings.List_Description;
-                ListCmd.OnExecute(() =>
-                {
-                    app.ShowHelp("list");
-                    return 0;
-                });
+                listCmd.Command("source", sourceCmd => sourceCmd.Description = Strings.ListSourceCommandDescription);
+                listCmd.Command("client-cert", clientCertCmd => clientCertCmd.Description = Strings.ListClientCertCommandDescription);
+                listCmd.Description = Strings.List_Description;
             });
+        }
+
+        internal static void Register(Command app, Func<ILogger> getLogger)
+        {
+            var listCmd = new DocumentedCommand("list", Strings.List_Description, "https://aka.ms/dotnet/nuget/list");
+
+            // list source
+            var sourceCmd = new DocumentedCommand("source", Strings.ListSourceCommandDescription, "https://aka.ms/dotnet/nuget/list/source");
+            var format = VerbCommandHelpers.CreateStringOption("--format", Strings.SourcesCommandFormatDescription);
+            var configfile = VerbCommandHelpers.CreateStringOption("--configfile", Strings.Option_ConfigFile);
+
+            sourceCmd.Options.Add(format);
+            sourceCmd.Options.Add(configfile);
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateForceEnglishOutputOption());
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateHelpOption());
+            sourceCmd.SetAction((parseResult, cancellationToken) =>
+            {
+                var args = new ListSourceArgs()
+                {
+                    Format = parseResult.GetValue(format),
+                    Configfile = parseResult.GetValue(configfile),
+                };
+
+                return Task.FromResult(VerbCommandHelpers.RunVerb(() => ListSourceRunner.Run(args, getLogger)));
+            });
+            listCmd.Subcommands.Add(sourceCmd);
+
+            // list client-cert
+            var clientCertCmd = new DocumentedCommand("client-cert", Strings.ListClientCertCommandDescription, "https://aka.ms/dotnet/nuget/list/client-cert");
+            var ccConfigfile = VerbCommandHelpers.CreateStringOption("--configfile", Strings.Option_ConfigFile);
+
+            clientCertCmd.Options.Add(ccConfigfile);
+            clientCertCmd.Options.Add(VerbCommandHelpers.CreateForceEnglishOutputOption());
+            clientCertCmd.Options.Add(VerbCommandHelpers.CreateHelpOption());
+            clientCertCmd.SetAction((parseResult, cancellationToken) =>
+            {
+                var args = new ListClientCertArgs()
+                {
+                    Configfile = parseResult.GetValue(ccConfigfile),
+                };
+
+                return Task.FromResult(VerbCommandHelpers.RunVerb(() => ListClientCertRunner.Run(args, getLogger)));
+            });
+            listCmd.Subcommands.Add(clientCertCmd);
+
+            app.Subcommands.Add(listCmd);
         }
     }
 
     internal partial class RemoveVerbParser
     {
-        internal static void Register(CommandLineApplication app,
-                                      Func<ILogger> getLogger)
+        internal static void Register(CommandLineApplication app)
         {
-            app.Command("remove", RemoveCmd =>
+            app.Command("remove", removeCmd =>
             {
-                RemoveCmd.Command("source", SourceCmd =>
-                {
-                    CommandArgument name = SourceCmd.Argument(
-                        "name", Strings.SourcesCommandNameDescription);
-                    CommandOption configfile = SourceCmd.Option(
-                        "--configfile",
-                        Strings.Option_ConfigFile,
-                        CommandOptionType.SingleValue);
-                    SourceCmd.HelpOption("-h|--help");
-                    SourceCmd.Description = Strings.RemoveSourceCommandDescription;
-                    SourceCmd.OnExecute(() =>
-                    {
-                        var args = new RemoveSourceArgs()
-                        {
-                            Name = name.Value,
-                            Configfile = configfile.Value(),
-                        };
-
-                        RemoveSourceRunner.Run(args, getLogger);
-                        return 0;
-                    });
-                });
-                RemoveCmd.Command("client-cert", ClientCertCmd =>
-                {
-                    CommandOption packagesource = ClientCertCmd.Option(
-                        "-s|--package-source",
-                        Strings.Option_PackageSource,
-                        CommandOptionType.SingleValue);
-                    CommandOption configfile = ClientCertCmd.Option(
-                        "--configfile",
-                        Strings.Option_ConfigFile,
-                        CommandOptionType.SingleValue);
-                    ClientCertCmd.HelpOption("-h|--help");
-                    ClientCertCmd.Description = Strings.RemoveClientCertCommandDescription;
-                    ClientCertCmd.OnExecute(() =>
-                    {
-                        var args = new RemoveClientCertArgs()
-                        {
-                            PackageSource = packagesource.Value(),
-                            Configfile = configfile.Value(),
-                        };
-
-                        RemoveClientCertRunner.Run(args, getLogger);
-                        return 0;
-                    });
-                });
-                RemoveCmd.HelpOption("-h|--help");
-                RemoveCmd.Description = Strings.Remove_Description;
-                RemoveCmd.OnExecute(() =>
-                {
-                    app.ShowHelp("remove");
-                    return 0;
-                });
+                removeCmd.Command("source", sourceCmd => sourceCmd.Description = Strings.RemoveSourceCommandDescription);
+                removeCmd.Command("client-cert", clientCertCmd => clientCertCmd.Description = Strings.RemoveClientCertCommandDescription);
+                removeCmd.Description = Strings.Remove_Description;
             });
+        }
+
+        internal static void Register(Command app, Func<ILogger> getLogger)
+        {
+            var removeCmd = new DocumentedCommand("remove", Strings.Remove_Description, "https://aka.ms/dotnet/nuget/remove");
+
+            // remove source
+            var sourceCmd = new DocumentedCommand("source", Strings.RemoveSourceCommandDescription, "https://aka.ms/dotnet/nuget/remove/source");
+            var nameArgument = VerbCommandHelpers.CreateNameArgument("name", Strings.SourcesCommandNameDescription);
+            var configfile = VerbCommandHelpers.CreateStringOption("--configfile", Strings.Option_ConfigFile);
+
+            sourceCmd.Arguments.Add(nameArgument);
+            sourceCmd.Options.Add(configfile);
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateForceEnglishOutputOption());
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateHelpOption());
+            sourceCmd.SetAction((parseResult, cancellationToken) =>
+            {
+                var args = new RemoveSourceArgs()
+                {
+                    Name = parseResult.GetValue(nameArgument),
+                    Configfile = parseResult.GetValue(configfile),
+                };
+
+                return Task.FromResult(VerbCommandHelpers.RunVerb(() => RemoveSourceRunner.Run(args, getLogger)));
+            });
+            removeCmd.Subcommands.Add(sourceCmd);
+
+            // remove client-cert
+            var clientCertCmd = new DocumentedCommand("client-cert", Strings.RemoveClientCertCommandDescription, "https://aka.ms/dotnet/nuget/remove/client-cert");
+            var ccPackageSource = VerbCommandHelpers.CreateStringOption("--package-source", Strings.Option_PackageSource, "-s");
+            var ccConfigfile = VerbCommandHelpers.CreateStringOption("--configfile", Strings.Option_ConfigFile);
+
+            clientCertCmd.Options.Add(ccPackageSource);
+            clientCertCmd.Options.Add(ccConfigfile);
+            clientCertCmd.Options.Add(VerbCommandHelpers.CreateForceEnglishOutputOption());
+            clientCertCmd.Options.Add(VerbCommandHelpers.CreateHelpOption());
+            clientCertCmd.SetAction((parseResult, cancellationToken) =>
+            {
+                var args = new RemoveClientCertArgs()
+                {
+                    PackageSource = parseResult.GetValue(ccPackageSource),
+                    Configfile = parseResult.GetValue(ccConfigfile),
+                };
+
+                return Task.FromResult(VerbCommandHelpers.RunVerb(() => RemoveClientCertRunner.Run(args, getLogger)));
+            });
+            removeCmd.Subcommands.Add(clientCertCmd);
+
+            app.Subcommands.Add(removeCmd);
         }
     }
 
     internal partial class UpdateVerbParser
     {
-        internal static void Register(CommandLineApplication app,
-                                      Func<ILogger> getLogger)
+        internal static void Register(CommandLineApplication app)
         {
-            app.Command("update", UpdateCmd =>
+            app.Command("update", updateCmd =>
             {
-                UpdateCmd.Command("source", SourceCmd =>
-                {
-                    CommandArgument name = SourceCmd.Argument(
-                        "name", Strings.SourcesCommandNameDescription);
-                    CommandOption source = SourceCmd.Option(
-                        "-s|--source",
-                        Strings.SourcesCommandSourceDescription,
-                        CommandOptionType.SingleValue);
-                    CommandOption username = SourceCmd.Option(
-                        "-u|--username",
-                        Strings.SourcesCommandUsernameDescription,
-                        CommandOptionType.SingleValue);
-                    CommandOption password = SourceCmd.Option(
-                        "-p|--password",
-                        Strings.SourcesCommandPasswordDescription,
-                        CommandOptionType.SingleValue);
-                    CommandOption storePasswordInClearText = SourceCmd.Option(
-                        "--store-password-in-clear-text",
-                        Strings.SourcesCommandStorePasswordInClearTextDescription,
-                        CommandOptionType.NoValue);
-                    CommandOption validAuthenticationTypes = SourceCmd.Option(
-                        "--valid-authentication-types",
-                        Strings.SourcesCommandValidAuthenticationTypesDescription,
-                        CommandOptionType.SingleValue);
-                    CommandOption protocolVersion = SourceCmd.Option(
-                        "--protocol-version",
-                        Strings.SourcesCommandProtocolVersionDescription,
-                        CommandOptionType.SingleValue);
-                    CommandOption configfile = SourceCmd.Option(
-                        "--configfile",
-                        Strings.Option_ConfigFile,
-                        CommandOptionType.SingleValue);
-                    CommandOption allowInsecureConnections = SourceCmd.Option(
-                        "--allow-insecure-connections",
-                        Strings.SourcesCommandAllowInsecureConnectionsDescription,
-                        CommandOptionType.NoValue);
-                    SourceCmd.HelpOption("-h|--help");
-                    SourceCmd.Description = Strings.UpdateSourceCommandDescription;
-                    SourceCmd.OnExecute(() =>
-                    {
-                        var args = new UpdateSourceArgs()
-                        {
-                            Name = name.Value,
-                            Source = source.Value(),
-                            Username = username.Value(),
-                            Password = password.Value(),
-                            StorePasswordInClearText = storePasswordInClearText.HasValue(),
-                            ValidAuthenticationTypes = validAuthenticationTypes.Value(),
-                            ProtocolVersion = protocolVersion.Value(),
-                            Configfile = configfile.Value(),
-                            AllowInsecureConnections = allowInsecureConnections.HasValue(),
-                        };
-
-                        UpdateSourceRunner.Run(args, getLogger);
-                        return 0;
-                    });
-                });
-                UpdateCmd.Command("client-cert", ClientCertCmd =>
-                {
-                    CommandOption packagesource = ClientCertCmd.Option(
-                        "-s|--package-source",
-                        Strings.Option_PackageSource,
-                        CommandOptionType.SingleValue);
-                    CommandOption path = ClientCertCmd.Option(
-                        "--path",
-                        Strings.Option_Path,
-                        CommandOptionType.SingleValue);
-                    CommandOption password = ClientCertCmd.Option(
-                        "--password",
-                        Strings.Option_Password,
-                        CommandOptionType.SingleValue);
-                    CommandOption storepasswordincleartext = ClientCertCmd.Option(
-                        "--store-password-in-clear-text",
-                        Strings.Option_StorePasswordInClearText,
-                        CommandOptionType.NoValue);
-                    CommandOption storelocation = ClientCertCmd.Option(
-                        "--store-location",
-                        Strings.Option_StoreLocation,
-                        CommandOptionType.SingleValue);
-                    CommandOption storename = ClientCertCmd.Option(
-                        "--store-name",
-                        Strings.Option_StoreName,
-                        CommandOptionType.SingleValue);
-                    CommandOption findby = ClientCertCmd.Option(
-                        "--find-by",
-                        Strings.Option_FindBy,
-                        CommandOptionType.SingleValue);
-                    CommandOption findvalue = ClientCertCmd.Option(
-                        "--find-value",
-                        Strings.Option_FindValue,
-                        CommandOptionType.SingleValue);
-                    CommandOption force = ClientCertCmd.Option(
-                        "-f|--force",
-                        Strings.Option_Force,
-                        CommandOptionType.NoValue);
-                    CommandOption configfile = ClientCertCmd.Option(
-                        "--configfile",
-                        Strings.Option_ConfigFile,
-                        CommandOptionType.SingleValue);
-                    ClientCertCmd.HelpOption("-h|--help");
-                    ClientCertCmd.Description = Strings.UpdateClientCertCommandDescription;
-                    ClientCertCmd.OnExecute(() =>
-                    {
-                        var args = new UpdateClientCertArgs()
-                        {
-                            PackageSource = packagesource.Value(),
-                            Path = path.Value(),
-                            Password = password.Value(),
-                            StorePasswordInClearText = storepasswordincleartext.HasValue(),
-                            StoreLocation = storelocation.Value(),
-                            StoreName = storename.Value(),
-                            FindBy = findby.Value(),
-                            FindValue = findvalue.Value(),
-                            Force = force.HasValue(),
-                            Configfile = configfile.Value(),
-                        };
-
-                        UpdateClientCertRunner.Run(args, getLogger);
-                        return 0;
-                    });
-                });
-                UpdateCmd.HelpOption("-h|--help");
-                UpdateCmd.Description = Strings.Update_Description;
-                UpdateCmd.OnExecute(() =>
-                {
-                    app.ShowHelp("update");
-                    return 0;
-                });
+                updateCmd.Command("source", sourceCmd => sourceCmd.Description = Strings.UpdateSourceCommandDescription);
+                updateCmd.Command("client-cert", clientCertCmd => clientCertCmd.Description = Strings.UpdateClientCertCommandDescription);
+                updateCmd.Description = Strings.Update_Description;
             });
         }
-    }
 
+        internal static void Register(Command app, Func<ILogger> getLogger)
+        {
+            var updateCmd = new DocumentedCommand("update", Strings.Update_Description, "https://aka.ms/dotnet/nuget/update");
+
+            // update source
+            var sourceCmd = new DocumentedCommand("source", Strings.UpdateSourceCommandDescription, "https://aka.ms/dotnet/nuget/update/source");
+            var nameArgument = VerbCommandHelpers.CreateNameArgument("name", Strings.SourcesCommandNameDescription);
+            var source = VerbCommandHelpers.CreateStringOption("--source", Strings.SourcesCommandSourceDescription, "-s");
+            var username = VerbCommandHelpers.CreateStringOption("--username", Strings.SourcesCommandUsernameDescription, "-u");
+            var password = VerbCommandHelpers.CreateStringOption("--password", Strings.SourcesCommandPasswordDescription, "-p");
+            var storePasswordInClearText = VerbCommandHelpers.CreateBoolOption("--store-password-in-clear-text", Strings.SourcesCommandStorePasswordInClearTextDescription);
+            var validAuthenticationTypes = VerbCommandHelpers.CreateStringOption("--valid-authentication-types", Strings.SourcesCommandValidAuthenticationTypesDescription);
+            var protocolVersion = VerbCommandHelpers.CreateStringOption("--protocol-version", Strings.SourcesCommandProtocolVersionDescription);
+            var configfile = VerbCommandHelpers.CreateStringOption("--configfile", Strings.Option_ConfigFile);
+            var allowInsecureConnections = VerbCommandHelpers.CreateBoolOption("--allow-insecure-connections", Strings.SourcesCommandAllowInsecureConnectionsDescription);
+
+            sourceCmd.Arguments.Add(nameArgument);
+            sourceCmd.Options.Add(source);
+            sourceCmd.Options.Add(username);
+            sourceCmd.Options.Add(password);
+            sourceCmd.Options.Add(storePasswordInClearText);
+            sourceCmd.Options.Add(validAuthenticationTypes);
+            sourceCmd.Options.Add(protocolVersion);
+            sourceCmd.Options.Add(configfile);
+            sourceCmd.Options.Add(allowInsecureConnections);
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateForceEnglishOutputOption());
+            sourceCmd.Options.Add(VerbCommandHelpers.CreateHelpOption());
+            sourceCmd.SetAction((parseResult, cancellationToken) =>
+            {
+                var args = new UpdateSourceArgs()
+                {
+                    Name = parseResult.GetValue(nameArgument),
+                    Source = parseResult.GetValue(source),
+                    Username = parseResult.GetValue(username),
+                    Password = parseResult.GetValue(password),
+                    StorePasswordInClearText = parseResult.GetValue(storePasswordInClearText),
+                    ValidAuthenticationTypes = parseResult.GetValue(validAuthenticationTypes),
+                    ProtocolVersion = parseResult.GetValue(protocolVersion),
+                    Configfile = parseResult.GetValue(configfile),
+                    AllowInsecureConnections = parseResult.GetValue(allowInsecureConnections),
+                };
+
+                return Task.FromResult(VerbCommandHelpers.RunVerb(() => UpdateSourceRunner.Run(args, getLogger)));
+            });
+            updateCmd.Subcommands.Add(sourceCmd);
+
+            // update client-cert
+            var clientCertCmd = new DocumentedCommand("client-cert", Strings.UpdateClientCertCommandDescription, "https://aka.ms/dotnet/nuget/update/client-cert");
+            var ccPackageSource = VerbCommandHelpers.CreateStringOption("--package-source", Strings.Option_PackageSource, "-s");
+            var ccPath = VerbCommandHelpers.CreateStringOption("--path", Strings.Option_Path);
+            var ccPassword = VerbCommandHelpers.CreateStringOption("--password", Strings.Option_Password);
+            var ccStorePasswordInClearText = VerbCommandHelpers.CreateBoolOption("--store-password-in-clear-text", Strings.Option_StorePasswordInClearText);
+            var ccStoreLocation = VerbCommandHelpers.CreateStringOption("--store-location", Strings.Option_StoreLocation);
+            var ccStoreName = VerbCommandHelpers.CreateStringOption("--store-name", Strings.Option_StoreName);
+            var ccFindBy = VerbCommandHelpers.CreateStringOption("--find-by", Strings.Option_FindBy);
+            var ccFindValue = VerbCommandHelpers.CreateStringOption("--find-value", Strings.Option_FindValue);
+            var ccForce = VerbCommandHelpers.CreateBoolOption("--force", Strings.Option_Force, "-f");
+            var ccConfigfile = VerbCommandHelpers.CreateStringOption("--configfile", Strings.Option_ConfigFile);
+
+            clientCertCmd.Options.Add(ccPackageSource);
+            clientCertCmd.Options.Add(ccPath);
+            clientCertCmd.Options.Add(ccPassword);
+            clientCertCmd.Options.Add(ccStorePasswordInClearText);
+            clientCertCmd.Options.Add(ccStoreLocation);
+            clientCertCmd.Options.Add(ccStoreName);
+            clientCertCmd.Options.Add(ccFindBy);
+            clientCertCmd.Options.Add(ccFindValue);
+            clientCertCmd.Options.Add(ccForce);
+            clientCertCmd.Options.Add(ccConfigfile);
+            clientCertCmd.Options.Add(VerbCommandHelpers.CreateForceEnglishOutputOption());
+            clientCertCmd.Options.Add(VerbCommandHelpers.CreateHelpOption());
+            clientCertCmd.SetAction((parseResult, cancellationToken) =>
+            {
+                var args = new UpdateClientCertArgs()
+                {
+                    PackageSource = parseResult.GetValue(ccPackageSource),
+                    Path = parseResult.GetValue(ccPath),
+                    Password = parseResult.GetValue(ccPassword),
+                    StorePasswordInClearText = parseResult.GetValue(ccStorePasswordInClearText),
+                    StoreLocation = parseResult.GetValue(ccStoreLocation),
+                    StoreName = parseResult.GetValue(ccStoreName),
+                    FindBy = parseResult.GetValue(ccFindBy),
+                    FindValue = parseResult.GetValue(ccFindValue),
+                    Force = parseResult.GetValue(ccForce),
+                    Configfile = parseResult.GetValue(ccConfigfile),
+                };
+
+                return Task.FromResult(VerbCommandHelpers.RunVerb(() => UpdateClientCertRunner.Run(args, getLogger)));
+            });
+            updateCmd.Subcommands.Add(clientCertCmd);
+
+            app.Subcommands.Add(updateCmd);
+        }
+    }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -91,6 +91,10 @@ namespace NuGet.CommandLine.XPlat
 
             NuGet.Common.Migrations.MigrationRunner.Run();
 
+            NetworkProtocolUtility.SetConnectionLimit();
+
+            XPlatUtility.SetUserAgent();
+
             // TODO: Migrating from Microsoft.Extensions.CommandLineUtils.CommandLineApplication to System.Commandline.Command
             // If we are looking to add further commands here, we should also look to redesign this parsing logic at that time
             // See related issues:
@@ -133,6 +137,27 @@ namespace NuGet.CommandLine.XPlat
                     ConfigCommand.Register(rootCommand, getHidePrefixLogger);
                     Commands.Why.WhyCommand.Register(nugetCommand, lazyConsole, virtualProjectBuilder);
                     Commands.Why.WhyCommand.Register(rootCommand, lazyConsole, virtualProjectBuilder);
+                    LocalsCommand.Register(nugetCommand, getHidePrefixLogger);
+                    LocalsCommand.Register(rootCommand, getHidePrefixLogger);
+                    DeleteCommand.Register(nugetCommand, getHidePrefixLogger);
+                    DeleteCommand.Register(rootCommand, getHidePrefixLogger);
+                    PushCommand.Register(nugetCommand, getHidePrefixLogger);
+                    PushCommand.Register(rootCommand, getHidePrefixLogger);
+                    Action<LogLevel> setLogLevel = (logLevel) => log.VerbosityLevel = logLevel;
+                    VerifyCommand.Register(nugetCommand, getHidePrefixLogger, setLogLevel, () => new VerifyCommandRunner());
+                    VerifyCommand.Register(rootCommand, getHidePrefixLogger, setLogLevel, () => new VerifyCommandRunner());
+                    AddVerbParser.Register(nugetCommand, getHidePrefixLogger);
+                    AddVerbParser.Register(rootCommand, getHidePrefixLogger);
+                    DisableVerbParser.Register(nugetCommand, getHidePrefixLogger);
+                    DisableVerbParser.Register(rootCommand, getHidePrefixLogger);
+                    EnableVerbParser.Register(nugetCommand, getHidePrefixLogger);
+                    EnableVerbParser.Register(rootCommand, getHidePrefixLogger);
+                    ListVerbParser.Register(nugetCommand, getHidePrefixLogger);
+                    ListVerbParser.Register(rootCommand, getHidePrefixLogger);
+                    RemoveVerbParser.Register(nugetCommand, getHidePrefixLogger);
+                    RemoveVerbParser.Register(rootCommand, getHidePrefixLogger);
+                    UpdateVerbParser.Register(nugetCommand, getHidePrefixLogger);
+                    UpdateVerbParser.Register(rootCommand, getHidePrefixLogger);
                 }
 
                 CancellationTokenSource tokenSource = new CancellationTokenSource();
@@ -140,14 +165,21 @@ namespace NuGet.CommandLine.XPlat
                 int exitCodeValue = 0;
                 ParseResult parseResult = rootCommand.Parse(args);
 
+                // The migrated delete/push/verify commands and the source/client-cert verbs invoke runners that throw
+                // on failure. Disable System.CommandLine's default exception handler for them so their exceptions flow
+                // to the handler below and are reported through NuGet's logger, matching the legacy parser's behavior.
+                bool useNuGetExceptionHandling = UseNuGetExceptionHandling(args);
+
                 try
                 {
-                    exitCodeValue = parseResult.Invoke();
+                    exitCodeValue = useNuGetExceptionHandling
+                        ? parseResult.Invoke(new InvocationConfiguration { EnableDefaultExceptionHandler = false })
+                        : parseResult.Invoke();
                 }
                 catch (Exception ex)
                 {
                     LogException(ex, log);
-                    exitCodeValue = ExitCodes.Error;
+                    exitCodeValue = useNuGetExceptionHandling ? ExitCodes.InvalidArguments : ExitCodes.Error;
                 }
 
                 return exitCodeValue;
@@ -164,10 +196,6 @@ namespace NuGet.CommandLine.XPlat
                     .Where(e => e != null)
                     .ToArray();
             }
-
-            NetworkProtocolUtility.SetConnectionLimit();
-
-            XPlatUtility.SetUserAgent();
 
             app.OnExecute(() =>
             {
@@ -261,7 +289,12 @@ namespace NuGet.CommandLine.XPlat
             }
 
             string arg0 = args[0];
-            if (arg0 == "config" || arg0 == "why")
+            if (arg0 == "config" || arg0 == "why" || arg0 == "locals" || arg0 == "delete" || arg0 == "push" || arg0 == "verify")
+            {
+                return true;
+            }
+
+            if (args.Length >= 2 && IsSourceOrClientCertVerb(arg0, args[1]))
             {
                 return true;
             }
@@ -284,6 +317,43 @@ namespace NuGet.CommandLine.XPlat
             return false;
         }
 
+        // Returns true for the source/client-cert management verbs that have been migrated to System.CommandLine.
+        // Only the exact verb/noun pairs that exist are routed, to preserve legacy behavior for unsupported pairs
+        // (e.g. `disable client-cert`).
+        private static bool IsSourceOrClientCertVerb(string verb, string noun)
+        {
+            switch (verb)
+            {
+                case "add":
+                case "list":
+                case "remove":
+                case "update":
+                    return noun == "source" || noun == "client-cert";
+                case "disable":
+                case "enable":
+                    return noun == "source";
+                default:
+                    return false;
+            }
+        }
+
+        // Returns true for the migrated commands whose runners throw on error and rely on NuGet's exception logging
+        // (rather than System.CommandLine's default exception handler) to report failures and return exit code 1.
+        private static bool UseNuGetExceptionHandling(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                return false;
+            }
+
+            string arg0 = args[0];
+            if (arg0 == "delete" || arg0 == "push" || arg0 == "verify")
+            {
+                return true;
+            }
+
+            return args.Length >= 2 && IsSourceOrClientCertVerb(arg0, args[1]);
+        }
 
         internal static void LogException(Exception e, ILogger log)
         {
@@ -328,16 +398,16 @@ namespace NuGet.CommandLine.XPlat
             {
                 // "dotnet nuget *" commands
                 app.Name = DotnetNuGetAppName;
-                CommandParsers.Register(app, getHidePrefixLogger);
-                DeleteCommand.Register(app, getHidePrefixLogger);
-                PushCommand.Register(app, getHidePrefixLogger);
-                LocalsCommand.Register(app, getHidePrefixLogger);
-                VerifyCommand.Register(app, getHidePrefixLogger, setLogLevel, () => new VerifyCommandRunner());
+                CommandParsers.Register(app);
                 TrustedSignersCommand.Register(app, getHidePrefixLogger, setLogLevel);
                 SignCommand.Register(app, getHidePrefixLogger, setLogLevel, () => new SignCommandRunner());
                 // The commands below are implemented with System.CommandLine, and are here only for `dotnet nuget --help`
                 ConfigCommand.Register(app);
                 Commands.Why.WhyCommand.Register(app);
+                LocalsCommand.Register(app);
+                DeleteCommand.Register(app);
+                PushCommand.Register(app);
+                VerifyCommand.Register(app);
             }
 
             app.FullName = Strings.App_FullName;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
@@ -21,7 +21,7 @@ namespace NuGet.CommandLine.XPlat
         /// user. In other words, the default case should only be hit with <c>m</c> or <c>minimal</c> but we use <see cref="Common.LogLevel.Minimal"/>
         /// as the default case to avoid errors.
         /// </summary>
-        public static LogLevel MSBuildVerbosityToNuGetLogLevel(string verbosity)
+        public static LogLevel MSBuildVerbosityToNuGetLogLevel(string? verbosity)
         {
             switch (verbosity?.ToUpperInvariant())
             {
@@ -63,7 +63,7 @@ namespace NuGet.CommandLine.XPlat
             UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet xplat"));
         }
 
-        internal static ISettings ProcessConfigFile(string configFile)
+        internal static ISettings ProcessConfigFile(string? configFile)
         {
             if (string.IsNullOrEmpty(configFile))
             {

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetSourcesTests.cs
@@ -1222,24 +1222,14 @@ namespace Dotnet.Integration.Test
                 // 3rd - nextParam
                 string badCommand = commandSplit[badCommandIndex];
 
+                // System.CommandLine writes parse errors to stderr, so assert against the combined output.
                 // Assert command
-                Assert.Contains("'" + badCommand + "'", result.Output, StringComparison.InvariantCultureIgnoreCase);
+                Assert.Contains("'" + badCommand + "'", result.AllOutput, StringComparison.InvariantCultureIgnoreCase);
 
-
-                // Assert invalid argument message
-                string invalidMessage;
-                if (badCommand.StartsWith("-"))
-                {
-                    invalidMessage = ": Unrecognized option";
-                }
-                else
-                {
-                    invalidMessage = ": Unrecognized command";
-                }
-
-                Assert.True(result.Output.Contains(invalidMessage), "Expected error is " + invalidMessage + ". Actual error is " + result.Output);
-                // Verify traits of help message in stdout
-                Assert.Contains("Specify --help for a list of available options and commands.", result.Output);
+                // Assert invalid argument message. System.CommandLine (and the legacy parser used for
+                // unrecognized verb subcommands) report unrecognized tokens with this message.
+                const string invalidMessage = "Unrecognized command or argument";
+                Assert.True(result.AllOutput.Contains(invalidMessage), "Expected error is " + invalidMessage + ". Actual error is " + result.AllOutput);
             }
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -261,17 +261,14 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Theory]
-        [InlineData("locals -list")]
-        [InlineData("locals -clear")]
-        [InlineData("locals --l")]
-        [InlineData("locals --c")]
-        public void Locals_Success_InvalidFlags_HelpMessage(string args)
+        [InlineData("locals -list", "An invalid local resource name was provided.")]
+        [InlineData("locals -clear", "Both operations, --list and --clear, are not supported in the same command. Please specify only one operation.")]
+        [InlineData("locals --l", "Please specify an operation i.e. --list or --clear.")]
+        [InlineData("locals --c", "Please specify an operation i.e. --list or --clear.")]
+        public void Locals_Success_InvalidFlags_HelpMessage(string args, string expectedResult)
         {
             DotnetCli.Should().NotBeNull(because: "Could not locate the dotnet CLI");
             XplatDll.Should().NotBeNull(because: "Could not locate the Xplat dll");
-
-            // Arrange
-            var expectedResult = $"Unrecognized option '{args.Split(null)[1]}'";
 
             // Act
             var result = CommandRunner.Run(

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatVerifyTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatVerifyTests.cs
@@ -3,12 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.CommandLine;
 using System.Threading.Tasks;
-using Microsoft.Extensions.CommandLineUtils;
 using Moq;
 using NuGet.CommandLine.XPlat;
 using NuGet.Commands;
 using NuGet.Common;
+using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -25,21 +26,17 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Fact]
-        public void VerifyCommandArgsParsing_MissingPackagePath_Throws()
+        public void VerifyCommandArgsParsing_MissingPackagePath_LogsError()
         {
-            VerifyCommandArgs(
-                (mockCommandRunner, testApp, getLogLevel) =>
-                {
-                    // Arrange
-                    var argList = new List<string>() { "verify" };
+            // Arrange
+            var log = new TestCommandOutputLogger(_testOutputHelper);
 
-                    // Act
-                    var ex = Assert.Throws<AggregateException>(() => testApp.Execute(argList.ToArray()));
+            // Act
+            int exitCode = Program.MainInternal(new[] { "verify" }, log, TestEnvironmentVariableReader.EmptyInstance);
 
-                    // Assert
-                    Assert.IsType<ArgumentException>(ex.InnerException);
-                    Assert.Equal("Unable to verify package. Argument '<package-paths>' not provided.", ex.InnerException.Message);
-                });
+            // Assert
+            Assert.Equal(1, exitCode);
+            Assert.Contains("Unable to verify package. Argument '<package-paths>' not provided.", log.ShowErrors());
         }
 
         [Theory]
@@ -47,16 +44,29 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("-Signatures")]
         [InlineData("-certificate-fingerprint")]
         [InlineData("--h")]
-        public void VerifyCommandArgsParsing_UnrcognizedOption_Throws(string unrecognizedOption)
+        public void VerifyCommandArgsParsing_UnrecognizedOption_TreatedAsPackagePath(string unrecognizedOption)
         {
             VerifyCommandArgs(
-                (mockCommandRunner, testApp, getLogLevel) =>
+                (mockCommandRunner, logger, rootCommand, getLogLevel) =>
                 {
                     //Arrange
+                    VerifyArgs capturedArgs = null!;
+                    mockCommandRunner
+                        .Setup(m => m.ExecuteCommandAsync(It.IsAny<VerifyArgs>()))
+                        .Callback<VerifyArgs>(a => capturedArgs = a)
+                        .Returns(Task.FromResult(0));
                     string[] args = new string[] { "verify", unrecognizedOption };
 
-                    // Act & Assert
-                    Assert.Throws<CommandParsingException>(() => testApp.Execute(args));
+                    // Act
+                    ParseResult parseResult = rootCommand.Parse(args);
+                    parseResult.Invoke();
+
+                    // Assert
+                    // System.CommandLine treats option-like tokens that don't match a defined option
+                    // as values for the package-paths argument.
+                    Assert.Empty(parseResult.Errors);
+                    Assert.NotNull(capturedArgs);
+                    Assert.Contains(unrecognizedOption, capturedArgs.PackagePaths);
                 });
         }
 
@@ -75,13 +85,14 @@ namespace NuGet.XPlat.FuncTest
         public void VerifyCommandArgsParsing_VerbosityOption(string option, string verbosity, LogLevel logLevel)
         {
             VerifyCommandArgs(
-                (mockCommandRunner, testApp, getLogLevel) =>
+                (mockCommandRunner, logger, rootCommand, getLogLevel) =>
                 {
-                    // Arrange                   
+                    // Arrange
                     var argList = new List<string> { "verify", "packageX.nupkg", option, verbosity };
 
                     // Act
-                    var result = testApp.Execute(argList.ToArray());
+                    ParseResult parseResult = rootCommand.Parse(argList.ToArray());
+                    int result = parseResult.Invoke();
 
                     // Assert
                     Assert.Equal(logLevel, getLogLevel());
@@ -89,25 +100,24 @@ namespace NuGet.XPlat.FuncTest
                 });
         }
 
-        private void VerifyCommandArgs(Action<Mock<IVerifyCommandRunner>, CommandLineApplication, Func<LogLevel>> verify)
+        private void VerifyCommandArgs(Action<Mock<IVerifyCommandRunner>, TestCommandOutputLogger, RootCommand, Func<LogLevel>> verify)
         {
             // Arrange
             var logLevel = LogLevel.Information;
             var logger = new TestCommandOutputLogger(_testOutputHelper);
-            var testApp = new CommandLineApplication();
+            var rootCommand = new RootCommand();
             var mockCommandRunner = new Mock<IVerifyCommandRunner>();
             mockCommandRunner
                 .Setup(m => m.ExecuteCommandAsync(It.IsAny<VerifyArgs>()))
                 .Returns(Task.FromResult(0));
 
-            testApp.Name = "dotnet nuget_test";
-            VerifyCommand.Register(testApp,
+            VerifyCommand.Register(rootCommand,
                 () => logger,
                 ll => logLevel = ll,
                 () => mockCommandRunner.Object);
 
             // Act & Assert
-            verify(mockCommandRunner, testApp, () => logLevel);
+            verify(mockCommandRunner, logger, rootCommand, () => logLevel);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug
 
 Fixes: https://github.com/NuGet/Home/issues/11996
 
 ## Description
 
 Migrates the remaining `dotnet nuget` source/client-cert verbs and the `delete`, `push`, `verify`, and `locals` commands from the deprecated `Microsoft.Extensions.CommandLineUtils` parser to `System.CommandLine`, continuing the parser migration tracked by NuGet/Home#11996 (umbrella NuGet/Home#14848).
 
 Commands migrated in this PR:
 - `locals`, `delete`, `push`, `verify`
 - `add`/`list`/`remove`/`update`/`enable`/`disable source`
 - `add`/`list`/`remove`/`update client-cert`
 
 Routing remains dual-mode during the migration: `Program.MainInternal` dispatches the migrated commands to the new `System.CommandLine` parsers and leaves not-yet-migrated commands (`add`/`remove`/`list package`, `sign`, `trusted-signers`) on the legacy parser. The shim and the `Microsoft.Extensions.CommandLineUtils` dependency will be removed in a later PR once all commands are migrated.
 
 ### Exception handling
 
 The migrated commands call legacy shared runners (`DeleteRunner`, `PushRunner`, `VerifyCommandRunner`, the source/client-cert runners) that **throw** on failure rather than returning exit codes like the newer template runners. Instead of adding broad `catch (Exception)` blocks per command (which would require new `CA1031` suppressions), `System.CommandLine`'s default exception handler is disabled only for these commands, so their exceptions flow to the existing top-level handler in `MainInternal`, which logs through NuGet's logger and returns exit code 1 — preserving the legacy error output and exit codes. Behavior for commands outside this migration (`why`, `config`, `package`) is unchanged.

## PR Checklist
 
 - [x] Meaningful title, helpful description and a linked NuGet/Home issue
 - [x] Added tests
 - [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.