### PR TITLE
Build and publish NuGet.Client.EndToEnd.TestData if needed

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -83,7 +83,7 @@
     <PackageVersion Include="MSTest.TestAdapter" Version="$(MSTestPackageVersion)" />
     <PackageVersion Include="MSTest.TestFramework" Version="$(MSTestPackageVersion)" />
     <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageVersion Include="NuGet.Client.EndToEnd.TestData" Version="1.0.0" />
+    <PackageVersion Include="NuGet.Client.EndToEnd.TestData" Version="1.0.3" />
     <PackageVersion Include="NuGet.Core" Version="2.14.0-rtm-832" />
     <PackageVersion Include="NuGetValidator" version="2.1.1" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -10,6 +10,10 @@ parameters:
   values:
   - Real
   - Test
+- name: PublishEndToEndTestData
+  displayName: Publish EndToEnd TestData Package
+  type: boolean
+  default: false
 
 resources:
   repositories:
@@ -56,3 +60,4 @@ extends:
         RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
         SigningType: ${{ parameters.SigningType }}
         TryRunOneLocBuild: true
+        PublishEndToEndTestData: ${{ parameters.PublishEndToEndTestData }}

--- a/eng/pipelines/templates/Build.yml
+++ b/eng/pipelines/templates/Build.yml
@@ -4,6 +4,9 @@ parameters:
   - name: SigningType
     displayName: Type of signing to use
     type: string
+  - name: PublishEndToEndTestData
+    type: boolean
+    default: false
 
 steps:
   - task: PowerShell@1
@@ -130,6 +133,50 @@ steps:
       solution: "build\\build.proj"
       configuration: "$(BuildConfiguration)"
       msbuildArguments: "/restore:false /target:Pack /property:BuildRTM=$(BuildRTM) /property:ExcludeTestProjects=$(BuildRTM) /property:BuildNumber=$(BuildNumber) /binarylogger:$(Build.StagingDirectory)\\binlog\\11.Pack.binlog /property:MicroBuild_SigningEnabled=false"
+
+  - ${{ if and(eq(parameters.PublishEndToEndTestData, true), not(parameters.BuildRTM)) }}:
+    # The EndToEnd test data package bundles nested .nupkg fixtures as content. It is generated into a
+    # staging directory that is deliberately OUTSIDE the repo 'artifacts' tree so it is never signed
+    # (SignTool would recurse into and corrupt the nested fixtures), never picked up by BAR publishing,
+    # and never scanned by the product SBOM. It is published unsigned to the dnceng nuget-build feed
+    # via the '- output: nuget' block in pipeline.yml.
+    - task: PowerShell@1
+      displayName: "Prepare EndToEnd TestData output directory"
+      condition: "succeeded()"
+      inputs:
+        scriptType: "inlineScript"
+        inlineScript: |
+          $dir = "$(Build.StagingDirectory)\e2etestdata"
+          if (Test-Path $dir) { Remove-Item -Path $dir -Recurse -Force }
+          New-Item -ItemType Directory -Path $dir -Force | Out-Null
+
+    - task: MSBuild@1
+      displayName: "Build GenerateTestPackages"
+      condition: "succeeded()"
+      inputs:
+        solution: "test\\TestExtensions\\GenerateTestPackages\\GenerateTestPackages.csproj"
+        configuration: "$(BuildConfiguration)"
+        msbuildArguments: "/restore:true /property:BuildNumber=$(BuildNumber) /binarylogger:$(Build.StagingDirectory)\\binlog\\GenerateTestPackages.binlog /property:MicroBuild_SigningEnabled=false"
+
+    - task: PowerShell@1
+      displayName: "Generate EndToEnd TestData Package"
+      condition: "succeeded()"
+      inputs:
+        scriptName: "$(Build.Repository.LocalPath)\\scripts\\e2etests\\CreateTestDataPackage.ps1"
+        arguments: "-configuration '$(BuildConfiguration)' -outputDirectoryPath '$(Build.StagingDirectory)\\e2etestdata'"
+
+    - task: PowerShell@1
+      displayName: "Verify EndToEnd TestData Package exists"
+      condition: "succeeded()"
+      inputs:
+        scriptType: "inlineScript"
+        inlineScript: |
+          $packages = @(Get-ChildItem -Path "$(Build.StagingDirectory)\e2etestdata\NuGet.Client.EndToEnd.TestData.*.nupkg" -ErrorAction SilentlyContinue)
+          if ($packages.Count -ne 1) {
+            Write-Host "##vso[task.LogIssue type=error;]Expected exactly one NuGet.Client.EndToEnd.TestData package, but found $($packages.Count)."
+            exit 1
+          }
+          Write-Host "Found EndToEnd TestData package: $($packages[0].Name)"
 
   - task: PowerShell@1
     displayName: "Check expected packages exist for publishing"

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -16,6 +16,10 @@ parameters:
   values:
   - Real
   - Test
+- name: PublishEndToEndTestData
+  displayName: Publish EndToEnd TestData Package
+  type: boolean
+  default: false
 
 stages:
 - stage: Initialize
@@ -183,11 +187,24 @@ stages:
         targetPath: "$(Build.StagingDirectory)/sbom"
         sbomEnabled: false
 
+      # Publishes the generated EndToEnd test data package (and its SBOM) as a pipeline artifact. The
+      # NuGet.Client-Release pipeline downloads this artifact and pushes it to the public dnceng nuget-build
+      # feed. The package is generated into $(Build.StagingDirectory)\e2etestdata by Build.yml (outside the
+      # signed/BAR/product-SBOM artifacts tree).
+      - ${{ if eq(parameters.PublishEndToEndTestData, true) }}:
+        - output: pipelineArtifact
+          displayName: 'Publish EndToEnd TestData package'
+          condition: "and(succeeded(), eq(variables['BuildRTM'], 'false'), eq(variables['IsOfficialBuild'], 'true'))"
+          targetPath: '$(Build.StagingDirectory)\e2etestdata'
+          artifactName: 'EndToEndTestData'
+          sbomBuildDropPath: '$(Build.StagingDirectory)\e2etestdata'
+
     steps:
     - template: /eng/pipelines/templates/Build.yml@self
       parameters:
         BuildRTM: false
         SigningType: ${{ parameters.SigningType }}
+        PublishEndToEndTestData: ${{ parameters.PublishEndToEndTestData }}
 
 - stage: Build_For_Publishing
   displayName: Build NuGet published to nuget.org
@@ -250,6 +267,7 @@ stages:
       parameters:
         BuildRTM: true
         SigningType: ${{ parameters.SigningType }}
+        PublishEndToEndTestData: ${{ parameters.PublishEndToEndTestData }}
 
 - ${{ if eq(parameters.isOfficialBuild, true) }}:
   - template: /eng/common/templates-official/post-build/post-build.yml

--- a/scripts/e2etests/CreateTestDataPackage.ps1
+++ b/scripts/e2etests/CreateTestDataPackage.ps1
@@ -58,7 +58,19 @@ Function Get-File([string[]] $pathParts)
 
 Function Get-GenerateTestPackagesFile()
 {
-    Return Get-File($repositoryRootDirectoryPath, 'artifacts', 'GenerateTestPackages', "$toolsetVersion.0", 'bin', $configuration, 'net472', 'GenerateTestPackages.exe')
+    $filePathWithToolset = [System.IO.Path]::Combine($repositoryRootDirectoryPath, 'artifacts', 'GenerateTestPackages', "$toolsetVersion.0", 'bin', $configuration, 'net472', 'GenerateTestPackages.exe')
+    if (Test-Path $filePathWithToolset)
+    {
+        Return [System.IO.FileInfo]::new($filePathWithToolset)
+    }
+
+    $filePathWithoutToolset = [System.IO.Path]::Combine($repositoryRootDirectoryPath, 'artifacts', 'GenerateTestPackages', 'bin', $configuration, 'net472', 'GenerateTestPackages.exe')
+    if (Test-Path $filePathWithoutToolset)
+    {
+        Return [System.IO.FileInfo]::new($filePathWithoutToolset)
+    }
+
+    throw [System.IO.FileNotFoundException]::new("Could not find GenerateTestPackages.exe.  Please build first.  Probed:`n  $filePathWithToolset`n  $filePathWithoutToolset", $filePathWithoutToolset)
 }
 
 Function Get-NuGetFile()

--- a/test/EndToEnd/NuGet.Client.EndToEnd.TestData.nuspec
+++ b/test/EndToEnd/NuGet.Client.EndToEnd.TestData.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>NuGet.Client.EndToEnd.TestData</id>
-    <version>1.0.0</version>
+    <version>1.0.3</version>
     <title>Test data for NuGet.Client EndToEnd tests</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/test/EndToEnd/Packages/InstallPackagesConfigLocal/InstallPackagesConfigLocalGraph.dgml
+++ b/test/EndToEnd/Packages/InstallPackagesConfigLocal/InstallPackagesConfigLocalGraph.dgml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+  <Nodes>
+    <Node Id="A:1.0.0" Label="A:1.0.0" />
+    <Node Id="B:1.0.0" Label="B:1.0.0" />
+  </Nodes>
+  <Links>
+    <Link Source="A:1.0.0" Target="B:1.0.0" />
+  </Links>
+  <Properties>
+    <Property Id="Label" Label="Label" Description="Displayable label of an Annotatable object" DataType="System.String" />
+  </Properties>
+</DirectedGraph>


### PR DESCRIPTION
# Bug

Fixes: 
Pipelines PR https://devdiv.visualstudio.com/DevDiv/_git/NuGet.Client-Pipelines/pullrequest/746014

 ## Description
 
Adds the ability to publish a new version of the `NuGet.Client.EndToEnd.TestData` package, which is required to unblock the Apex integration tests. 

**Because the package needs to be published in an AzDO dnceng feed, we need to do a CI to publish a new package version. This is the **NuGet.Client** half of a two-repo change, the companion PR in  `NuGet.Client-Pipelines` performs the actual push to the dnceng `nuget-build` feed, this is because `NuGet.Client-Pipelines` already has a connection to `NuGet Development - DevDiv` azure subscription and makes more sense since we also have package publish steps there.**
 
 **What this PR does**
 - Bumps `NuGet.Client.EndToEnd.TestData` to **1.0.3** (`.nuspec` + the `Directory.Packages.props` pin).
 - Adds an opt-in, queue-time **`PublishEndToEndTestData`** parameter (default `false`),  threaded `official.yml → pipeline.yml → Build.yml`. It only runs in **non-RTM, official** builds.
 - When enabled, the official build compiles `GenerateTestPackages`, runs  `CreateTestDataPackage.ps1`, and generates the package into an **isolated staging directory** (`$(Build.StagingDirectory)\e2etestdata`), then verifies exactly one package was produced and publishes it (with an SBOM) as the **`EndToEndTestData`** pipeline artifact.
 - The `NuGet.Client-Release` pipeline downloads that artifact and pushes it to the public dnceng `nuget-build` feed (companion PR).
 - Adds missing `.dgml` file to fix E2E test `InstallPackagesConfigLocal`
 
 **Why the package is isolated from `artifacts/`**
 The package bundles 700+ nested mock `.nupkg` fixtures as content. Generating it outside the repo `artifacts` tree keeps it out of: MicroBuild signing (SignTool recurses into and would corrupt the nested fixtures), BAR/Maestro publishing, and the product SBOM scan.
 
 **How to publish a new version** (rare):
 1. Queue **NuGetClient-Official** with `PublishEndToEndTestData = true` → produces the artifact.
 2. Run **NuGet.Client-Release** with its `PublishEndToEndTestData = true` and run only the
    `Publish EndToEnd TestData` stage.
 
 **Possible Permissions needed: ** the `nuget-build-dnceng-public` service connection must be authorized for the `NuGet.Client-Release` pipeline.
 
 
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- ~[ ] Added tests~
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
