### PR TITLE
Annotate dynamic and trim not compatible code paths

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -40,6 +43,10 @@ namespace NuGet.Protocol
         /// Serialize object to the JSON.
         /// </summary>
         /// <param name="obj">The object.</param>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based serialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based serialization.")]
+#endif
         public static string ToJson(this object obj, Formatting formatting = Formatting.None)
         {
             return JsonConvert.SerializeObject(obj, formatting, JsonExtensions.ObjectSerializationSettings);
@@ -50,6 +57,10 @@ namespace NuGet.Protocol
         /// </summary>
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="json">JSON representation of object</param>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         public static T? FromJson<T>(this string json)
         {
             return JsonConvert.DeserializeObject<T>(json, JsonExtensions.ObjectSerializationSettings);
@@ -61,6 +72,10 @@ namespace NuGet.Protocol
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="json">JSON representation of object</param>
         /// <param name="settings">The settings.</param>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         public static T? FromJson<T>(this string json, JsonSerializerSettings settings)
         {
             return JsonConvert.DeserializeObject<T>(json, settings);
@@ -71,6 +86,10 @@ namespace NuGet.Protocol
         /// </summary>
         /// <param name="json">JSON representation of object</param>
         /// <param name="type">The object type.</param>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         public static object? FromJson(this string json, Type type)
         {
             return JsonConvert.DeserializeObject(json, type, JsonExtensions.ObjectSerializationSettings);
@@ -80,6 +99,10 @@ namespace NuGet.Protocol
         /// Serialize object to JToken.
         /// </summary>
         /// <param name="obj">The object.</param>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based serialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based serialization.")]
+#endif
         public static JToken ToJToken(this object obj)
         {
             return JToken.FromObject(obj, JsonExtensions.JsonObjectSerializer);
@@ -90,6 +113,10 @@ namespace NuGet.Protocol
         /// </summary>
         /// <typeparam name="T">Type of object.</typeparam>
         /// <param name="jtoken">The JToken to be deserialized.</param>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         public static T? FromJToken<T>(this JToken jtoken)
         {
             return jtoken.ToObject<T>(JsonExtensions.JsonObjectSerializer);
@@ -100,6 +127,10 @@ namespace NuGet.Protocol
         /// </summary>
         /// <param name="jtoken">The JToken to be deserialized.</param>
         /// <param name="type">The object type.</param>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         public static object? FromJToken(this JToken jtoken, Type type)
         {
             return jtoken.ToObject(type, JsonExtensions.JsonObjectSerializer);
@@ -111,6 +142,10 @@ namespace NuGet.Protocol
         /// <typeparam name="T">Type of property to return.</typeparam>
         /// <param name="jobject">The JObject to be deserialized.</param>
         /// <param name="propertyName">The property name.</param>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         public static T? GetJObjectProperty<T>(this JObject jobject, string propertyName)
         {
             var targetProperty = jobject.GetValue(propertyName: propertyName, comparison: StringComparison.OrdinalIgnoreCase);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/JsonSerializationUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/JsonSerializationUtilities.cs
@@ -4,6 +4,9 @@
 #nullable disable
 
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -44,6 +47,10 @@ namespace NuGet.Protocol.Plugins
         /// <returns>An instance of <typeparamref name="T" />.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="json" />
         /// is either <see langword="null" /> or an empty string.</exception>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         public static T Deserialize<T>(string json)
             where T : class
         {
@@ -65,6 +72,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="value">An object to serialize.</param>
         /// <returns>A <see cref="JObject" />.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="value" /> is <see langword="null" />.</exception>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based serialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based serialization.")]
+#endif
         public static JObject FromObject(object value)
         {
             if (value == null)
@@ -81,6 +92,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="writer">A JSON writer.</param>
         /// <param name="value">The value to serialize.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="value" /> is <see langword="null" />.</exception>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based serialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based serialization.")]
+#endif
         public static void Serialize(JsonWriter writer, object value)
         {
             if (writer == null)
@@ -98,6 +113,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="jObject">A JSON object.</param>
         /// <returns>An instance of <typeparamref name="T" />.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="jObject" /> is <see langword="null" />.</exception>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         public static T ToObject<T>(JObject jObject)
         {
             if (jObject == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageUtilities.cs
@@ -92,7 +92,9 @@ namespace NuGet.Protocol.Plugins
             using (var stringWriter = new System.IO.StringWriter())
             using (var jsonWriter = new Newtonsoft.Json.JsonTextWriter(stringWriter))
             {
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
                 JsonSerializationUtilities.Serialize(jsonWriter, message.PayloadObject);
+#pragma warning restore IL2026, IL3050
                 return stringWriter.ToString();
             }
         }
@@ -119,7 +121,9 @@ namespace NuGet.Protocol.Plugins
 
             if (message.PayloadObject is Newtonsoft.Json.Linq.JObject jobj)
             {
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
                 return JsonSerializationUtilities.ToObject<TPayload>(jobj);
+#pragma warning restore IL2026, IL3050
             }
 
             return (TPayload)message.PayloadObject;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
@@ -149,7 +149,9 @@ namespace NuGet.Protocol.Plugins
                     else
                     {
                         using var jsonWriter = new Newtonsoft.Json.JsonTextWriter(_textWriter) { CloseOutput = false };
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
                         JsonSerializationUtilities.Serialize(jsonWriter, message);
+#pragma warning restore IL2026, IL3050
 
                         // We need to terminate JSON objects with a delimiter (i.e.:  a single
                         // newline sequence) to signal to the receiver when to stop reading.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/StandardInputReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/StandardInputReceiver.cs
@@ -134,7 +134,9 @@ namespace NuGet.Protocol.Plugins
                     }
                     else
                     {
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
                         message = JsonSerializationUtilities.Deserialize<Message>(line);
+#pragma warning restore IL2026, IL3050
                     }
 
                     if (message != null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
@@ -116,7 +116,9 @@ namespace NuGet.Protocol.Plugins
                     }
                     else
                     {
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
                         message = JsonSerializationUtilities.Deserialize<Message>(e.Line);
+#pragma warning restore IL2026, IL3050
                     }
 
                     if (message != null)

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
@@ -31,7 +31,9 @@ namespace NuGet.Protocol
                 throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToParseRepoSignInfor, JsonProperties.SigningCertificates, source.PackageSource.Source));
 
             AllRepositorySigned = allRepositorySigned;
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
             RepositoryCertificateInfos = data.OfType<JObject>().Select(p => p.FromJToken<RepositoryCertificateInfo>());
+#pragma warning restore IL2026, IL3050
 
             foreach (var repositoryCertificateInfo in RepositoryCertificateInfos)
             {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14934

## Description

Add `[RequiresUnreferencedCode]` and `[RequiresDynamicCode]` annotations to public `Newtonsoft.Json`-based serialization/deserialization APIs in `NuGet.Protocol`.

This marks all public methods that rely on NSJ's reflection-based serialization as trim/AOT-unsafe, so consumers get compile-time warnings when calling them in trimmed or AOT-compiled applications. Internal callers within NuGet.Protocol suppress the warnings at their call sites since they're legacy code paths gated behind the STJ feature switch.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
