### PR TITLE
Fix stale Browse tab details pane after installing a package with Package Source Mapping enabled

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -246,7 +246,20 @@ namespace NuGet.PackageManagement.UI
             {
                 _detailModel.PackageSourceMappingViewModel.SettingsChanged();
                 _detailModel.SetInstalledOrUpdateButtonIsEnabled();
-                RefreshAfterSettingsChanged(sender, e);
+
+                // When an action is executing, this settings change is a side effect of that action
+                // (e.g. auto-creating a package source mapping on install). The mapping is saved before
+                // the action's package changes are applied, so refreshing now would read pre-action state
+                // and race the post-action refresh, leaving the UI stale. Defer to the action's completion,
+                // which already performs a full refresh.
+                if (_isExecutingAction)
+                {
+                    _isRefreshRequired = true;
+                }
+                else
+                {
+                    RefreshAfterSettingsChanged(sender, e);
+                }
             }
             finally
             {


### PR DESCRIPTION

# Bug
 
 Fixes: https://github.com/NuGet/Home/issues/14923
 
 ## Description
  When Package Source Mapping is enabled and you install a package in the Browse tab that does not match any existing mapping pattern, the details pane stays stale after the install completes: it keeps showing the **Install** version dropdown as if the package were not installed. The correct status only appears after a *second* package action ("delayed by one"). Without source mapping, the UI refreshes correctly.
 
 ### Root cause (a regression)
 
 Installing a package that needs a new mapping causes NuGet to auto-create one. In `UIActionEngine`, that mapping is saved **before** the package changes are applied:
 
 1. `ConfigureNewPackageSourceMappings(...)` saves the mapping, which raises
    `ISettings.SettingsChanged` synchronously — *before the install runs*.
 2. `ExecuteActionsAsync(...)` actually installs the package.
 3. `RaiseProjectActionsExecuted(...)` triggers the normal post-install refresh.
 
 PR #7022 ("Audit Sources Changed event triggers Package Manager UI to refresh") changed `Settings_SettingsChanged` to kick off a fire-and-forget package search via `RefreshAfterSettingsChanged`. As a side effect, during an install-with-auto-mapping that search now runs at step 1 — reading **pre-install** state — and, being async, can complete *after* the correct post-install refresh, overwriting it with the stale "not installed" state. This regressed behavior that worked in 6.14.3 (where the settings-changed handler did not search).
 
 ### Fix
 
 In `Settings_SettingsChanged`, when an action is already executing, defer the refresh by setting `_isRefreshRequired = true` instead of starting an immediate search. The `ExecuteAction` completion path already performs a full `RefreshAsync(clearCache: true)` that refreshes both the package list and the details pane with the correct post-install state. Standalone settings changes (audit sources, user-toggled mappings) still refresh immediately because no action is executing — preserving the behavior added in #7022.
 
 The change is minimal, additive, and guarded, reusing the existing `_isExecutingAction` / `_isRefreshRequired` deferral pattern already used by the other refresh paths.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[ ] Added tests~ PM UI change, hard to test
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
