### PR TITLE
Fix vulnerability icon for multi-project solution PM UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -728,7 +728,7 @@ namespace NuGet.PackageManagement.UI
 
                 if (_packageModel is IVulnerableCapable vulnerableCapable)
                 {
-                    UpdateVulnerabilityInfo(vulnerableCapable);
+                    UpdateVulnerabilityInfo(vulnerableCapable, Version);
                 }
             },
             cancellationToken);
@@ -768,7 +768,7 @@ namespace NuGet.PackageManagement.UI
                 await vulnerabilityDatabaseCapability.PopulateDataAsync(VsShellUtilities.ShutdownToken);
                 cancellationToken.ThrowIfCancellationRequested();
 
-                UpdateVulnerabilityInfo(vulnerabilityDatabaseCapability);
+                UpdateVulnerabilityInfo(vulnerabilityDatabaseCapability, packageIdentity.Version);
             },
             cancellationToken);
         }
@@ -800,14 +800,14 @@ namespace NuGet.PackageManagement.UI
             OnPropertyChanged(nameof(AlternatePackage));
         }
 
-        private void UpdateVulnerabilityInfo(IVulnerableCapable vulnerableCapable)
+        private void UpdateVulnerabilityInfo(IVulnerableCapable vulnerableCapable, NuGetVersion version)
         {
             if (vulnerableCapable == null)
             {
                 return;
             }
 
-            SetVulnerabilityMaxSeverity(Version, (int)vulnerableCapable.VulnerabilityMaxSeverity);
+            SetVulnerabilityMaxSeverity(version, (int)vulnerableCapable.VulnerabilityMaxSeverity);
             OnPropertyChanged(nameof(IsPackageVulnerable));
             OnPropertyChanged(nameof(IsPackageWithWarnings));
             OnPropertyChanged(nameof(Vulnerabilities));

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageItemViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageItemViewModelTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Collections.Immutable;
 using System.IO;
 using System.Reflection;
@@ -19,6 +20,7 @@ using NuGet.PackageManagement.UI.Test.Models.Package;
 using NuGet.PackageManagement.UI.ViewModels;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
+using NuGet.Protocol;
 using NuGet.Packaging.Core;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -630,6 +632,61 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
                 VerifyImageResult(result);
                 Assert.Equal(IconBitmapStatus.FetchedIcon, packageItemViewModel.BitmapStatus);
             }
+        }
+
+        [Fact]
+        public void UpdateInstalledPackagesVulnerabilities_WithDifferentVersion_AddsQueriedVersionToVulnerableVersions()
+        {
+            // Arrange
+            var modelVersion = new NuGetVersion("12.0.1");
+            var queriedVersion = new NuGetVersion("12.0.2");
+            var modelIdentity = new PackageIdentity("Newtonsoft.Json", modelVersion);
+            var queriedIdentity = new PackageIdentity("Newtonsoft.Json", queriedVersion);
+
+            var vulnerabilityInfo = new List<PackageVulnerabilityMetadataContextInfo>
+            {
+                new PackageVulnerabilityMetadataContextInfo(
+                    new Uri("https://github.com/advisories/GHSA-1234"),
+                    (int)PackageVulnerabilitySeverity.High)
+            };
+
+            var mockVulnService = new Mock<IPackageVulnerabilityService>();
+            mockVulnService
+                .Setup(s => s.GetVulnerabilityInfoAsync(
+                    It.IsAny<PackageIdentity>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(vulnerabilityInfo);
+
+            PackageModel packageModel = PackageModelCreationTestHelper.CreateRemotePackageModel(
+                modelIdentity,
+                vulnerableCapability: Mock.Of<IVulnerableCapable>(),
+                deprecationCapability: Mock.Of<IDeprecationCapable>(),
+                embeddedResourcesCapability: Mock.Of<IEmbeddedResourcesCapable>());
+
+            var viewModel = new PackageItemViewModel(
+                _searchService.Object,
+                packageModel,
+                mockVulnService.Object);
+
+            var statusChangedEvent = new ManualResetEventSlim(false);
+            viewModel.PropertyChanged += (object sender, PropertyChangedEventArgs e) =>
+            {
+                if (e.PropertyName == nameof(PackageItemViewModel.Status))
+                {
+                    statusChangedEvent.Set();
+                }
+            };
+
+            // Act - simulate what PackageItemLoader.GetCurrent() does for duplicate entries
+            viewModel.UpdateInstalledPackagesVulnerabilities(queriedIdentity);
+
+            // Wait for the fire-and-forget async operation to complete
+            statusChangedEvent.Wait(TimeSpan.FromSeconds(10));
+
+            // Assert - the queried version (12.0.2) should be in VulnerableVersions
+            viewModel.VulnerableVersions.Should().ContainKey(queriedVersion,
+                because: $"vulnerability data was queried for version {queriedVersion}, " +
+                         $"but VulnerableVersions only contains: [{string.Join(", ", viewModel.VulnerableVersions.Keys)}]");
         }
     }
 }


### PR DESCRIPTION
# Bug
 
Fixes: https://github.com/NuGet/Home/issues/14024
Fixes: https://github.com/NuGet/Home/issues/14322
 
 ## Description
 
 In the solution-level PM UI Installed tab, when multiple projects reference different vulnerable versions of the same package, only the first project's version gets the vulnerability warning icon. The other projects' versions are missing the icon.
 
 The root cause is in `PackageItemViewModel.UpdateVulnerabilityInfo()`, which always used `Version` (the model's version) as the key when adding to the `VulnerableVersions` dictionary. When `UpdateInstalledPackagesVulnerabilities` queried vulnerability data for a different installed version, the result was stored under the model version instead of the queried version. This meant `VulnerableVersions.TryGetValue()` in `PackageSolutionDetailControlModel.UpdateInstalledVersionsAsync()` only succeeded for the model version.
 
 The fix adds a `NuGetVersion version` parameter to `UpdateVulnerabilityInfo` so each call site passes the correct version: `Version` for the model's own data, and `packageIdentity.Version` for queried installed versions.
 
 Regression introduced by PR #6370.
 
 ## PR Checklist
 
 - [x] Meaningful title, helpful description and a linked NuGet/Home issue
 - [x] Added tests
 - [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A