### PR TITLE
Remove JToken deserialization from an obsolete feature 

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -825,7 +825,6 @@ NuGet.Protocol.PackageSearchResourceV2Feed
 NuGet.Protocol.PackageSearchResourceV2FeedProvider
 NuGet.Protocol.PackageSearchResourceV2FeedProvider.PackageSearchResourceV2FeedProvider() -> void
 NuGet.Protocol.PackageSearchResourceV3
-~NuGet.Protocol.PackageSearchResourceV3.PackageSearchResourceV3(NuGet.Protocol.RawSearchResourceV3 searchResource) -> void
 NuGet.Protocol.PackageSearchResourceV3Provider
 NuGet.Protocol.PackageSearchResourceV3Provider.PackageSearchResourceV3Provider() -> void
 NuGet.Protocol.PackageUpdateResourceV2Provider

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -825,7 +825,6 @@ NuGet.Protocol.PackageSearchResourceV2Feed
 NuGet.Protocol.PackageSearchResourceV2FeedProvider
 NuGet.Protocol.PackageSearchResourceV2FeedProvider.PackageSearchResourceV2FeedProvider() -> void
 NuGet.Protocol.PackageSearchResourceV3
-~NuGet.Protocol.PackageSearchResourceV3.PackageSearchResourceV3(NuGet.Protocol.RawSearchResourceV3 searchResource) -> void
 NuGet.Protocol.PackageSearchResourceV3Provider
 NuGet.Protocol.PackageSearchResourceV3Provider.PackageSearchResourceV3Provider() -> void
 NuGet.Protocol.PackageUpdateResourceV2Provider

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -26,12 +26,6 @@ namespace NuGet.Protocol
         private readonly Uri[] _searchEndpoints;
         private readonly IEnvironmentVariableReader _environmentVariableReader;
 
-        [Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
-        public PackageSearchResourceV3(RawSearchResourceV3 searchResource)
-            : base()
-        {
-        }
-
         internal PackageSearchResourceV3(HttpSource client, IEnumerable<Uri> searchEndpoints)
             : this(client, searchEndpoints, environmentVariableReader: null)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -26,15 +26,10 @@ namespace NuGet.Protocol
         private readonly Uri[] _searchEndpoints;
         private readonly IEnvironmentVariableReader _environmentVariableReader;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        private readonly RawSearchResourceV3 _rawSearchResource;
-#pragma warning restore CS0618 // Type or member is obsolete
-
         [Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
         public PackageSearchResourceV3(RawSearchResourceV3 searchResource)
             : base()
         {
-            _rawSearchResource = searchResource;
         }
 
         internal PackageSearchResourceV3(HttpSource client, IEnumerable<Uri> searchEndpoints)
@@ -63,27 +58,15 @@ namespace NuGet.Protocol
         /// <returns>List of package meta data.</returns>
         public override async Task<IEnumerable<IPackageSearchMetadata>> SearchAsync(string searchTerm, SearchFilter filter, int skip, int take, Common.ILogger log, CancellationToken cancellationToken)
         {
-            IEnumerable<PackageSearchMetadata> searchResultMetadata;
             var metadataCache = new MetadataReferenceCache();
 
-            if (_client != null && _searchEndpoints != null)
-            {
-                searchResultMetadata = await Search(
-                    searchTerm,
-                    filter,
-                    skip,
-                    take,
-                    log,
-                    cancellationToken);
-            }
-            else
-            {
-#pragma warning disable CS0618
-                var searchResultJsonObjects = await _rawSearchResource.Search(searchTerm, filter, skip, take, Common.NullLogger.Instance, cancellationToken);
-#pragma warning restore CS0618
-                searchResultMetadata = searchResultJsonObjects
-                    .Select(s => s.FromJToken<PackageSearchMetadata>());
-            }
+            var searchResultMetadata = await Search(
+                searchTerm,
+                filter,
+                skip,
+                take,
+                log,
+                cancellationToken);
 
             var searchResults = searchResultMetadata
                 .Select(m => m.WithVersions(() => GetVersions(m, filter)))


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14935

## Description

Raw search is an obsolete feature and this feature, It searches and store search results as `JToken`s but they are only deserialized into an actual object here in `PakcageSearchResourceV3`. This PR removes the support for an obsolete constructor which enabled SearchAsync to do Raw Search. 

Note: In order for `SearchAsync` to be able to do raw search, the object created must have been created with the obsolete constructor in PackageSearchResourceV3. So this will only break users using the obsolete constructor.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
