### PR TITLE
Leverage the new IMcpServerInfoService to detect server availability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' == ''">3.3.4</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
-    <NewtonsoftJsonPackageVersion Condition="'$(NewtonsoftJsonPackageVersion)' == ''">13.0.3</NewtonsoftJsonPackageVersion>
+    <NewtonsoftJsonPackageVersion Condition="'$(NewtonsoftJsonPackageVersion)' == ''">13.0.4</NewtonsoftJsonPackageVersion>
     <SystemFormatsAsn1PackageVersion Condition="'$(SystemFormatsAsn1PackageVersion)' == ''">8.0.2</SystemFormatsAsn1PackageVersion>
 
     <!-- Read docs/updating-packages.md before updating System.Text.Json's version -->
@@ -55,7 +55,7 @@
     <PackageVersion Include="Microsoft.DotNet.SignTool" Version="10.0.0-beta.25367.5" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(MicrosoftExtensionsFileProvidersAbstractionsPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsFileSystemGlobbingPackageVersion)" />
-    <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="17.10.40173" />
+    <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="18.8.850" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
     <!-- Microsoft.TeamFoundationServer.ExtendedClient has vulnerable dependencies Microsoft.IdentityModel.JsonWebTokens and System.IdentityModel.Tokens.Jwt . When it's upgraded, try removing the pinned packages -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,6 +62,7 @@
     <PackageVersion Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="16.153.0" />
     <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="18.0.0-preview-1-10723-180" />
     <PackageVersion Include="Microsoft.TestPlatform.Portable" Version="17.1.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost" Version="18.8.850" />
     <PackageVersion Include="Microsoft.VisualStudio.Copilot" Version="18.0.848-alpha" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServices" Version="4.3.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Markdown.Platform" Version="17.14.76-preview" />
@@ -126,7 +127,7 @@
               '$(MSBuildProjectFile)' == 'NuGet.VisualStudio.Interop.csproj' OR
               '$(MSBuildProjectFile)' == 'NuGet.SolutionRestoreManager.Interop.csproj'">
     <PackageVersion Include="Microsoft.ServiceHub.Framework" Version="4.8.55" />
-    <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost" Version="17.10.191" />
+    <PackageVersion Update="Microsoft.VisualStudio.ComponentModelHost" Version="17.10.191" />
     <PackageVersion Update="Microsoft.VisualStudio.SDK" Version="" />
     <!-- Microsoft.VisualStudio.Shell.15.0 has vulnerable dependencies System.Text.Json. When it's upgraded, try removing the pinned packages -->
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="18.0.2345-preview.1" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -42,10 +42,13 @@
       <package pattern="moq" />
       <package pattern="MSTest.TestAdapter" />
       <package pattern="MSTest.TestFramework" />
+      <package pattern="Nerdbank.MessagePack" />
       <package pattern="nerdbank.streams" />
       <package pattern="netstandard.library" />
       <package pattern="newtonsoft.json" />
       <package pattern="nuget.*" />
+      <package pattern="Nullable" />
+      <package pattern="PolyType" />
       <package pattern="runtime.*" />
       <package pattern="sharpziplib" />
       <package pattern="Spectre.*" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "10.0.100",
+    "dotnet": "10.0.300",
     "pinned": true
   },
   "msbuild-sdks": {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIFactory.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/UserInterfaceService/NuGetUIFactory.cs
@@ -25,8 +25,8 @@ namespace NuGet.PackageManagement.UI
     [Export(typeof(INuGetUIFactory))]
     internal sealed class NuGetUIFactory : INuGetUIFactory
     {
-        [Import]
-        private ICommonOperations CommonOperations { get; set; }
+        private readonly ICommonOperations _commonOperations;
+        private readonly INuGetUILogger _outputConsoleLogger;
 
         [Import]
         private Lazy<IDeleteOnRestartManager> DeleteOnRestartManager { get; set; }
@@ -36,9 +36,6 @@ namespace NuGet.PackageManagement.UI
 
         [Import]
         private Lazy<IOptionsPageActivator> OptionsPageActivator { get; set; }
-
-        [Import]
-        private INuGetUILogger OutputConsoleLogger { get; set; }
 
         [Import]
         private Lazy<IPackageRestoreManager> PackageRestoreManager { get; set; }
@@ -70,6 +67,8 @@ namespace NuGet.PackageManagement.UI
             INuGetUILogger logger,
             ISourceControlManagerProvider sourceControlManagerProvider)
         {
+            _commonOperations = commonOperations;
+            _outputConsoleLogger = logger;
             ProjectContext = new NuGetUIProjectContext(
                 commonOperations,
                 logger,
@@ -98,7 +97,7 @@ namespace NuGet.PackageManagement.UI
 
             return await NuGetUI.CreateAsync(
                 serviceBroker,
-                CommonOperations,
+                _commonOperations,
                 ProjectContext,
                 SourceRepositoryProvider.Value,
                 Settings.Value,
@@ -109,7 +108,7 @@ namespace NuGet.PackageManagement.UI
                 DeleteOnRestartManager.Value,
                 SolutionUserOptions,
                 LockService.Value,
-                OutputConsoleLogger,
+                _outputConsoleLogger,
                 RestoreProgressReporter.Value,
                 NuGetTelemetryProvider,
                 CancellationToken.None,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSolutionManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSolutionManagerService.cs
@@ -22,7 +22,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private readonly AuthorizationServiceClient _authorizationServiceClient;
 
         [Import]
-        private IVsSolutionManager? SolutionManager { get; set; }
+        private IVsSolutionManager SolutionManager { get; set; } = null!;
 
         public event EventHandler<string>? AfterNuGetCacheUpdated;
         public event EventHandler<IProjectContextInfo>? AfterProjectRenamed;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/FixVulnerabilitiesWithCopilotErrorType.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/FixVulnerabilitiesWithCopilotErrorType.cs
@@ -12,5 +12,8 @@ namespace NuGet.PackageManagement.Telemetry
         McpToolServiceNotAvailable,
         CopilotAccessDenied,
         NuGetSolverNotAvailable,
+        McpServerInfoServiceNotAvailable,
+        McpServerStateNotAvailable,
+        McpServerNotActive,
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/FixVulnerabilitiesWithCopilotErrorType.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/FixVulnerabilitiesWithCopilotErrorType.cs
@@ -13,7 +13,6 @@ namespace NuGet.PackageManagement.Telemetry
         CopilotAccessDenied,
         NuGetSolverNotAvailable,
         McpServerInfoServiceNotAvailable,
-        McpServerStateNotAvailable,
         McpServerNotActive,
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
@@ -47,7 +47,25 @@ namespace NuGetVSExtension
                 return CopilotToolSessionResult.Failure(CopilotToolSessionError.ServiceBrokerNotAvailable);
             }
 
-            // 3. Acquire Copilot service, ownership transfers to CopilotToolSession on success
+            // 3. Verify the required MCP server is registered and active
+            IMcpServerInfoService? mcpServerInfoService = await ServiceBroker.GetProxyAsync<IMcpServerInfoService>(McpServiceIdentities.ServerInfoService.Descriptor, cancellationToken);
+            using (mcpServerInfoService as IDisposable)
+            {
+                if (mcpServerInfoService is null)
+                {
+                    return CopilotToolSessionResult.Failure(CopilotToolSessionError.McpServerInfoServiceNotAvailable);
+                }
+
+                // The NuGet MCP server may be registered under different names depending on how it
+                // was installed (in-VS vs. Anthropic/GitHub MCP registry). It is considered available
+                // if any of the acceptable names reports an Active or Suspended state.
+                if (!await IsServerAvailableAsync(mcpServerInfoService, acceptableMcpServerNames, cancellationToken))
+                {
+                    return CopilotToolSessionResult.Failure(CopilotToolSessionError.McpServerNotActive);
+                }
+            }
+
+            // 4. Acquire Copilot service, ownership transfers to CopilotToolSession on success
 #pragma warning disable ISB001 // Dispose objects before losing scope - ownership is transferred to CopilotToolSession on success
             ICopilotService? copilotService = await ServiceBroker.GetProxyAsync<ICopilotService>(CopilotDescriptors.CopilotService, cancellationToken);
 #pragma warning restore ISB001
@@ -55,27 +73,6 @@ namespace NuGetVSExtension
             bool ownershipTransferred = false;
             try
             {
-                // 3. Verify the required MCP server is registered and active
-                IMcpServerInfoService? mcpServerInfoService = await ServiceBroker.GetProxyAsync<IMcpServerInfoService>(McpServiceIdentities.ServerInfoService.Descriptor, cancellationToken);
-                using (mcpServerInfoService as IDisposable)
-                {
-                    if (mcpServerInfoService is null)
-                    {
-                        return CopilotToolSessionResult.Failure(CopilotToolSessionError.McpServerInfoServiceNotAvailable);
-                    }
-
-                    McpServerState? state = await mcpServerInfoService.GetServerStateAsync(requiredServerName, cancellationToken);
-                    if (state is null)
-                    {
-                        return CopilotToolSessionResult.Failure(CopilotToolSessionError.McpServerStateNotAvailable);
-                    }
-
-                    if (!(state.Value == McpServerState.Active || state.Value == McpServerState.Suspended))
-                    {
-                        return CopilotToolSessionResult.Failure(CopilotToolSessionError.McpServerNotActive);
-                    }
-                }
-
                 if (copilotService is null)
                 {
                     return CopilotToolSessionResult.Failure(CopilotToolSessionError.CopilotServiceNotAvailable);
@@ -90,9 +87,9 @@ namespace NuGetVSExtension
                         return CopilotToolSessionResult.Failure(CopilotToolSessionError.McpToolServiceNotAvailable);
                     }
 
-                    // 5. Verify the required tool is available. We match on ServerNameOfFunction + Group
+                    // 6. Verify the required tool is available. We match on ServerNameOfFunction + Group
                     //    (the same logical NuGet MCP tool can be exposed under different Group values
-                    //    depending on how it was installed â€” in-VS vs. Anthropic/GitHub MCP registry).
+                    //    depending on how it was installed - in-VS vs. Anthropic/GitHub MCP registry).
                     IReadOnlyList<CopilotFunctionDescriptor>? functions = await cfp.GetFunctionsAsync(correlationId, cancellationToken);
                     if (!IsToolAvailable(functions, mcpToolName, acceptableMcpServerNames))
                     {
@@ -130,6 +127,23 @@ namespace NuGetVSExtension
                 .Any(f => string.Equals(f.ServerNameOfFunction, mcpToolName, StringComparison.OrdinalIgnoreCase)
                        && f.Group is not null
                        && acceptableMcpServerNames.Contains(f.Group, StringComparer.OrdinalIgnoreCase)) ?? false;
+        }
+
+        internal static async Task<bool> IsServerAvailableAsync(
+            IMcpServerInfoService mcpServerInfoService,
+            IReadOnlyCollection<string> acceptableMcpServerNames,
+            CancellationToken cancellationToken)
+        {
+            foreach (string serverName in acceptableMcpServerNames)
+            {
+                McpServerState? state = await mcpServerInfoService.GetServerStateAsync(serverName, cancellationToken);
+                if (state is McpServerState.Active or McpServerState.Suspended)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Copilot;
+using Microsoft.VisualStudio.Copilot.Internal.Mcp;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 using NuGet.VisualStudio;
@@ -22,7 +23,7 @@ namespace NuGetVSExtension
         private const string AuthStatusDetermined = "c936efcc-6baa-4ad3-9c2b-7ba750acf18f";
         private static readonly Guid CopilotReadyUIContext = new(AuthStatusDetermined);
 
-        [Import(typeof(SVsFullAccessServiceBroker))]
+        [Import(typeof(SVsFullAccessServiceBroker), AllowDefault = true)]
         public IServiceBroker? ServiceBroker { get; set; }
 
         public async Task<CopilotToolSessionResult> TryCreateToolSessionAsync(
@@ -54,12 +55,33 @@ namespace NuGetVSExtension
             bool ownershipTransferred = false;
             try
             {
+                // 3. Verify the required MCP server is registered and active
+                IMcpServerInfoService? mcpServerInfoService = await ServiceBroker.GetProxyAsync<IMcpServerInfoService>(McpServiceIdentities.ServerInfoService.Descriptor, cancellationToken);
+                using (mcpServerInfoService as IDisposable)
+                {
+                    if (mcpServerInfoService is null)
+                    {
+                        return CopilotToolSessionResult.Failure(CopilotToolSessionError.McpServerInfoServiceNotAvailable);
+                    }
+
+                    McpServerState? state = await mcpServerInfoService.GetServerStateAsync(requiredServerName, cancellationToken);
+                    if (state is null)
+                    {
+                        return CopilotToolSessionResult.Failure(CopilotToolSessionError.McpServerStateNotAvailable);
+                    }
+
+                    if (!(state.Value == McpServerState.Active || state.Value == McpServerState.Suspended))
+                    {
+                        return CopilotToolSessionResult.Failure(CopilotToolSessionError.McpServerNotActive);
+                    }
+                }
+
                 if (copilotService is null)
                 {
                     return CopilotToolSessionResult.Failure(CopilotToolSessionError.CopilotServiceNotAvailable);
                 }
 
-                // 4. Acquire MCP tool function provider and get available functions
+                // 5. Acquire MCP tool function provider and get available functions
                 ICopilotFunctionProvider? cfp = await ServiceBroker.GetProxyAsync<ICopilotFunctionProvider>(CopilotDescriptors.McpToolService, cancellationToken);
                 using (cfp as IDisposable)
                 {
@@ -77,7 +99,7 @@ namespace NuGetVSExtension
                         return CopilotToolSessionResult.Failure(CopilotToolSessionError.ToolNotAvailable);
                     }
 
-                    // 6. Start Copilot thread
+                    // 7. Start Copilot thread
                     CopilotThreadOptions options = new(clientId);
                     CopilotThread thread = await copilotService.StartThreadAsync(options, cancellationToken);
 

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolSessionError.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolSessionError.cs
@@ -15,7 +15,6 @@ namespace NuGetVSExtension
         McpToolServiceNotAvailable,
         ToolNotAvailable,
         McpServerInfoServiceNotAvailable,
-        McpServerStateNotAvailable,
         McpServerNotActive,
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolSessionError.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolSessionError.cs
@@ -14,5 +14,8 @@ namespace NuGetVSExtension
         CopilotServiceNotAvailable,
         McpToolServiceNotAvailable,
         ToolNotAvailable,
+        McpServerInfoServiceNotAvailable,
+        McpServerStateNotAvailable,
+        McpServerNotActive,
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerablitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerablitiesService.cs
@@ -31,12 +31,12 @@ namespace NuGetVSExtension
                     CopilotDefaultTypes.StringName);
 
         [Import(typeof(ICopilotToolInvocationService))]
-        public ICopilotToolInvocationService? ToolInvocationService { get; set; }
+        public ICopilotToolInvocationService ToolInvocationService { get; set; } = null!;
 
-        [Import(typeof(IVsSolutionManager))]
+        [Import(typeof(IVsSolutionManager), AllowDefault = true)]
         public IVsSolutionManager? SolutionManager { get; set; }
 
-        [Import(typeof(VisualStudioActivityLogger))]
+        [Import(typeof(VisualStudioActivityLogger), AllowDefault = true)]
         public ILogger? ActivityLogger { get; set; }
 
         public async Task LaunchFixVulnerabilitiesAsync(CancellationToken cancellationToken)
@@ -93,6 +93,9 @@ namespace NuGetVSExtension
                 CopilotToolSessionError.ServiceBrokerNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.ServiceBrokerNotAvailable, Resources.Error_ServiceBrokerNotAvailable),
                 CopilotToolSessionError.CopilotServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.CopilotServiceNotAvailable, Resources.Error_CopilotServiceNotAvailable),
                 CopilotToolSessionError.McpToolServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.McpToolServiceNotAvailable, Resources.Error_McpToolServiceNotAvailable),
+                CopilotToolSessionError.McpServerInfoServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.McpServerInfoServiceNotAvailable, Resources.Error_McpServerStateNotAvailable),
+                CopilotToolSessionError.McpServerStateNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.McpServerStateNotAvailable, Resources.Error_McpServerStateNotAvailable),
+                CopilotToolSessionError.McpServerNotActive => (FixVulnerabilitiesWithCopilotErrorType.McpServerNotActive, Resources.Error_McpServerNotActive),
                 CopilotToolSessionError.ToolNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.NuGetSolverNotAvailable, Resources.Error_NuGetSolverNotAvailable),
                 _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),
             };

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerablitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerablitiesService.cs
@@ -94,7 +94,6 @@ namespace NuGetVSExtension
                 CopilotToolSessionError.CopilotServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.CopilotServiceNotAvailable, Resources.Error_CopilotServiceNotAvailable),
                 CopilotToolSessionError.McpToolServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.McpToolServiceNotAvailable, Resources.Error_McpToolServiceNotAvailable),
                 CopilotToolSessionError.McpServerInfoServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.McpServerInfoServiceNotAvailable, Resources.Error_McpServerStateNotAvailable),
-                CopilotToolSessionError.McpServerStateNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.McpServerStateNotAvailable, Resources.Error_McpServerStateNotAvailable),
                 CopilotToolSessionError.McpServerNotActive => (FixVulnerabilitiesWithCopilotErrorType.McpServerNotActive, Resources.Error_McpServerNotActive),
                 CopilotToolSessionError.ToolNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.NuGetSolverNotAvailable, Resources.Error_NuGetSolverNotAvailable),
                 _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerablitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerablitiesService.cs
@@ -93,7 +93,7 @@ namespace NuGetVSExtension
                 CopilotToolSessionError.ServiceBrokerNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.ServiceBrokerNotAvailable, Resources.Error_ServiceBrokerNotAvailable),
                 CopilotToolSessionError.CopilotServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.CopilotServiceNotAvailable, Resources.Error_CopilotServiceNotAvailable),
                 CopilotToolSessionError.McpToolServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.McpToolServiceNotAvailable, Resources.Error_McpToolServiceNotAvailable),
-                CopilotToolSessionError.McpServerInfoServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.McpServerInfoServiceNotAvailable, Resources.Error_McpServerStateNotAvailable),
+                CopilotToolSessionError.McpServerInfoServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.McpServerInfoServiceNotAvailable, Resources.Error_McpServerInfoServiceNotAvailable),
                 CopilotToolSessionError.McpServerNotActive => (FixVulnerabilitiesWithCopilotErrorType.McpServerNotActive, Resources.Error_McpServerNotActive),
                 CopilotToolSessionError.ToolNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.NuGetSolverNotAvailable, Resources.Error_NuGetSolverNotAvailable),
                 _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -106,7 +106,7 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Access denied. Please ensure you are signed in to GitHub Copilot..
+        ///   Looks up a localized string similar to Access denied. Ensure you are signed in to GitHub Copilot..
         /// </summary>
         internal static string Error_CopilotAccessDenied {
             get {
@@ -115,7 +115,7 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in..
+        ///   Looks up a localized string similar to GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in..
         /// </summary>
         internal static string Error_CopilotNotReady {
             get {
@@ -124,7 +124,7 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in..
+        ///   Looks up a localized string similar to GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in..
         /// </summary>
         internal static string Error_CopilotServiceNotAvailable {
             get {
@@ -133,7 +133,7 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again..
+        ///   Looks up a localized string similar to The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again..
         /// </summary>
         internal static string Error_McpServerNotActive {
             get {
@@ -142,7 +142,7 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in..
+        ///   Looks up a localized string similar to Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in..
         /// </summary>
         internal static string Error_McpServerInfoServiceNotAvailable {
             get {
@@ -151,7 +151,7 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in..
+        ///   Looks up a localized string similar to MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in..
         /// </summary>
         internal static string Error_McpToolServiceNotAvailable {
             get {
@@ -160,7 +160,7 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again..
+        ///   Looks up a localized string similar to The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again..
         /// </summary>
         internal static string Error_NuGetSolverNotAvailable {
             get {
@@ -214,7 +214,7 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Service Broker is not available. Please ensure Visual Studio is running correctly..
+        ///   Looks up a localized string similar to Service Broker is not available. Ensure Visual Studio is running correctly..
         /// </summary>
         internal static string Error_ServiceBrokerNotAvailable {
             get {

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -142,11 +142,11 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again..
+        ///   Looks up a localized string similar to Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in..
         /// </summary>
-        internal static string Error_McpServerStateNotAvailable {
+        internal static string Error_McpServerInfoServiceNotAvailable {
             get {
-                return ResourceManager.GetString("Error_McpServerStateNotAvailable", resourceCulture);
+                return ResourceManager.GetString("Error_McpServerInfoServiceNotAvailable", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -133,6 +133,24 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again..
+        /// </summary>
+        internal static string Error_McpServerNotActive {
+            get {
+                return ResourceManager.GetString("Error_McpServerNotActive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again..
+        /// </summary>
+        internal static string Error_McpServerStateNotAvailable {
+            get {
+                return ResourceManager.GetString("Error_McpServerStateNotAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in..
         /// </summary>
         internal static string Error_McpToolServiceNotAvailable {

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -296,4 +296,12 @@
     <value>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
+  <data name="Error_McpServerStateNotAvailable" xml:space="preserve">
+    <value>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
+    <comment>Do not translate GitHub or Copilot</comment>
+  </data>
+  <data name="Error_McpServerNotActive" xml:space="preserve">
+    <value>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
+    <comment>Do not translate GitHub or Copilot</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -274,34 +274,34 @@
     <value>Fix my NuGet package vulnerabilities</value>
   </data>
   <data name="Error_CopilotNotReady" xml:space="preserve">
-    <value>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</value>
+    <value>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
   <data name="Error_ServiceBrokerNotAvailable" xml:space="preserve">
-    <value>Service Broker is not available. Please ensure Visual Studio is running correctly.</value>
+    <value>Service Broker is not available. Ensure Visual Studio is running correctly.</value>
   </data>
   <data name="Error_CopilotServiceNotAvailable" xml:space="preserve">
-    <value>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</value>
+    <value>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
   <data name="Error_McpToolServiceNotAvailable" xml:space="preserve">
-    <value>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</value>
+    <value>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
   <data name="Error_CopilotAccessDenied" xml:space="preserve">
-    <value>Access denied. Please ensure you are signed in to GitHub Copilot.</value>
+    <value>Access denied. Ensure you are signed in to GitHub Copilot.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
   <data name="Error_NuGetSolverNotAvailable" xml:space="preserve">
-    <value>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
+    <value>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
   <data name="Error_McpServerInfoServiceNotAvailable" xml:space="preserve">
-    <value>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</value>
+    <value>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
   <data name="Error_McpServerNotActive" xml:space="preserve">
-    <value>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
+    <value>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -296,8 +296,8 @@
     <value>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
-  <data name="Error_McpServerStateNotAvailable" xml:space="preserve">
-    <value>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
+  <data name="Error_McpServerInfoServiceNotAvailable" xml:space="preserve">
+    <value>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
   <data name="Error_McpServerNotActive" xml:space="preserve">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">Přístup byl odepřen. Ujistěte se prosím, že jste přihlášení ke službě GitHub Copilot.</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">Přístup byl odepřen. Ujistěte se prosím, že jste přihlášení ke službě GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot není připravený. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot není připravený. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Služba GitHub Copilot není k dispozici. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Služba GitHub Copilot není k dispozici. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Služba MCP Tool není k dispozici. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Služba MCP Tool není k dispozici. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">Nástroj Řešič NuGet není k dispozici. Povolte prosím NuGet MCP Server v okně chatu GitHub Copilota a zkuste to znovu.</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">Nástroj Řešič NuGet není k dispozici. Povolte prosím NuGet MCP Server v okně chatu GitHub Copilota a zkuste to znovu.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Service Broker není k dispozici. Ujistěte se prosím, že Visual Studio běží správně.</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Service Broker není k dispozici. Ujistěte se prosím, že Visual Studio běží správně.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -37,6 +37,16 @@
         <target state="translated">Služba GitHub Copilot není k dispozici. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">Služba MCP Tool není k dispozici. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -37,14 +37,14 @@
         <target state="translated">Služba GitHub Copilot není k dispozici. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -37,14 +37,14 @@
         <target state="translated">GitHub Copilot-Dienst nicht verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">Zugriff verweigert. Stellen Sie sicher, dass Sie bei GitHub Copilot angemeldet sind.</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">Zugriff verweigert. Stellen Sie sicher, dass Sie bei GitHub Copilot angemeldet sind.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot nicht verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot nicht verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot-Dienst nicht verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot-Dienst nicht verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">MCP-Tooldienst nicht verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">MCP-Tooldienst nicht verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">Das NuGet-Lösertool ist nicht verfügbar. Aktivieren Sie den NuGet MCP-Server im GitHub Copilot-Chatfenster, und versuchen Sie es noch mal.</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">Das NuGet-Lösertool ist nicht verfügbar. Aktivieren Sie den NuGet MCP-Server im GitHub Copilot-Chatfenster, und versuchen Sie es noch mal.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Service Broker ist nicht verfügbar. Bitte stellen Sie sicher, dass Visual Studio ordnungsgemäß ausgeführt wird.</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Service Broker ist nicht verfügbar. Bitte stellen Sie sicher, dass Visual Studio ordnungsgemäß ausgeführt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -37,6 +37,16 @@
         <target state="translated">GitHub Copilot-Dienst nicht verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">MCP-Tooldienst nicht verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -37,14 +37,14 @@
         <target state="translated">El servicio de GitHub Copilot no está disponible. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -37,6 +37,16 @@
         <target state="translated">El servicio de GitHub Copilot no está disponible. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">El servicio de herramientas MCP no está disponible. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">Acceso denegado. Asegúrese de que ha iniciado sesión en GitHub Copilot.</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">Acceso denegado. Asegúrese de que ha iniciado sesión en GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot no está listo. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot no está listo. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">El servicio de GitHub Copilot no está disponible. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">El servicio de GitHub Copilot no está disponible. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">El servicio de herramientas MCP no está disponible. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">El servicio de herramientas MCP no está disponible. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">La herramienta de solucionador de NuGet no está disponible. Habilite el servidor MCP de NuGet en la ventana de chat de GitHub Copilot e inténtelo de nuevo.</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">La herramienta de solucionador de NuGet no está disponible. Habilite el servidor MCP de NuGet en la ventana de chat de GitHub Copilot e inténtelo de nuevo.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Service Broker no está disponible. Asegúrese de que Visual Studio se ejecuta correctamente.</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Service Broker no está disponible. Asegúrese de que Visual Studio se ejecuta correctamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">Accès refusé. Vérifiez que vous êtes connecté(e) à GitHub Copilot.</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">Accès refusé. Vérifiez que vous êtes connecté(e) à GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Désolé, GitHub Copilot n’est pas prêt. Veuillez vérifier que GitHub Copilot est installé et que vous êtes connecté(e).</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Désolé, GitHub Copilot n’est pas prêt. Veuillez vérifier que GitHub Copilot est installé et que vous êtes connecté(e).</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Désolé, le service de GitHub Copilot n’est pas disponible. Veuillez vérifier que GitHub Copilot est installé et que vous êtes connecté(e).</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Désolé, le service de GitHub Copilot n’est pas disponible. Veuillez vérifier que GitHub Copilot est installé et que vous êtes connecté(e).</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Désolé, le service MCP Tool n’est pas disponible. Veuillez vérifier que GitHub Copilot est installé et que vous êtes connecté(e).</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Désolé, le service MCP Tool n’est pas disponible. Veuillez vérifier que GitHub Copilot est installé et que vous êtes connecté(e).</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">Désolé, l’outil Solutionneur NuGet n’est pas disponible. Veuillez activer le serveur MCP NuGet dans la fenêtre de conversation GitHub Copilot et réessayer.</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">Désolé, l’outil Solutionneur NuGet n’est pas disponible. Veuillez activer le serveur MCP NuGet dans la fenêtre de conversation GitHub Copilot et réessayer.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Désolé, Service Broker n’est pas disponible. Veuillez vérifier que Visual Studio fonctionne correctement.</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Désolé, Service Broker n’est pas disponible. Veuillez vérifier que Visual Studio fonctionne correctement.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -37,14 +37,14 @@
         <target state="translated">Désolé, le service de GitHub Copilot n’est pas disponible. Veuillez vérifier que GitHub Copilot est installé et que vous êtes connecté(e).</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -37,6 +37,16 @@
         <target state="translated">Désolé, le service de GitHub Copilot n’est pas disponible. Veuillez vérifier que GitHub Copilot est installé et que vous êtes connecté(e).</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">Désolé, le service MCP Tool n’est pas disponible. Veuillez vérifier que GitHub Copilot est installé et que vous êtes connecté(e).</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">Accesso negato. Assicurati di aver effettuato l'accesso a GitHub Copilot.</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">Accesso negato. Assicurati di aver effettuato l'accesso a GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot non è pronto. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot non è pronto. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Il servizio GitHub Copilot non è disponibile. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Il servizio GitHub Copilot non è disponibile. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Il servizio dello strumento MCP non è disponibile. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Il servizio dello strumento MCP non è disponibile. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">Lo strumento Risolutore NuGet non è disponibile. Abilitare il server NuGet MCP nella finestra di chat di GitHub Copilot e riprovare.</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">Lo strumento Risolutore NuGet non è disponibile. Abilitare il server NuGet MCP nella finestra di chat di GitHub Copilot e riprovare.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Service Broker non è disponibile. Verificare che Visual Studio sia correttamente in esecuzione.</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Service Broker non è disponibile. Verificare che Visual Studio sia correttamente in esecuzione.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -37,6 +37,16 @@
         <target state="translated">Il servizio GitHub Copilot non è disponibile. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">Il servizio dello strumento MCP non è disponibile. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -37,14 +37,14 @@
         <target state="translated">Il servizio GitHub Copilot non è disponibile. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">アクセスが拒否されました。GitHub Copilot にサインインしていることを確認してください。</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">アクセスが拒否されました。GitHub Copilot にサインインしていることを確認してください。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot の準備ができていません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot の準備ができていません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot サービスを利用できません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot サービスを利用できません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">MCP ツール サービスは使用できません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">MCP ツール サービスは使用できません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">NuGet ソルバー ツールは使用できません。GitHub Copilot Chat ウィンドウで NuGet MCP Server を有効にして、もう一度お試しください。</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">NuGet ソルバー ツールは使用できません。GitHub Copilot Chat ウィンドウで NuGet MCP Server を有効にして、もう一度お試しください。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Service Broker は利用できません。Visual Studio が正しく起動していることを確認してください。</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Service Broker は利用できません。Visual Studio が正しく起動していることを確認してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -37,14 +37,14 @@
         <target state="translated">GitHub Copilot サービスを利用できません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -37,6 +37,16 @@
         <target state="translated">GitHub Copilot サービスを利用できません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">MCP ツール サービスは使用できません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">액세스가 거부되었습니다. GitHub Copilot에 로그인되어 있는지 확인하세요.</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">액세스가 거부되었습니다. GitHub Copilot에 로그인되어 있는지 확인하세요.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot이 준비되지 않았습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot이 준비되지 않았습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot 서비스를 사용할 수 없습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot 서비스를 사용할 수 없습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">MCP 도구 서비스를 사용할 수 없습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">MCP 도구 서비스를 사용할 수 없습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">NuGet 해결사 도구를 사용할 수 없습니다. GitHub Copilot 채팅 창에서 NuGet MCP 서버를 활성화한 후 다시 시도하세요.</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">NuGet 해결사 도구를 사용할 수 없습니다. GitHub Copilot 채팅 창에서 NuGet MCP 서버를 활성화한 후 다시 시도하세요.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Service Broker를 사용할 수 없습니다. Visual Studio가 올바르게 실행되고 있는지 확인하세요.</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Service Broker를 사용할 수 없습니다. Visual Studio가 올바르게 실행되고 있는지 확인하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -37,6 +37,16 @@
         <target state="translated">GitHub Copilot 서비스를 사용할 수 없습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">MCP 도구 서비스를 사용할 수 없습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -37,14 +37,14 @@
         <target state="translated">GitHub Copilot 서비스를 사용할 수 없습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -37,14 +37,14 @@
         <target state="translated">Usługa GitHub Copilot jest niedostępna. Upewnij się, że usługa GitHub Copilot jest zainstalowana i zalogowano się.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">Odmowa dostępu. Upewnij się, że zalogowano się do usługi GitHub Copilot.</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">Odmowa dostępu. Upewnij się, że zalogowano się do usługi GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Usługa GitHub Copilot nie jest gotowa. Upewnij się, że usługa GitHub Copilot jest zainstalowana i zalogowano się.</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Usługa GitHub Copilot nie jest gotowa. Upewnij się, że usługa GitHub Copilot jest zainstalowana i zalogowano się.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Usługa GitHub Copilot jest niedostępna. Upewnij się, że usługa GitHub Copilot jest zainstalowana i zalogowano się.</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Usługa GitHub Copilot jest niedostępna. Upewnij się, że usługa GitHub Copilot jest zainstalowana i zalogowano się.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Usługa narzędzia MCP jest niedostępna. Upewnij się, że usługa GitHub Copilot jest zainstalowana i zalogowano się.</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Usługa narzędzia MCP jest niedostępna. Upewnij się, że usługa GitHub Copilot jest zainstalowana i zalogowano się.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">Narzędzie NuGet Solver jest niedostępne. Włącz serwer NuGet MCP w oknie czatu narzędzia GitHub Copilot i spróbuj ponownie.</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">Narzędzie NuGet Solver jest niedostępne. Włącz serwer NuGet MCP w oknie czatu narzędzia GitHub Copilot i spróbuj ponownie.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Technologia Service Broker jest niedostępna. Upewnij się, że program Visual Studio działa poprawnie.</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Technologia Service Broker jest niedostępna. Upewnij się, że program Visual Studio działa poprawnie.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -37,6 +37,16 @@
         <target state="translated">Usługa GitHub Copilot jest niedostępna. Upewnij się, że usługa GitHub Copilot jest zainstalowana i zalogowano się.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">Usługa narzędzia MCP jest niedostępna. Upewnij się, że usługa GitHub Copilot jest zainstalowana i zalogowano się.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">Acesso negado. Verifique se você está conectado ao GitHub Copilot.</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">Acesso negado. Verifique se você está conectado ao GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">O GitHub Copilot não está pronto. Verifique se o GitHub Copilot está instalado e conectado.</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">O GitHub Copilot não está pronto. Verifique se o GitHub Copilot está instalado e conectado.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">O serviço GitHub Copilot não está disponível. Verifique se o GitHub Copilot está instalado e conectado.</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">O serviço GitHub Copilot não está disponível. Verifique se o GitHub Copilot está instalado e conectado.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">O Serviço de Ferramenta MCP não está disponível. Verifique se o GitHub Copilot está instalado e conectado.</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">O Serviço de Ferramenta MCP não está disponível. Verifique se o GitHub Copilot está instalado e conectado.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">A ferramenta NuGet Solver não está disponível. Habilite o Servidor MCP do NuGet na janela de chat do GitHub Copilot e tente novamente.</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">A ferramenta NuGet Solver não está disponível. Habilite o Servidor MCP do NuGet na janela de chat do GitHub Copilot e tente novamente.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Service Broker não está disponível. Verifique se o Visual Studio está sendo executado corretamente.</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Service Broker não está disponível. Verifique se o Visual Studio está sendo executado corretamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -37,14 +37,14 @@
         <target state="translated">O serviço GitHub Copilot não está disponível. Verifique se o GitHub Copilot está instalado e conectado.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -37,6 +37,16 @@
         <target state="translated">O serviço GitHub Copilot não está disponível. Verifique se o GitHub Copilot está instalado e conectado.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">O Serviço de Ferramenta MCP não está disponível. Verifique se o GitHub Copilot está instalado e conectado.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">Отказано в доступе. Убедитесь, что вы вошли в GitHub Copilot.</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">Отказано в доступе. Убедитесь, что вы вошли в GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot не готов. Убедитесь, что GitHub Copilot установлен и вы вошли в свою учетную запись.</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot не готов. Убедитесь, что GitHub Copilot установлен и вы вошли в свою учетную запись.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Служба GitHub Copilot недоступна. Убедитесь, что GitHub Copilot установлен и вы вошли в свою учетную запись.</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Служба GitHub Copilot недоступна. Убедитесь, что GitHub Copilot установлен и вы вошли в свою учетную запись.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">Служба MCP Tool Service недоступна. Убедитесь, что GitHub Copilot установлен и вы вошли в свою учетную запись.</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">Служба MCP Tool Service недоступна. Убедитесь, что GitHub Copilot установлен и вы вошли в свою учетную запись.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">Средство NuGet Solver недоступно. Включите сервер MCP NuGet в окне чата GitHub Copilot и повторите попытку.</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">Средство NuGet Solver недоступно. Включите сервер MCP NuGet в окне чата GitHub Copilot и повторите попытку.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Служба Service Broker недоступна. Убедитесь, что Visual Studio работает корректно.</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Служба Service Broker недоступна. Убедитесь, что Visual Studio работает корректно.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -37,6 +37,16 @@
         <target state="translated">Служба GitHub Copilot недоступна. Убедитесь, что GitHub Copilot установлен и вы вошли в свою учетную запись.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">Служба MCP Tool Service недоступна. Убедитесь, что GitHub Copilot установлен и вы вошли в свою учетную запись.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -37,14 +37,14 @@
         <target state="translated">Служба GitHub Copilot недоступна. Убедитесь, что GitHub Copilot установлен и вы вошли в свою учетную запись.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -37,6 +37,16 @@
         <target state="translated">GitHub Copilot Hizmeti kullanılamıyor. Lütfen GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">MCP Araç Hizmeti kullanılamıyor. Lütfen GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">Erişim reddedildi. Lütfen GitHub Copilot’ta oturum açtığınızdan emin olun.</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">Erişim reddedildi. Lütfen GitHub Copilot’ta oturum açtığınızdan emin olun.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot hazır değil. Lütfen GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot hazır değil. Lütfen GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot Hizmeti kullanılamıyor. Lütfen GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot Hizmeti kullanılamıyor. Lütfen GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">MCP Araç Hizmeti kullanılamıyor. Lütfen GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">MCP Araç Hizmeti kullanılamıyor. Lütfen GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">NuGet Oyun Yardımcısı aracı kullanılamıyor. Lütfen GitHub Copilot sohbet penceresinde NuGet MCP Sunucusu'nu etkinleştirin ve yeniden deneyin.</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">NuGet Oyun Yardımcısı aracı kullanılamıyor. Lütfen GitHub Copilot sohbet penceresinde NuGet MCP Sunucusu'nu etkinleştirin ve yeniden deneyin.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Hizmet Aracısı kullanılamıyor. Lütfen Visual Studio’nun düzgün çalıştığından emin olun.</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Hizmet Aracısı kullanılamıyor. Lütfen Visual Studio’nun düzgün çalıştığından emin olun.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -37,14 +37,14 @@
         <target state="translated">GitHub Copilot Hizmeti kullanılamıyor. Lütfen GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">访问被拒绝。请确保你已登录 GitHub Copilot。</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">访问被拒绝。请确保你已登录 GitHub Copilot。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot 未就绪。请确保 GitHub Copilot 已安装并登录。</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot 未就绪。请确保 GitHub Copilot 已安装并登录。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot 服务不可用。请确保 GitHub Copilot 已安装并登录。</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot 服务不可用。请确保 GitHub Copilot 已安装并登录。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">MCP 工具服务不可用。请确保 GitHub Copilot 已安装并登录。</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">MCP 工具服务不可用。请确保 GitHub Copilot 已安装并登录。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">NuGet 求解器工具不可用。请在 GitHub Copilot 聊天窗口中启用 NuGet MCP 服务器，然后重试。</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">NuGet 求解器工具不可用。请在 GitHub Copilot 聊天窗口中启用 NuGet MCP 服务器，然后重试。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Service Broker 不可用。请确保 Visual Studio 正确运行。</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Service Broker 不可用。请确保 Visual Studio 正确运行。</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -37,14 +37,14 @@
         <target state="translated">GitHub Copilot 服务不可用。请确保 GitHub Copilot 已安装并登录。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -37,6 +37,16 @@
         <target state="translated">GitHub Copilot 服务不可用。请确保 GitHub Copilot 已安装并登录。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">MCP 工具服务不可用。请确保 GitHub Copilot 已安装并登录。</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -37,6 +37,16 @@
         <target state="translated">GitHub Copilot 服務無法使用。請確保已安裝並登入 GitHub Copilot。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerNotActive">
+        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
+      <trans-unit id="Error_McpServerStateNotAvailable">
+        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
         <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">MCP 工具服務無法使用。請確保已安裝並登入 GitHub Copilot。</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -37,14 +37,14 @@
         <target state="translated">GitHub Copilot 服務無法使用。請確保已安裝並登入 GitHub Copilot。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_McpServerInfoServiceNotAvailable">
+        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
         <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
         <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
-        <note>Do not translate GitHub or Copilot</note>
-      </trans-unit>
-      <trans-unit id="Error_McpServerStateNotAvailable">
-        <source>The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not available. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -23,38 +23,38 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_CopilotAccessDenied">
-        <source>Access denied. Please ensure you are signed in to GitHub Copilot.</source>
-        <target state="translated">存取遭拒。請確保您已登入 GitHub Copilot。</target>
+        <source>Access denied. Ensure you are signed in to GitHub Copilot.</source>
+        <target state="needs-review-translation">存取遭拒。請確保您已登入 GitHub Copilot。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotNotReady">
-        <source>GitHub Copilot is not ready. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot 尚未就緒。請確保已安裝並登入 GitHub Copilot。</target>
+        <source>GitHub Copilot is not ready. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot 尚未就緒。請確保已安裝並登入 GitHub Copilot。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
-        <source>GitHub Copilot Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">GitHub Copilot 服務無法使用。請確保已安裝並登入 GitHub Copilot。</target>
+        <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">GitHub Copilot 服務無法使用。請確保已安裝並登入 GitHub Copilot。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerInfoServiceNotAvailable">
-        <source>Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="new">Unable to determine the status of the NuGet MCP Server. Please ensure GitHub Copilot is installed and signed in.</target>
+        <source>Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="new">Unable to determine the status of the NuGet MCP Server. Ensure GitHub Copilot is installed and signed in.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpServerNotActive">
-        <source>The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="new">The NuGet MCP Server is not active. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <source>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_McpToolServiceNotAvailable">
-        <source>MCP Tool Service is not available. Please ensure GitHub Copilot is installed and signed in.</source>
-        <target state="translated">MCP 工具服務無法使用。請確保已安裝並登入 GitHub Copilot。</target>
+        <source>MCP Tool Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
+        <target state="needs-review-translation">MCP 工具服務無法使用。請確保已安裝並登入 GitHub Copilot。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_NuGetSolverNotAvailable">
-        <source>The NuGet Solver tool is unavailable. Please enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
-        <target state="translated">NuGet 求解器工具無法使用。請在 GitHub Copilot 聊天視窗啟用 NuGet MCP 伺服器，然後再試一次。</target>
+        <source>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="needs-review-translation">NuGet 求解器工具無法使用。請在 GitHub Copilot 聊天視窗啟用 NuGet MCP 伺服器，然後再試一次。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
       <trans-unit id="Error_PackageSourceMappingPattern_Missing">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Error_ServiceBrokerNotAvailable">
-        <source>Service Broker is not available. Please ensure Visual Studio is running correctly.</source>
-        <target state="translated">Service Broker 無法使用。請確保 Visual Studio 正常執行。</target>
+        <source>Service Broker is not available. Ensure Visual Studio is running correctly.</source>
+        <target state="needs-review-translation">Service Broker 無法使用。請確保 Visual Studio 正常執行。</target>
         <note />
       </trans-unit>
       <trans-unit id="NoProjectSelected">

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/.vsixignore
@@ -12,6 +12,7 @@ Microsoft.DataAI.NuGetRecommender.Contracts.dll
 Microsoft.Extensions.DependencyInjection.dll
 Microsoft.Extensions.DependencyInjection.Abstractions.dll
 Microsoft.Extensions.FileProviders.Abstractions.dll
+Microsoft.Extensions.Logging.Abstractions.dll
 Microsoft.Extensions.Primitives.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll
@@ -21,6 +22,7 @@ Microsoft.IdentityModel.Tokens.dll
 Microsoft.Internal.VisualStudio.Shell.Framework.dll
 Microsoft.Internal.VisualStudio.Shell.Framework.resources.dll
 Microsoft.ML.Tokenizers.dll
+Nerdbank.MessagePack.dll
 Microsoft.TeamFoundation.Build.Client.dll
 Microsoft.TeamFoundation.Build.Client.resources.dll
 Microsoft.TeamFoundation.Build.Common.dll
@@ -104,6 +106,8 @@ Microsoft.VisualStudio.Services.TestResults.WebApi.dll
 Microsoft.VisualStudio.Setup.Common.dll
 Microsoft.VisualStudio.Shell.Styles.dll
 Microsoft.VisualStudio.Shell.Styles.resources.dll
+PolyType.dll
+System.ClientModel.dll
 System.Drawing.Common.dll
 System.Formats.Nrbf.dll
 System.IdentityModel.Tokens.Jwt.dll

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" />
     <PackageReference Include="Microsoft.VisualStudio.Sdk" />
   </ItemGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/VisualStudioContextHelper.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/VisualStudioContextHelper.cs
@@ -14,10 +14,12 @@ namespace NuGet.VisualStudio
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(token);
             IVsShell shell = await ServiceLocator.GetGlobalServiceAsync<SVsShell, IVsShell>();
+#pragma warning disable CS0618 // Type or member is obsolete
             return shell != null &&
                 shell.GetProperty((int)__VSSPROPID11.VSSPROPID_ShellMode, out object value) == VSConstants.S_OK &&
                 value is int shellMode &&
                 shellMode == (int)__VSShellMode.VSSM_Server;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Credentials/NuGet.Credentials.csproj
+++ b/src/NuGet.Core/NuGet.Credentials/NuGet.Credentials.csproj
@@ -8,7 +8,7 @@
     <IncludeInVSIX>true</IncludeInVSIX>
     <XPLATProject>true</XPLATProject>
     <UsePublicApiAnalyzer>perTfm</UsePublicApiAnalyzer>
-    <NoWarn>$(NoWarn);RS0041</NoWarn>
+    <NoWarn>$(NoWarn);RS0041;IL2026;IL3050</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">

--- a/src/NuGet.Core/NuGet.Credentials/NuGet.Credentials.csproj
+++ b/src/NuGet.Core/NuGet.Credentials/NuGet.Credentials.csproj
@@ -8,7 +8,7 @@
     <IncludeInVSIX>true</IncludeInVSIX>
     <XPLATProject>true</XPLATProject>
     <UsePublicApiAnalyzer>perTfm</UsePublicApiAnalyzer>
-    <NoWarn>$(NoWarn);RS0041;IL2026;IL3050</NoWarn>
+    <NoWarn>$(NoWarn);RS0041</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
@@ -5,6 +5,9 @@
 
 using System;
 using System.Diagnostics;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -170,6 +173,10 @@ namespace NuGet.Credentials
         /// </summary>
         public int TimeoutSeconds { get; }
 
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Legacy command-line credential provider infrastructure; Newtonsoft.Json deserializes the concrete PluginCredentialResponse type, which is preserved here.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Legacy command-line credential provider infrastructure; Newtonsoft.Json deserializes the concrete PluginCredentialResponse type, which is preserved here.")]
+#endif
         private PluginCredentialResponse GetPluginResponse(PluginCredentialRequest request,
             CancellationToken cancellationToken)
         {

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
     <TargetFramework />
-    <NoWarn>$(NoWarn);CS1591;CS1573;CS0012;RS0041</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS1573;CS0012;RS0041;IL2026;IL3050</NoWarn>
     <PackageTags>nuget protocol</PackageTags>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
     <TargetFramework />
-    <NoWarn>$(NoWarn);CS1591;CS1573;CS0012;RS0041;IL2026;IL3050</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS1573;CS0012;RS0041</NoWarn>
     <PackageTags>nuget protocol</PackageTags>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
@@ -127,7 +127,6 @@ namespace NuGet.PackageManagement.Test.Telemetry
         [InlineData(FixVulnerabilitiesWithCopilotErrorType.CopilotAccessDenied)]
         [InlineData(FixVulnerabilitiesWithCopilotErrorType.NuGetSolverNotAvailable)]
         [InlineData(FixVulnerabilitiesWithCopilotErrorType.McpServerInfoServiceNotAvailable)]
-        [InlineData(FixVulnerabilitiesWithCopilotErrorType.McpServerStateNotAvailable)]
         [InlineData(FixVulnerabilitiesWithCopilotErrorType.McpServerNotActive)]
         public void CreateWithVulnerabilityInfoBarFixWithCopilot_WithAllErrorTypes_CreatesEventWithCorrectProperties(FixVulnerabilitiesWithCopilotErrorType errorType)
         {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
@@ -125,6 +125,10 @@ namespace NuGet.PackageManagement.Test.Telemetry
         [InlineData(FixVulnerabilitiesWithCopilotErrorType.CopilotServiceNotAvailable)]
         [InlineData(FixVulnerabilitiesWithCopilotErrorType.McpToolServiceNotAvailable)]
         [InlineData(FixVulnerabilitiesWithCopilotErrorType.CopilotAccessDenied)]
+        [InlineData(FixVulnerabilitiesWithCopilotErrorType.NuGetSolverNotAvailable)]
+        [InlineData(FixVulnerabilitiesWithCopilotErrorType.McpServerInfoServiceNotAvailable)]
+        [InlineData(FixVulnerabilitiesWithCopilotErrorType.McpServerStateNotAvailable)]
+        [InlineData(FixVulnerabilitiesWithCopilotErrorType.McpServerNotActive)]
         public void CreateWithVulnerabilityInfoBarFixWithCopilot_WithAllErrorTypes_CreatesEventWithCorrectProperties(FixVulnerabilitiesWithCopilotErrorType errorType)
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/CopilotToolInvocationServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/CopilotToolInvocationServiceTests.cs
@@ -4,8 +4,13 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Copilot;
+using Microsoft.VisualStudio.Copilot.Internal.Mcp;
+using Moq;
 using NuGet.PackageManagement.VisualStudio;
 using NuGetVSExtension;
 using Xunit;
@@ -99,6 +104,86 @@ namespace NuGet.Tools.Test
             };
 
             Assert.True(CopilotToolInvocationService.IsToolAvailable(functions, ValidNuGetToolName, AcceptableGroups));
+        }
+
+        [Theory]
+        [InlineData(McpServerState.Active, true)]
+        [InlineData(McpServerState.Suspended, true)]
+        [InlineData(McpServerState.Unknown, false)]
+        [InlineData(McpServerState.NotStarted, false)]
+        [InlineData(McpServerState.InputRequired, false)]
+        [InlineData(McpServerState.AuthRequired, false)]
+        [InlineData(McpServerState.Starting, false)]
+        [InlineData(McpServerState.Failed, false)]
+        [InlineData(McpServerState.Disabled, false)]
+        [InlineData(McpServerState.TrustRejected, false)]
+        [InlineData(null, false)]   // Server state not reported
+        public async Task IsServerAvailableAsync_SingleServerState_ReturnsExpected(McpServerState? state, bool expected)
+        {
+            IMcpServerInfoService infoService = CreateInfoService((McpServerConstants.NuGetMcpServerName, state));
+
+            bool result = await CopilotToolInvocationService.IsServerAvailableAsync(
+                infoService,
+                new[] { McpServerConstants.NuGetMcpServerName },
+                CancellationToken.None);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public async Task IsServerAvailableAsync_MultipleServers_OneActive_ReturnsTrue()
+        {
+            // First acceptable name is not active, second one is - verifies all names are checked.
+            IMcpServerInfoService infoService = CreateInfoService(
+                (McpServerConstants.NuGetMcpServerName, McpServerState.Failed),
+                (McpServerConstants.ComMicrosoftNuGetMcpServerName, McpServerState.Active));
+
+            bool result = await CopilotToolInvocationService.IsServerAvailableAsync(
+                infoService,
+                AcceptableGroups,
+                CancellationToken.None);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsServerAvailableAsync_MultipleServers_NoneActive_ReturnsFalse()
+        {
+            IMcpServerInfoService infoService = CreateInfoService(
+                (McpServerConstants.NuGetMcpServerName, McpServerState.Failed),
+                (McpServerConstants.ComMicrosoftNuGetMcpServerName, McpServerState.Disabled));
+
+            bool result = await CopilotToolInvocationService.IsServerAvailableAsync(
+                infoService,
+                AcceptableGroups,
+                CancellationToken.None);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsServerAvailableAsync_EmptyServerNames_ReturnsFalse()
+        {
+            IMcpServerInfoService infoService = CreateInfoService();
+
+            bool result = await CopilotToolInvocationService.IsServerAvailableAsync(
+                infoService,
+                new string[0],
+                CancellationToken.None);
+
+            Assert.False(result);
+        }
+
+        private static IMcpServerInfoService CreateInfoService(params (string ServerName, McpServerState? State)[] states)
+        {
+            Dictionary<string, McpServerState?> map = states.ToDictionary(s => s.ServerName, s => s.State);
+
+            var mock = new Mock<IMcpServerInfoService>();
+            mock.Setup(s => s.GetServerStateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns((string name, CancellationToken _) =>
+                    new ValueTask<McpServerState?>(map.TryGetValue(name, out McpServerState? state) ? state : null));
+
+            return mock.Object;
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3790

## Description
Improves the reliability of the Fix Vulnerabilities with Copilot flow by adding an upfront check that the NuGet MCP Server is registered and running before starting a Copilot tool session. Previously the only signal was the presence of the NuGet MCP tool. We now also query the MCP server's state directly via the new `IMcpServerInfoService`, treating the server as available when any of its acceptable names reports an Active or Suspended state. This requires bumping the VS SDK packages to 18.8.850 (with corresponding .vsixignore and MEF-analyzer adjustments) and adds new error states/messages for when the server's status can't be determined or the server isn't active.

Upgraded Microsoft.VisualStudio.ComponentModelHost to 18.8.850 to resolve a CS0433 type-collision introduced by the Microsoft.Internal.VisualStudio.Shell.Framework 18.8.850 bump

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
