### PR TITLE
Add analyzer section in project.assets.json file

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -797,8 +797,7 @@ namespace NuGet.Build.Tasks.Console
                     PackagesToPrune = prunedReferences,
                     RuntimeIdentifierGraphPath = msBuildProjectInstance.GetProperty(nameof(TargetFrameworkInformation.RuntimeIdentifierGraphPath)),
                     TargetAlias = targetAlias,
-                    Warn = warn,
-                    RestoreEnableAnalyzerAssets = msBuildProjectInstance.IsPropertyTrue("RestoreEnableAnalyzerAssets")
+                    Warn = warn
                 };
 
                 targetFrameworkInfos.Add(targetFrameworkInformation);
@@ -1190,6 +1189,7 @@ namespace NuGet.Build.Tasks.Console
             restoreMetadata.SdkAnalysisLevel = MSBuildRestoreUtility.GetSdkAnalysisLevel(project.GetProperty("SdkAnalysisLevel"));
             restoreMetadata.UseLegacyDependencyResolver = project.IsPropertyTrue("RestoreUseLegacyDependencyResolver");
             restoreMetadata.RestoreDoNotWriteDependencyGraphSpec = project.IsPropertyTrue("RestoreDoNotWriteDependencyGraphSpec");
+            restoreMetadata.RestoreEnableAnalyzerAssets = project.IsPropertyTrue("RestoreEnableAnalyzerAssets");
 
             return (restoreMetadata, targetFrameworkInfos);
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -797,7 +797,8 @@ namespace NuGet.Build.Tasks.Console
                     PackagesToPrune = prunedReferences,
                     RuntimeIdentifierGraphPath = msBuildProjectInstance.GetProperty(nameof(TargetFrameworkInformation.RuntimeIdentifierGraphPath)),
                     TargetAlias = targetAlias,
-                    Warn = warn
+                    Warn = warn,
+                    RestoreEnableAnalyzerAssets = msBuildProjectInstance.IsPropertyTrue("RestoreEnableAnalyzerAssets")
                 };
 
                 targetFrameworkInfos.Add(targetFrameworkInformation);

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -1189,7 +1189,7 @@ namespace NuGet.Build.Tasks.Console
             restoreMetadata.SdkAnalysisLevel = MSBuildRestoreUtility.GetSdkAnalysisLevel(project.GetProperty("SdkAnalysisLevel"));
             restoreMetadata.UseLegacyDependencyResolver = project.IsPropertyTrue("RestoreUseLegacyDependencyResolver");
             restoreMetadata.RestoreDoNotWriteDependencyGraphSpec = project.IsPropertyTrue("RestoreDoNotWriteDependencyGraphSpec");
-            restoreMetadata.RestoreEnableAnalyzerAssets = project.IsPropertyTrue("RestoreEnableAnalyzerAssets");
+            restoreMetadata.RestoreEnableAnalyzerAssets = GetRestoreEnableAnalyzerAssets(project, projectsByTargetFramework.Values);
 
             return (restoreMetadata, targetFrameworkInfos);
 
@@ -1206,6 +1206,19 @@ namespace NuGet.Build.Tasks.Console
 
                 return (projectStyleResult.ProjectStyle, projectStyleResult.PackagesConfigFilePath);
             }
+        }
+
+        internal static bool GetRestoreEnableAnalyzerAssets(IMSBuildProject project, IEnumerable<IMSBuildProject> innerBuilds)
+        {
+            foreach (IMSBuildProject innerBuild in innerBuilds.NoAllocEnumerate())
+            {
+                if (innerBuild.IsPropertyTrue("RestoreEnableAnalyzerAssets"))
+                {
+                    return true;
+                }
+            }
+
+            return project.IsPropertyTrue("RestoreEnableAnalyzerAssets");
         }
 
         internal static bool GetPackagePruningDefault(IEnumerable<IMSBuildProject> innerBuilds)

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -80,6 +80,12 @@ Copyright (c) .NET Foundation. All rights reserved.
                     AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                     AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0'))">all</NuGetAuditMode>
     <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
+    <!-- Analyzer assets restore is only available for projects targeting .NET 11 or greater. Force the opt-in off for older frameworks. -->
+    <RestoreEnableAnalyzerAssets Condition="'$(RestoreEnableAnalyzerAssets)' == 'true'
+                    AND !('$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                    AND '$(TargetFrameworkVersion)' != ''
+                    AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '11.0')))">false</RestoreEnableAnalyzerAssets>
+    <RestoreEnableAnalyzerAssets Condition="'$(RestoreEnableAnalyzerAssets)' == '' AND '$(TargetFrameworks)' == ''">false</RestoreEnableAnalyzerAssets>
   </PropertyGroup>
 
   <!-- Package pruning is enabled for all projects targeting .NET 10 or greater, including multi-targeted projects. -->
@@ -876,6 +882,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources)</RestoreAdditionalProjectSources>
         <RestoreAdditionalProjectFallbackFolders>$(RestoreAdditionalProjectFallbackFolders)</RestoreAdditionalProjectFallbackFolders>
         <RestoreAdditionalProjectFallbackFoldersExcludes>$(RestoreAdditionalProjectFallbackFoldersExcludes)</RestoreAdditionalProjectFallbackFoldersExcludes>
+        <RestoreEnableAnalyzerAssets>$(RestoreEnableAnalyzerAssets)</RestoreEnableAnalyzerAssets>
       </_RestoreSettingsPerFramework>
     </ItemGroup>
   </Target>
@@ -898,6 +905,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ConvertToAbsolutePath Paths="$(RestoreOutputPath)" Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' OR '$(RestoreProjectStyle)' == 'ProjectJson'">
       <Output TaskParameter="AbsolutePaths" PropertyName="RestoreOutputAbsolutePath" />
     </ConvertToAbsolutePath>
+
+    <ItemGroup Condition="'$(TargetFrameworks)' != ''">
+      <_RestoreSettingsWithAnalyzerAssets
+        Include="@(_RestoreSettingsPerFramework)"
+        Condition="'%(_RestoreSettingsPerFramework.RestoreEnableAnalyzerAssets)' == 'true'" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_RestoreEffectiveEnableAnalyzerAssets>$(RestoreEnableAnalyzerAssets)</_RestoreEffectiveEnableAnalyzerAssets>
+      <_RestoreEffectiveEnableAnalyzerAssets Condition="'$(TargetFrameworks)' != ''">false</_RestoreEffectiveEnableAnalyzerAssets>
+      <_RestoreEffectiveEnableAnalyzerAssets Condition="'$(TargetFrameworks)' != '' AND '@(_RestoreSettingsWithAnalyzerAssets)' != ''">true</_RestoreEffectiveEnableAnalyzerAssets>
+    </PropertyGroup>
 
     <!--
       Determine project name for the assets file.
@@ -974,6 +993,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <NETCoreSdkVersion>$(NETCoreSdkVersion)</NETCoreSdkVersion>
         <RestoreUseLegacyDependencyResolver>$(RestoreUseLegacyDependencyResolver)</RestoreUseLegacyDependencyResolver>
         <RestoreDoNotWriteDependencyGraphSpec>$(RestoreDoNotWriteDependencyGraphSpec)</RestoreDoNotWriteDependencyGraphSpec>
+        <RestoreEnableAnalyzerAssets>$(_RestoreEffectiveEnableAnalyzerAssets)</RestoreEnableAnalyzerAssets>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -977,6 +977,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <NETCoreSdkVersion>$(NETCoreSdkVersion)</NETCoreSdkVersion>
         <RestoreUseLegacyDependencyResolver>$(RestoreUseLegacyDependencyResolver)</RestoreUseLegacyDependencyResolver>
         <RestoreDoNotWriteDependencyGraphSpec>$(RestoreDoNotWriteDependencyGraphSpec)</RestoreDoNotWriteDependencyGraphSpec>
+        <RestoreEnableAnalyzerAssets>$(RestoreEnableAnalyzerAssets)</RestoreEnableAnalyzerAssets>
       </_RestoreGraphEntry>
     </ItemGroup>
 
@@ -1200,7 +1201,6 @@ Copyright (c) .NET Foundation. All rights reserved.
         <WindowsTargetPlatformMinVersion>$(WindowsTargetPlatformMinVersion)</WindowsTargetPlatformMinVersion>
         <RestoreEnablePackagePruning>$(RestoreEnablePackagePruning)</RestoreEnablePackagePruning>
         <RestorePackagePruningDefault>$(RestorePackagePruningDefault)</RestorePackagePruningDefault>
-        <RestoreEnableAnalyzerAssets>$(RestoreEnableAnalyzerAssets)</RestoreEnableAnalyzerAssets>
         <NuGetAuditMode>$(NuGetAuditMode)</NuGetAuditMode>
       </_RestoreGraphEntry>
     </ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -80,11 +80,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                     AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                     AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0'))">all</NuGetAuditMode>
     <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
-    <!-- Analyzer assets restore is only available for projects targeting .NET 11 or greater. Force the opt-in off for older frameworks. -->
-    <RestoreEnableAnalyzerAssets Condition="'$(RestoreEnableAnalyzerAssets)' == 'true'
-                    AND !('$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                    AND '$(TargetFrameworkVersion)' != ''
-                    AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '11.0')))">false</RestoreEnableAnalyzerAssets>
+    <!-- Analyzer assets restore defaults to off. An explicit RestoreEnableAnalyzerAssets opt-in (or opt-out) is
+         honored on any target framework, so users can opt into the new behavior before it is enabled by default. -->
     <RestoreEnableAnalyzerAssets Condition="'$(RestoreEnableAnalyzerAssets)' == '' AND '$(TargetFrameworks)' == ''">false</RestoreEnableAnalyzerAssets>
   </PropertyGroup>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -80,8 +80,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                     AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
                     AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0'))">all</NuGetAuditMode>
     <NuGetAuditMode Condition=" '$(NuGetAuditMode)' == '' ">direct</NuGetAuditMode>
-    <!-- Analyzer assets restore defaults to off. An explicit RestoreEnableAnalyzerAssets opt-in (or opt-out) is
-         honored on any target framework, so users can opt into the new behavior before it is enabled by default. -->
+    <!-- Analyzer assets restore defaults to off. An opt-in on the outer build or any target framework enables analyzer assets project-wide. -->
     <RestoreEnableAnalyzerAssets Condition="'$(RestoreEnableAnalyzerAssets)' == '' AND '$(TargetFrameworks)' == ''">false</RestoreEnableAnalyzerAssets>
   </PropertyGroup>
 
@@ -1202,6 +1201,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RestoreEnablePackagePruning>$(RestoreEnablePackagePruning)</RestoreEnablePackagePruning>
         <RestorePackagePruningDefault>$(RestorePackagePruningDefault)</RestorePackagePruningDefault>
         <NuGetAuditMode>$(NuGetAuditMode)</NuGetAuditMode>
+        <RestoreEnableAnalyzerAssets>$(RestoreEnableAnalyzerAssets)</RestoreEnableAnalyzerAssets>
       </_RestoreGraphEntry>
     </ItemGroup>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -882,7 +882,6 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources)</RestoreAdditionalProjectSources>
         <RestoreAdditionalProjectFallbackFolders>$(RestoreAdditionalProjectFallbackFolders)</RestoreAdditionalProjectFallbackFolders>
         <RestoreAdditionalProjectFallbackFoldersExcludes>$(RestoreAdditionalProjectFallbackFoldersExcludes)</RestoreAdditionalProjectFallbackFoldersExcludes>
-        <RestoreEnableAnalyzerAssets>$(RestoreEnableAnalyzerAssets)</RestoreEnableAnalyzerAssets>
       </_RestoreSettingsPerFramework>
     </ItemGroup>
   </Target>
@@ -905,18 +904,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ConvertToAbsolutePath Paths="$(RestoreOutputPath)" Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' OR '$(RestoreProjectStyle)' == 'ProjectJson'">
       <Output TaskParameter="AbsolutePaths" PropertyName="RestoreOutputAbsolutePath" />
     </ConvertToAbsolutePath>
-
-    <ItemGroup Condition="'$(TargetFrameworks)' != ''">
-      <_RestoreSettingsWithAnalyzerAssets
-        Include="@(_RestoreSettingsPerFramework)"
-        Condition="'%(_RestoreSettingsPerFramework.RestoreEnableAnalyzerAssets)' == 'true'" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <_RestoreEffectiveEnableAnalyzerAssets>$(RestoreEnableAnalyzerAssets)</_RestoreEffectiveEnableAnalyzerAssets>
-      <_RestoreEffectiveEnableAnalyzerAssets Condition="'$(TargetFrameworks)' != ''">false</_RestoreEffectiveEnableAnalyzerAssets>
-      <_RestoreEffectiveEnableAnalyzerAssets Condition="'$(TargetFrameworks)' != '' AND '@(_RestoreSettingsWithAnalyzerAssets)' != ''">true</_RestoreEffectiveEnableAnalyzerAssets>
-    </PropertyGroup>
 
     <!--
       Determine project name for the assets file.
@@ -993,7 +980,6 @@ Copyright (c) .NET Foundation. All rights reserved.
         <NETCoreSdkVersion>$(NETCoreSdkVersion)</NETCoreSdkVersion>
         <RestoreUseLegacyDependencyResolver>$(RestoreUseLegacyDependencyResolver)</RestoreUseLegacyDependencyResolver>
         <RestoreDoNotWriteDependencyGraphSpec>$(RestoreDoNotWriteDependencyGraphSpec)</RestoreDoNotWriteDependencyGraphSpec>
-        <RestoreEnableAnalyzerAssets>$(_RestoreEffectiveEnableAnalyzerAssets)</RestoreEnableAnalyzerAssets>
       </_RestoreGraphEntry>
     </ItemGroup>
 
@@ -1217,6 +1203,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <WindowsTargetPlatformMinVersion>$(WindowsTargetPlatformMinVersion)</WindowsTargetPlatformMinVersion>
         <RestoreEnablePackagePruning>$(RestoreEnablePackagePruning)</RestoreEnablePackagePruning>
         <RestorePackagePruningDefault>$(RestorePackagePruningDefault)</RestorePackagePruningDefault>
+        <RestoreEnableAnalyzerAssets>$(RestoreEnableAnalyzerAssets)</RestoreEnableAnalyzerAssets>
         <NuGetAuditMode>$(NuGetAuditMode)</NuGetAuditMode>
       </_RestoreGraphEntry>
     </ItemGroup>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -183,7 +183,7 @@ namespace NuGet.Commands
                 var flattenedFlags = IncludeFlagUtils.FlattenDependencyTypes(_includeFlagGraphs, project, targetGraph);
 
                 // Check if warnings should be displayed for the current framework.
-                var tfi = project.GetTargetFramework(targetGraph.Framework);
+                var tfi = project.GetNearestTargetFramework(targetGraph.Framework, targetGraph.TargetAlias);
 
                 // Analyzer assets are honored per target framework (gated to .NET 11+ via the opt-in value).
                 bool restoreEnableAnalyzerAssets = tfi.RestoreEnableAnalyzerAssets;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -158,6 +158,20 @@ namespace NuGet.Commands
             var restoreMetadata = project.RestoreMetadata;
             var rootProjectStyle = restoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
 
+            // Analyzer assets are a project-wide opt-in: when any target framework opts in, analyzer assets are
+            // honored for every target framework (mirrors how package pruning is enabled project-wide once any
+            // framework qualifies, see PackageSpecFactory.GetPackagePruningDefault). The per-framework value is
+            // already gated to .NET 11+ in NuGet.targets, so it is only ever true for a qualifying framework.
+            bool restoreEnableAnalyzerAssets = false;
+            foreach (TargetFrameworkInformation framework in project.TargetFrameworks.NoAllocEnumerate())
+            {
+                if (framework.RestoreEnableAnalyzerAssets)
+                {
+                    restoreEnableAnalyzerAssets = true;
+                    break;
+                }
+            }
+
             // Add the targets
             foreach (var targetGraph in targetGraphs
                 .OrderBy(graph => graph.Framework.ToString(), StringComparer.Ordinal)
@@ -184,9 +198,6 @@ namespace NuGet.Commands
 
                 // Check if warnings should be displayed for the current framework.
                 var tfi = project.GetNearestTargetFramework(targetGraph.Framework, targetGraph.TargetAlias);
-
-                // Analyzer assets are honored per target framework (gated to .NET 11+ via the opt-in value).
-                bool restoreEnableAnalyzerAssets = tfi.RestoreEnableAnalyzerAssets;
 
                 bool warnForImportsOnGraph = tfi.Warn
                     && (target.TargetFramework is FallbackFramework

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -158,19 +158,9 @@ namespace NuGet.Commands
             var restoreMetadata = project.RestoreMetadata;
             var rootProjectStyle = restoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
 
-            // Analyzer assets are a project-wide opt-in: when any target framework opts in, analyzer assets are
-            // honored for every target framework (mirrors how package pruning is enabled project-wide once any
-            // framework qualifies, see PackageSpecFactory.GetPackagePruningDefault). The per-framework value is
-            // already gated to .NET 11+ in NuGet.targets, so it is only ever true for a qualifying framework.
-            bool restoreEnableAnalyzerAssets = false;
-            foreach (TargetFrameworkInformation framework in project.TargetFrameworks.NoAllocEnumerate())
-            {
-                if (framework.RestoreEnableAnalyzerAssets)
-                {
-                    restoreEnableAnalyzerAssets = true;
-                    break;
-                }
-            }
+            // Analyzer assets are a project-wide opt-in (the RestoreEnableAnalyzerAssets MSBuild property).
+            // When enabled, analyzer assets are honored for every target framework.
+            bool restoreEnableAnalyzerAssets = restoreMetadata?.RestoreEnableAnalyzerAssets ?? false;
 
             // Add the targets
             foreach (var targetGraph in targetGraphs

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -187,9 +187,9 @@ namespace NuGet.Commands
                 var flattenedFlags = IncludeFlagUtils.FlattenDependencyTypes(_includeFlagGraphs, project, targetGraph);
 
                 // Check if warnings should be displayed for the current framework.
-                var tfi = project.GetNearestTargetFramework(targetGraph.Framework, targetGraph.TargetAlias);
+                var tfi = project.GetTargetFramework(targetGraph.TargetAlias);
 
-                bool warnForImportsOnGraph = tfi.Warn
+                bool warnForImportsOnGraph = tfi?.Warn == true
                     && (target.TargetFramework is FallbackFramework
                         || target.TargetFramework is AssetTargetFallbackFramework);
 
@@ -233,7 +233,7 @@ namespace NuGet.Commands
                         }
 
                         var package = packageInfo.Package;
-                        var libraryDependency = tfi.Dependencies.FirstOrDefault(e => e.Name.Equals(library.Name, StringComparison.OrdinalIgnoreCase));
+                        var libraryDependency = tfi?.Dependencies.FirstOrDefault(e => e.Name.Equals(library.Name, StringComparison.OrdinalIgnoreCase));
 
                         (LockFileTargetLibrary targetLibrary, bool usedFallbackFramework, NuGetFramework compileAssetFramework, NuGetFramework runtimeAssetFramework) = LockFileUtils.CreateLockFileTargetLibrary(
                             libraryDependency?.Aliases,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -155,7 +155,9 @@ namespace NuGet.Commands
 
             var librariesWithWarnings = new HashSet<LibraryIdentity>();
 
-            var rootProjectStyle = project.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
+            var restoreMetadata = project.RestoreMetadata;
+            var rootProjectStyle = restoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
+            bool restoreEnableAnalyzerAssets = restoreMetadata?.RestoreEnableAnalyzerAssets == true;
 
             // Add the targets
             foreach (var targetGraph in targetGraphs
@@ -238,6 +240,7 @@ namespace NuGet.Commands
                             dependencyType: includeFlags,
                             targetFrameworkOverride: null,
                             dependencies: graphItem.Data.Dependencies,
+                            restoreEnableAnalyzerAssets: restoreEnableAnalyzerAssets,
                             cache: lockFileBuilderCache);
 
                         target.Libraries.Add(targetLibrary);
@@ -258,6 +261,7 @@ namespace NuGet.Commands
                                     targetFrameworkOverride: nonFallbackFramework,
                                     dependencyType: includeFlags,
                                     dependencies: graphItem.Data.Dependencies,
+                                    restoreEnableAnalyzerAssets: restoreEnableAnalyzerAssets,
                                     cache: lockFileBuilderCache);
                                 usedFallbackFramework = !targetLibrary.Equals(targetLibraryWithoutFallback);
                             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -157,7 +157,6 @@ namespace NuGet.Commands
 
             var restoreMetadata = project.RestoreMetadata;
             var rootProjectStyle = restoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
-            bool restoreEnableAnalyzerAssets = restoreMetadata?.RestoreEnableAnalyzerAssets == true;
 
             // Add the targets
             foreach (var targetGraph in targetGraphs
@@ -185,6 +184,9 @@ namespace NuGet.Commands
 
                 // Check if warnings should be displayed for the current framework.
                 var tfi = project.GetTargetFramework(targetGraph.Framework);
+
+                // Analyzer assets are honored per target framework (gated to .NET 11+ via the opt-in value).
+                bool restoreEnableAnalyzerAssets = tfi.RestoreEnableAnalyzerAssets;
 
                 bool warnForImportsOnGraph = tfi.Warn
                     && (target.TargetFramework is FallbackFramework

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilderCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilderCache.cs
@@ -31,7 +31,7 @@ namespace NuGet.Commands
         private readonly ConcurrentDictionary<CriteriaKey, List<(List<SelectionCriteria>, bool)>> _criteriaSets =
             new();
 
-        private readonly ConcurrentDictionary<(CriteriaKey, string path, string aliases, LibraryIncludeFlags, int dependencyCount), Lazy<(LockFileTargetLibrary, bool, NuGetFramework, NuGetFramework)>> _lockFileTargetLibraryCache =
+        private readonly ConcurrentDictionary<(CriteriaKey, string path, string aliases, LibraryIncludeFlags, int dependencyCount, bool restoreEnableAnalyzerAssets), Lazy<(LockFileTargetLibrary, bool, NuGetFramework, NuGetFramework)>> _lockFileTargetLibraryCache =
             new();
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace NuGet.Commands
         /// <summary>
         /// Try to get a LockFileTargetLibrary from the cache.
         /// </summary>
-        internal (LockFileTargetLibrary, bool, NuGetFramework, NuGetFramework) GetLockFileTargetLibrary(RestoreTargetGraph graph, NuGetFramework framework, LocalPackageInfo localPackageInfo, string aliases, LibraryIncludeFlags libraryIncludeFlags, List<LibraryDependency> dependencies, Func<(LockFileTargetLibrary, bool, NuGetFramework, NuGetFramework)> valueFactory)
+        internal (LockFileTargetLibrary, bool, NuGetFramework, NuGetFramework) GetLockFileTargetLibrary(RestoreTargetGraph graph, NuGetFramework framework, LocalPackageInfo localPackageInfo, string aliases, LibraryIncludeFlags libraryIncludeFlags, List<LibraryDependency> dependencies, bool restoreEnableAnalyzerAssets, Func<(LockFileTargetLibrary, bool, NuGetFramework, NuGetFramework)> valueFactory)
         {
             // Comparing RuntimeGraph for equality is very expensive,
             // so in case of a request where the RuntimeGraph is not empty we avoid using the cache.
@@ -116,7 +116,7 @@ namespace NuGet.Commands
             localPackageInfo = localPackageInfo ?? throw new ArgumentNullException(nameof(localPackageInfo));
             var criteriaKey = new CriteriaKey(graph.TargetGraphName, framework);
             var packagePath = localPackageInfo.ExpandedPath;
-            return _lockFileTargetLibraryCache.GetOrAdd((criteriaKey, packagePath, aliases, libraryIncludeFlags, dependencies.Count),
+            return _lockFileTargetLibraryCache.GetOrAdd((criteriaKey, packagePath, aliases, libraryIncludeFlags, dependencies.Count, restoreEnableAnalyzerAssets),
                 key => new Lazy<(LockFileTargetLibrary, bool, NuGetFramework, NuGetFramework)>(valueFactory)).Value;
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -155,8 +155,7 @@ namespace NuGet.Commands
 
         // Analyzer assets names
         private const string AnalyzerAssetsEnabled = "AnalyzerAssets.Enabled";
-        private const string AnalyzerAssetsCount = "AnalyzerAssets.Count";
-        private const string AnalyzerAssetsExcludedCount = "AnalyzerAssets.Excluded.Count";
+        private const string AnalyzerAssetsExcluded = "AnalyzerAssets.Excluded";
         private const string AnalyzerAssetsPackagesWithAnalyzersCount = "AnalyzerAssets.PackagesWithAnalyzers.Count";
         private const string AnalyzerAssetsPackagesWithExcludedAnalyzersCount = "AnalyzerAssets.PackagesWithExcludedAnalyzers.Count";
         private const string AnalyzerAssetsExcludedByPrivateAssetsCount = "AnalyzerAssets.ExcludedByPrivateAssets.Count";
@@ -469,11 +468,12 @@ namespace NuGet.Commands
 
         /// <summary>
         /// Reports analyzer-asset usage so the impact of enabling <c>RestoreEnableAnalyzerAssets</c> by
-        /// default can be measured ahead of the rollout. The counts are derived from the resolved dependency
-        /// graphs and the package file lists, so they are reported on every restore regardless of whether the
-        /// feature is currently enabled. This lets us see, before flipping the default, how many packages and
-        /// analyzer assemblies would stop being applied because <c>PrivateAssets</c>/<c>ExcludeAssets</c> would
-        /// finally be honored.
+        /// default can be measured ahead of the rollout. The data is derived from the resolved dependency
+        /// graphs and the package file lists, so it is reported on every restore regardless of whether the
+        /// feature is currently enabled. This lets us see, before flipping the default, how many packages
+        /// would stop having their analyzers applied because <c>PrivateAssets</c>/<c>ExcludeAssets</c> would
+        /// finally be honored. Detection is per package (not per analyzer assembly): the rollout decision is
+        /// driven by whether a package's analyzers are affected, not by how many assemblies it ships.
         /// </summary>
         /// <remarks>
         /// Analyzers are not runtime-identifier specific, so only the target-framework graphs (those with a
@@ -482,27 +482,22 @@ namespace NuGet.Commands
         /// </remarks>
         private void PopulateAnalyzerAssetsTelemetry(TelemetryEvent telemetryEvent, LockFile assetsFile, List<RestoreTargetGraph> graphs, PackageSpec project)
         {
-            // Count the analyzer assemblies each package contributes, from the always-present libraries section.
-            var analyzerAssemblyCountByPackage = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            // Identify which packages contribute at least one analyzer assembly, from the always-present
+            // libraries section. Detection is per package (not per assembly) since the rollout decision is
+            // driven by whether a package's analyzers are affected, not by how many assemblies it ships.
+            var packagesWithAnalyzerAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (LockFileLibrary library in assetsFile.Libraries)
             {
-                int analyzerAssemblyCount = 0;
                 foreach (string file in library.Files)
                 {
                     if (IsAnalyzerAssemblyPath(file))
                     {
-                        analyzerAssemblyCount++;
+                        packagesWithAnalyzerAssemblies.Add(GetAnalyzerPackageKey(library.Name, library.Version));
+                        break;
                     }
-                }
-
-                if (analyzerAssemblyCount > 0)
-                {
-                    analyzerAssemblyCountByPackage[GetAnalyzerPackageKey(library.Name, library.Version)] = analyzerAssemblyCount;
                 }
             }
 
-            int appliedAnalyzerAssemblies = 0;
-            int excludedAnalyzerAssemblies = 0;
             int packagesWithAnalyzers = 0;
             int packagesWithExcludedAnalyzers = 0;
             int excludedByPrivateAssets = 0;
@@ -527,7 +522,7 @@ namespace NuGet.Commands
                         continue;
                     }
 
-                    if (!analyzerAssemblyCountByPackage.TryGetValue(GetAnalyzerPackageKey(library.Name, library.Version), out int analyzerAssemblyCount))
+                    if (!packagesWithAnalyzerAssemblies.Contains(GetAnalyzerPackageKey(library.Name, library.Version)))
                     {
                         continue;
                     }
@@ -541,12 +536,10 @@ namespace NuGet.Commands
 
                     if ((includeFlags & LibraryIncludeFlags.Analyzers) != LibraryIncludeFlags.None)
                     {
-                        appliedAnalyzerAssemblies += analyzerAssemblyCount;
                         continue;
                     }
 
                     // The package contributes analyzers, but they would be filtered out for this project.
-                    excludedAnalyzerAssemblies += analyzerAssemblyCount;
                     packagesWithExcludedAnalyzers++;
 
                     // Attribute the exclusion: a direct reference whose own IncludeAssets/ExcludeAssets drops
@@ -569,8 +562,7 @@ namespace NuGet.Commands
                 }
             }
 
-            telemetryEvent[AnalyzerAssetsCount] = appliedAnalyzerAssemblies;
-            telemetryEvent[AnalyzerAssetsExcludedCount] = excludedAnalyzerAssemblies;
+            telemetryEvent[AnalyzerAssetsExcluded] = packagesWithExcludedAnalyzers > 0;
             telemetryEvent[AnalyzerAssetsPackagesWithAnalyzersCount] = packagesWithAnalyzers;
             telemetryEvent[AnalyzerAssetsPackagesWithExcludedAnalyzersCount] = packagesWithExcludedAnalyzers;
             telemetryEvent[AnalyzerAssetsExcludedByPrivateAssetsCount] = excludedByPrivateAssets;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -420,7 +420,7 @@ namespace NuGet.Commands
             }
 
             telemetry.TelemetryEvent[AuditEnabled] = auditEnabled ? "enabled" : "disabled";
-            telemetry.TelemetryEvent[AnalyzerAssetsEnabled] = _request.Project.TargetFrameworks.Any(e => e.RestoreEnableAnalyzerAssets);
+            telemetry.TelemetryEvent[AnalyzerAssetsEnabled] = _request.Project.RestoreMetadata?.RestoreEnableAnalyzerAssets ?? false;
 
             PopulatePruningEnabledTelemetry(_request.Project, telemetry.TelemetryEvent);
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -486,9 +486,9 @@ namespace NuGet.Commands
             // libraries section. Detection is per package (not per assembly) since the rollout decision is
             // driven by whether a package's analyzers are affected, not by how many assemblies it ships.
             var packagesWithAnalyzerAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (LockFileLibrary library in assetsFile.Libraries)
+            foreach (LockFileLibrary library in assetsFile.Libraries.NoAllocEnumerate())
             {
-                foreach (string file in library.Files)
+                foreach (string file in library.Files.NoAllocEnumerate())
                 {
                     if (IsAnalyzerAssemblyPath(file))
                     {
@@ -503,7 +503,7 @@ namespace NuGet.Commands
             int excludedByPrivateAssets = 0;
             int excludedByExcludeAssets = 0;
 
-            foreach (RestoreTargetGraph graph in graphs)
+            foreach (RestoreTargetGraph graph in graphs.NoAllocEnumerate())
             {
                 // Analyzers are not runtime specific; only inspect the target framework graphs.
                 if (graph.RuntimeIdentifier != null)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -512,7 +512,7 @@ namespace NuGet.Commands
                 }
 
                 Dictionary<string, LibraryIncludeFlags> flattenedFlags = IncludeFlagUtils.FlattenDependencyTypes(_includeFlagGraphs, project, graph);
-                TargetFrameworkInformation targetFrameworkInformation = project.GetTargetFramework(graph.Framework);
+                TargetFrameworkInformation targetFrameworkInformation = project.GetNearestTargetFramework(graph.Framework, graph.TargetAlias);
 
                 foreach (GraphItem<RemoteResolveResult> graphItem in graph.Flattened)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -416,7 +416,7 @@ namespace NuGet.Commands
             }
 
             telemetry.TelemetryEvent[AuditEnabled] = auditEnabled ? "enabled" : "disabled";
-            telemetry.TelemetryEvent[AnalyzerAssetsEnabled] = _request.Project.RestoreMetadata?.RestoreEnableAnalyzerAssets ?? false;
+            telemetry.TelemetryEvent[AnalyzerAssetsEnabled] = _request.Project.TargetFrameworks.Any(e => e.RestoreEnableAnalyzerAssets);
 
             PopulatePruningEnabledTelemetry(_request.Project, telemetry.TelemetryEvent);
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -153,6 +153,10 @@ namespace NuGet.Commands
         private const string PackagePruningRemovablePackagesCount = "Pruning.RemovablePackages.Count";
         private const string PackagePruningDirectCount = "Pruning.Pruned.Direct.Count";
 
+        // Analyzer assets names
+        private const string AnalyzerAssetsEnabled = "AnalyzerAssets.Enabled";
+        private const string AnalyzerAssetsCount = "AnalyzerAssets.Count";
+
         internal readonly bool _enableNewDependencyResolver;
         private readonly bool _isLockFileEnabled;
 
@@ -357,6 +361,7 @@ namespace NuGet.Commands
 
                 telemetry.TelemetryEvent[UpdatedAssetsFile] = restoreResult._isAssetsFileDirty.Value;
                 telemetry.TelemetryEvent[UpdatedMSBuildFiles] = restoreResult._dirtyMSBuildFiles.Value.Count > 0;
+                telemetry.TelemetryEvent[AnalyzerAssetsCount] = CountAnalyzerAssets(assetsFile);
 
                 return restoreResult;
             }
@@ -411,6 +416,7 @@ namespace NuGet.Commands
             }
 
             telemetry.TelemetryEvent[AuditEnabled] = auditEnabled ? "enabled" : "disabled";
+            telemetry.TelemetryEvent[AnalyzerAssetsEnabled] = _request.Project.RestoreMetadata?.RestoreEnableAnalyzerAssets ?? false;
 
             PopulatePruningEnabledTelemetry(_request.Project, telemetry.TelemetryEvent);
         }
@@ -454,6 +460,37 @@ namespace NuGet.Commands
             telemetryEvent[PackagePruningFrameworksEnabledCount] = pruningEnabledCount;
             telemetryEvent[PackagePruningFrameworksDisabledCount] = pruningDisabledCount;
             telemetryEvent[PackagePruningFrameworksUnsupportedCount] = pruningNotApplicableCount;
+        }
+
+        /// <summary>
+        /// Counts the analyzer assets written to the assets file, excluding '_._' placeholders that
+        /// represent analyzers excluded from the project. Reflects the depth of analyzer-assets adoption.
+        /// </summary>
+        private static int CountAnalyzerAssets(LockFile assetsFile)
+        {
+            int count = 0;
+
+            foreach (LockFileTarget target in assetsFile.Targets)
+            {
+                foreach (LockFileTargetLibrary library in target.Libraries)
+                {
+                    IList<LockFileItem> analyzerAssets = library.AnalyzerAssets;
+                    if (analyzerAssets == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (LockFileItem asset in analyzerAssets)
+                    {
+                        if (!asset.Path.EndsWith("_._", StringComparison.Ordinal))
+                        {
+                            count++;
+                        }
+                    }
+                }
+            }
+
+            return count;
         }
 
         private async Task<(RestoreResult, bool, CacheFile)> EvaluateNoOpAsync(TelemetryActivity telemetry, CacheFile cacheFile, Stopwatch restoreTime)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -482,7 +482,7 @@ namespace NuGet.Commands
 
                     foreach (LockFileItem asset in analyzerAssets)
                     {
-                        if (!asset.Path.EndsWith("_._", StringComparison.Ordinal))
+                        if (!asset.Path.EndsWith(PackagingCoreConstants.ForwardSlashEmptyFolder, StringComparison.Ordinal))
                         {
                             count++;
                         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -156,6 +156,11 @@ namespace NuGet.Commands
         // Analyzer assets names
         private const string AnalyzerAssetsEnabled = "AnalyzerAssets.Enabled";
         private const string AnalyzerAssetsCount = "AnalyzerAssets.Count";
+        private const string AnalyzerAssetsExcludedCount = "AnalyzerAssets.Excluded.Count";
+        private const string AnalyzerAssetsPackagesWithAnalyzersCount = "AnalyzerAssets.PackagesWithAnalyzers.Count";
+        private const string AnalyzerAssetsPackagesWithExcludedAnalyzersCount = "AnalyzerAssets.PackagesWithExcludedAnalyzers.Count";
+        private const string AnalyzerAssetsExcludedByPrivateAssetsCount = "AnalyzerAssets.ExcludedByPrivateAssets.Count";
+        private const string AnalyzerAssetsExcludedByExcludeAssetsCount = "AnalyzerAssets.ExcludedByExcludeAssets.Count";
 
         internal readonly bool _enableNewDependencyResolver;
         private readonly bool _isLockFileEnabled;
@@ -361,7 +366,7 @@ namespace NuGet.Commands
 
                 telemetry.TelemetryEvent[UpdatedAssetsFile] = restoreResult._isAssetsFileDirty.Value;
                 telemetry.TelemetryEvent[UpdatedMSBuildFiles] = restoreResult._dirtyMSBuildFiles.Value.Count > 0;
-                telemetry.TelemetryEvent[AnalyzerAssetsCount] = CountAnalyzerAssets(assetsFile);
+                PopulateAnalyzerAssetsTelemetry(telemetry.TelemetryEvent, assetsFile, graphs, _request.Project);
 
                 return restoreResult;
             }
@@ -463,34 +468,132 @@ namespace NuGet.Commands
         }
 
         /// <summary>
-        /// Counts the analyzer assets written to the assets file, excluding '_._' placeholders that
-        /// represent analyzers excluded from the project. Reflects the depth of analyzer-assets adoption.
+        /// Reports analyzer-asset usage so the impact of enabling <c>RestoreEnableAnalyzerAssets</c> by
+        /// default can be measured ahead of the rollout. The counts are derived from the resolved dependency
+        /// graphs and the package file lists, so they are reported on every restore regardless of whether the
+        /// feature is currently enabled. This lets us see, before flipping the default, how many packages and
+        /// analyzer assemblies would stop being applied because <c>PrivateAssets</c>/<c>ExcludeAssets</c> would
+        /// finally be honored.
         /// </summary>
-        private static int CountAnalyzerAssets(LockFile assetsFile)
+        /// <remarks>
+        /// Analyzers are not runtime-identifier specific, so only the target-framework graphs (those with a
+        /// null runtime identifier) are inspected to avoid counting the same package once per RID. This runs on
+        /// the full-restore path only (after the no-op short-circuit), where the dependency graphs are available.
+        /// </remarks>
+        private void PopulateAnalyzerAssetsTelemetry(TelemetryEvent telemetryEvent, LockFile assetsFile, List<RestoreTargetGraph> graphs, PackageSpec project)
         {
-            int count = 0;
-
-            foreach (LockFileTarget target in assetsFile.Targets)
+            // Count the analyzer assemblies each package contributes, from the always-present libraries section.
+            var analyzerAssemblyCountByPackage = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            foreach (LockFileLibrary library in assetsFile.Libraries)
             {
-                foreach (LockFileTargetLibrary library in target.Libraries)
+                int analyzerAssemblyCount = 0;
+                foreach (string file in library.Files)
                 {
-                    IList<LockFileItem> analyzerAssets = library.AnalyzerAssets;
-                    if (analyzerAssets == null)
+                    if (IsAnalyzerAssemblyPath(file))
+                    {
+                        analyzerAssemblyCount++;
+                    }
+                }
+
+                if (analyzerAssemblyCount > 0)
+                {
+                    analyzerAssemblyCountByPackage[GetAnalyzerPackageKey(library.Name, library.Version)] = analyzerAssemblyCount;
+                }
+            }
+
+            int appliedAnalyzerAssemblies = 0;
+            int excludedAnalyzerAssemblies = 0;
+            int packagesWithAnalyzers = 0;
+            int packagesWithExcludedAnalyzers = 0;
+            int excludedByPrivateAssets = 0;
+            int excludedByExcludeAssets = 0;
+
+            foreach (RestoreTargetGraph graph in graphs)
+            {
+                // Analyzers are not runtime specific; only inspect the target framework graphs.
+                if (graph.RuntimeIdentifier != null)
+                {
+                    continue;
+                }
+
+                Dictionary<string, LibraryIncludeFlags> flattenedFlags = IncludeFlagUtils.FlattenDependencyTypes(_includeFlagGraphs, project, graph);
+                TargetFrameworkInformation targetFrameworkInformation = project.GetTargetFramework(graph.Framework);
+
+                foreach (GraphItem<RemoteResolveResult> graphItem in graph.Flattened)
+                {
+                    LibraryIdentity library = graphItem.Key;
+                    if (library.Type != LibraryType.Package)
                     {
                         continue;
                     }
 
-                    foreach (LockFileItem asset in analyzerAssets)
+                    if (!analyzerAssemblyCountByPackage.TryGetValue(GetAnalyzerPackageKey(library.Name, library.Version), out int analyzerAssemblyCount))
                     {
-                        if (!asset.Path.EndsWith(PackagingCoreConstants.ForwardSlashEmptyFolder, StringComparison.Ordinal))
-                        {
-                            count++;
-                        }
+                        continue;
+                    }
+
+                    packagesWithAnalyzers++;
+
+                    if (!flattenedFlags.TryGetValue(library.Name, out LibraryIncludeFlags includeFlags))
+                    {
+                        includeFlags = ~LibraryIncludeFlags.ContentFiles;
+                    }
+
+                    if ((includeFlags & LibraryIncludeFlags.Analyzers) != LibraryIncludeFlags.None)
+                    {
+                        appliedAnalyzerAssemblies += analyzerAssemblyCount;
+                        continue;
+                    }
+
+                    // The package contributes analyzers, but they would be filtered out for this project.
+                    excludedAnalyzerAssemblies += analyzerAssemblyCount;
+                    packagesWithExcludedAnalyzers++;
+
+                    // Attribute the exclusion: a direct reference whose own IncludeAssets/ExcludeAssets drops
+                    // analyzers is counted separately from analyzers suppressed transitively via PrivateAssets
+                    // (the default for analyzers), since the transitive case is the surprising one for customers.
+                    LibraryDependency directDependency = targetFrameworkInformation?.Dependencies.FirstOrDefault(
+                        dependency => dependency.Name.Equals(library.Name, StringComparison.OrdinalIgnoreCase));
+
+                    bool excludedByOwnAssetsFilter = directDependency != null
+                        && (directDependency.IncludeType & LibraryIncludeFlags.Analyzers) == LibraryIncludeFlags.None;
+
+                    if (excludedByOwnAssetsFilter)
+                    {
+                        excludedByExcludeAssets++;
+                    }
+                    else
+                    {
+                        excludedByPrivateAssets++;
                     }
                 }
             }
 
-            return count;
+            telemetryEvent[AnalyzerAssetsCount] = appliedAnalyzerAssemblies;
+            telemetryEvent[AnalyzerAssetsExcludedCount] = excludedAnalyzerAssemblies;
+            telemetryEvent[AnalyzerAssetsPackagesWithAnalyzersCount] = packagesWithAnalyzers;
+            telemetryEvent[AnalyzerAssetsPackagesWithExcludedAnalyzersCount] = packagesWithExcludedAnalyzers;
+            telemetryEvent[AnalyzerAssetsExcludedByPrivateAssetsCount] = excludedByPrivateAssets;
+            telemetryEvent[AnalyzerAssetsExcludedByExcludeAssetsCount] = excludedByExcludeAssets;
+        }
+
+        private static string GetAnalyzerPackageKey(string id, NuGetVersion version)
+        {
+            return id + "/" + version?.ToNormalizedString();
+        }
+
+        /// <summary>
+        /// Determines whether a package file path is an analyzer assembly. This intentionally mirrors the
+        /// detection used by ManagedCodeConventions.ManagedCodePatterns.AnalyzerAssemblies (any '.dll' under
+        /// 'analyzers/' at any depth, excluding satellite '.resources.dll' assemblies), but as a cheap string
+        /// check so analyzer packages can be counted from the package file list for telemetry even when analyzer
+        /// assets are not selected (the feature is off), without allocating a content-item collection per package.
+        /// </summary>
+        private static bool IsAnalyzerAssemblyPath(string path)
+        {
+            return path.StartsWith("analyzers/", StringComparison.Ordinal)
+                && path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                && !path.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase);
         }
 
         private async Task<(RestoreResult, bool, CacheFile)> EvaluateNoOpAsync(TelemetryActivity telemetry, CacheFile cacheFile, Stopwatch restoreTime)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -42,6 +42,7 @@ namespace NuGet.Commands
                 dependencyType: dependencyType,
                 targetFrameworkOverride: null,
                 dependencies: null,
+                restoreEnableAnalyzerAssets: false,
                 cache: new LockFileBuilderCache());
             return lockFileTargetLibrary;
         }
@@ -56,62 +57,84 @@ namespace NuGet.Commands
         /// <param name="dependencyType">The resolved dependency type.</param>
         /// <param name="targetFrameworkOverride">The original framework if the asset selection is happening for a fallback framework.</param>
         /// <param name="dependencies">The dependencies of this package.</param>
+        /// <param name="restoreEnableAnalyzerAssets">Whether analyzer assets should be selected for the lock file.</param>
         /// <param name="cache">The lock file build cache.</param>
         /// <returns>The LockFileTargetLibrary, whether a fallback framework criteria was used to select it, the framework selected for compile assets, and the framework selected for runtime assets.</returns>
         internal static (LockFileTargetLibrary, bool, NuGetFramework, NuGetFramework) CreateLockFileTargetLibrary(
-                string aliases,
-                LockFileLibrary library,
-                LocalPackageInfo package,
-                RestoreTargetGraph targetGraph,
-                LibraryIncludeFlags dependencyType,
-                NuGetFramework targetFrameworkOverride,
-                List<LibraryDependency> dependencies,
-                LockFileBuilderCache cache)
+            string aliases,
+            LockFileLibrary library,
+            LocalPackageInfo package,
+            RestoreTargetGraph targetGraph,
+            LibraryIncludeFlags dependencyType,
+            NuGetFramework targetFrameworkOverride,
+            List<LibraryDependency> dependencies,
+            bool restoreEnableAnalyzerAssets,
+            LockFileBuilderCache cache)
         {
             var runtimeIdentifier = targetGraph.RuntimeIdentifier;
             var framework = targetFrameworkOverride ?? targetGraph.Framework;
 
-            return cache.GetLockFileTargetLibrary(targetGraph, framework, package, aliases, dependencyType, dependencies,
-                () =>
+            return cache.GetLockFileTargetLibrary(
+                targetGraph,
+                framework,
+                package,
+                aliases,
+                dependencyType,
+                dependencies,
+                restoreEnableAnalyzerAssets,
+                CreateLockFileTargetLibraryCore);
+
+            (LockFileTargetLibrary, bool, NuGetFramework, NuGetFramework) CreateLockFileTargetLibraryCore()
+            {
+                LockFileTargetLibrary lockFileLib = null;
+                NuGetFramework compileAssetFramework = null;
+                NuGetFramework runtimeAssetFramework = null;
+                // This will throw an appropriate error if the nuspec is missing
+                var nuspec = package.Nuspec;
+
+                List<(List<SelectionCriteria> orderedCriteria, bool fallbackUsed)> orderedCriteriaSets = cache.GetLabeledSelectionCriteria(targetGraph, framework);
+                var contentItems = cache.GetContentItems(library, package);
+
+                var packageTypes = nuspec.GetPackageTypes().AsList();
+                bool fallbackUsed = false;
+
+                for (var i = 0; i < orderedCriteriaSets.Count; i++)
                 {
-                    LockFileTargetLibrary lockFileLib = null;
-                    NuGetFramework compileAssetFramework = null;
-                    NuGetFramework runtimeAssetFramework = null;
-                    // This will throw an appropriate error if the nuspec is missing
-                    var nuspec = package.Nuspec;
-
-                    List<(List<SelectionCriteria> orderedCriteria, bool fallbackUsed)> orderedCriteriaSets = cache.GetLabeledSelectionCriteria(targetGraph, framework);
-                    var contentItems = cache.GetContentItems(library, package);
-
-                    var packageTypes = nuspec.GetPackageTypes().AsList();
-                    bool fallbackUsed = false;
-
-                    for (var i = 0; i < orderedCriteriaSets.Count; i++)
+                    (lockFileLib, compileAssetFramework, runtimeAssetFramework) = CreateLockFileTargetLibrary(
+                        aliases,
+                        library,
+                        package,
+                        targetGraph.Conventions,
+                        dependencyType,
+                        framework,
+                        runtimeIdentifier,
+                        contentItems,
+                        nuspec,
+                        packageTypes,
+                        orderedCriteriaSets[i].orderedCriteria,
+                        restoreEnableAnalyzerAssets);
+                    // Check if compatible assets were found.
+                    // If no compatible assets were found and this is the last check
+                    // continue on with what was given, this will fail in the normal
+                    // compat verification.
+                    if (CompatibilityChecker.HasCompatibleAssets(lockFileLib))
                     {
-                        (lockFileLib, compileAssetFramework, runtimeAssetFramework) = CreateLockFileTargetLibrary(aliases, library, package, targetGraph.Conventions, dependencyType,
-                             framework, runtimeIdentifier, contentItems, nuspec, packageTypes, orderedCriteriaSets[i].orderedCriteria);
-                        // Check if compatible assets were found.
-                        // If no compatible assets were found and this is the last check
-                        // continue on with what was given, this will fail in the normal
-                        // compat verification.
-                        if (CompatibilityChecker.HasCompatibleAssets(lockFileLib))
-                        {
-                            fallbackUsed = orderedCriteriaSets[i].fallbackUsed;
-                            // Stop when compatible assets are found.
-                            break;
-                        }
+                        fallbackUsed = orderedCriteriaSets[i].fallbackUsed;
+                        // Stop when compatible assets are found.
+                        break;
                     }
+                }
 
-                    // Add dependencies
-                    AddDependencies(dependencies, lockFileLib, framework, nuspec);
+                // Add dependencies
+                AddDependencies(dependencies, lockFileLib, framework, nuspec);
 
-                    // Exclude items
-                    ExcludeItems(lockFileLib, dependencyType);
+                // Exclude items
+                ExcludeItems(lockFileLib, dependencyType);
 
-                    lockFileLib.Freeze();
+                lockFileLib.Freeze();
 
-                    return (lockFileLib, fallbackUsed, compileAssetFramework, runtimeAssetFramework);
-                });
+                return (lockFileLib, fallbackUsed, compileAssetFramework, runtimeAssetFramework);
+            }
         }
 
         /// <summary>
@@ -178,7 +201,8 @@ namespace NuGet.Commands
             ContentItemCollection contentItems,
             NuspecReader nuspec,
             IList<PackageType> packageTypes,
-            List<SelectionCriteria> orderedCriteria)
+            List<SelectionCriteria> orderedCriteria,
+            bool restoreEnableAnalyzerAssets)
         {
             LockFileTargetLibrary lockFileLib = new LockFileTargetLibrary()
             {
@@ -223,6 +247,12 @@ namespace NuGet.Commands
                 orderedCriteria,
                 contentItems,
                 managedCodeConventions.Patterns.ResourceAssemblies);
+
+            // Analyzers
+            if (restoreEnableAnalyzerAssets)
+            {
+                lockFileLib.AnalyzerAssets = GetAnalyzerLockFileItems(library.Files);
+            }
 
             // Native
             lockFileLib.NativeLibraries = GetLockFileItems(
@@ -728,6 +758,99 @@ namespace NuGet.Commands
         }
 
         /// <summary>
+        /// Create analyzer lock file items for every analyzer assembly in the package.
+        /// Mirrors the SDK's analyzer detection: any '.dll' under 'analyzers/' at any depth,
+        /// excluding satellite '.resources.dll' assemblies. Each item carries 'codeLanguage' and
+        /// (when present in the path) 'compilerApiVersion' metadata, mirroring how content files carry
+        /// 'codeLanguage', so the SDK can select the applicable analyzers from the metadata.
+        /// </summary>
+        private static IList<LockFileItem> GetAnalyzerLockFileItems(IList<string> files)
+        {
+            var lockFileItems = new List<LockFileItem>();
+            foreach (var file in files)
+            {
+                if (IsAnalyzerAssetPath(file))
+                {
+                    var lockFileItem = new LockFileItem(file);
+                    (var codeLanguage, var compilerApiVersion) = GetAnalyzerAssetMetadata(file);
+
+                    lockFileItem.Properties[LockFileContentFile.CodeLanguageProperty] = codeLanguage;
+                    if (compilerApiVersion != null)
+                    {
+                        lockFileItem.Properties[LockFileItem.CompilerApiVersionProperty] = compilerApiVersion;
+                    }
+
+                    lockFileItems.Add(lockFileItem);
+                }
+            }
+
+            lockFileItems.Sort(static (x, y) => string.CompareOrdinal(x.Path, y.Path));
+
+            return lockFileItems;
+        }
+
+        private static bool IsAnalyzerAssetPath(string path)
+        {
+            return path.StartsWith("analyzers/", StringComparison.Ordinal)
+                && path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                && !path.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Derives the analyzer selection metadata from the asset path.
+        /// The path layout is analyzers/{framework}/{compiler?}/{architecture?}/{language?}/.../{assembly}.dll,
+        /// where the language ('cs', 'vb', 'fs') and compiler version ('roslynX.Y') segments are optional.
+        /// </summary>
+        /// <returns>
+        /// The code language ('cs', 'vb', 'fs', or 'any' when the path has no language segment) and the
+        /// compiler API version ('roslynX.Y', or null when the path has no compiler version segment).
+        /// </returns>
+        private static (string CodeLanguage, string CompilerApiVersion) GetAnalyzerAssetMetadata(string path)
+        {
+            string codeLanguage = ManagedCodeConventions.PropertyNames.AnyValue;
+            string compilerApiVersion = null;
+
+            int lastSeparator = path.LastIndexOf('/');
+            int segmentStart = 0;
+            while (segmentStart < lastSeparator)
+            {
+                int separator = path.IndexOf('/', segmentStart);
+                int segmentLength = separator - segmentStart;
+                ReadOnlySpan<char> segment = path.AsSpan(segmentStart, segmentLength);
+
+                if (segment.Equals("cs".AsSpan(), StringComparison.OrdinalIgnoreCase))
+                {
+                    codeLanguage = "cs";
+                }
+                else if (segment.Equals("vb".AsSpan(), StringComparison.OrdinalIgnoreCase))
+                {
+                    codeLanguage = "vb";
+                }
+                else if (segment.Equals("fs".AsSpan(), StringComparison.OrdinalIgnoreCase))
+                {
+                    codeLanguage = "fs";
+                }
+                else if (compilerApiVersion == null && IsCompilerApiVersionSegment(segment))
+                {
+                    compilerApiVersion = path.Substring(segmentStart, segmentLength).ToLowerInvariant();
+                }
+
+                segmentStart = separator + 1;
+            }
+
+            return (codeLanguage, compilerApiVersion);
+        }
+
+        private static bool IsCompilerApiVersionSegment(ReadOnlySpan<char> segment)
+        {
+            const string roslynPrefix = "roslyn";
+
+            return segment.Length > roslynPrefix.Length
+                && segment.StartsWith(roslynPrefix.AsSpan(), StringComparison.OrdinalIgnoreCase)
+                && char.IsDigit(segment[roslynPrefix.Length]);
+        }
+
+        /// <summary>
         /// Get packageId.targets and packageId.props
         /// </summary>
         private static IEnumerable<LockFileItem> GetBuildItemsForPackageId(
@@ -835,7 +958,7 @@ namespace NuGet.Commands
         /// Clears a lock file group and replaces the first item with _._ if
         /// the group has items. Empty groups are left alone.
         /// </summary>
-        private static void ClearIfExists<T>(IList<T> group, Func<string, T> factory) where T : LockFileItem
+        private static void ClearIfExists<T>(IList<T> group, Func<string, T> factory, bool copyProperties = true) where T : LockFileItem
         {
             if (GroupHasNonEmptyItems(group))
             {
@@ -862,9 +985,12 @@ namespace NuGet.Commands
                 var emptyItem = factory(emptyDir);
 
                 // Copy over the properties from the first
-                foreach (var pair in firstItem.Properties)
+                if (copyProperties)
                 {
-                    emptyItem.Properties.Add(pair.Key, pair.Value);
+                    foreach (var pair in firstItem.Properties)
+                    {
+                        emptyItem.Properties.Add(pair.Key, pair.Value);
+                    }
                 }
 
                 group.Add(emptyItem);
@@ -1050,6 +1176,11 @@ namespace NuGet.Commands
             if ((dependencyType & LibraryIncludeFlags.Native) == LibraryIncludeFlags.None)
             {
                 ClearIfExists(lockFileLib.NativeLibraries, static path => new LockFileItem(path));
+            }
+
+            if ((dependencyType & LibraryIncludeFlags.Analyzers) == LibraryIncludeFlags.None)
+            {
+                ClearIfExists(lockFileLib.AnalyzerAssets, static path => new LockFileItem(path), copyProperties: false);
             }
 
             if ((dependencyType & LibraryIncludeFlags.ContentFiles) == LibraryIncludeFlags.None

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -810,11 +810,11 @@ namespace NuGet.Commands
             string codeLanguage = ManagedCodeConventions.PropertyNames.AnyValue;
             string compilerApiVersion = null;
 
-            int lastSeparator = path.LastIndexOf('/');
+            int lastSeparator = path.LastIndexOf(Path.AltDirectorySeparatorChar);
             int segmentStart = 0;
             while (segmentStart < lastSeparator)
             {
-                int separator = path.IndexOf('/', segmentStart);
+                int separator = path.IndexOf(Path.AltDirectorySeparatorChar, segmentStart);
                 int segmentLength = separator - segmentStart;
                 ReadOnlySpan<char> segment = path.AsSpan(segmentStart, segmentLength);
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -251,7 +251,7 @@ namespace NuGet.Commands
             // Analyzers
             if (restoreEnableAnalyzerAssets)
             {
-                lockFileLib.AnalyzerAssets = GetAnalyzerLockFileItems(library.Files);
+                lockFileLib.AnalyzerAssets = GetAnalyzerLockFileItems(contentItems, managedCodeConventions);
             }
 
             // Native
@@ -759,29 +759,26 @@ namespace NuGet.Commands
 
         /// <summary>
         /// Create analyzer lock file items for every analyzer assembly in the package.
-        /// Mirrors the SDK's analyzer detection: any '.dll' under 'analyzers/' at any depth,
-        /// excluding satellite '.resources.dll' assemblies. Each item carries 'codeLanguage' and
-        /// (when present in the path) 'compilerApiVersion' metadata, mirroring how content files carry
-        /// 'codeLanguage', so the SDK can select the applicable analyzers from the metadata.
+        /// Detection uses the shared <see cref="ManagedCodeConventions"/> analyzer pattern (any '.dll' under
+        /// 'analyzers/' at any depth, excluding satellite '.resources.dll' assemblies). Each item carries
+        /// 'codeLanguage' and (when present in the path) 'compilerApiVersion' metadata, mirroring how content
+        /// files carry 'codeLanguage', so the SDK can select the applicable analyzers from the metadata.
         /// </summary>
-        private static IList<LockFileItem> GetAnalyzerLockFileItems(IList<string> files)
+        private static IList<LockFileItem> GetAnalyzerLockFileItems(ContentItemCollection contentItems, ManagedCodeConventions managedCodeConventions)
         {
             var lockFileItems = new List<LockFileItem>();
-            foreach (var file in files)
+            foreach (ContentItem item in contentItems.FindItems(managedCodeConventions.Patterns.AnalyzerAssemblies))
             {
-                if (IsAnalyzerAssetPath(file))
+                var lockFileItem = new LockFileItem(item.Path);
+                (var codeLanguage, var compilerApiVersion) = GetAnalyzerAssetMetadata(item.Path);
+
+                lockFileItem.Properties[LockFileContentFile.CodeLanguageProperty] = codeLanguage;
+                if (compilerApiVersion != null)
                 {
-                    var lockFileItem = new LockFileItem(file);
-                    (var codeLanguage, var compilerApiVersion) = GetAnalyzerAssetMetadata(file);
-
-                    lockFileItem.Properties[LockFileContentFile.CodeLanguageProperty] = codeLanguage;
-                    if (compilerApiVersion != null)
-                    {
-                        lockFileItem.Properties[LockFileItem.CompilerApiVersionProperty] = compilerApiVersion;
-                    }
-
-                    lockFileItems.Add(lockFileItem);
+                    lockFileItem.Properties[LockFileItem.CompilerApiVersionProperty] = compilerApiVersion;
                 }
+
+                lockFileItems.Add(lockFileItem);
             }
 
             lockFileItems.Sort(static (x, y) => string.CompareOrdinal(x.Path, y.Path));
@@ -789,17 +786,12 @@ namespace NuGet.Commands
             return lockFileItems;
         }
 
-        private static bool IsAnalyzerAssetPath(string path)
-        {
-            return path.StartsWith("analyzers/", StringComparison.Ordinal)
-                && path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
-                && !path.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase);
-        }
-
         /// <summary>
-        /// Derives the analyzer selection metadata from the asset path.
-        /// The path layout is analyzers/{framework}/{compiler?}/{architecture?}/{language?}/.../{assembly}.dll,
-        /// where the language ('cs', 'vb', 'fs') and compiler version ('roslynX.Y') segments are optional.
+        /// Derives the analyzer selection metadata by scanning the directory segments of the asset path.
+        /// The 'codeLanguage' ('cs', 'vb', 'fs') and 'compilerApiVersion' ('roslynX.Y') segments are optional
+        /// and may appear at any depth and in either order — for example 'analyzers/dotnet/cs/A.dll' or
+        /// 'analyzers/dotnet/roslyn4.7/cs/A.dll' (the most common real-world layout, where the language follows
+        /// the compiler version). Each segment is inspected rather than assuming a fixed folder layout.
         /// </summary>
         /// <returns>
         /// The code language ('cs', 'vb', 'fs', or 'any' when the path has no language segment) and the
@@ -818,6 +810,7 @@ namespace NuGet.Commands
                 int segmentLength = separator - segmentStart;
                 ReadOnlySpan<char> segment = path.AsSpan(segmentStart, segmentLength);
 
+                // The 'cs'/'vb'/'fs' literals are interned, so comparing against them does not allocate.
                 if (segment.Equals("cs".AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     codeLanguage = "cs";
@@ -832,13 +825,29 @@ namespace NuGet.Commands
                 }
                 else if (compilerApiVersion == null && IsCompilerApiVersionSegment(segment))
                 {
-                    compilerApiVersion = path.Substring(segmentStart, segmentLength).ToLowerInvariant();
+                    // The stored string is the single necessary allocation; compiler version segments are
+                    // conventionally already lowercase, so avoid a second allocation from ToLowerInvariant.
+                    string segmentValue = path.Substring(segmentStart, segmentLength);
+                    compilerApiVersion = IsLowerInvariant(segment) ? segmentValue : segmentValue.ToLowerInvariant();
                 }
 
                 segmentStart = separator + 1;
             }
 
             return (codeLanguage, compilerApiVersion);
+        }
+
+        private static bool IsLowerInvariant(ReadOnlySpan<char> segment)
+        {
+            foreach (char c in segment)
+            {
+                if (char.IsUpper(c))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static bool IsCompilerApiVersionSegment(ReadOnlySpan<char> segment)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -328,6 +328,7 @@ namespace NuGet.Commands
                 result.RestoreMetadata.SdkAnalysisLevel = GetSdkAnalysisLevel(specItem.GetProperty("SdkAnalysisLevel"));
                 result.RestoreMetadata.UseLegacyDependencyResolver = IsPropertyTrue(specItem, "RestoreUseLegacyDependencyResolver");
                 result.RestoreMetadata.RestoreDoNotWriteDependencyGraphSpec = IsPropertyTrue(specItem, "RestoreDoNotWriteDependencyGraphSpec");
+                result.RestoreMetadata.RestoreEnableAnalyzerAssets = IsPropertyTrue(specItem, "RestoreEnableAnalyzerAssets");
                 result.RestoreSettings.SdkVersion = GetSdkAnalysisLevel(specItem.GetProperty("NETCoreSdkVersion"));
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -328,6 +328,7 @@ namespace NuGet.Commands
                 result.RestoreMetadata.SdkAnalysisLevel = GetSdkAnalysisLevel(specItem.GetProperty("SdkAnalysisLevel"));
                 result.RestoreMetadata.UseLegacyDependencyResolver = IsPropertyTrue(specItem, "RestoreUseLegacyDependencyResolver");
                 result.RestoreMetadata.RestoreDoNotWriteDependencyGraphSpec = IsPropertyTrue(specItem, "RestoreDoNotWriteDependencyGraphSpec");
+                result.RestoreMetadata.RestoreEnableAnalyzerAssets = IsPropertyTrue(specItem, "RestoreEnableAnalyzerAssets");
                 result.RestoreSettings.SdkVersion = GetSdkAnalysisLevel(specItem.GetProperty("NETCoreSdkVersion"));
             }
 
@@ -572,8 +573,7 @@ namespace NuGet.Commands
                     Imports = imports,
                     RuntimeIdentifierGraphPath = runtimeIdentifierGraphPath,
                     TargetAlias = targetAlias,
-                    Warn = warn,
-                    RestoreEnableAnalyzerAssets = IsPropertyTrue(item, "RestoreEnableAnalyzerAssets")
+                    Warn = warn
                 };
 
                 yield return targetFrameworkInfo;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -328,7 +328,7 @@ namespace NuGet.Commands
                 result.RestoreMetadata.SdkAnalysisLevel = GetSdkAnalysisLevel(specItem.GetProperty("SdkAnalysisLevel"));
                 result.RestoreMetadata.UseLegacyDependencyResolver = IsPropertyTrue(specItem, "RestoreUseLegacyDependencyResolver");
                 result.RestoreMetadata.RestoreDoNotWriteDependencyGraphSpec = IsPropertyTrue(specItem, "RestoreDoNotWriteDependencyGraphSpec");
-                result.RestoreMetadata.RestoreEnableAnalyzerAssets = IsPropertyTrue(specItem, "RestoreEnableAnalyzerAssets");
+                result.RestoreMetadata.RestoreEnableAnalyzerAssets = GetRestoreEnableAnalyzerAssets(specItem, GetItemByType(items, "TargetFrameworkInformation"));
                 result.RestoreSettings.SdkVersion = GetSdkAnalysisLevel(specItem.GetProperty("NETCoreSdkVersion"));
             }
 
@@ -1081,6 +1081,19 @@ namespace NuGet.Commands
                 specItem.GetProperty("RestorePackagesWithLockFile"),
                 specItem.GetProperty("NuGetLockFilePath"),
                 IsPropertyTrue(specItem, "RestoreLockedMode"));
+        }
+
+        private static bool GetRestoreEnableAnalyzerAssets(IMSBuildItem project, IEnumerable<IMSBuildItem> targetFrameworks)
+        {
+            foreach (IMSBuildItem targetFramework in targetFrameworks.NoAllocEnumerate())
+            {
+                if (IsPropertyTrue(targetFramework, "RestoreEnableAnalyzerAssets"))
+                {
+                    return true;
+                }
+            }
+
+            return IsPropertyTrue(project, "RestoreEnableAnalyzerAssets");
         }
 
         public static RestoreAuditProperties GetRestoreAuditProperties(IMSBuildItem specItem, IEnumerable<IMSBuildItem> allItems, HashSet<string> suppressionItems)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -328,7 +328,6 @@ namespace NuGet.Commands
                 result.RestoreMetadata.SdkAnalysisLevel = GetSdkAnalysisLevel(specItem.GetProperty("SdkAnalysisLevel"));
                 result.RestoreMetadata.UseLegacyDependencyResolver = IsPropertyTrue(specItem, "RestoreUseLegacyDependencyResolver");
                 result.RestoreMetadata.RestoreDoNotWriteDependencyGraphSpec = IsPropertyTrue(specItem, "RestoreDoNotWriteDependencyGraphSpec");
-                result.RestoreMetadata.RestoreEnableAnalyzerAssets = IsPropertyTrue(specItem, "RestoreEnableAnalyzerAssets");
                 result.RestoreSettings.SdkVersion = GetSdkAnalysisLevel(specItem.GetProperty("NETCoreSdkVersion"));
             }
 
@@ -573,7 +572,8 @@ namespace NuGet.Commands
                     Imports = imports,
                     RuntimeIdentifierGraphPath = runtimeIdentifierGraphPath,
                     TargetAlias = targetAlias,
-                    Warn = warn
+                    Warn = warn,
+                    RestoreEnableAnalyzerAssets = IsPropertyTrue(item, "RestoreEnableAnalyzerAssets")
                 };
 
                 yield return targetFrameworkInfo;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
@@ -190,7 +190,6 @@ namespace NuGet.Commands.Restore.Utility
             restoreMetadata.SdkAnalysisLevel = MSBuildRestoreUtility.GetSdkAnalysisLevel(outerBuild.GetProperty("SdkAnalysisLevel"));
             restoreMetadata.UseLegacyDependencyResolver = outerBuild.IsPropertyTrue("RestoreUseLegacyDependencyResolver");
             restoreMetadata.RestoreDoNotWriteDependencyGraphSpec = outerBuild.IsPropertyTrue("RestoreDoNotWriteDependencyGraphSpec");
-            restoreMetadata.RestoreEnableAnalyzerAssets = GetRestoreEnableAnalyzerAssets(project);
 
             return (restoreMetadata, targetFrameworkInfos);
 
@@ -268,7 +267,8 @@ namespace NuGet.Commands.Restore.Utility
                     PackagesToPrune = prunedReferences,
                     RuntimeIdentifierGraphPath = msBuildProjectInstance.GetProperty(nameof(TargetFrameworkInformation.RuntimeIdentifierGraphPath)),
                     TargetAlias = targetAlias,
-                    Warn = warn
+                    Warn = warn,
+                    RestoreEnableAnalyzerAssets = msBuildProjectInstance.IsPropertyTrue("RestoreEnableAnalyzerAssets")
                 };
 
                 targetFrameworkInfos.Add(targetFrameworkInformation);
@@ -287,27 +287,6 @@ namespace NuGet.Commands.Restore.Utility
                 }
             }
             return false;
-        }
-
-        private static bool GetRestoreEnableAnalyzerAssets(IProject project)
-        {
-            bool isMultiTargeting = project.TargetFrameworks.Count > 1
-                || !string.IsNullOrWhiteSpace(project.OuterBuild.GetProperty("TargetFrameworks"));
-
-            if (isMultiTargeting)
-            {
-                foreach (var item in project.TargetFrameworks.NoAllocEnumerate())
-                {
-                    if (item.Value.IsPropertyTrue("RestoreEnableAnalyzerAssets"))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            return project.OuterBuild.IsPropertyTrue("RestoreEnableAnalyzerAssets");
         }
 
         private static RestoreAuditProperties? GetRestoreAuditProperties(IProject project)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
@@ -190,6 +190,7 @@ namespace NuGet.Commands.Restore.Utility
             restoreMetadata.SdkAnalysisLevel = MSBuildRestoreUtility.GetSdkAnalysisLevel(outerBuild.GetProperty("SdkAnalysisLevel"));
             restoreMetadata.UseLegacyDependencyResolver = outerBuild.IsPropertyTrue("RestoreUseLegacyDependencyResolver");
             restoreMetadata.RestoreDoNotWriteDependencyGraphSpec = outerBuild.IsPropertyTrue("RestoreDoNotWriteDependencyGraphSpec");
+            restoreMetadata.RestoreEnableAnalyzerAssets = GetRestoreEnableAnalyzerAssets(project);
 
             return (restoreMetadata, targetFrameworkInfos);
 
@@ -286,6 +287,27 @@ namespace NuGet.Commands.Restore.Utility
                 }
             }
             return false;
+        }
+
+        private static bool GetRestoreEnableAnalyzerAssets(IProject project)
+        {
+            bool isMultiTargeting = project.TargetFrameworks.Count > 1
+                || !string.IsNullOrWhiteSpace(project.OuterBuild.GetProperty("TargetFrameworks"));
+
+            if (isMultiTargeting)
+            {
+                foreach (var item in project.TargetFrameworks.NoAllocEnumerate())
+                {
+                    if (item.Value.IsPropertyTrue("RestoreEnableAnalyzerAssets"))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            return project.OuterBuild.IsPropertyTrue("RestoreEnableAnalyzerAssets");
         }
 
         private static RestoreAuditProperties? GetRestoreAuditProperties(IProject project)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
@@ -190,6 +190,7 @@ namespace NuGet.Commands.Restore.Utility
             restoreMetadata.SdkAnalysisLevel = MSBuildRestoreUtility.GetSdkAnalysisLevel(outerBuild.GetProperty("SdkAnalysisLevel"));
             restoreMetadata.UseLegacyDependencyResolver = outerBuild.IsPropertyTrue("RestoreUseLegacyDependencyResolver");
             restoreMetadata.RestoreDoNotWriteDependencyGraphSpec = outerBuild.IsPropertyTrue("RestoreDoNotWriteDependencyGraphSpec");
+            restoreMetadata.RestoreEnableAnalyzerAssets = outerBuild.IsPropertyTrue("RestoreEnableAnalyzerAssets");
 
             return (restoreMetadata, targetFrameworkInfos);
 
@@ -267,8 +268,7 @@ namespace NuGet.Commands.Restore.Utility
                     PackagesToPrune = prunedReferences,
                     RuntimeIdentifierGraphPath = msBuildProjectInstance.GetProperty(nameof(TargetFrameworkInformation.RuntimeIdentifierGraphPath)),
                     TargetAlias = targetAlias,
-                    Warn = warn,
-                    RestoreEnableAnalyzerAssets = msBuildProjectInstance.IsPropertyTrue("RestoreEnableAnalyzerAssets")
+                    Warn = warn
                 };
 
                 targetFrameworkInfos.Add(targetFrameworkInformation);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/PackageSpecFactory.cs
@@ -190,7 +190,7 @@ namespace NuGet.Commands.Restore.Utility
             restoreMetadata.SdkAnalysisLevel = MSBuildRestoreUtility.GetSdkAnalysisLevel(outerBuild.GetProperty("SdkAnalysisLevel"));
             restoreMetadata.UseLegacyDependencyResolver = outerBuild.IsPropertyTrue("RestoreUseLegacyDependencyResolver");
             restoreMetadata.RestoreDoNotWriteDependencyGraphSpec = outerBuild.IsPropertyTrue("RestoreDoNotWriteDependencyGraphSpec");
-            restoreMetadata.RestoreEnableAnalyzerAssets = outerBuild.IsPropertyTrue("RestoreEnableAnalyzerAssets");
+            restoreMetadata.RestoreEnableAnalyzerAssets = GetRestoreEnableAnalyzerAssets(project);
 
             return (restoreMetadata, targetFrameworkInfos);
 
@@ -287,6 +287,19 @@ namespace NuGet.Commands.Restore.Utility
                 }
             }
             return false;
+        }
+
+        private static bool GetRestoreEnableAnalyzerAssets(IProject project)
+        {
+            foreach (var targetFramework in project.TargetFrameworks.NoAllocEnumerate())
+            {
+                if (targetFramework.Value.IsPropertyTrue("RestoreEnableAnalyzerAssets"))
+                {
+                    return true;
+                }
+            }
+
+            return project.OuterBuild.IsPropertyTrue("RestoreEnableAnalyzerAssets");
         }
 
         private static RestoreAuditProperties? GetRestoreAuditProperties(IProject project)

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs
@@ -36,6 +36,10 @@ namespace NuGet.Client
             PropertyNames.CodeLanguage,
             parser: CodeLanguage_Parser);
 
+        private static readonly ContentPropertyDefinition AnalyzerAssemblyProperty = new ContentPropertyDefinition(
+            PropertyNames.AnalyzerAssembly,
+            parser: AnalyzerAssembly_Parser);
+
         private static readonly Dictionary<string, object> NetTFMTable = new Dictionary<string, object>
         {
             { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) },
@@ -85,6 +89,7 @@ namespace NuGet.Client
             props[MSBuildProperty.Name] = MSBuildProperty;
             props[SatelliteAssemblyProperty.Name] = SatelliteAssemblyProperty;
             props[CodeLanguageProperty.Name] = CodeLanguageProperty;
+            props[AnalyzerAssemblyProperty.Name] = AnalyzerAssemblyProperty;
 
             props[PropertyNames.RuntimeIdentifier] = new ContentPropertyDefinition(
                 PropertyNames.RuntimeIdentifier,
@@ -296,6 +301,23 @@ namespace NuGet.Client
             return null;
         }
 
+        /// <summary>
+        /// Matches an analyzer assembly: a '.dll' (at any depth, so the token is terminal and may receive a
+        /// multi-segment remainder) excluding satellite '.resources.dll' assemblies. Mirrors the SDK's analyzer
+        /// detection apart from the 'analyzers/' folder casing, which the content model matches case-insensitively.
+        /// </summary>
+        private static object? AnalyzerAssembly_Parser(ReadOnlyMemory<char> s, PatternTable? _, bool matchOnly)
+        {
+            ReadOnlySpan<char> span = s.Span;
+            if (span.EndsWith(".dll".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                && !span.EndsWith(".resources.dll".AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+                return matchOnly ? string.Empty : s.ToString();
+            }
+
+            return null;
+        }
+
         private static bool TargetFrameworkName_CompatibilityTest(object? criteria, object? available)
         {
             var criteriaFrameworkName = criteria as NuGetFramework;
@@ -472,6 +494,11 @@ namespace NuGet.Client
             /// </summary>
             public PatternSet MSBuildTransitiveFiles { get; }
 
+            /// <summary>
+            /// Pattern used to identify analyzer assemblies, at any depth under 'analyzers/'.
+            /// </summary>
+            public PatternSet AnalyzerAssemblies { get; }
+
             internal ManagedCodePatterns(ManagedCodeConventions conventions)
             {
                 AnyTargettedFile = new PatternSet(
@@ -627,6 +654,17 @@ namespace NuGet.Client
                         new PatternDefinition("buildTransitive/{tfm}/{msbuild}", table: DotnetAnyTable),
                         new PatternDefinition("buildTransitive/{msbuild}", table: null, defaults: DefaultTfmAny)
                     });
+
+                AnalyzerAssemblies = new PatternSet(
+                    conventions.Properties,
+                    groupPatterns: new PatternDefinition[]
+                    {
+                        new PatternDefinition("analyzers/{analyzerAssembly}"),
+                    },
+                    pathPatterns: new PatternDefinition[]
+                    {
+                        new PatternDefinition("analyzers/{analyzerAssembly}"),
+                    });
             }
         }
 
@@ -640,6 +678,7 @@ namespace NuGet.Client
             public static readonly string MSBuild = "msbuild";
             public static readonly string SatelliteAssembly = "satelliteAssembly";
             public static readonly string CodeLanguage = "codeLanguage";
+            public static readonly string AnalyzerAssembly = "analyzerAssembly";
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.AnalyzerAssemblies.get -> NuGet.ContentModel.PatternSet!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.AnalyzerAssembly -> string!

--- a/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Packaging/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+NuGet.Client.ManagedCodeConventions.ManagedCodePatterns.AnalyzerAssemblies.get -> NuGet.ContentModel.PatternSet!
+static readonly NuGet.Client.ManagedCodeConventions.PropertyNames.AnalyzerAssembly -> string!

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -96,6 +96,7 @@ namespace NuGet.ProjectModel
         private static readonly byte[] UsingMicrosoftNETSdk = Encoding.UTF8.GetBytes("UsingMicrosoftNETSdk");
         private static readonly byte[] UseLegacyDependencyResolverPropertyName = Encoding.UTF8.GetBytes("restoreUseLegacyDependencyResolver");
         private static readonly byte[] RestoreDoNotWriteDependencyGraphSpecPropertyName = Encoding.UTF8.GetBytes("restoreDoNotWriteDependencyGraphSpec");
+        private static readonly byte[] RestoreEnableAnalyzerAssetsPropertyName = Encoding.UTF8.GetBytes("restoreEnableAnalyzerAssets");
         private static readonly byte[] PackagesToPrunePropertyName = Encoding.UTF8.GetBytes("packagesToPrune");
 
         internal static PackageSpec GetPackageSpecUtf8JsonStreamReader(Stream stream, string name, string packageSpecPath, IEnvironmentVariableReader environmentVariableReader, string snapshotValue = null)
@@ -777,6 +778,7 @@ namespace NuGet.ProjectModel
             NuGetVersion sdkAnalysisLevel = null;
             bool useLegacyDependencyResolver = false;
             bool restoreDoNotWriteDependencyGraphSpec = false;
+            bool restoreEnableAnalyzerAssets = false;
 
             if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
             {
@@ -1039,6 +1041,10 @@ namespace NuGet.ProjectModel
                     {
                         restoreDoNotWriteDependencyGraphSpec = jsonReader.ReadNextTokenAsBoolOrThrowAnException(RestoreDoNotWriteDependencyGraphSpecPropertyName, Strings.Invalid_AttributeValue);
                     }
+                    else if (jsonReader.ValueTextEquals(RestoreEnableAnalyzerAssetsPropertyName))
+                    {
+                        restoreEnableAnalyzerAssets = jsonReader.ReadNextTokenAsBoolOrThrowAnException(RestoreEnableAnalyzerAssetsPropertyName, Strings.Invalid_AttributeValue);
+                    }
                     else
                     {
                         jsonReader.Skip();
@@ -1068,6 +1074,7 @@ namespace NuGet.ProjectModel
             msbuildMetadata.UsingMicrosoftNETSdk = usingMicrosoftNetSdk;
             msbuildMetadata.UseLegacyDependencyResolver = useLegacyDependencyResolver;
             msbuildMetadata.RestoreDoNotWriteDependencyGraphSpec = restoreDoNotWriteDependencyGraphSpec;
+            msbuildMetadata.RestoreEnableAnalyzerAssets = restoreEnableAnalyzerAssets;
 
             if (configFilePaths != null)
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -778,7 +778,6 @@ namespace NuGet.ProjectModel
             NuGetVersion sdkAnalysisLevel = null;
             bool useLegacyDependencyResolver = false;
             bool restoreDoNotWriteDependencyGraphSpec = false;
-            bool restoreEnableAnalyzerAssets = false;
 
             if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
             {
@@ -1041,10 +1040,6 @@ namespace NuGet.ProjectModel
                     {
                         restoreDoNotWriteDependencyGraphSpec = jsonReader.ReadNextTokenAsBoolOrThrowAnException(RestoreDoNotWriteDependencyGraphSpecPropertyName, Strings.Invalid_AttributeValue);
                     }
-                    else if (jsonReader.ValueTextEquals(RestoreEnableAnalyzerAssetsPropertyName))
-                    {
-                        restoreEnableAnalyzerAssets = jsonReader.ReadNextTokenAsBoolOrThrowAnException(RestoreEnableAnalyzerAssetsPropertyName, Strings.Invalid_AttributeValue);
-                    }
                     else
                     {
                         jsonReader.Skip();
@@ -1074,7 +1069,6 @@ namespace NuGet.ProjectModel
             msbuildMetadata.UsingMicrosoftNETSdk = usingMicrosoftNetSdk;
             msbuildMetadata.UseLegacyDependencyResolver = useLegacyDependencyResolver;
             msbuildMetadata.RestoreDoNotWriteDependencyGraphSpec = restoreDoNotWriteDependencyGraphSpec;
-            msbuildMetadata.RestoreEnableAnalyzerAssets = restoreEnableAnalyzerAssets;
 
             if (configFilePaths != null)
             {
@@ -1429,6 +1423,7 @@ namespace NuGet.ProjectModel
             string runtimeIdentifierGraphPath = null;
             string targetAlias = string.Empty;
             bool warn = false;
+            bool restoreEnableAnalyzerAssets = false;
             Dictionary<string, PrunePackageReference> packagesToPrune = null;
 
             NuGetFramework secondaryFramework = default;
@@ -1513,6 +1508,10 @@ namespace NuGet.ProjectModel
                     {
                         warn = jsonReader.ReadNextTokenAsBoolOrFalse();
                     }
+                    else if (jsonReader.ValueTextEquals(RestoreEnableAnalyzerAssetsPropertyName))
+                    {
+                        restoreEnableAnalyzerAssets = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
                     else if (jsonReader.ValueTextEquals(PackagesToPrunePropertyName))
                     {
                         packagesToPrune ??= new Dictionary<string, PrunePackageReference>(StringComparer.OrdinalIgnoreCase);
@@ -1539,7 +1538,8 @@ namespace NuGet.ProjectModel
                 RuntimeIdentifierGraphPath = runtimeIdentifierGraphPath,
                 PackagesToPrune = packagesToPrune,
                 TargetAlias = targetAlias,
-                Warn = warn
+                Warn = warn,
+                RestoreEnableAnalyzerAssets = restoreEnableAnalyzerAssets
             };
 
             if (frameworkName == null) // V3 writers don't set the framework property, so use the key instead.

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.Utf8JsonStreamReader.cs
@@ -778,6 +778,7 @@ namespace NuGet.ProjectModel
             NuGetVersion sdkAnalysisLevel = null;
             bool useLegacyDependencyResolver = false;
             bool restoreDoNotWriteDependencyGraphSpec = false;
+            bool restoreEnableAnalyzerAssets = false;
 
             if (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.StartObject)
             {
@@ -1010,6 +1011,10 @@ namespace NuGet.ProjectModel
                     {
                         usingMicrosoftNetSdk = jsonReader.ReadNextTokenAsBoolOrThrowAnException(UsingMicrosoftNETSdk, Strings.Invalid_AttributeValue);
                     }
+                    else if (jsonReader.ValueTextEquals(RestoreEnableAnalyzerAssetsPropertyName))
+                    {
+                        restoreEnableAnalyzerAssets = jsonReader.ReadNextTokenAsBoolOrFalse();
+                    }
                     else if (jsonReader.ValueTextEquals(SdkAnalysisLevel))
                     {
                         string sdkAnalysisLevelString = jsonReader.ReadNextTokenAsString();
@@ -1067,6 +1072,7 @@ namespace NuGet.ProjectModel
             msbuildMetadata.RestoreAuditProperties = auditProperties;
             msbuildMetadata.SdkAnalysisLevel = sdkAnalysisLevel;
             msbuildMetadata.UsingMicrosoftNETSdk = usingMicrosoftNetSdk;
+            msbuildMetadata.RestoreEnableAnalyzerAssets = restoreEnableAnalyzerAssets;
             msbuildMetadata.UseLegacyDependencyResolver = useLegacyDependencyResolver;
             msbuildMetadata.RestoreDoNotWriteDependencyGraphSpec = restoreDoNotWriteDependencyGraphSpec;
 
@@ -1423,7 +1429,6 @@ namespace NuGet.ProjectModel
             string runtimeIdentifierGraphPath = null;
             string targetAlias = string.Empty;
             bool warn = false;
-            bool restoreEnableAnalyzerAssets = false;
             Dictionary<string, PrunePackageReference> packagesToPrune = null;
 
             NuGetFramework secondaryFramework = default;
@@ -1508,10 +1513,6 @@ namespace NuGet.ProjectModel
                     {
                         warn = jsonReader.ReadNextTokenAsBoolOrFalse();
                     }
-                    else if (jsonReader.ValueTextEquals(RestoreEnableAnalyzerAssetsPropertyName))
-                    {
-                        restoreEnableAnalyzerAssets = jsonReader.ReadNextTokenAsBoolOrFalse();
-                    }
                     else if (jsonReader.ValueTextEquals(PackagesToPrunePropertyName))
                     {
                         packagesToPrune ??= new Dictionary<string, PrunePackageReference>(StringComparer.OrdinalIgnoreCase);
@@ -1538,8 +1539,7 @@ namespace NuGet.ProjectModel
                 RuntimeIdentifierGraphPath = runtimeIdentifierGraphPath,
                 PackagesToPrune = packagesToPrune,
                 TargetAlias = targetAlias,
-                Warn = warn,
-                RestoreEnableAnalyzerAssets = restoreEnableAnalyzerAssets
+                Warn = warn
             };
 
             if (frameworkName == null) // V3 writers don't set the framework property, so use the key instead.

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -46,6 +46,7 @@ namespace NuGet.ProjectModel
         private const string FrameworkAssembliesProperty = "frameworkAssemblies";
         private const string RuntimeProperty = "runtime";
         private const string CompileProperty = "compile";
+        private const string AnalyzersProperty = "analyzers";
         private const string NativeProperty = "native";
         private const string BuildProperty = "build";
         private const string BuildMultiTargetingProperty = "buildMultiTargeting";
@@ -410,6 +411,14 @@ namespace NuGet.ProjectModel
                 var ordered = library.CompileTimeAssemblies.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
                 writer.WritePropertyName(CompileProperty);
+                JsonUtility.WriteObject(writer, ordered, WriteFileItem);
+            }
+
+            if (library.AnalyzerAssets.Count > 0)
+            {
+                var ordered = library.AnalyzerAssets.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
+
+                writer.WritePropertyName(AnalyzersProperty);
                 JsonUtility.WriteObject(writer, ordered, WriteFileItem);
             }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
@@ -12,6 +12,7 @@ namespace NuGet.ProjectModel
     public class LockFileItem : IEquatable<LockFileItem>
     {
         public static readonly string AliasesProperty = "aliases";
+        public static readonly string CompilerApiVersionProperty = "compilerApiVersion";
         private static readonly object PropertiesLock = new object();
 
         public LockFileItem(string path)

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTargetLibrary.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTargetLibrary.cs
@@ -21,6 +21,7 @@ namespace NuGet.ProjectModel
         private static readonly PropertyKey RuntimeAssembliesKey = new(nameof(RuntimeAssemblies));
         private static readonly PropertyKey ResourceAssembliesKey = new(nameof(ResourceAssemblies));
         private static readonly PropertyKey CompileTimeAssembliesKey = new(nameof(CompileTimeAssemblies));
+        private static readonly PropertyKey AnalyzerAssetsKey = new(nameof(AnalyzerAssets));
         private static readonly PropertyKey NativeLibrariesKey = new(nameof(NativeLibraries));
         private static readonly PropertyKey BuildKey = new(nameof(Build));
         private static readonly PropertyKey BuildMultiTargetingKey = new(nameof(BuildMultiTargeting));
@@ -108,6 +109,12 @@ namespace NuGet.ProjectModel
             set => SetListProperty(CompileTimeAssembliesKey, value);
         }
 
+        public IList<LockFileItem> AnalyzerAssets
+        {
+            get => GetListProperty<LockFileItem>(AnalyzerAssetsKey);
+            set => SetListProperty(AnalyzerAssetsKey, value);
+        }
+
         public IList<LockFileItem> NativeLibraries
         {
             get => GetListProperty<LockFileItem>(NativeLibrariesKey);
@@ -180,6 +187,7 @@ namespace NuGet.ProjectModel
                 && IsListOrderedEqual<LockFileItem>(RuntimeAssembliesKey, static o => o.Path)
                 && IsListOrderedEqual<LockFileItem>(ResourceAssembliesKey, static o => o.Path)
                 && IsListOrderedEqual<LockFileItem>(CompileTimeAssembliesKey, static o => o.Path)
+                && IsListOrderedEqual<LockFileItem>(AnalyzerAssetsKey, static o => o.Path)
                 && IsListOrderedEqual<LockFileItem>(NativeLibrariesKey, static o => o.Path)
                 && IsListOrderedEqual<LockFileContentFile>(ContentFilesKey, static o => o.Path)
                 && IsListOrderedEqual<LockFileRuntimeTarget>(RuntimeTargetsKey, static o => o.Path)
@@ -221,6 +229,7 @@ namespace NuGet.ProjectModel
             combiner.AddUnorderedSequence(RuntimeAssemblies);
             combiner.AddUnorderedSequence(ResourceAssemblies);
             combiner.AddUnorderedSequence(CompileTimeAssemblies);
+            combiner.AddUnorderedSequence(AnalyzerAssets);
             combiner.AddUnorderedSequence(NativeLibraries);
             combiner.AddUnorderedSequence(ContentFiles);
             combiner.AddUnorderedSequence(RuntimeTargets);

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileTargetLibraryConverter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/Utf8JsonStreamLockFileTargetLibraryConverter.cs
@@ -28,6 +28,9 @@ namespace NuGet.ProjectModel
     ///     "compile": {
     ///         <see cref="Utf8JsonStreamLockFileItemConverter{T}"/>,
     ///     },
+    ///     "analyzers": {
+    ///         <see cref="Utf8JsonStreamLockFileItemConverter{T}"/>,
+    ///     },
     ///     "runtime": {
     ///         <see cref="Utf8JsonStreamLockFileItemConverter{T}"/>,
     ///     },
@@ -59,6 +62,7 @@ namespace NuGet.ProjectModel
         private static readonly byte[] FrameworkAssembliesPropertyName = Encoding.UTF8.GetBytes("frameworkAssemblies");
         private static readonly byte[] RuntimePropertyName = Encoding.UTF8.GetBytes("runtime");
         private static readonly byte[] CompilePropertyName = Encoding.UTF8.GetBytes("compile");
+        private static readonly byte[] AnalyzersPropertyName = Encoding.UTF8.GetBytes("analyzers");
         private static readonly byte[] ResourcePropertyName = Encoding.UTF8.GetBytes("resource");
         private static readonly byte[] NativePropertyName = Encoding.UTF8.GetBytes("native");
         private static readonly byte[] BuildPropertyName = Encoding.UTF8.GetBytes("build");
@@ -119,6 +123,11 @@ namespace NuGet.ProjectModel
                 {
                     reader.Read();
                     lockFileTargetLibrary.CompileTimeAssemblies = reader.ReadObjectAsList<LockFileItem>(Utf8JsonStreamLockFileConverters.LockFileItemConverter);
+                }
+                else if (reader.ValueTextEquals(AnalyzersPropertyName))
+                {
+                    reader.Read();
+                    lockFileTargetLibrary.AnalyzerAssets = reader.ReadObjectAsList<LockFileItem>(Utf8JsonStreamLockFileConverters.LockFileItemConverter);
                 }
                 else if (reader.ValueTextEquals(ResourcePropertyName))
                 {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -170,6 +170,7 @@ namespace NuGet.ProjectModel
             SetValueIfTrue(writer, "centralPackageVersionOverrideDisabled", msbuildMetadata.CentralPackageVersionOverrideDisabled);
             SetValueIfTrue(writer, "CentralPackageTransitivePinningEnabled", msbuildMetadata.CentralPackageTransitivePinningEnabled);
             SetValueIfFalse(writer, "UsingMicrosoftNETSdk", msbuildMetadata.UsingMicrosoftNETSdk);
+            SetValueIfTrue(writer, "restoreEnableAnalyzerAssets", msbuildMetadata.RestoreEnableAnalyzerAssets);
             SetValueIfTrue(writer, "restoreUseLegacyDependencyResolver", msbuildMetadata.UseLegacyDependencyResolver);
             SetValueIfTrue(writer, "restoreDoNotWriteDependencyGraphSpec", msbuildMetadata.RestoreDoNotWriteDependencyGraphSpec);
         }
@@ -539,7 +540,6 @@ namespace NuGet.ProjectModel
                     SetValueIfNotNull(writer, "secondaryFramework",
                         (DeconstructFallbackFrameworks(framework.FrameworkName) as DualCompatibilityFramework)?.SecondaryFramework.GetShortFolderName());
                     SetValueIfTrue(writer, "warn", framework.Warn);
-                    SetValueIfTrue(writer, "restoreEnableAnalyzerAssets", framework.RestoreEnableAnalyzerAssets);
                     SetDownloadDependencies(writer, framework.DownloadDependencies);
                     SetFrameworkReferences(writer, framework.FrameworkReferences);
                     SetValueIfNotNull(writer, "runtimeIdentifierGraphPath", framework.RuntimeIdentifierGraphPath);

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -172,7 +172,6 @@ namespace NuGet.ProjectModel
             SetValueIfFalse(writer, "UsingMicrosoftNETSdk", msbuildMetadata.UsingMicrosoftNETSdk);
             SetValueIfTrue(writer, "restoreUseLegacyDependencyResolver", msbuildMetadata.UseLegacyDependencyResolver);
             SetValueIfTrue(writer, "restoreDoNotWriteDependencyGraphSpec", msbuildMetadata.RestoreDoNotWriteDependencyGraphSpec);
-            SetValueIfTrue(writer, "restoreEnableAnalyzerAssets", msbuildMetadata.RestoreEnableAnalyzerAssets);
         }
 
 
@@ -540,6 +539,7 @@ namespace NuGet.ProjectModel
                     SetValueIfNotNull(writer, "secondaryFramework",
                         (DeconstructFallbackFrameworks(framework.FrameworkName) as DualCompatibilityFramework)?.SecondaryFramework.GetShortFolderName());
                     SetValueIfTrue(writer, "warn", framework.Warn);
+                    SetValueIfTrue(writer, "restoreEnableAnalyzerAssets", framework.RestoreEnableAnalyzerAssets);
                     SetDownloadDependencies(writer, framework.DownloadDependencies);
                     SetFrameworkReferences(writer, framework.FrameworkReferences);
                     SetValueIfNotNull(writer, "runtimeIdentifierGraphPath", framework.RuntimeIdentifierGraphPath);

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -172,6 +172,7 @@ namespace NuGet.ProjectModel
             SetValueIfFalse(writer, "UsingMicrosoftNETSdk", msbuildMetadata.UsingMicrosoftNETSdk);
             SetValueIfTrue(writer, "restoreUseLegacyDependencyResolver", msbuildMetadata.UseLegacyDependencyResolver);
             SetValueIfTrue(writer, "restoreDoNotWriteDependencyGraphSpec", msbuildMetadata.RestoreDoNotWriteDependencyGraphSpec);
+            SetValueIfTrue(writer, "restoreEnableAnalyzerAssets", msbuildMetadata.RestoreEnableAnalyzerAssets);
         }
 
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -155,6 +155,11 @@ namespace NuGet.ProjectModel
         /// </summary>
         public bool RestoreDoNotWriteDependencyGraphSpec { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether analyzer assets should be restored.
+        /// </summary>
+        public bool RestoreEnableAnalyzerAssets { get; set; }
+
         public override int GetHashCode()
         {
             StringComparer osStringComparer = PathUtility.GetStringComparerBasedOnOS();
@@ -189,6 +194,7 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(SdkAnalysisLevel);
             hashCode.AddObject(UseLegacyDependencyResolver);
             hashCode.AddObject(RestoreDoNotWriteDependencyGraphSpec);
+            hashCode.AddObject(RestoreEnableAnalyzerAssets);
 
             return hashCode.CombinedHash;
         }
@@ -236,9 +242,10 @@ namespace NuGet.ProjectModel
                    EqualityUtility.EqualsWithNullCheck(CentralPackageTransitivePinningEnabled, other.CentralPackageTransitivePinningEnabled) &&
                    RestoreAuditProperties == other.RestoreAuditProperties &&
                    UsingMicrosoftNETSdk == other.UsingMicrosoftNETSdk &&
-                   EqualityUtility.EqualsWithNullCheck(SdkAnalysisLevel, other.SdkAnalysisLevel) &&
-                   UseLegacyDependencyResolver == other.UseLegacyDependencyResolver &&
-                   RestoreDoNotWriteDependencyGraphSpec == other.RestoreDoNotWriteDependencyGraphSpec;
+                    EqualityUtility.EqualsWithNullCheck(SdkAnalysisLevel, other.SdkAnalysisLevel) &&
+                    UseLegacyDependencyResolver == other.UseLegacyDependencyResolver &&
+                    RestoreDoNotWriteDependencyGraphSpec == other.RestoreDoNotWriteDependencyGraphSpec &&
+                    RestoreEnableAnalyzerAssets == other.RestoreEnableAnalyzerAssets;
         }
 
         private HashSet<string> GetSources(IList<PackageSource> sources)
@@ -293,6 +300,7 @@ namespace NuGet.ProjectModel
             clone.UsingMicrosoftNETSdk = UsingMicrosoftNETSdk;
             clone.UseLegacyDependencyResolver = UseLegacyDependencyResolver;
             clone.RestoreDoNotWriteDependencyGraphSpec = RestoreDoNotWriteDependencyGraphSpec;
+            clone.RestoreEnableAnalyzerAssets = RestoreEnableAnalyzerAssets;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -147,6 +147,13 @@ namespace NuGet.ProjectModel
         /// </summary>
         public bool UsingMicrosoftNETSdk { get; set; }
 
+        /// <summary>
+        /// Whether analyzer assets are tracked in the assets file. This is a project-wide opt-in
+        /// (the <c>RestoreEnableAnalyzerAssets</c> MSBuild property); when enabled, analyzer assets
+        /// are honored for every target framework.
+        /// </summary>
+        public bool RestoreEnableAnalyzerAssets { get; set; }
+
         public bool UseLegacyDependencyResolver { get; set; }
 
         /// <summary>
@@ -186,6 +193,7 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(CentralPackageTransitivePinningEnabled);
             hashCode.AddObject(RestoreAuditProperties);
             hashCode.AddObject(UsingMicrosoftNETSdk);
+            hashCode.AddObject(RestoreEnableAnalyzerAssets);
             hashCode.AddObject(SdkAnalysisLevel);
             hashCode.AddObject(UseLegacyDependencyResolver);
             hashCode.AddObject(RestoreDoNotWriteDependencyGraphSpec);
@@ -236,6 +244,7 @@ namespace NuGet.ProjectModel
                    EqualityUtility.EqualsWithNullCheck(CentralPackageTransitivePinningEnabled, other.CentralPackageTransitivePinningEnabled) &&
                    RestoreAuditProperties == other.RestoreAuditProperties &&
                    UsingMicrosoftNETSdk == other.UsingMicrosoftNETSdk &&
+                   RestoreEnableAnalyzerAssets == other.RestoreEnableAnalyzerAssets &&
                     EqualityUtility.EqualsWithNullCheck(SdkAnalysisLevel, other.SdkAnalysisLevel) &&
                     UseLegacyDependencyResolver == other.UseLegacyDependencyResolver &&
                     RestoreDoNotWriteDependencyGraphSpec == other.RestoreDoNotWriteDependencyGraphSpec;
@@ -291,6 +300,7 @@ namespace NuGet.ProjectModel
             clone.RestoreAuditProperties = RestoreAuditProperties?.Clone();
             clone.SdkAnalysisLevel = SdkAnalysisLevel;
             clone.UsingMicrosoftNETSdk = UsingMicrosoftNETSdk;
+            clone.RestoreEnableAnalyzerAssets = RestoreEnableAnalyzerAssets;
             clone.UseLegacyDependencyResolver = UseLegacyDependencyResolver;
             clone.RestoreDoNotWriteDependencyGraphSpec = RestoreDoNotWriteDependencyGraphSpec;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -155,11 +155,6 @@ namespace NuGet.ProjectModel
         /// </summary>
         public bool RestoreDoNotWriteDependencyGraphSpec { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether analyzer assets should be restored.
-        /// </summary>
-        public bool RestoreEnableAnalyzerAssets { get; set; }
-
         public override int GetHashCode()
         {
             StringComparer osStringComparer = PathUtility.GetStringComparerBasedOnOS();
@@ -194,7 +189,6 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(SdkAnalysisLevel);
             hashCode.AddObject(UseLegacyDependencyResolver);
             hashCode.AddObject(RestoreDoNotWriteDependencyGraphSpec);
-            hashCode.AddObject(RestoreEnableAnalyzerAssets);
 
             return hashCode.CombinedHash;
         }
@@ -244,8 +238,7 @@ namespace NuGet.ProjectModel
                    UsingMicrosoftNETSdk == other.UsingMicrosoftNETSdk &&
                     EqualityUtility.EqualsWithNullCheck(SdkAnalysisLevel, other.SdkAnalysisLevel) &&
                     UseLegacyDependencyResolver == other.UseLegacyDependencyResolver &&
-                    RestoreDoNotWriteDependencyGraphSpec == other.RestoreDoNotWriteDependencyGraphSpec &&
-                    RestoreEnableAnalyzerAssets == other.RestoreEnableAnalyzerAssets;
+                    RestoreDoNotWriteDependencyGraphSpec == other.RestoreDoNotWriteDependencyGraphSpec;
         }
 
         private HashSet<string> GetSources(IList<PackageSource> sources)
@@ -300,7 +293,6 @@ namespace NuGet.ProjectModel
             clone.UsingMicrosoftNETSdk = UsingMicrosoftNETSdk;
             clone.UseLegacyDependencyResolver = UseLegacyDependencyResolver;
             clone.RestoreDoNotWriteDependencyGraphSpec = RestoreDoNotWriteDependencyGraphSpec;
-            clone.RestoreEnableAnalyzerAssets = RestoreEnableAnalyzerAssets;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+~static readonly NuGet.ProjectModel.LockFileItem.CompilerApiVersionProperty -> string
+NuGet.ProjectModel.LockFileTargetLibrary.AnalyzerAssets.get -> System.Collections.Generic.IList<NuGet.ProjectModel.LockFileItem!>!
+NuGet.ProjectModel.LockFileTargetLibrary.AnalyzerAssets.set -> void
+NuGet.ProjectModel.ProjectRestoreMetadata.RestoreEnableAnalyzerAssets.get -> bool
+NuGet.ProjectModel.ProjectRestoreMetadata.RestoreEnableAnalyzerAssets.set -> void

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -2,5 +2,5 @@
 ~static readonly NuGet.ProjectModel.LockFileItem.CompilerApiVersionProperty -> string
 NuGet.ProjectModel.LockFileTargetLibrary.AnalyzerAssets.get -> System.Collections.Generic.IList<NuGet.ProjectModel.LockFileItem!>!
 NuGet.ProjectModel.LockFileTargetLibrary.AnalyzerAssets.set -> void
-NuGet.ProjectModel.ProjectRestoreMetadata.RestoreEnableAnalyzerAssets.get -> bool
-NuGet.ProjectModel.ProjectRestoreMetadata.RestoreEnableAnalyzerAssets.set -> void
+NuGet.ProjectModel.TargetFrameworkInformation.RestoreEnableAnalyzerAssets.get -> bool
+NuGet.ProjectModel.TargetFrameworkInformation.RestoreEnableAnalyzerAssets.init -> void

--- a/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.ProjectModel/PublicAPI.Unshipped.txt
@@ -2,5 +2,5 @@
 ~static readonly NuGet.ProjectModel.LockFileItem.CompilerApiVersionProperty -> string
 NuGet.ProjectModel.LockFileTargetLibrary.AnalyzerAssets.get -> System.Collections.Generic.IList<NuGet.ProjectModel.LockFileItem!>!
 NuGet.ProjectModel.LockFileTargetLibrary.AnalyzerAssets.set -> void
-NuGet.ProjectModel.TargetFrameworkInformation.RestoreEnableAnalyzerAssets.get -> bool
-NuGet.ProjectModel.TargetFrameworkInformation.RestoreEnableAnalyzerAssets.init -> void
+NuGet.ProjectModel.ProjectRestoreMetadata.RestoreEnableAnalyzerAssets.get -> bool
+NuGet.ProjectModel.ProjectRestoreMetadata.RestoreEnableAnalyzerAssets.set -> void

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -63,12 +63,6 @@ namespace NuGet.ProjectModel
         public bool Warn { get; init; }
 
         /// <summary>
-        /// Whether analyzer assets should be tracked in the assets file for this target framework.
-        /// Reflects the framework-specific, gated value of <c>RestoreEnableAnalyzerAssets</c>.
-        /// </summary>
-        public bool RestoreEnableAnalyzerAssets { get; init; }
-
-        /// <summary>
         /// List of dependencies that are not part of the graph resolution.
         /// </summary>
         public ImmutableArray<DownloadDependency> DownloadDependencies
@@ -144,7 +138,6 @@ namespace NuGet.ProjectModel
             Imports = cloneFrom.Imports;
             AssetTargetFallback = cloneFrom.AssetTargetFallback;
             Warn = cloneFrom.Warn;
-            RestoreEnableAnalyzerAssets = cloneFrom.RestoreEnableAnalyzerAssets;
             DownloadDependencies = cloneFrom.DownloadDependencies;
             CentralPackageVersions = cloneFrom.CentralPackageVersions;
             FrameworkReferences = cloneFrom.FrameworkReferences;
@@ -166,7 +159,6 @@ namespace NuGet.ProjectModel
             hashCode.AddUnorderedSequence(Dependencies);
             hashCode.AddSequence((IReadOnlyList<NuGetFramework>)Imports);
             hashCode.AddObject(Warn);
-            hashCode.AddObject(RestoreEnableAnalyzerAssets);
             hashCode.AddUnorderedSequence(DownloadDependencies);
             hashCode.AddUnorderedSequence(FrameworkReferences);
             if (RuntimeIdentifierGraphPath != null)
@@ -200,7 +192,6 @@ namespace NuGet.ProjectModel
                    EqualityUtility.OrderedEquals(Dependencies, other.Dependencies, dependency => dependency.Name, StringComparer.OrdinalIgnoreCase) &&
                    Imports.SequenceEqualWithNullCheck(other.Imports) &&
                    Warn == other.Warn &&
-                   RestoreEnableAnalyzerAssets == other.RestoreEnableAnalyzerAssets &&
                    AssetTargetFallback == other.AssetTargetFallback &&
                    EqualityUtility.OrderedEquals(DownloadDependencies, other.DownloadDependencies, e => e.Name, StringComparer.OrdinalIgnoreCase) &&
                    EqualityUtility.OrderedEquals(FrameworkReferences, other.FrameworkReferences, e => e.Name, ComparisonUtility.FrameworkReferenceNameComparer) &&

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -63,6 +63,12 @@ namespace NuGet.ProjectModel
         public bool Warn { get; init; }
 
         /// <summary>
+        /// Whether analyzer assets should be tracked in the assets file for this target framework.
+        /// Reflects the framework-specific, gated value of <c>RestoreEnableAnalyzerAssets</c>.
+        /// </summary>
+        public bool RestoreEnableAnalyzerAssets { get; init; }
+
+        /// <summary>
         /// List of dependencies that are not part of the graph resolution.
         /// </summary>
         public ImmutableArray<DownloadDependency> DownloadDependencies
@@ -138,6 +144,7 @@ namespace NuGet.ProjectModel
             Imports = cloneFrom.Imports;
             AssetTargetFallback = cloneFrom.AssetTargetFallback;
             Warn = cloneFrom.Warn;
+            RestoreEnableAnalyzerAssets = cloneFrom.RestoreEnableAnalyzerAssets;
             DownloadDependencies = cloneFrom.DownloadDependencies;
             CentralPackageVersions = cloneFrom.CentralPackageVersions;
             FrameworkReferences = cloneFrom.FrameworkReferences;
@@ -159,6 +166,7 @@ namespace NuGet.ProjectModel
             hashCode.AddUnorderedSequence(Dependencies);
             hashCode.AddSequence((IReadOnlyList<NuGetFramework>)Imports);
             hashCode.AddObject(Warn);
+            hashCode.AddObject(RestoreEnableAnalyzerAssets);
             hashCode.AddUnorderedSequence(DownloadDependencies);
             hashCode.AddUnorderedSequence(FrameworkReferences);
             if (RuntimeIdentifierGraphPath != null)
@@ -192,6 +200,7 @@ namespace NuGet.ProjectModel
                    EqualityUtility.OrderedEquals(Dependencies, other.Dependencies, dependency => dependency.Name, StringComparer.OrdinalIgnoreCase) &&
                    Imports.SequenceEqualWithNullCheck(other.Imports) &&
                    Warn == other.Warn &&
+                   RestoreEnableAnalyzerAssets == other.RestoreEnableAnalyzerAssets &&
                    AssetTargetFallback == other.AssetTargetFallback &&
                    EqualityUtility.OrderedEquals(DownloadDependencies, other.DownloadDependencies, e => e.Name, StringComparer.OrdinalIgnoreCase) &&
                    EqualityUtility.OrderedEquals(FrameworkReferences, other.FrameworkReferences, e => e.Name, ComparisonUtility.FrameworkReferenceNameComparer) &&

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3328,6 +3328,86 @@ EndGlobal";
             return assetsFile;
         }
 
+#if SDK_NEXT
+        [Theory]
+        [InlineData(false, false)] // Standard task-based restore
+        [InlineData(true, true)]   // Static graph with PackageSpecFactory
+        [InlineData(true, false)]  // Static graph with legacy PackageSpec construction
+        public async Task DotnetRestore_MultiTargetedProjectWithAnalyzerAssetsEnabledForOneFramework_WritesAnalyzersForAllFrameworks(
+            bool useStaticGraphRestore,
+            bool usePackageSpecFactory)
+        {
+            // Arrange
+            using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
+            const string PackageId = "AnalyzerPackage";
+            const string AnalyzerPath = "analyzers/dotnet/cs/Analyzer.dll";
+            var package = new SimpleTestPackageContext(PackageId, "1.0.0")
+            {
+                UseDefaultRuntimeAssemblies = false,
+            };
+            package.AddFile(AnalyzerPath);
+            package.AddFile("lib/netstandard2.0/Package.dll");
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, package);
+
+            var projectName = "AnalyzerProject";
+            var workingDirectory = Path.Combine(pathContext.SolutionRoot, projectName);
+            var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+            _dotnetFixture.CreateDotnetNewProject(
+                pathContext.SolutionRoot,
+                projectName,
+                "classlib",
+                testOutputHelper: _testOutputHelper);
+
+            using (var stream = File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
+            {
+                var xml = XDocument.Load(stream);
+                ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net10.0;net11.0");
+                ProjectFileUtils.AddProperty(
+                    xml,
+                    "RestoreEnableAnalyzerAssets",
+                    bool.TrueString,
+                    " '$(TargetFramework)' == 'net11.0' ");
+                ProjectFileUtils.AddItem(
+                    xml,
+                    "PackageReference",
+                    PackageId,
+                    string.Empty,
+                    [],
+                    new Dictionary<string, string>() { { "Version", package.Version } });
+                ProjectFileUtils.WriteXmlToFile(xml, stream);
+            }
+
+            var environmentVariables = new Dictionary<string, string>()
+            {
+                { PackageSpecFactory.EnvironmentVariableName, usePackageSpecFactory.ToString() }
+            };
+            string staticGraphArgument = useStaticGraphRestore
+                ? " /p:RestoreUseStaticGraphEvaluation=true"
+                : string.Empty;
+
+            // Act
+            _dotnetFixture.RunDotnetExpectSuccess(
+                workingDirectory,
+                $"restore {projectFile} /p:DisableImplicitFrameworkReferences=true{staticGraphArgument}",
+                environmentVariables,
+                testOutputHelper: _testOutputHelper);
+
+            // Assert
+            string assetsFilePath = Path.Combine(workingDirectory, "obj", LockFileFormat.AssetsFileName);
+            LockFile assetsFile = new LockFileFormat().Read(assetsFilePath);
+            assetsFile.PackageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
+
+            foreach (string targetAlias in new[] { "net10.0", "net11.0" })
+            {
+                LockFileTarget target = assetsFile.GetTarget(targetAlias, string.Empty);
+                LockFileTargetLibrary targetLibrary = target.Libraries.Single(
+                    library => library.Name.Equals(PackageId, StringComparison.OrdinalIgnoreCase));
+                targetLibrary.AnalyzerAssets.Should().ContainSingle(
+                    analyzer => analyzer.Path.Equals(AnalyzerPath, StringComparison.Ordinal));
+            }
+        }
+#endif
+
         [Theory]
         [InlineData(null, "all")]
         [InlineData("direct", "direct")]

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3332,7 +3332,7 @@ EndGlobal";
         [InlineData(false, false)] // Standard task-based restore
         [InlineData(true, true)]   // Static graph with PackageSpecFactory
         [InlineData(true, false)]  // Static graph with legacy PackageSpec construction
-        public async Task DotnetRestore_MultiTargetedProjectWithAnalyzerAssetsEnabled_WritesAnalyzersForAllFrameworks(
+        public async Task DotnetRestore_MultiTargetedProjectWithAnalyzerAssetsEnabledForOneFramework_WritesAnalyzersForAllFrameworks(
             bool useStaticGraphRestore,
             bool usePackageSpecFactory)
         {
@@ -3364,7 +3364,8 @@ EndGlobal";
                 ProjectFileUtils.AddProperty(
                     xml,
                     "RestoreEnableAnalyzerAssets",
-                    bool.TrueString);
+                    bool.TrueString,
+                    " '$(TargetFramework)' == 'net11.0' ");
                 ProjectFileUtils.AddItem(
                     xml,
                     "PackageReference",

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -3328,12 +3328,11 @@ EndGlobal";
             return assetsFile;
         }
 
-#if SDK_NEXT
         [Theory]
         [InlineData(false, false)] // Standard task-based restore
         [InlineData(true, true)]   // Static graph with PackageSpecFactory
         [InlineData(true, false)]  // Static graph with legacy PackageSpec construction
-        public async Task DotnetRestore_MultiTargetedProjectWithAnalyzerAssetsEnabledForOneFramework_WritesAnalyzersForAllFrameworks(
+        public async Task DotnetRestore_MultiTargetedProjectWithAnalyzerAssetsEnabled_WritesAnalyzersForAllFrameworks(
             bool useStaticGraphRestore,
             bool usePackageSpecFactory)
         {
@@ -3365,8 +3364,7 @@ EndGlobal";
                 ProjectFileUtils.AddProperty(
                     xml,
                     "RestoreEnableAnalyzerAssets",
-                    bool.TrueString,
-                    " '$(TargetFramework)' == 'net11.0' ");
+                    bool.TrueString);
                 ProjectFileUtils.AddItem(
                     xml,
                     "PackageReference",
@@ -3406,7 +3404,6 @@ EndGlobal";
                     analyzer => analyzer.Path.Equals(AnalyzerPath, StringComparison.Ordinal));
             }
         }
-#endif
 
         [Theory]
         [InlineData(null, "all")]

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/GenerateRestoreGraphFileTargetTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/GenerateRestoreGraphFileTargetTests.cs
@@ -66,5 +66,57 @@ namespace Msbuild.Integration.Test
                 regularDgSpec.Should().BeEquivalentTo(staticGraphDgSpec);
             }
         }
+
+        [PlatformFact(Platform.Windows)]
+        public async Task GenerateRestoreGraphFile_WithRestoreEnableAnalyzerAssets_WritesMetadataForBothStaticGraphAndStandard()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+                var net461 = NuGetFramework.Parse("net461");
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+                packageX.Files.Clear();
+                packageX.AddFile("lib/net461/a.dll");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    net461);
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                solution.Projects.Add(projectA);
+
+                solution.Create();
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                    pathContext.PackageSource,
+                    packageX);
+
+                var standardDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "standard.dgspec.json");
+                var staticGraphDgSpecFile = Path.Combine(pathContext.WorkingDirectory, "staticGraph.dgspec.json");
+                var targetPath = projectA.ProjectPath;
+
+                // Act
+                // RestoreEnableAnalyzerAssets is a project-wide opt-in read from project restore metadata. It must
+                // be captured identically by the standard (task-based) and static graph restore evaluation paths.
+                _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:GenerateRestoreGraphFile /p:RestoreEnableAnalyzerAssets=true /p:RestoreGraphOutputPath=\"{standardDgSpecFile}\" {targetPath}", testOutputHelper: _testOutputHelper);
+                _msbuildFixture.RunMsBuild(pathContext.WorkingDirectory, $"/t:GenerateRestoreGraphFile /p:RestoreEnableAnalyzerAssets=true /p:RestoreGraphOutputPath=\"{staticGraphDgSpecFile}\" /p:RestoreUseStaticGraphEvaluation=true {targetPath}", testOutputHelper: _testOutputHelper);
+
+                var regularDgSpec = File.ReadAllText(standardDgSpecFile);
+                var staticGraphDgSpec = File.ReadAllText(staticGraphDgSpecFile);
+
+                // Assert
+                // The property is only serialized when true, so its presence proves the opt-in reached restore metadata.
+                regularDgSpec.Should().Contain("restoreEnableAnalyzerAssets");
+                staticGraphDgSpec.Should().Contain("restoreEnableAnalyzerAssets");
+                regularDgSpec.Should().BeEquivalentTo(staticGraphDgSpec);
+            }
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetPropertyDefaultsTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetPropertyDefaultsTests.cs
@@ -160,5 +160,48 @@ namespace Msbuild.Integration.Test
             // Assert
             resultText.Should().Be(expected);
         }
+
+        [Theory]
+        // .NET 11 and greater: opt-in is honored.
+        [InlineData("net11.0", "true")]
+        [InlineData("net12.0", "true")]
+        // Older .NET (Core): opt-in is forced off.
+        [InlineData("net10.0", "false")]
+        [InlineData("net9.0", "false")]
+        [InlineData("net8.0", "false")]
+        [InlineData("netcoreapp3.1", "false")]
+        // .NET Standard: not available.
+        [InlineData("netstandard2.1", "false")]
+        [InlineData("netstandard2.0", "false")]
+        // .NET Framework: not available.
+        [InlineData("net48", "false")]
+        public void AnalyzerAssetsAvailability_RestoreEnableAnalyzerAssets_OnlyAvailableForNet11OrGreater(string targetFramework, string expected)
+        {
+            // Arrange
+            using var testDirectory = TestDirectory.Create();
+
+            // The opt-in is set in the project so that the gating in NuGet.targets (imported afterwards) can override it.
+            string projectText = @"<Project>
+    <PropertyGroup>
+        <RestoreEnableAnalyzerAssets>true</RestoreEnableAnalyzerAssets>
+    </PropertyGroup>
+    <Import Project=""$(NuGetRestoreTargets)"" />
+</Project>";
+            var projectFilePath = Path.Combine(testDirectory, "my.proj");
+            File.WriteAllText(projectFilePath, projectText);
+
+            string args = $"{projectFilePath} -getProperty:RestoreEnableAnalyzerAssets";
+
+            var framework = NuGetFramework.Parse(targetFramework);
+            args += $" -p:TargetFrameworkIdentifier={framework.Framework}";
+            args += $" -p:TargetFrameworkVersion={framework.Version}";
+
+            // Act
+            var result = _fixture.RunMsBuild(testDirectory, args);
+            var resultText = result.Output.Trim();
+
+            // Assert
+            resultText.Should().Be(expected);
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetPropertyDefaultsTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/NuGetPropertyDefaultsTests.cs
@@ -162,25 +162,22 @@ namespace Msbuild.Integration.Test
         }
 
         [Theory]
-        // .NET 11 and greater: opt-in is honored.
-        [InlineData("net11.0", "true")]
-        [InlineData("net12.0", "true")]
-        // Older .NET (Core): opt-in is forced off.
-        [InlineData("net10.0", "false")]
-        [InlineData("net9.0", "false")]
-        [InlineData("net8.0", "false")]
-        [InlineData("netcoreapp3.1", "false")]
-        // .NET Standard: not available.
-        [InlineData("netstandard2.1", "false")]
-        [InlineData("netstandard2.0", "false")]
-        // .NET Framework: not available.
-        [InlineData("net48", "false")]
-        public void AnalyzerAssetsAvailability_RestoreEnableAnalyzerAssets_OnlyAvailableForNet11OrGreater(string targetFramework, string expected)
+        // An explicit RestoreEnableAnalyzerAssets opt-in is honored on every target framework, so users can
+        // opt into the new behavior before it is enabled by default.
+        [InlineData("net12.0")]
+        [InlineData("net11.0")]
+        [InlineData("net10.0")]
+        [InlineData("net9.0")]
+        [InlineData("net8.0")]
+        [InlineData("netcoreapp3.1")]
+        [InlineData("netstandard2.1")]
+        [InlineData("netstandard2.0")]
+        [InlineData("net48")]
+        public void AnalyzerAssetsAvailability_RestoreEnableAnalyzerAssets_OptInHonoredOnAllFrameworks(string targetFramework)
         {
             // Arrange
             using var testDirectory = TestDirectory.Create();
 
-            // The opt-in is set in the project so that the gating in NuGet.targets (imported afterwards) can override it.
             string projectText = @"<Project>
     <PropertyGroup>
         <RestoreEnableAnalyzerAssets>true</RestoreEnableAnalyzerAssets>
@@ -201,7 +198,40 @@ namespace Msbuild.Integration.Test
             var resultText = result.Output.Trim();
 
             // Assert
-            resultText.Should().Be(expected);
+            resultText.Should().Be("true");
+        }
+
+        [Theory]
+        // Analyzer assets restore defaults to off when the opt-in is not set, on every target framework.
+        [InlineData("net12.0")]
+        [InlineData("net11.0")]
+        [InlineData("net10.0")]
+        [InlineData("net8.0")]
+        [InlineData("netstandard2.0")]
+        [InlineData("net48")]
+        public void AnalyzerAssetsAvailability_RestoreEnableAnalyzerAssets_DefaultsToFalse(string targetFramework)
+        {
+            // Arrange
+            using var testDirectory = TestDirectory.Create();
+
+            string projectText = @"<Project>
+    <Import Project=""$(NuGetRestoreTargets)"" />
+</Project>";
+            var projectFilePath = Path.Combine(testDirectory, "my.proj");
+            File.WriteAllText(projectFilePath, projectText);
+
+            string args = $"{projectFilePath} -getProperty:RestoreEnableAnalyzerAssets";
+
+            var framework = NuGetFramework.Parse(targetFramework);
+            args += $" -p:TargetFrameworkIdentifier={framework.Framework}";
+            args += $" -p:TargetFrameworkVersion={framework.Version}";
+
+            // Act
+            var result = _fixture.RunMsBuild(testDirectory, args);
+            var resultText = result.Output.Trim();
+
+            // Assert
+            resultText.Should().Be("false");
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -1289,6 +1289,37 @@ namespace NuGet.Build.Tasks.Console.Test
 
         [Theory]
         [InlineData("true", "false", "false", true)]
+        [InlineData("false", "true", "false", true)]
+        [InlineData("false", "false", "true", true)]
+        [InlineData("false", "false", "false", false)]
+        public void GetRestoreEnableAnalyzerAssets(string outerValue, string firstInnerValue, string secondInnerValue, bool expected)
+        {
+            // Arrange
+            var project = new MockMSBuildProject(new Dictionary<string, string>
+            {
+                ["RestoreEnableAnalyzerAssets"] = outerValue,
+            });
+            var innerBuilds = new List<IMSBuildProject>
+            {
+                new MockMSBuildProject(new Dictionary<string, string>
+                {
+                    ["RestoreEnableAnalyzerAssets"] = firstInnerValue,
+                }),
+                new MockMSBuildProject(new Dictionary<string, string>
+                {
+                    ["RestoreEnableAnalyzerAssets"] = secondInnerValue,
+                }),
+            };
+
+            // Act
+            bool result = MSBuildStaticGraphRestore.GetRestoreEnableAnalyzerAssets(project, innerBuilds);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("true", "false", "false", true)]
         [InlineData("true", "", "false", true)]
         [InlineData("", "", "false", false)]
         public void GetPackagePruningDefault(string firstDefault, string secondDefault, string thirdDefault, bool expected)

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -1098,6 +1098,42 @@ namespace NuGet.Build.Tasks.Console.Test
         }
 
         [Fact]
+        public void GetTargetFrameworkInfos_WithRestoreEnableAnalyzerAssets_SetsValuePerFramework()
+        {
+            // Arrange
+            var innerNodes = new Dictionary<string, IMSBuildProject>
+            {
+                ["net8.0"] = new MockMSBuildProject("Project",
+                    new Dictionary<string, string>
+                    {
+                        { "TargetFramework", "net8.0" },
+                        { "TargetFrameworkIdentifier", ".NETCoreApp" },
+                        { "TargetFrameworkVersion", "v8.0" },
+                        { "TargetFrameworkMoniker", ".NETCoreApp,Version=v8.0" },
+                        { "RestoreEnableAnalyzerAssets", "false" },
+                    },
+                    new Dictionary<string, IList<IMSBuildItem>>()),
+                ["net9.0"] = new MockMSBuildProject("Project",
+                    new Dictionary<string, string>
+                    {
+                        { "TargetFramework", "net9.0" },
+                        { "TargetFrameworkIdentifier", ".NETCoreApp" },
+                        { "TargetFrameworkVersion", "v9.0" },
+                        { "TargetFrameworkMoniker", ".NETCoreApp,Version=v9.0" },
+                        { "RestoreEnableAnalyzerAssets", "true" },
+                    },
+                    new Dictionary<string, IList<IMSBuildItem>>()),
+            };
+
+            // Act
+            var targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: false, isPruningEnabledGlobally: false);
+
+            // Assert
+            targetFrameworkInfos.Single(e => e.TargetAlias == "net8.0").RestoreEnableAnalyzerAssets.Should().BeFalse();
+            targetFrameworkInfos.Single(e => e.TargetAlias == "net9.0").RestoreEnableAnalyzerAssets.Should().BeTrue();
+        }
+
+        [Fact]
         public void GetTargetFrameworkInfos_WithPrunePackageReferences()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Console.Test/MSBuildStaticGraphRestoreTests.cs
@@ -1098,42 +1098,6 @@ namespace NuGet.Build.Tasks.Console.Test
         }
 
         [Fact]
-        public void GetTargetFrameworkInfos_WithRestoreEnableAnalyzerAssets_SetsValuePerFramework()
-        {
-            // Arrange
-            var innerNodes = new Dictionary<string, IMSBuildProject>
-            {
-                ["net8.0"] = new MockMSBuildProject("Project",
-                    new Dictionary<string, string>
-                    {
-                        { "TargetFramework", "net8.0" },
-                        { "TargetFrameworkIdentifier", ".NETCoreApp" },
-                        { "TargetFrameworkVersion", "v8.0" },
-                        { "TargetFrameworkMoniker", ".NETCoreApp,Version=v8.0" },
-                        { "RestoreEnableAnalyzerAssets", "false" },
-                    },
-                    new Dictionary<string, IList<IMSBuildItem>>()),
-                ["net9.0"] = new MockMSBuildProject("Project",
-                    new Dictionary<string, string>
-                    {
-                        { "TargetFramework", "net9.0" },
-                        { "TargetFrameworkIdentifier", ".NETCoreApp" },
-                        { "TargetFrameworkVersion", "v9.0" },
-                        { "TargetFrameworkMoniker", ".NETCoreApp,Version=v9.0" },
-                        { "RestoreEnableAnalyzerAssets", "true" },
-                    },
-                    new Dictionary<string, IList<IMSBuildItem>>()),
-            };
-
-            // Act
-            var targetFrameworkInfos = MSBuildStaticGraphRestore.GetTargetFrameworkInfos(innerNodes, isCpvmEnabled: false, isPruningEnabledGlobally: false);
-
-            // Assert
-            targetFrameworkInfos.Single(e => e.TargetAlias == "net8.0").RestoreEnableAnalyzerAssets.Should().BeFalse();
-            targetFrameworkInfos.Single(e => e.TargetAlias == "net9.0").RestoreEnableAnalyzerAssets.Should().BeTrue();
-        }
-
-        [Fact]
         public void GetTargetFrameworkInfos_WithPrunePackageReferences()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -5007,8 +5007,8 @@ namespace NuGet.Commands.Test
                         targetFrameworks: "net8.0;net9.0",
                         crossTargeting: true,
                         restoreEnableAnalyzerAssets: true),
-                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0"),
-                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0"),
+                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0", restoreEnableAnalyzerAssets: false),
+                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0", restoreEnableAnalyzerAssets: false),
                 };
 
                 // Act
@@ -5044,6 +5044,34 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 projectSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public void GetPackageSpec_WithAnalyzerAssetsEnabledInAnyTargetFramework_EnablesAnalyzerAssets()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var projectRoot = Path.Combine(workingDir, "a");
+                var projectPath = Path.Combine(projectRoot, "a.csproj");
+
+                var items = new List<IDictionary<string, string>>
+                {
+                    CreateAnalyzerProjectSpecItem(
+                        projectPath,
+                        targetFrameworks: "net8.0;net9.0",
+                        crossTargeting: true,
+                        restoreEnableAnalyzerAssets: false),
+                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0", restoreEnableAnalyzerAssets: false),
+                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0", restoreEnableAnalyzerAssets: true),
+                };
+
+                // Act
+                var projectSpec = GetSingleProjectSpec(items);
+
+                // Assert
+                projectSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
             }
         }
 
@@ -5083,9 +5111,10 @@ namespace NuGet.Commands.Test
 
         private static Dictionary<string, string> CreateAnalyzerTargetFrameworkInformationItem(
             string targetFramework,
-            string targetFrameworkVersion)
+            string targetFrameworkVersion,
+            bool? restoreEnableAnalyzerAssets = null)
         {
-            return new Dictionary<string, string>()
+            var item = new Dictionary<string, string>()
             {
                 { "Type", "TargetFrameworkInformation" },
                 { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
@@ -5094,6 +5123,13 @@ namespace NuGet.Commands.Test
                 { "TargetFrameworkVersion", $"v{targetFrameworkVersion}" },
                 { "TargetFrameworkMoniker", $".NETCoreApp,Version=v{targetFrameworkVersion}" },
             };
+
+            if (restoreEnableAnalyzerAssets.HasValue)
+            {
+                item["RestoreEnableAnalyzerAssets"] = restoreEnableAnalyzerAssets.Value ? "true" : "false";
+            }
+
+            return item;
         }
 
         private Dictionary<string, string> WithUniqueName(Dictionary<string, string> item, string uniqueName)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -988,6 +988,40 @@ namespace NuGet.Commands.Test
                     { "PrivateAssets", "all" },
                 });
 
+                // A net46 -> AnalyzerInclude
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "Dependency" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "Id", "analyzerInclude" },
+                    { "VersionRange", "1.0.0" },
+                    { "TargetFrameworks", "net46" },
+                    { "IncludeAssets", "compile;analyzers" },
+                    { "ExcludeAssets", "compile" },
+                });
+
+                // A net46 -> AnalyzerExclude
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "Dependency" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "Id", "analyzerExclude" },
+                    { "VersionRange", "1.0.0" },
+                    { "TargetFrameworks", "net46" },
+                    { "ExcludeAssets", "analyzers" },
+                });
+
+                // A net46 -> AnalyzerPrivate
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "Dependency" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "Id", "analyzerPrivate" },
+                    { "VersionRange", "1.0.0" },
+                    { "TargetFrameworks", "net46" },
+                    { "PrivateAssets", "analyzers" },
+                });
+
                 var wrappedItems = items.Select(CreateItems).ToList();
 
                 // Act
@@ -996,6 +1030,9 @@ namespace NuGet.Commands.Test
                 var x = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46")).Dependencies.Single(e => e.Name == "x");
                 var y = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46")).Dependencies.Single(e => e.Name == "y");
                 var z = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46")).Dependencies.Single(e => e.Name == "z");
+                var analyzerInclude = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46")).Dependencies.Single(e => e.Name == "analyzerInclude");
+                var analyzerExclude = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46")).Dependencies.Single(e => e.Name == "analyzerExclude");
+                var analyzerPrivate = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46")).Dependencies.Single(e => e.Name == "analyzerPrivate");
 
                 // Assert
                 // X
@@ -1009,6 +1046,18 @@ namespace NuGet.Commands.Test
                 // Z
                 Assert.Equal(LibraryIncludeFlags.All, z.IncludeType);
                 Assert.Equal(LibraryIncludeFlags.All, z.SuppressParent);
+
+                // AnalyzerInclude
+                Assert.Equal(LibraryIncludeFlags.Analyzers, analyzerInclude.IncludeType);
+                Assert.Equal(LibraryIncludeFlagUtils.DefaultSuppressParent, analyzerInclude.SuppressParent);
+
+                // AnalyzerExclude
+                Assert.Equal(LibraryIncludeFlags.All & ~LibraryIncludeFlags.Analyzers, analyzerExclude.IncludeType);
+                Assert.Equal(LibraryIncludeFlagUtils.DefaultSuppressParent, analyzerExclude.SuppressParent);
+
+                // AnalyzerPrivate
+                Assert.Equal(LibraryIncludeFlags.All, analyzerPrivate.IncludeType);
+                Assert.Equal(LibraryIncludeFlags.Analyzers, analyzerPrivate.SuppressParent);
             }
         }
 
@@ -4917,6 +4966,133 @@ namespace NuGet.Commands.Test
                 // Assert
                 project1Spec.RestoreMetadata.RestoreDoNotWriteDependencyGraphSpec.Should().Be(expectedValue);
             }
+        }
+
+        [Fact]
+        public void GetPackageSpec_WithAnalyzerAssetMetadata_PopulatesAnalyzerRestoreMetadata()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var projectRoot = Path.Combine(workingDir, "a");
+                var projectPath = Path.Combine(projectRoot, "a.csproj");
+
+                var items = new List<IDictionary<string, string>>
+                {
+                    CreateAnalyzerProjectSpecItem(projectPath),
+                };
+
+                // Act
+                var projectSpec = GetSingleProjectSpec(items);
+
+                // Assert
+                projectSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public void GetPackageSpec_WithProjectSpecAnalyzerAssetsEnabled_EnablesAnalyzerAssets()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var projectRoot = Path.Combine(workingDir, "a");
+                var projectPath = Path.Combine(projectRoot, "a.csproj");
+
+                var items = new List<IDictionary<string, string>>
+                {
+                    CreateAnalyzerProjectSpecItem(
+                        projectPath,
+                        targetFrameworks: "net8.0;net9.0",
+                        restoreEnableAnalyzerAssets: true,
+                        crossTargeting: true),
+                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0"),
+                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0"),
+                };
+
+                // Act
+                var projectSpec = GetSingleProjectSpec(items);
+
+                // Assert
+                projectSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public void GetPackageSpec_WithProjectSpecAnalyzerAssetsDisabled_DoesNotEnableAnalyzerAssets()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var projectRoot = Path.Combine(workingDir, "a");
+                var projectPath = Path.Combine(projectRoot, "a.csproj");
+
+                var items = new List<IDictionary<string, string>>
+                {
+                    CreateAnalyzerProjectSpecItem(
+                        projectPath,
+                        targetFrameworks: "net8.0;net9.0",
+                        restoreEnableAnalyzerAssets: false,
+                        crossTargeting: true),
+                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0"),
+                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0"),
+                };
+
+                // Act
+                var projectSpec = GetSingleProjectSpec(items);
+
+                // Assert
+                projectSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
+            }
+        }
+
+        private PackageSpec GetSingleProjectSpec(IEnumerable<IDictionary<string, string>> items)
+        {
+            var wrappedItems = items.Select(CreateItems).ToList();
+            var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+
+            return dgSpec.Projects.Single();
+        }
+
+        private static Dictionary<string, string> CreateAnalyzerProjectSpecItem(
+            string projectPath,
+            string targetFrameworks = "net46",
+            bool restoreEnableAnalyzerAssets = true,
+            bool crossTargeting = false)
+        {
+            var item = new Dictionary<string, string>()
+            {
+                { "Type", "ProjectSpec" },
+                { "Version", "2.0.0" },
+                { "ProjectName", "a" },
+                { "ProjectStyle", "PackageReference" },
+                { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                { "ProjectPath", projectPath },
+                { "TargetFrameworks", targetFrameworks },
+                { "RestoreEnableAnalyzerAssets", restoreEnableAnalyzerAssets ? "true" : "false" },
+            };
+
+            if (crossTargeting)
+            {
+                item["CrossTargeting"] = "true";
+            }
+
+            return item;
+        }
+
+        private static Dictionary<string, string> CreateAnalyzerTargetFrameworkInformationItem(
+            string targetFramework,
+            string targetFrameworkVersion)
+        {
+            return new Dictionary<string, string>()
+            {
+                { "Type", "TargetFrameworkInformation" },
+                { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                { "TargetFramework", targetFramework },
+                { "TargetFrameworkIdentifier", ".NETCoreApp" },
+                { "TargetFrameworkVersion", $"v{targetFrameworkVersion}" },
+                { "TargetFrameworkMoniker", $".NETCoreApp,Version=v{targetFrameworkVersion}" },
+            };
         }
 
         private Dictionary<string, string> WithUniqueName(Dictionary<string, string> item, string uniqueName)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -4969,7 +4969,7 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
-        public void GetPackageSpec_WithAnalyzerAssetMetadata_PopulatesAnalyzerRestoreMetadata()
+        public void GetPackageSpec_WithAnalyzerAssetMetadata_PopulatesTargetFramework()
         {
             using (var workingDir = TestDirectory.Create())
             {
@@ -4979,14 +4979,15 @@ namespace NuGet.Commands.Test
 
                 var items = new List<IDictionary<string, string>>
                 {
-                    CreateAnalyzerProjectSpecItem(projectPath),
+                    CreateAnalyzerProjectSpecItem(projectPath, targetFrameworks: "net8.0"),
+                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0", restoreEnableAnalyzerAssets: true),
                 };
 
                 // Act
                 var projectSpec = GetSingleProjectSpec(items);
 
                 // Assert
-                projectSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
+                projectSpec.TargetFrameworks.Single().RestoreEnableAnalyzerAssets.Should().BeTrue();
             }
         }
 
@@ -5004,17 +5005,16 @@ namespace NuGet.Commands.Test
                     CreateAnalyzerProjectSpecItem(
                         projectPath,
                         targetFrameworks: "net8.0;net9.0",
-                        restoreEnableAnalyzerAssets: true,
                         crossTargeting: true),
-                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0"),
-                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0"),
+                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0", restoreEnableAnalyzerAssets: true),
+                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0", restoreEnableAnalyzerAssets: true),
                 };
 
                 // Act
                 var projectSpec = GetSingleProjectSpec(items);
 
                 // Assert
-                projectSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
+                projectSpec.TargetFrameworks.Should().OnlyContain(f => f.RestoreEnableAnalyzerAssets);
             }
         }
 
@@ -5032,17 +5032,16 @@ namespace NuGet.Commands.Test
                     CreateAnalyzerProjectSpecItem(
                         projectPath,
                         targetFrameworks: "net8.0;net9.0",
-                        restoreEnableAnalyzerAssets: false,
                         crossTargeting: true),
-                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0"),
-                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0"),
+                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0", restoreEnableAnalyzerAssets: false),
+                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0", restoreEnableAnalyzerAssets: false),
                 };
 
                 // Act
                 var projectSpec = GetSingleProjectSpec(items);
 
                 // Assert
-                projectSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
+                projectSpec.TargetFrameworks.Should().OnlyContain(f => !f.RestoreEnableAnalyzerAssets);
             }
         }
 
@@ -5057,7 +5056,6 @@ namespace NuGet.Commands.Test
         private static Dictionary<string, string> CreateAnalyzerProjectSpecItem(
             string projectPath,
             string targetFrameworks = "net46",
-            bool restoreEnableAnalyzerAssets = true,
             bool crossTargeting = false)
         {
             var item = new Dictionary<string, string>()
@@ -5069,7 +5067,6 @@ namespace NuGet.Commands.Test
                 { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                 { "ProjectPath", projectPath },
                 { "TargetFrameworks", targetFrameworks },
-                { "RestoreEnableAnalyzerAssets", restoreEnableAnalyzerAssets ? "true" : "false" },
             };
 
             if (crossTargeting)
@@ -5082,7 +5079,8 @@ namespace NuGet.Commands.Test
 
         private static Dictionary<string, string> CreateAnalyzerTargetFrameworkInformationItem(
             string targetFramework,
-            string targetFrameworkVersion)
+            string targetFrameworkVersion,
+            bool restoreEnableAnalyzerAssets = false)
         {
             return new Dictionary<string, string>()
             {
@@ -5092,6 +5090,7 @@ namespace NuGet.Commands.Test
                 { "TargetFrameworkIdentifier", ".NETCoreApp" },
                 { "TargetFrameworkVersion", $"v{targetFrameworkVersion}" },
                 { "TargetFrameworkMoniker", $".NETCoreApp,Version=v{targetFrameworkVersion}" },
+                { "RestoreEnableAnalyzerAssets", restoreEnableAnalyzerAssets ? "true" : "false" },
             };
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -4969,7 +4969,7 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
-        public void GetPackageSpec_WithAnalyzerAssetMetadata_PopulatesTargetFramework()
+        public void GetPackageSpec_WithAnalyzerAssetMetadata_PopulatesRestoreMetadata()
         {
             using (var workingDir = TestDirectory.Create())
             {
@@ -4979,15 +4979,15 @@ namespace NuGet.Commands.Test
 
                 var items = new List<IDictionary<string, string>>
                 {
-                    CreateAnalyzerProjectSpecItem(projectPath, targetFrameworks: "net8.0"),
-                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0", restoreEnableAnalyzerAssets: true),
+                    CreateAnalyzerProjectSpecItem(projectPath, targetFrameworks: "net8.0", restoreEnableAnalyzerAssets: true),
+                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0"),
                 };
 
                 // Act
                 var projectSpec = GetSingleProjectSpec(items);
 
                 // Assert
-                projectSpec.TargetFrameworks.Single().RestoreEnableAnalyzerAssets.Should().BeTrue();
+                projectSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
             }
         }
 
@@ -5005,16 +5005,17 @@ namespace NuGet.Commands.Test
                     CreateAnalyzerProjectSpecItem(
                         projectPath,
                         targetFrameworks: "net8.0;net9.0",
-                        crossTargeting: true),
-                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0", restoreEnableAnalyzerAssets: true),
-                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0", restoreEnableAnalyzerAssets: true),
+                        crossTargeting: true,
+                        restoreEnableAnalyzerAssets: true),
+                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0"),
+                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0"),
                 };
 
                 // Act
                 var projectSpec = GetSingleProjectSpec(items);
 
                 // Assert
-                projectSpec.TargetFrameworks.Should().OnlyContain(f => f.RestoreEnableAnalyzerAssets);
+                projectSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
             }
         }
 
@@ -5032,16 +5033,17 @@ namespace NuGet.Commands.Test
                     CreateAnalyzerProjectSpecItem(
                         projectPath,
                         targetFrameworks: "net8.0;net9.0",
-                        crossTargeting: true),
-                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0", restoreEnableAnalyzerAssets: false),
-                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0", restoreEnableAnalyzerAssets: false),
+                        crossTargeting: true,
+                        restoreEnableAnalyzerAssets: false),
+                    CreateAnalyzerTargetFrameworkInformationItem("net8.0", "8.0"),
+                    CreateAnalyzerTargetFrameworkInformationItem("net9.0", "9.0"),
                 };
 
                 // Act
                 var projectSpec = GetSingleProjectSpec(items);
 
                 // Assert
-                projectSpec.TargetFrameworks.Should().OnlyContain(f => !f.RestoreEnableAnalyzerAssets);
+                projectSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
             }
         }
 
@@ -5056,7 +5058,8 @@ namespace NuGet.Commands.Test
         private static Dictionary<string, string> CreateAnalyzerProjectSpecItem(
             string projectPath,
             string targetFrameworks = "net46",
-            bool crossTargeting = false)
+            bool crossTargeting = false,
+            bool restoreEnableAnalyzerAssets = false)
         {
             var item = new Dictionary<string, string>()
             {
@@ -5067,6 +5070,7 @@ namespace NuGet.Commands.Test
                 { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                 { "ProjectPath", projectPath },
                 { "TargetFrameworks", targetFrameworks },
+                { "RestoreEnableAnalyzerAssets", restoreEnableAnalyzerAssets ? "true" : "false" },
             };
 
             if (crossTargeting)
@@ -5079,8 +5083,7 @@ namespace NuGet.Commands.Test
 
         private static Dictionary<string, string> CreateAnalyzerTargetFrameworkInformationItem(
             string targetFramework,
-            string targetFrameworkVersion,
-            bool restoreEnableAnalyzerAssets = false)
+            string targetFrameworkVersion)
         {
             return new Dictionary<string, string>()
             {
@@ -5090,7 +5093,6 @@ namespace NuGet.Commands.Test
                 { "TargetFrameworkIdentifier", ".NETCoreApp" },
                 { "TargetFrameworkVersion", $"v{targetFrameworkVersion}" },
                 { "TargetFrameworkMoniker", $".NETCoreApp,Version=v{targetFrameworkVersion}" },
-                { "RestoreEnableAnalyzerAssets", restoreEnableAnalyzerAssets ? "true" : "false" },
             };
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -28,6 +28,7 @@ using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Test;
+using NuGet.Repositories;
 using NuGet.RuntimeModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -4319,6 +4320,59 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
             Assert.Equal("NU1603", projectInformationEvent["SuppressedWarningCodes"]);
             Assert.Null(projectInformationEvent["WarningCodes"]);
+        }
+
+        [Fact]
+        public async Task LockFileBuilder_WithUnmatchedTargetAlias_DoesNotThrow()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            const string ProjectName = "TestProject";
+            const string PackageId = "a";
+            NuGetFramework framework = NuGetFramework.Parse("net45");
+            PackageSpec packageSpec = ProjectTestHelpers.GetPackageSpec(ProjectName, pathContext.SolutionRoot, framework.GetShortFolderName(), PackageId);
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                new SimpleTestPackageContext(PackageId, "1.0.0"));
+
+            var logger = new TestLogger();
+            TestRestoreRequest request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+            RestoreResult restoreResult = await new RestoreCommand(request).ExecuteAsync();
+            restoreResult.Success.Should().BeTrue(because: logger.ShowMessages());
+
+            var context = new TestRemoteWalkContext();
+            var provider = new DependencyProvider();
+            provider.Package(PackageId, "1.0.0");
+            context.LocalLibraryProviders.Add(provider);
+
+            var walker = new RemoteDependencyWalker(context);
+            GraphNode<RemoteResolveResult> rootNode = await DoWalkAsync(walker, PackageId, framework);
+            RestoreTargetGraph targetGraph = RestoreTargetGraph.Create(
+                RuntimeGraph.Empty,
+                new[] { rootNode },
+                context,
+                targetAlias: "unmatched",
+                framework,
+                runtimeIdentifier: null);
+
+            var lockFileBuilder = new LockFileBuilder(
+                LockFileFormat.AliasedVersion,
+                logger,
+                new Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>>());
+
+            // Act
+            Action act = () => lockFileBuilder.CreateLockFile(
+                previousLockFile: null,
+                packageSpec,
+                new[] { targetGraph },
+                new[] { new NuGetv3LocalRepository(pathContext.UserPackagesFolder) },
+                context,
+                new LockFileBuilderCache());
+
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -142,6 +142,171 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 projectInformationEvent["AnalyzerAssets.Enabled"].Should().Be(true);
                 // The analyzer package ships five analyzer assemblies; satellite and non-analyzer files are excluded.
                 projectInformationEvent["AnalyzerAssets.Count"].Should().Be(5);
+                projectInformationEvent["AnalyzerAssets.Excluded.Count"].Should().Be(0);
+                projectInformationEvent["AnalyzerAssets.PackagesWithAnalyzers.Count"].Should().Be(1);
+                projectInformationEvent["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"].Should().Be(0);
+                projectInformationEvent["AnalyzerAssets.ExcludedByPrivateAssets.Count"].Should().Be(0);
+                projectInformationEvent["AnalyzerAssets.ExcludedByExcludeAssets.Count"].Should().Be(0);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithAnalyzerAssetsDisabled_StillEmitsAnalyzerAssetsTelemetryAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: false);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+
+                // Set up telemetry capture *after* package creation, which also emits telemetry.
+                var telemetryEvents = new ConcurrentQueue<TelemetryEvent>();
+                var telemetryService = new Mock<INuGetTelemetryService>(MockBehavior.Loose);
+                telemetryService
+                    .Setup(x => x.EmitTelemetryEvent(It.IsAny<TelemetryEvent>()))
+                    .Callback<TelemetryEvent>(x => telemetryEvents.Enqueue(x));
+                TelemetryActivity.NuGetTelemetryService = telemetryService.Object;
+
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
+                // The feature is off, but the blast-radius counts are still reported so the impact of enabling
+                // it by default can be measured. Nothing is filtered here, so all five analyzers are "applied".
+                projectInformationEvent["AnalyzerAssets.Enabled"].Should().Be(false);
+                projectInformationEvent["AnalyzerAssets.Count"].Should().Be(5);
+                projectInformationEvent["AnalyzerAssets.PackagesWithAnalyzers.Count"].Should().Be(1);
+                projectInformationEvent["AnalyzerAssets.Excluded.Count"].Should().Be(0);
+                projectInformationEvent["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"].Should().Be(0);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithExcludeAssetsAnalyzers_EmitsExcludedByExcludeAssetsTelemetryAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true,
+                    includeType: LibraryIncludeFlags.All & ~LibraryIncludeFlags.Analyzers);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+
+                var telemetryEvents = new ConcurrentQueue<TelemetryEvent>();
+                var telemetryService = new Mock<INuGetTelemetryService>(MockBehavior.Loose);
+                telemetryService
+                    .Setup(x => x.EmitTelemetryEvent(It.IsAny<TelemetryEvent>()))
+                    .Callback<TelemetryEvent>(x => telemetryEvents.Enqueue(x));
+                TelemetryActivity.NuGetTelemetryService = telemetryService.Object;
+
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
+                // ExcludeAssets="analyzers" on the project's own reference filters all five analyzers.
+                projectInformationEvent["AnalyzerAssets.Count"].Should().Be(0);
+                projectInformationEvent["AnalyzerAssets.Excluded.Count"].Should().Be(5);
+                projectInformationEvent["AnalyzerAssets.PackagesWithAnalyzers.Count"].Should().Be(1);
+                projectInformationEvent["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"].Should().Be(1);
+                projectInformationEvent["AnalyzerAssets.ExcludedByExcludeAssets.Count"].Should().Be(1);
+                projectInformationEvent["AnalyzerAssets.ExcludedByPrivateAssets.Count"].Should().Be(0);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithPrivateAssetsAnalyzersOnTransitiveProjectReference_EmitsExcludedByPrivateAssetsTelemetryAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var libraryDirectory = Path.Combine(pathContext.SolutionRoot, "Library");
+                Directory.CreateDirectory(libraryDirectory);
+
+                var appDirectory = Path.Combine(pathContext.SolutionRoot, "App");
+                Directory.CreateDirectory(appDirectory);
+
+                var librarySpec = CreateAnalyzerPackageSpec(
+                    libraryDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true,
+                    suppressParent: LibraryIncludeFlags.Analyzers,
+                    projectName: "Library");
+
+                var appSpec = CreateAnalyzerProjectSpec(
+                        "App",
+                        appDirectory,
+                        ImmutableArray<LibraryDependency>.Empty,
+                        restoreEnableAnalyzerAssets: true)
+                    .WithTestProjectReference(librarySpec);
+
+                var libraryLogger = new TestLogger();
+                var libraryRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, libraryLogger, librarySpec);
+                var libraryRestoreCommand = new RestoreCommand(libraryRequest);
+
+                // Restore the library first; only the app restore telemetry is captured below.
+                var libraryResult = await libraryRestoreCommand.ExecuteAsync();
+                libraryResult.Success.Should().BeTrue(because: libraryLogger.ShowMessages());
+
+                var telemetryEvents = new ConcurrentQueue<TelemetryEvent>();
+                var telemetryService = new Mock<INuGetTelemetryService>(MockBehavior.Loose);
+                telemetryService
+                    .Setup(x => x.EmitTelemetryEvent(It.IsAny<TelemetryEvent>()))
+                    .Callback<TelemetryEvent>(x => telemetryEvents.Enqueue(x));
+                TelemetryActivity.NuGetTelemetryService = telemetryService.Object;
+
+                var appLogger = new TestLogger();
+                var appRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, appLogger, appSpec, librarySpec);
+                var appRestoreCommand = new RestoreCommand(appRequest);
+
+                // Act
+                var appResult = await appRestoreCommand.ExecuteAsync();
+
+                // Assert
+                appResult.Success.Should().BeTrue(because: appLogger.ShowMessages());
+
+                var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
+                // The analyzers flow transitively through the Library project reference, where PrivateAssets="analyzers"
+                // (the default) suppresses them for the consuming App.
+                projectInformationEvent["AnalyzerAssets.Count"].Should().Be(0);
+                projectInformationEvent["AnalyzerAssets.Excluded.Count"].Should().Be(5);
+                projectInformationEvent["AnalyzerAssets.PackagesWithAnalyzers.Count"].Should().Be(1);
+                projectInformationEvent["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"].Should().Be(1);
+                projectInformationEvent["AnalyzerAssets.ExcludedByPrivateAssets.Count"].Should().Be(1);
+                projectInformationEvent["AnalyzerAssets.ExcludedByExcludeAssets.Count"].Should().Be(0);
             }
         }
 
@@ -3951,6 +4116,11 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["Audit.Enabled"] = value => value.Should().Be("enabled"),
                 ["AnalyzerAssets.Enabled"] = value => value.Should().BeOfType<bool>(),
                 ["AnalyzerAssets.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.Excluded.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.PackagesWithAnalyzers.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.ExcludedByPrivateAssets.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.ExcludedByExcludeAssets.Count"] = value => value.Should().BeOfType<int>(),
                 ["Audit.Level"] = value => value.Should().Be(0),
                 ["Audit.Mode"] = value => value.Should().Be("Unknown"),
                 ["Audit.SuppressedAdvisories.Defined.Count"] = value => value.Should().Be(1),
@@ -4337,6 +4507,11 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["PackagesWithFloatingVersionCount"] = value => value.Should().Be(0),
                 ["AnalyzerAssets.Enabled"] = value => value.Should().BeOfType<bool>(),
                 ["AnalyzerAssets.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.Excluded.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.PackagesWithAnalyzers.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.ExcludedByPrivateAssets.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.ExcludedByExcludeAssets.Count"] = value => value.Should().BeOfType<int>(),
                 ["NewPackagesInstalledCount"] = value => value.Should().Be(1),
                 ["AnyPackageIdContainsNonAlphanumericDotDashOrUnderscoreCharacters"] = value => value.Should().Be(false),
                 ["EvaluateLockFileDuration"] = value => value.Should().NotBeNull(),

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -103,6 +103,60 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
 
         [Fact]
+        public async Task RestoreCommand_WithAnalyzerAssetsEnabledOnOneFramework_HonorsAnalyzersForAllFrameworksAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                // Multi-targeted project where only the net9.0 framework opts in. Analyzer assets are a
+                // project-wide opt-in, so the net8.0 framework honors analyzers too even though it did not opt in.
+                var net80 = new TargetFrameworkInformation
+                {
+                    FrameworkName = NuGetFramework.Parse("net8.0"),
+                    Dependencies = [CreateAnalyzerPackageDependency(package.Id, LibraryIncludeFlags.All, suppressParent: null)],
+                    RestoreEnableAnalyzerAssets = false,
+                };
+                var net90 = new TargetFrameworkInformation
+                {
+                    FrameworkName = NuGetFramework.Parse("net9.0"),
+                    Dependencies = [CreateAnalyzerPackageDependency(package.Id, LibraryIncludeFlags.All, suppressParent: null)],
+                    RestoreEnableAnalyzerAssets = true,
+                };
+
+                var packageSpec = PackageReferenceSpecBuilder.Create("AnalyzerProject", projectDirectory)
+                    .WithTargetFrameworks([net80, net90])
+                    .Build()
+                    .WithTestRestoreMetadata();
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var net80Library = result.LockFile.GetTarget(NuGetFramework.Parse("net8.0"), runtimeIdentifier: null)
+                    .Libraries.Single(library => library.Name == package.Id);
+                var net90Library = result.LockFile.GetTarget(NuGetFramework.Parse("net9.0"), runtimeIdentifier: null)
+                    .Libraries.Single(library => library.Name == package.Id);
+
+                AssertAnalyzerAssetsSelected(net80Library);
+                AssertAnalyzerAssetsSelected(net90Library);
+            }
+        }
+
+        [Fact]
         public async Task RestoreCommand_WithAnalyzerAssetsEnabled_EmitsAnalyzerAssetsTelemetryAsync()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -4769,12 +4769,11 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                     {
                         FrameworkName = NuGetFramework.Parse("netstandard2.0"),
                         Dependencies = dependencies,
+                        RestoreEnableAnalyzerAssets = restoreEnableAnalyzerAssets,
                     },
                 ])
                 .Build()
                 .WithTestRestoreMetadata();
-
-            packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets = restoreEnableAnalyzerAssets;
 
             return packageSpec;
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -140,9 +140,8 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
                 var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
                 projectInformationEvent["AnalyzerAssets.Enabled"].Should().Be(true);
-                // The analyzer package ships five analyzer assemblies; satellite and non-analyzer files are excluded.
-                projectInformationEvent["AnalyzerAssets.Count"].Should().Be(5);
-                projectInformationEvent["AnalyzerAssets.Excluded.Count"].Should().Be(0);
+                // The analyzer package's analyzers all apply, so nothing is excluded.
+                projectInformationEvent["AnalyzerAssets.Excluded"].Should().Be(false);
                 projectInformationEvent["AnalyzerAssets.PackagesWithAnalyzers.Count"].Should().Be(1);
                 projectInformationEvent["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"].Should().Be(0);
                 projectInformationEvent["AnalyzerAssets.ExcludedByPrivateAssets.Count"].Should().Be(0);
@@ -187,12 +186,11 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 result.Success.Should().BeTrue(because: logger.ShowMessages());
 
                 var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
-                // The feature is off, but the blast-radius counts are still reported so the impact of enabling
-                // it by default can be measured. Nothing is filtered here, so all five analyzers are "applied".
+                // The feature is off, but the blast-radius data is still reported so the impact of enabling
+                // it by default can be measured. Nothing is filtered here.
                 projectInformationEvent["AnalyzerAssets.Enabled"].Should().Be(false);
-                projectInformationEvent["AnalyzerAssets.Count"].Should().Be(5);
                 projectInformationEvent["AnalyzerAssets.PackagesWithAnalyzers.Count"].Should().Be(1);
-                projectInformationEvent["AnalyzerAssets.Excluded.Count"].Should().Be(0);
+                projectInformationEvent["AnalyzerAssets.Excluded"].Should().Be(false);
                 projectInformationEvent["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"].Should().Be(0);
             }
         }
@@ -234,9 +232,8 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 result.Success.Should().BeTrue(because: logger.ShowMessages());
 
                 var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
-                // ExcludeAssets="analyzers" on the project's own reference filters all five analyzers.
-                projectInformationEvent["AnalyzerAssets.Count"].Should().Be(0);
-                projectInformationEvent["AnalyzerAssets.Excluded.Count"].Should().Be(5);
+                // ExcludeAssets="analyzers" on the project's own reference filters the package's analyzers.
+                projectInformationEvent["AnalyzerAssets.Excluded"].Should().Be(true);
                 projectInformationEvent["AnalyzerAssets.PackagesWithAnalyzers.Count"].Should().Be(1);
                 projectInformationEvent["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"].Should().Be(1);
                 projectInformationEvent["AnalyzerAssets.ExcludedByExcludeAssets.Count"].Should().Be(1);
@@ -301,8 +298,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
                 // The analyzers flow transitively through the Library project reference, where PrivateAssets="analyzers"
                 // (the default) suppresses them for the consuming App.
-                projectInformationEvent["AnalyzerAssets.Count"].Should().Be(0);
-                projectInformationEvent["AnalyzerAssets.Excluded.Count"].Should().Be(5);
+                projectInformationEvent["AnalyzerAssets.Excluded"].Should().Be(true);
                 projectInformationEvent["AnalyzerAssets.PackagesWithAnalyzers.Count"].Should().Be(1);
                 projectInformationEvent["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"].Should().Be(1);
                 projectInformationEvent["AnalyzerAssets.ExcludedByPrivateAssets.Count"].Should().Be(1);
@@ -4115,8 +4111,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["FallbackFoldersCount"] = value => value.Should().Be(0),
                 ["Audit.Enabled"] = value => value.Should().Be("enabled"),
                 ["AnalyzerAssets.Enabled"] = value => value.Should().BeOfType<bool>(),
-                ["AnalyzerAssets.Count"] = value => value.Should().BeOfType<int>(),
-                ["AnalyzerAssets.Excluded.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.Excluded"] = value => value.Should().BeOfType<bool>(),
                 ["AnalyzerAssets.PackagesWithAnalyzers.Count"] = value => value.Should().BeOfType<int>(),
                 ["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"] = value => value.Should().BeOfType<int>(),
                 ["AnalyzerAssets.ExcludedByPrivateAssets.Count"] = value => value.Should().BeOfType<int>(),
@@ -4506,8 +4501,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["TotalUniquePackagesCount"] = value => value.Should().Be(2),
                 ["PackagesWithFloatingVersionCount"] = value => value.Should().Be(0),
                 ["AnalyzerAssets.Enabled"] = value => value.Should().BeOfType<bool>(),
-                ["AnalyzerAssets.Count"] = value => value.Should().BeOfType<int>(),
-                ["AnalyzerAssets.Excluded.Count"] = value => value.Should().BeOfType<int>(),
+                ["AnalyzerAssets.Excluded"] = value => value.Should().BeOfType<bool>(),
                 ["AnalyzerAssets.PackagesWithAnalyzers.Count"] = value => value.Should().BeOfType<int>(),
                 ["AnalyzerAssets.PackagesWithExcludedAnalyzers.Count"] = value => value.Should().BeOfType<int>(),
                 ["AnalyzerAssets.ExcludedByPrivateAssets.Count"] = value => value.Should().BeOfType<int>(),

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -103,7 +103,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
 
         [Fact]
-        public async Task RestoreCommand_WithAnalyzerAssetsEnabledOnOneFramework_HonorsAnalyzersForAllFrameworksAsync()
+        public async Task RestoreCommand_WithAnalyzerAssetsEnabled_HonorsAnalyzersForAllFrameworksAsync()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -115,25 +115,24 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
                 Directory.CreateDirectory(projectDirectory);
 
-                // Multi-targeted project where only the net9.0 framework opts in. Analyzer assets are a
-                // project-wide opt-in, so the net8.0 framework honors analyzers too even though it did not opt in.
+                // Analyzer assets are a project-wide opt-in. In a multi-targeted project, when the project
+                // opts in, analyzers are honored for every target framework.
                 var net80 = new TargetFrameworkInformation
                 {
                     FrameworkName = NuGetFramework.Parse("net8.0"),
                     Dependencies = [CreateAnalyzerPackageDependency(package.Id, LibraryIncludeFlags.All, suppressParent: null)],
-                    RestoreEnableAnalyzerAssets = false,
                 };
                 var net90 = new TargetFrameworkInformation
                 {
                     FrameworkName = NuGetFramework.Parse("net9.0"),
                     Dependencies = [CreateAnalyzerPackageDependency(package.Id, LibraryIncludeFlags.All, suppressParent: null)],
-                    RestoreEnableAnalyzerAssets = true,
                 };
 
                 var packageSpec = PackageReferenceSpecBuilder.Create("AnalyzerProject", projectDirectory)
                     .WithTargetFrameworks([net80, net90])
                     .Build()
                     .WithTestRestoreMetadata();
+                packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets = true;
 
                 var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
                 var restoreCommand = new RestoreCommand(request);
@@ -4992,11 +4991,12 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                     {
                         FrameworkName = NuGetFramework.Parse("netstandard2.0"),
                         Dependencies = dependencies,
-                        RestoreEnableAnalyzerAssets = restoreEnableAnalyzerAssets,
                     },
                 ])
                 .Build()
                 .WithTestRestoreMetadata();
+
+            packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets = restoreEnableAnalyzerAssets;
 
             return packageSpec;
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -44,6 +44,901 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         private static SignedPackageVerifierSettings DefaultSettings = SignedPackageVerifierSettings.GetDefault(TestEnvironmentVariableReader.EmptyInstance);
 
         [Fact]
+        public async Task RestoreCommand_WithAnalyzerAssetsEnabled_WritesIdentifiedAnalyzerAssetsAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLibrary = GetAnalyzerTargetLibrary(result.LockFile, package.Id);
+                var analyzerAssets = GetAnalyzerAssetPaths(targetLibrary);
+
+                Assert.Equal(
+                    new[]
+                    {
+                        "analyzers/dotnet/NeutralAnalyzer.dll",
+                        "analyzers/dotnet/cs/CSharpAnalyzer.dll",
+                        "analyzers/dotnet/foo/UnknownFolderAnalyzer.dll",
+                        "analyzers/dotnet/fs/FSharpAnalyzer.dll",
+                        "analyzers/dotnet/vb/VisualBasicAnalyzer.dll",
+                    },
+                    analyzerAssets);
+
+                var assetsFile = File.ReadAllText(result.LockFilePath);
+                assetsFile.Should().Contain(@"""analyzers"": {");
+
+                // Each analyzer carries the codeLanguage derived from its path ("any" when language-agnostic),
+                // mirroring how content files carry codeLanguage metadata.
+                AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/NeutralAnalyzer.dll", codeLanguage: "any");
+                AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/cs/CSharpAnalyzer.dll", codeLanguage: "cs");
+                AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/foo/UnknownFolderAnalyzer.dll", codeLanguage: "any");
+                AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/fs/FSharpAnalyzer.dll", codeLanguage: "fs");
+                AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/vb/VisualBasicAnalyzer.dll", codeLanguage: "vb");
+
+                assetsFile.Should().Contain(@"""codeLanguage"": ""cs""");
+                assetsFile.Should().Contain(@"""codeLanguage"": ""any""");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithAnalyzerAssetsEnabled_EmitsAnalyzerAssetsTelemetryAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+
+                // Set up telemetry capture *after* package creation, which also emits telemetry.
+                var telemetryEvents = new ConcurrentQueue<TelemetryEvent>();
+                var telemetryService = new Mock<INuGetTelemetryService>(MockBehavior.Loose);
+                telemetryService
+                    .Setup(x => x.EmitTelemetryEvent(It.IsAny<TelemetryEvent>()))
+                    .Callback<TelemetryEvent>(x => telemetryEvents.Enqueue(x));
+                TelemetryActivity.NuGetTelemetryService = telemetryService.Object;
+
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                var projectInformationEvent = telemetryEvents.Single(e => e.Name.Equals("ProjectRestoreInformation"));
+                projectInformationEvent["AnalyzerAssets.Enabled"].Should().Be(true);
+                // The analyzer package ships five analyzer assemblies; satellite and non-analyzer files are excluded.
+                projectInformationEvent["AnalyzerAssets.Count"].Should().Be(5);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithCSharpSourceGeneratorAnalyzerDll_WritesAnalyzerAssetAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                package.AddFile("analyzers/dotnet/cs/SourceGenerator.dll");
+                package.AddFile("analyzers/dotnet/vb/VisualBasicSourceGenerator.dll");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                var targetLibrary = GetAnalyzerTargetLibrary(result.LockFile, package.Id);
+
+                Assert.Equal(
+                    new[]
+                    {
+                        "analyzers/dotnet/NeutralAnalyzer.dll",
+                        "analyzers/dotnet/cs/CSharpAnalyzer.dll",
+                        "analyzers/dotnet/cs/SourceGenerator.dll",
+                        "analyzers/dotnet/foo/UnknownFolderAnalyzer.dll",
+                        "analyzers/dotnet/fs/FSharpAnalyzer.dll",
+                        "analyzers/dotnet/vb/VisualBasicAnalyzer.dll",
+                        "analyzers/dotnet/vb/VisualBasicSourceGenerator.dll",
+                    },
+                    GetAnalyzerAssetPaths(targetLibrary));
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithAnalyzerAssetsDisabled_DoesNotWriteAnalyzerAssetsAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: false);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLibrary = GetAnalyzerTargetLibrary(result.LockFile, package.Id);
+                Assert.Empty(targetLibrary.AnalyzerAssets);
+
+                var assetsFile = File.ReadAllText(result.LockFilePath);
+                assetsFile.Should().NotContain(@"""analyzers"": {");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithExcludeAssetsAnalyzers_WritesAnalyzerAssetsPlaceholderAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true,
+                    includeType: LibraryIncludeFlags.All & ~LibraryIncludeFlags.Analyzers);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLibrary = GetAnalyzerTargetLibrary(result.LockFile, package.Id);
+                AssertAnalyzerAssetsExcluded(targetLibrary);
+
+                var assetsFile = File.ReadAllText(result.LockFilePath);
+                assetsFile.Should().Contain(@"""analyzers"": {");
+                assetsFile.Should().Contain(@"""analyzers/dotnet/_._"": {}");
+                assetsFile.Should().NotContain(@"""analyzers/dotnet/NeutralAnalyzer.dll"": {}");
+                assetsFile.Should().NotContain(@"""analyzers/dotnet/cs/CSharpAnalyzer.dll"": {}");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithIncludeAssetsCompileAndRuntime_WritesAnalyzerAssetsPlaceholderAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true,
+                    includeType: LibraryIncludeFlags.Compile | LibraryIncludeFlags.Runtime);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLibrary = GetAnalyzerTargetLibrary(result.LockFile, package.Id);
+                AssertAnalyzerAssetsExcluded(targetLibrary);
+
+                var assetsFile = File.ReadAllText(result.LockFilePath);
+                assetsFile.Should().Contain(@"""analyzers"": {");
+                assetsFile.Should().Contain(@"""analyzers/dotnet/_._"": {}");
+                assetsFile.Should().NotContain(@"""analyzers/dotnet/NeutralAnalyzer.dll"": {}");
+                assetsFile.Should().NotContain(@"""analyzers/dotnet/cs/CSharpAnalyzer.dll"": {}");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithPrivateAssetsAnalyzersOnTransitiveProjectReference_DoesNotFlowAnalyzerAssetsAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var libraryDirectory = Path.Combine(pathContext.SolutionRoot, "Library");
+                Directory.CreateDirectory(libraryDirectory);
+
+                var appDirectory = Path.Combine(pathContext.SolutionRoot, "App");
+                Directory.CreateDirectory(appDirectory);
+
+                var librarySpec = CreateAnalyzerPackageSpec(
+                    libraryDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true,
+                    suppressParent: LibraryIncludeFlags.Analyzers,
+                    projectName: "Library");
+
+                var appSpec = CreateAnalyzerProjectSpec(
+                        "App",
+                        appDirectory,
+                        ImmutableArray<LibraryDependency>.Empty,
+                        restoreEnableAnalyzerAssets: true)
+                    .WithTestProjectReference(librarySpec);
+
+                var libraryLogger = new TestLogger();
+                var libraryRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, libraryLogger, librarySpec);
+                var libraryRestoreCommand = new RestoreCommand(libraryRequest);
+
+                var appLogger = new TestLogger();
+                var appRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, appLogger, appSpec, librarySpec);
+                var appRestoreCommand = new RestoreCommand(appRequest);
+
+                // Act
+                var libraryResult = await libraryRestoreCommand.ExecuteAsync();
+                var appResult = await appRestoreCommand.ExecuteAsync();
+
+                // Assert
+                libraryResult.Success.Should().BeTrue(because: libraryLogger.ShowMessages());
+                appResult.Success.Should().BeTrue(because: appLogger.ShowMessages());
+
+                var libraryTargetLibrary = GetAnalyzerTargetLibrary(libraryResult.LockFile, package.Id);
+                AssertAnalyzerAssetsSelected(libraryTargetLibrary);
+
+                var appTargetLibrary = GetAnalyzerTargetLibrary(appResult.LockFile, package.Id);
+                AssertAnalyzerAssetsExcluded(appTargetLibrary);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithTransitiveAnalyzerPackage_WritesTransitiveAnalyzerAssetsAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var parentPackage = CreateAnalyzerPackageContext("ParentPackage");
+                var transitivePackage = CreateAnalyzerPackageContext("TransitiveAnalyzerPackage");
+                parentPackage.Dependencies.Add(transitivePackage);
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, parentPackage);
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, transitivePackage);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    parentPackage.Id,
+                    restoreEnableAnalyzerAssets: true);
+
+                var logger = new TestLogger();
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                var parentTargetLibrary = GetAnalyzerTargetLibrary(result.LockFile, parentPackage.Id);
+                AssertAnalyzerAssetsSelected(parentTargetLibrary);
+
+                var transitiveTargetLibrary = GetAnalyzerTargetLibrary(result.LockFile, transitivePackage.Id);
+                AssertAnalyzerAssetsSelected(transitiveTargetLibrary);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithExcludeAssetsAnalyzersOnTransitivePackage_WritesPlaceholdersAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var parentPackage = CreateAnalyzerPackageContext("ParentPackage");
+                var transitivePackage = CreateAnalyzerPackageContext("TransitiveAnalyzerPackage");
+                parentPackage.Dependencies.Add(transitivePackage);
+
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, parentPackage);
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, transitivePackage);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    parentPackage.Id,
+                    restoreEnableAnalyzerAssets: true,
+                    includeType: LibraryIncludeFlags.All & ~LibraryIncludeFlags.Analyzers);
+
+                var logger = new TestLogger();
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                var parentTargetLibrary = GetAnalyzerTargetLibrary(result.LockFile, parentPackage.Id);
+                AssertAnalyzerAssetsExcluded(parentTargetLibrary);
+
+                var transitiveTargetLibrary = GetAnalyzerTargetLibrary(result.LockFile, transitivePackage.Id);
+                AssertAnalyzerAssetsExcluded(transitiveTargetLibrary);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithAnalyzerPackageThroughProjectReference_DoesNotFlowAnalyzerAssetsAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var libraryDirectory = Path.Combine(pathContext.SolutionRoot, "Library");
+                Directory.CreateDirectory(libraryDirectory);
+
+                var appDirectory = Path.Combine(pathContext.SolutionRoot, "App");
+                Directory.CreateDirectory(appDirectory);
+
+                var librarySpec = CreateAnalyzerPackageSpec(
+                    libraryDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true,
+                    projectName: "Library");
+
+                var appSpec = CreateAnalyzerProjectSpec(
+                        "App",
+                        appDirectory,
+                        ImmutableArray<LibraryDependency>.Empty,
+                        restoreEnableAnalyzerAssets: true)
+                    .WithTestProjectReference(librarySpec);
+
+                var libraryLogger = new TestLogger();
+                var libraryRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, libraryLogger, librarySpec);
+                var libraryRestoreCommand = new RestoreCommand(libraryRequest);
+
+                var appLogger = new TestLogger();
+                var appRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, appLogger, appSpec, librarySpec);
+                var appRestoreCommand = new RestoreCommand(appRequest);
+
+                // Act
+                var libraryResult = await libraryRestoreCommand.ExecuteAsync();
+                var appResult = await appRestoreCommand.ExecuteAsync();
+
+                // Assert
+                libraryResult.Success.Should().BeTrue(because: libraryLogger.ShowMessages());
+                appResult.Success.Should().BeTrue(because: appLogger.ShowMessages());
+
+                var libraryTargetLibrary = GetAnalyzerTargetLibrary(libraryResult.LockFile, package.Id);
+                AssertAnalyzerAssetsSelected(libraryTargetLibrary);
+
+                var appTargetLibrary = GetAnalyzerTargetLibrary(appResult.LockFile, package.Id);
+                AssertAnalyzerAssetsExcluded(appTargetLibrary);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithProjectReferencePrivateAssetsWithoutAnalyzers_FlowsAnalyzerAssetsAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var libraryDirectory = Path.Combine(pathContext.SolutionRoot, "Library");
+                Directory.CreateDirectory(libraryDirectory);
+
+                var appDirectory = Path.Combine(pathContext.SolutionRoot, "App");
+                Directory.CreateDirectory(appDirectory);
+
+                var nonAnalyzerPrivateAssets = LibraryIncludeFlags.Build | LibraryIncludeFlags.ContentFiles;
+                var librarySpec = CreateAnalyzerPackageSpec(
+                    libraryDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true,
+                    suppressParent: nonAnalyzerPrivateAssets,
+                    projectName: "Library");
+
+                var appSpec = CreateAnalyzerProjectSpec(
+                        "App",
+                        appDirectory,
+                        ImmutableArray<LibraryDependency>.Empty,
+                        restoreEnableAnalyzerAssets: true)
+                    .WithTestProjectReference(librarySpec, nonAnalyzerPrivateAssets);
+
+                var libraryLogger = new TestLogger();
+                var libraryRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, libraryLogger, librarySpec);
+                var libraryRestoreCommand = new RestoreCommand(libraryRequest);
+
+                var appLogger = new TestLogger();
+                var appRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, appLogger, appSpec, librarySpec);
+                var appRestoreCommand = new RestoreCommand(appRequest);
+
+                // Act
+                var libraryResult = await libraryRestoreCommand.ExecuteAsync();
+                var appResult = await appRestoreCommand.ExecuteAsync();
+
+                // Assert
+                libraryResult.Success.Should().BeTrue(because: libraryLogger.ShowMessages());
+                appResult.Success.Should().BeTrue(because: appLogger.ShowMessages());
+
+                var libraryTargetLibrary = GetAnalyzerTargetLibrary(libraryResult.LockFile, package.Id);
+                AssertAnalyzerAssetsSelected(libraryTargetLibrary);
+
+                var appTargetLibrary = GetAnalyzerTargetLibrary(appResult.LockFile, package.Id);
+                AssertAnalyzerAssetsSelected(appTargetLibrary);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithProjectReferencePackageExcludeAssetsAnalyzers_WritesPlaceholdersAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var libraryDirectory = Path.Combine(pathContext.SolutionRoot, "Library");
+                Directory.CreateDirectory(libraryDirectory);
+
+                var appDirectory = Path.Combine(pathContext.SolutionRoot, "App");
+                Directory.CreateDirectory(appDirectory);
+
+                var librarySpec = CreateAnalyzerPackageSpec(
+                    libraryDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true,
+                    includeType: LibraryIncludeFlags.All & ~LibraryIncludeFlags.Analyzers,
+                    projectName: "Library");
+
+                var appSpec = CreateAnalyzerProjectSpec(
+                        "App",
+                        appDirectory,
+                        ImmutableArray<LibraryDependency>.Empty,
+                        restoreEnableAnalyzerAssets: true)
+                    .WithTestProjectReference(librarySpec);
+
+                var libraryLogger = new TestLogger();
+                var libraryRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, libraryLogger, librarySpec);
+                var libraryRestoreCommand = new RestoreCommand(libraryRequest);
+
+                var appLogger = new TestLogger();
+                var appRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, appLogger, appSpec, librarySpec);
+                var appRestoreCommand = new RestoreCommand(appRequest);
+
+                // Act
+                var libraryResult = await libraryRestoreCommand.ExecuteAsync();
+                var appResult = await appRestoreCommand.ExecuteAsync();
+
+                // Assert
+                libraryResult.Success.Should().BeTrue(because: libraryLogger.ShowMessages());
+                appResult.Success.Should().BeTrue(because: appLogger.ShowMessages());
+
+                var libraryTargetLibrary = GetAnalyzerTargetLibrary(libraryResult.LockFile, package.Id);
+                AssertAnalyzerAssetsExcluded(libraryTargetLibrary);
+
+                var appTargetLibrary = GetAnalyzerTargetLibrary(appResult.LockFile, package.Id);
+                AssertAnalyzerAssetsExcluded(appTargetLibrary);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithCompilerVersionAnalyzers_FlowsCompilerApiVersionMetadataAcrossProjectReferenceAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var package = new SimpleTestPackageContext("CompilerAnalyzerPackage")
+                {
+                    UseDefaultRuntimeAssemblies = false,
+                };
+                package.AddFile("analyzers/dotnet/cs/CSharpAnalyzer.dll");
+                package.AddFile("analyzers/dotnet/roslyn4.0/cs/RoslynAnalyzer.dll");
+                package.AddFile("lib/netstandard2.0/Package.dll");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var libraryDirectory = Path.Combine(pathContext.SolutionRoot, "Library");
+                Directory.CreateDirectory(libraryDirectory);
+
+                var appDirectory = Path.Combine(pathContext.SolutionRoot, "App");
+                Directory.CreateDirectory(appDirectory);
+
+                // PrivateAssets without analyzers so the analyzers flow across the project reference.
+                var nonAnalyzerPrivateAssets = LibraryIncludeFlags.Build | LibraryIncludeFlags.ContentFiles;
+                var librarySpec = CreateAnalyzerPackageSpec(
+                    libraryDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true,
+                    suppressParent: nonAnalyzerPrivateAssets,
+                    projectName: "Library");
+
+                var appSpec = CreateAnalyzerProjectSpec(
+                        "App",
+                        appDirectory,
+                        ImmutableArray<LibraryDependency>.Empty,
+                        restoreEnableAnalyzerAssets: true)
+                    .WithTestProjectReference(librarySpec, nonAnalyzerPrivateAssets);
+
+                var libraryLogger = new TestLogger();
+                var libraryRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, libraryLogger, librarySpec);
+                var libraryRestoreCommand = new RestoreCommand(libraryRequest);
+
+                var appLogger = new TestLogger();
+                var appRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, appLogger, appSpec, librarySpec);
+                var appRestoreCommand = new RestoreCommand(appRequest);
+
+                // Act
+                var libraryResult = await libraryRestoreCommand.ExecuteAsync();
+                var appResult = await appRestoreCommand.ExecuteAsync();
+
+                // Assert
+                libraryResult.Success.Should().BeTrue(because: libraryLogger.ShowMessages());
+                appResult.Success.Should().BeTrue(because: appLogger.ShowMessages());
+
+                // The compiler-version metadata is preserved on the analyzers that flow into the consuming project.
+                var appTargetLibrary = GetAnalyzerTargetLibrary(appResult.LockFile, package.Id);
+                Assert.Equal(
+                    new[]
+                    {
+                        "analyzers/dotnet/cs/CSharpAnalyzer.dll",
+                        "analyzers/dotnet/roslyn4.0/cs/RoslynAnalyzer.dll",
+                    },
+                    GetAnalyzerAssetPaths(appTargetLibrary));
+                AssertAnalyzerMetadata(appTargetLibrary, "analyzers/dotnet/cs/CSharpAnalyzer.dll", codeLanguage: "cs");
+                AssertAnalyzerMetadata(appTargetLibrary, "analyzers/dotnet/roslyn4.0/cs/RoslynAnalyzer.dll", codeLanguage: "cs", compilerApiVersion: "roslyn4.0");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithThreeHopProjectReferenceChain_FlowsAnalyzerAssetsToRootAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // App -> Library2 -> Library1 -> analyzer package
+                var package = CreateAnalyzerPackageContext("AnalyzerPackage");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var library1Directory = Path.Combine(pathContext.SolutionRoot, "Library1");
+                var library2Directory = Path.Combine(pathContext.SolutionRoot, "Library2");
+                var appDirectory = Path.Combine(pathContext.SolutionRoot, "App");
+                Directory.CreateDirectory(library1Directory);
+                Directory.CreateDirectory(library2Directory);
+                Directory.CreateDirectory(appDirectory);
+
+                // PrivateAssets without analyzers at every hop so the analyzers flow all the way to the root.
+                var nonAnalyzerPrivateAssets = LibraryIncludeFlags.Build | LibraryIncludeFlags.ContentFiles;
+
+                var library1Spec = CreateAnalyzerPackageSpec(
+                    library1Directory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true,
+                    suppressParent: nonAnalyzerPrivateAssets,
+                    projectName: "Library1");
+
+                var library2Spec = CreateAnalyzerProjectSpec(
+                        "Library2",
+                        library2Directory,
+                        ImmutableArray<LibraryDependency>.Empty,
+                        restoreEnableAnalyzerAssets: true)
+                    .WithTestProjectReference(library1Spec, nonAnalyzerPrivateAssets);
+
+                var appSpec = CreateAnalyzerProjectSpec(
+                        "App",
+                        appDirectory,
+                        ImmutableArray<LibraryDependency>.Empty,
+                        restoreEnableAnalyzerAssets: true)
+                    .WithTestProjectReference(library2Spec, nonAnalyzerPrivateAssets);
+
+                var appLogger = new TestLogger();
+                var appRequest = ProjectTestHelpers.CreateRestoreRequest(pathContext, appLogger, appSpec, library2Spec, library1Spec);
+                var appRestoreCommand = new RestoreCommand(appRequest);
+
+                // Act
+                var appResult = await appRestoreCommand.ExecuteAsync();
+
+                // Assert
+                appResult.Success.Should().BeTrue(because: appLogger.ShowMessages());
+
+                // The analyzer package is a 3-hop transitive dependency; its analyzers (with metadata) reach the root.
+                var appTargetLibrary = GetAnalyzerTargetLibrary(appResult.LockFile, package.Id);
+                AssertAnalyzerAssetsSelected(appTargetLibrary);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithAnalyzerTargetFrameworkAndArchitectureSegments_WritesIdentifiedAnalyzerAssetsAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = new SimpleTestPackageContext("AnalyzerPackage")
+                {
+                    UseDefaultRuntimeAssemblies = false,
+                };
+                package.AddFile("analyzers/dotnet8.0/TargetFrameworkAnalyzer.dll");
+                package.AddFile("analyzers/dotnet8.0/cs/TargetFrameworkCSharpAnalyzer.dll");
+                package.AddFile("analyzers/dotnet8.0/x64/TargetFrameworkArchitectureAnalyzer.dll");
+                package.AddFile("analyzers/dotnet8.0/x64/cs/TargetFrameworkArchitectureCSharpAnalyzer.dll");
+                package.AddFile("analyzers/dotnet/roslyn4.0/cs/CompilerApiVersionCSharpAnalyzer.dll");
+                package.AddFile("analyzers/dotnet/x64/ArchitectureAnalyzer.dll");
+                package.AddFile("analyzers/dotnet/x64/cs/ArchitectureCSharpAnalyzer.dll");
+                package.AddFile("analyzers/dotnet/x64/vb/ArchitectureVisualBasicAnalyzer.dll");
+                package.AddFile("analyzers/dotnet8.x/InvalidTargetFrameworkAnalyzer.dll");
+                package.AddFile("analyzers/dotnet/foo/InvalidArchitectureAnalyzer.dll");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                var targetLibrary = GetAnalyzerTargetLibrary(result.LockFile, package.Id);
+
+                Assert.Equal(
+                    new[]
+                    {
+                        "analyzers/dotnet/foo/InvalidArchitectureAnalyzer.dll",
+                        "analyzers/dotnet/roslyn4.0/cs/CompilerApiVersionCSharpAnalyzer.dll",
+                        "analyzers/dotnet/x64/ArchitectureAnalyzer.dll",
+                        "analyzers/dotnet/x64/cs/ArchitectureCSharpAnalyzer.dll",
+                        "analyzers/dotnet/x64/vb/ArchitectureVisualBasicAnalyzer.dll",
+                        "analyzers/dotnet8.0/TargetFrameworkAnalyzer.dll",
+                        "analyzers/dotnet8.0/cs/TargetFrameworkCSharpAnalyzer.dll",
+                        "analyzers/dotnet8.0/x64/TargetFrameworkArchitectureAnalyzer.dll",
+                        "analyzers/dotnet8.0/x64/cs/TargetFrameworkArchitectureCSharpAnalyzer.dll",
+                        "analyzers/dotnet8.x/InvalidTargetFrameworkAnalyzer.dll",
+                    },
+                    GetAnalyzerAssetPaths(targetLibrary));
+
+                // The compiler version ('roslynX.Y') and language segments are captured as metadata.
+                AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/roslyn4.0/cs/CompilerApiVersionCSharpAnalyzer.dll", codeLanguage: "cs", compilerApiVersion: "roslyn4.0");
+                AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/x64/cs/ArchitectureCSharpAnalyzer.dll", codeLanguage: "cs");
+                AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/x64/vb/ArchitectureVisualBasicAnalyzer.dll", codeLanguage: "vb");
+                AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/foo/InvalidArchitectureAnalyzer.dll", codeLanguage: "any");
+                AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet8.0/TargetFrameworkAnalyzer.dll", codeLanguage: "any");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithAnalyzerTargetOmitted_WritesIdentifiedAnalyzerAssetsAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = new SimpleTestPackageContext("AnalyzerPackage")
+                {
+                    UseDefaultRuntimeAssemblies = false,
+                };
+                package.AddFile("analyzers/NeutralAnalyzer.dll");
+                package.AddFile("analyzers/x64/ArchitectureAnalyzer.dll");
+                package.AddFile("analyzers/x64/cs/ArchitectureCSharpAnalyzer.dll");
+                package.AddFile("analyzers/cs/CSharpAnalyzer.dll");
+                package.AddFile("analyzers/vb/VisualBasicAnalyzer.dll");
+                package.AddFile("analyzers/cs/CSharpAnalyzer.resources.dll");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                var targetLibrary = GetAnalyzerTargetLibrary(result.LockFile, package.Id);
+
+                Assert.Equal(
+                    new[]
+                    {
+                        "analyzers/NeutralAnalyzer.dll",
+                        "analyzers/cs/CSharpAnalyzer.dll",
+                        "analyzers/vb/VisualBasicAnalyzer.dll",
+                        "analyzers/x64/ArchitectureAnalyzer.dll",
+                        "analyzers/x64/cs/ArchitectureCSharpAnalyzer.dll",
+                    },
+                    GetAnalyzerAssetPaths(targetLibrary));
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithDeeplyNestedAnalyzers_WritesAllAnalyzerAssetsRegardlessOfDepthAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = new SimpleTestPackageContext("AnalyzerPackage")
+                {
+                    UseDefaultRuntimeAssemblies = false,
+                };
+                package.AddFile("analyzers/dotnet/cs/Analyzer.dll");
+                package.AddFile("analyzers/dotnet/roslyn4.0/x64/cs/nested/TooDeepAnalyzer.dll");
+                package.AddFile("analyzers/a/b/c/d/e/f/g/VeryDeepAnalyzer.dll");
+                package.AddFile("analyzers/dotnet/cs/nested/Localized.resources.dll");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                var targetLibrary = GetAnalyzerTargetLibrary(result.LockFile, package.Id);
+
+                // All analyzer assemblies are included at any depth (matching the SDK), while satellite
+                // '.resources.dll' assemblies are excluded.
+                Assert.Equal(
+                    new[]
+                    {
+                        "analyzers/a/b/c/d/e/f/g/VeryDeepAnalyzer.dll",
+                        "analyzers/dotnet/cs/Analyzer.dll",
+                        "analyzers/dotnet/roslyn4.0/x64/cs/nested/TooDeepAnalyzer.dll",
+                    },
+                    GetAnalyzerAssetPaths(targetLibrary));
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_WithAnalyzerLikePathsOutsideAnalyzersFolder_AreNotSelectedAsync()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var package = new SimpleTestPackageContext("AnalyzerPackage")
+                {
+                    UseDefaultRuntimeAssemblies = false,
+                };
+                // Only assemblies under the 'analyzers/' directory are analyzers. A root-level 'analyzers.dll'
+                // and an unrelated 'analyzersfoo/' directory must not be mistaken for analyzer assets.
+                package.AddFile("analyzers.dll");
+                package.AddFile("analyzersfoo/NotAnAnalyzer.dll");
+                package.AddFile("analyzers/dotnet/cs/RealAnalyzer.dll");
+                await SimpleTestPackageUtility.CreateFullPackageAsync(pathContext.PackageSource, package);
+
+                var projectDirectory = Path.Combine(pathContext.SolutionRoot, "AnalyzerProject");
+                Directory.CreateDirectory(projectDirectory);
+
+                var packageSpec = CreateAnalyzerPackageSpec(
+                    projectDirectory,
+                    package.Id,
+                    restoreEnableAnalyzerAssets: true);
+
+                var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, packageSpec);
+                var restoreCommand = new RestoreCommand(request);
+
+                // Act
+                var result = await restoreCommand.ExecuteAsync();
+
+                // Assert
+                result.Success.Should().BeTrue(because: logger.ShowMessages());
+
+                var targetLibrary = GetAnalyzerTargetLibrary(result.LockFile, package.Id);
+
+                Assert.Equal(
+                    new[]
+                    {
+                        "analyzers/dotnet/cs/RealAnalyzer.dll",
+                    },
+                    GetAnalyzerAssetPaths(targetLibrary));
+            }
+        }
+
+        [Fact]
         public async Task RestoreCommand_VerifyRuntimeSpecificAssetsAreNotIncludedForCompile_RuntimeOnlyAsync()
         {
             // Arrange
@@ -3054,6 +3949,8 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["LocalSourcesCount"] = value => value.Should().Be(1),
                 ["FallbackFoldersCount"] = value => value.Should().Be(0),
                 ["Audit.Enabled"] = value => value.Should().Be("enabled"),
+                ["AnalyzerAssets.Enabled"] = value => value.Should().BeOfType<bool>(),
+                ["AnalyzerAssets.Count"] = value => value.Should().BeOfType<int>(),
                 ["Audit.Level"] = value => value.Should().Be(0),
                 ["Audit.Mode"] = value => value.Should().Be("Unknown"),
                 ["Audit.SuppressedAdvisories.Defined.Count"] = value => value.Should().Be(1),
@@ -3332,6 +4229,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["FallbackFoldersCount"] = value => value.Should().Be(0),
                 ["IsLockFileEnabled"] = value => value.Should().Be(false),
                 ["NoOpCacheFileAgeDays"] = value => value.Should().NotBeNull(),
+                ["AnalyzerAssets.Enabled"] = value => value.Should().BeOfType<bool>(),
                 ["UseLegacyDependencyResolver"] = value => value.Should().BeOfType<bool>(),
                 ["UsedLegacyDependencyResolver"] = value => value.Should().BeOfType<bool>(),
                 ["Audit.Enabled"] = value => value.Should().BeOfType<string>(),
@@ -3437,6 +4335,8 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["NoOpDuration"] = value => value.Should().NotBeNull(),
                 ["TotalUniquePackagesCount"] = value => value.Should().Be(2),
                 ["PackagesWithFloatingVersionCount"] = value => value.Should().Be(0),
+                ["AnalyzerAssets.Enabled"] = value => value.Should().BeOfType<bool>(),
+                ["AnalyzerAssets.Count"] = value => value.Should().BeOfType<int>(),
                 ["NewPackagesInstalledCount"] = value => value.Should().Be(1),
                 ["AnyPackageIdContainsNonAlphanumericDotDashOrUnderscoreCharacters"] = value => value.Should().Be(false),
                 ["EvaluateLockFileDuration"] = value => value.Should().NotBeNull(),
@@ -3817,6 +4717,137 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
             pairs[5].Framework.Should().Be(FrameworkConstants.CommonFrameworks.Net80);
             pairs[5].RuntimeIdentifier.Should().Be("win-x64");
+        }
+
+        private static SimpleTestPackageContext CreateAnalyzerPackageContext(string packageId)
+        {
+            var package = new SimpleTestPackageContext(packageId)
+            {
+                UseDefaultRuntimeAssemblies = false,
+            };
+
+            package.AddFile("analyzers/dotnet/NeutralAnalyzer.dll");
+            package.AddFile("analyzers/dotnet/cs/CSharpAnalyzer.dll");
+            package.AddFile("analyzers/dotnet/vb/VisualBasicAnalyzer.dll");
+            package.AddFile("analyzers/dotnet/fs/FSharpAnalyzer.dll");
+            package.AddFile("analyzers/dotnet/cs/CSharpAnalyzer.resources.dll");
+            package.AddFile("analyzers/dotnet/cs/NotAnAnalyzer.exe");
+            package.AddFile("analyzers/dotnet/cs/NotAnAnalyzer.winmd");
+            package.AddFile("analyzers/dotnet/foo/UnknownFolderAnalyzer.dll");
+            package.AddFile("lib/netstandard2.0/Package.dll");
+
+            return package;
+        }
+
+        private static PackageSpec CreateAnalyzerPackageSpec(
+            string projectDirectory,
+            string packageId,
+            bool restoreEnableAnalyzerAssets,
+            LibraryIncludeFlags includeType = LibraryIncludeFlags.All,
+            LibraryIncludeFlags? suppressParent = null,
+            string projectName = "AnalyzerProject")
+        {
+            return CreateAnalyzerProjectSpec(
+                projectName,
+                projectDirectory,
+                [
+                    CreateAnalyzerPackageDependency(packageId, includeType, suppressParent),
+                ],
+                restoreEnableAnalyzerAssets);
+        }
+
+        private static PackageSpec CreateAnalyzerProjectSpec(
+            string projectName,
+            string projectDirectory,
+            ImmutableArray<LibraryDependency> dependencies,
+            bool restoreEnableAnalyzerAssets)
+        {
+            var packageSpec = PackageReferenceSpecBuilder.Create(projectName, projectDirectory)
+                .WithTargetFrameworks(
+                [
+                    new TargetFrameworkInformation
+                    {
+                        FrameworkName = NuGetFramework.Parse("netstandard2.0"),
+                        Dependencies = dependencies,
+                    },
+                ])
+                .Build()
+                .WithTestRestoreMetadata();
+
+            packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets = restoreEnableAnalyzerAssets;
+
+            return packageSpec;
+        }
+
+        private static LibraryDependency CreateAnalyzerPackageDependency(
+            string packageId,
+            LibraryIncludeFlags includeType,
+            LibraryIncludeFlags? suppressParent)
+        {
+            return new LibraryDependency
+            {
+                LibraryRange = new LibraryRange(
+                    packageId,
+                    VersionRange.Parse("1.0.0"),
+                    LibraryDependencyTarget.All),
+                IncludeType = includeType,
+                SuppressParent = suppressParent ?? LibraryIncludeFlagUtils.DefaultSuppressParent,
+            };
+        }
+
+        private static List<string> GetAnalyzerAssetPaths(LockFileTargetLibrary targetLibrary)
+        {
+            return targetLibrary.AnalyzerAssets
+                .Select(item => item.Path)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        private static void AssertAnalyzerMetadata(LockFileTargetLibrary targetLibrary, string path, string codeLanguage, string compilerApiVersion = null)
+        {
+            var item = targetLibrary.AnalyzerAssets.Single(a => a.Path == path);
+
+            item.Properties.TryGetValue("codeLanguage", out var actualCodeLanguage);
+            actualCodeLanguage.Should().Be(codeLanguage, because: $"{path} should report its code language");
+
+            item.Properties.TryGetValue("compilerApiVersion", out var actualCompilerApiVersion);
+            actualCompilerApiVersion.Should().Be(compilerApiVersion, because: $"{path} should report its compiler API version");
+        }
+
+        private static void AssertAnalyzerAssetsSelected(LockFileTargetLibrary targetLibrary)
+        {
+            Assert.Equal(
+                new[]
+                {
+                    "analyzers/dotnet/NeutralAnalyzer.dll",
+                    "analyzers/dotnet/cs/CSharpAnalyzer.dll",
+                    "analyzers/dotnet/foo/UnknownFolderAnalyzer.dll",
+                    "analyzers/dotnet/fs/FSharpAnalyzer.dll",
+                    "analyzers/dotnet/vb/VisualBasicAnalyzer.dll",
+                },
+                GetAnalyzerAssetPaths(targetLibrary));
+
+            // Selected analyzers (including ones that flow across project references) carry their metadata.
+            AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/NeutralAnalyzer.dll", codeLanguage: "any");
+            AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/cs/CSharpAnalyzer.dll", codeLanguage: "cs");
+            AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/foo/UnknownFolderAnalyzer.dll", codeLanguage: "any");
+            AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/fs/FSharpAnalyzer.dll", codeLanguage: "fs");
+            AssertAnalyzerMetadata(targetLibrary, "analyzers/dotnet/vb/VisualBasicAnalyzer.dll", codeLanguage: "vb");
+        }
+
+        private static void AssertAnalyzerAssetsExcluded(LockFileTargetLibrary targetLibrary)
+        {
+            Assert.Equal(
+                new[]
+                {
+                    "analyzers/dotnet/_._",
+                },
+                GetAnalyzerAssetPaths(targetLibrary));
+        }
+
+        private static LockFileTargetLibrary GetAnalyzerTargetLibrary(LockFile lockFile, string packageId)
+        {
+            return lockFile.Targets.Single().Libraries.Single(library => library.Name == packageId);
         }
 
         private static TargetFrameworkInformation CreateTargetFrameworkInformation(ImmutableArray<LibraryDependency> dependencies, List<CentralPackageVersion> centralVersionsDependencies, NuGetFramework framework = null)
@@ -4246,4 +5277,3 @@ namespace NuGet.Commands.Test.RestoreCommandTests
         }
     }
 }
-

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/PackageSpecFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/PackageSpecFactoryTests.cs
@@ -63,7 +63,7 @@ public class PackageSpecFactoryTests
     }
 
     [Fact]
-    public void GetPackageSpec_WithAnalyzerAssetRestoreMetadata_PopulatesRestoreMetadata()
+    public void GetPackageSpec_WithAnalyzerAssetsEnabled_PopulatesTargetFramework()
     {
         // Arrange
         var factory = new TestPackageSpecFactory(outerBuild =>
@@ -77,11 +77,11 @@ public class PackageSpecFactoryTests
         var packageSpec = factory.Build();
 
         // Assert
-        packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
+        packageSpec.TargetFrameworks.Single().RestoreEnableAnalyzerAssets.Should().BeTrue();
     }
 
     [Fact]
-    public void GetPackageSpec_WithAnalyzerAssetsEnabledInInnerBuild_PopulatesRestoreMetadata()
+    public void GetPackageSpec_WithAnalyzerAssetsEnabledInInnerBuild_PopulatesThatTargetFrameworkOnly()
     {
         // Arrange
         var factory = new TestPackageSpecFactory(outerBuild =>
@@ -105,11 +105,12 @@ public class PackageSpecFactoryTests
         var packageSpec = factory.Build();
 
         // Assert
-        packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
+        packageSpec.TargetFrameworks.Single(f => f.FrameworkName.GetShortFolderName() == "net8.0").RestoreEnableAnalyzerAssets.Should().BeFalse();
+        packageSpec.TargetFrameworks.Single(f => f.FrameworkName.GetShortFolderName() == "net9.0").RestoreEnableAnalyzerAssets.Should().BeTrue();
     }
 
     [Fact]
-    public void GetPackageSpec_WithAnalyzerAssetsEnabledInOuterBuildButDisabledInAllInnerBuilds_DoesNotPopulateRestoreMetadata()
+    public void GetPackageSpec_WithAnalyzerAssetsDisabledInAllInnerBuilds_DoesNotPopulateAnyTargetFramework()
     {
         // Arrange
         var factory = new TestPackageSpecFactory(outerBuild =>
@@ -133,7 +134,7 @@ public class PackageSpecFactoryTests
         var packageSpec = factory.Build();
 
         // Assert
-        packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
+        packageSpec.TargetFrameworks.Should().OnlyContain(f => !f.RestoreEnableAnalyzerAssets);
     }
 
     [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/PackageSpecFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/PackageSpecFactoryTests.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
+using NuGet.LibraryModel;
 using NuGet.ProjectManagement;
 using Test.Utility;
 using Xunit;
@@ -57,5 +60,132 @@ public class PackageSpecFactoryTests
 
         // Assert
         packageSpec.RestoreMetadata.CentralPackageVersionsEnabled.Should().Be(expectedCpmEnabled);
+    }
+
+    [Fact]
+    public void GetPackageSpec_WithAnalyzerAssetRestoreMetadata_PopulatesRestoreMetadata()
+    {
+        // Arrange
+        var factory = new TestPackageSpecFactory(outerBuild =>
+        {
+            outerBuild.WithProperty("TargetFramework", "net8.0");
+            outerBuild.WithProperty("RestoreEnableAnalyzerAssets", "true");
+            outerBuild.WithItem("PackageReference", "SomePackage", null);
+        });
+
+        // Act
+        var packageSpec = factory.Build();
+
+        // Assert
+        packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetPackageSpec_WithAnalyzerAssetsEnabledInInnerBuild_PopulatesRestoreMetadata()
+    {
+        // Arrange
+        var factory = new TestPackageSpecFactory(outerBuild =>
+        {
+            outerBuild.WithProperty("TargetFrameworks", "net8.0;net9.0");
+            outerBuild.WithProperty("RestoreEnableAnalyzerAssets", "false");
+            outerBuild.WithItem("PackageReference", "SomePackage", null);
+        })
+        .WithInnerBuild(innerBuild =>
+        {
+            innerBuild.WithProperty("TargetFramework", "net8.0");
+            innerBuild.WithProperty("RestoreEnableAnalyzerAssets", "false");
+        })
+        .WithInnerBuild(innerBuild =>
+        {
+            innerBuild.WithProperty("TargetFramework", "net9.0");
+            innerBuild.WithProperty("RestoreEnableAnalyzerAssets", "true");
+        });
+
+        // Act
+        var packageSpec = factory.Build();
+
+        // Assert
+        packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetPackageSpec_WithAnalyzerAssetsEnabledInOuterBuildButDisabledInAllInnerBuilds_DoesNotPopulateRestoreMetadata()
+    {
+        // Arrange
+        var factory = new TestPackageSpecFactory(outerBuild =>
+        {
+            outerBuild.WithProperty("TargetFrameworks", "net8.0;net9.0");
+            outerBuild.WithProperty("RestoreEnableAnalyzerAssets", "true");
+            outerBuild.WithItem("PackageReference", "SomePackage", null);
+        })
+        .WithInnerBuild(innerBuild =>
+        {
+            innerBuild.WithProperty("TargetFramework", "net8.0");
+            innerBuild.WithProperty("RestoreEnableAnalyzerAssets", "false");
+        })
+        .WithInnerBuild(innerBuild =>
+        {
+            innerBuild.WithProperty("TargetFramework", "net9.0");
+            innerBuild.WithProperty("RestoreEnableAnalyzerAssets", "false");
+        });
+
+        // Act
+        var packageSpec = factory.Build();
+
+        // Assert
+        packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetPackageSpec_WithPackageReferenceAnalyzerAssetMetadata_PopulatesDependencyAssetFlags()
+    {
+        // Arrange
+        var factory = new TestPackageSpecFactory(outerBuild =>
+        {
+            outerBuild.WithProperty("TargetFramework", "net8.0");
+            outerBuild.WithItem(
+                "PackageReference",
+                "SomePackage",
+                [
+                    new KeyValuePair<string, string>("IncludeAssets", "runtime;analyzers"),
+                    new KeyValuePair<string, string>("ExcludeAssets", "runtime"),
+                    new KeyValuePair<string, string>("PrivateAssets", "analyzers"),
+                ]);
+        });
+
+        // Act
+        var packageSpec = factory.Build();
+        var dependency = packageSpec.TargetFrameworks.Single().Dependencies.Single();
+
+        // Assert
+        dependency.IncludeType.Should().Be(LibraryIncludeFlags.Analyzers);
+        dependency.SuppressParent.Should().Be(LibraryIncludeFlags.Analyzers);
+    }
+
+    [Fact]
+    public void GetPackageSpec_WithProjectReferenceAnalyzerAssetMetadata_PopulatesProjectReferenceAssetFlags()
+    {
+        // Arrange
+        var factory = new TestPackageSpecFactory(outerBuild =>
+        {
+            outerBuild.WithProperty("TargetFramework", "net8.0");
+            outerBuild.WithItem(
+                ProjectItems.ProjectReference,
+                "..\\Referenced\\Referenced.csproj",
+                [
+                    new KeyValuePair<string, string>("IncludeAssets", "runtime;analyzers"),
+                    new KeyValuePair<string, string>("ExcludeAssets", "runtime"),
+                    new KeyValuePair<string, string>("PrivateAssets", "analyzers"),
+                ]);
+        });
+
+        // Act
+        var packageSpec = factory.Build();
+        var projectReference = packageSpec.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Single();
+
+        // Assert
+        projectReference.IncludeAssets.Should().Be(LibraryIncludeFlags.Runtime | LibraryIncludeFlags.Analyzers);
+        projectReference.ExcludeAssets.Should().Be(LibraryIncludeFlags.Runtime);
+        projectReference.PrivateAssets.Should().Be(LibraryIncludeFlags.Analyzers);
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/PackageSpecFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/PackageSpecFactoryTests.cs
@@ -81,7 +81,7 @@ public class PackageSpecFactoryTests
     }
 
     [Fact]
-    public void GetPackageSpec_WithAnalyzerAssetsEnabledInInnerBuildOnly_IsNotEnabled()
+    public void GetPackageSpec_WithAnalyzerAssetsEnabledInAnyInnerBuild_IsEnabled()
     {
         // Arrange
         var factory = new TestPackageSpecFactory(outerBuild =>
@@ -105,7 +105,7 @@ public class PackageSpecFactoryTests
         var packageSpec = factory.Build();
 
         // Assert
-        packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
+        packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
     }
 
     [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/PackageSpecFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/Utility/PackageSpecFactoryTests.cs
@@ -63,7 +63,7 @@ public class PackageSpecFactoryTests
     }
 
     [Fact]
-    public void GetPackageSpec_WithAnalyzerAssetsEnabled_PopulatesTargetFramework()
+    public void GetPackageSpec_WithAnalyzerAssetsEnabled_PopulatesRestoreMetadata()
     {
         // Arrange
         var factory = new TestPackageSpecFactory(outerBuild =>
@@ -77,11 +77,11 @@ public class PackageSpecFactoryTests
         var packageSpec = factory.Build();
 
         // Assert
-        packageSpec.TargetFrameworks.Single().RestoreEnableAnalyzerAssets.Should().BeTrue();
+        packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
     }
 
     [Fact]
-    public void GetPackageSpec_WithAnalyzerAssetsEnabledInInnerBuild_PopulatesThatTargetFrameworkOnly()
+    public void GetPackageSpec_WithAnalyzerAssetsEnabledInInnerBuildOnly_IsNotEnabled()
     {
         // Arrange
         var factory = new TestPackageSpecFactory(outerBuild =>
@@ -105,12 +105,11 @@ public class PackageSpecFactoryTests
         var packageSpec = factory.Build();
 
         // Assert
-        packageSpec.TargetFrameworks.Single(f => f.FrameworkName.GetShortFolderName() == "net8.0").RestoreEnableAnalyzerAssets.Should().BeFalse();
-        packageSpec.TargetFrameworks.Single(f => f.FrameworkName.GetShortFolderName() == "net9.0").RestoreEnableAnalyzerAssets.Should().BeTrue();
+        packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
     }
 
     [Fact]
-    public void GetPackageSpec_WithAnalyzerAssetsDisabledInAllInnerBuilds_DoesNotPopulateAnyTargetFramework()
+    public void GetPackageSpec_WithAnalyzerAssetsEnabledInOuterBuild_IsEnabledRegardlessOfInnerBuilds()
     {
         // Arrange
         var factory = new TestPackageSpecFactory(outerBuild =>
@@ -134,7 +133,7 @@ public class PackageSpecFactoryTests
         var packageSpec = factory.Build();
 
         // Assert
-        packageSpec.TargetFrameworks.Should().OnlyContain(f => !f.RestoreEnableAnalyzerAssets);
+        packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
     }
 
     [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ContentModelTests/ContentModelAnalyzerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ContentModelTests/ContentModelAnalyzerTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Client;
+using NuGet.ContentModel;
+using NuGet.RuntimeModel;
+using Xunit;
+
+namespace NuGet.Packaging.Test.ContentModelTests
+{
+    public class ContentModelAnalyzerTests
+    {
+        private static ManagedCodeConventions CreateConventions()
+        {
+            return new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+        }
+
+        private static List<string> FindAnalyzers(params string[] files)
+        {
+            var conventions = CreateConventions();
+            var collection = new ContentItemCollection();
+            collection.Load(files);
+
+            return collection
+                .FindItems(conventions.Patterns.AnalyzerAssemblies)
+                .Select(item => item.Path)
+                .OrderBy(path => path, System.StringComparer.Ordinal)
+                .ToList();
+        }
+
+        [Fact]
+        public void AnalyzerAssemblies_MatchesAssembliesAtAnyDepth()
+        {
+            var analyzers = FindAnalyzers(
+                "analyzers/Root.dll",
+                "analyzers/dotnet/NeutralAnalyzer.dll",
+                "analyzers/dotnet/cs/CSharpAnalyzer.dll",
+                "analyzers/dotnet/roslyn4.0/cs/VersionedAnalyzer.dll",
+                "analyzers/a/b/c/d/e/f/g/VeryDeepAnalyzer.dll");
+
+            Assert.Equal(
+                new[]
+                {
+                    "analyzers/Root.dll",
+                    "analyzers/a/b/c/d/e/f/g/VeryDeepAnalyzer.dll",
+                    "analyzers/dotnet/NeutralAnalyzer.dll",
+                    "analyzers/dotnet/cs/CSharpAnalyzer.dll",
+                    "analyzers/dotnet/roslyn4.0/cs/VersionedAnalyzer.dll",
+                },
+                analyzers);
+        }
+
+        [Fact]
+        public void AnalyzerAssemblies_ExcludesSatelliteResourceAssemblies()
+        {
+            var analyzers = FindAnalyzers(
+                "analyzers/dotnet/cs/CSharpAnalyzer.dll",
+                "analyzers/dotnet/cs/CSharpAnalyzer.resources.dll");
+
+            Assert.Equal(new[] { "analyzers/dotnet/cs/CSharpAnalyzer.dll" }, analyzers);
+        }
+
+        [Fact]
+        public void AnalyzerAssemblies_ExcludesNonDllFiles()
+        {
+            var analyzers = FindAnalyzers(
+                "analyzers/dotnet/cs/Analyzer.dll",
+                "analyzers/dotnet/cs/NotAnAnalyzer.exe",
+                "analyzers/dotnet/cs/NotAnAnalyzer.winmd",
+                "analyzers/dotnet/cs/readme.txt");
+
+            Assert.Equal(new[] { "analyzers/dotnet/cs/Analyzer.dll" }, analyzers);
+        }
+
+        [Fact]
+        public void AnalyzerAssemblies_ExcludesAssembliesOutsideAnalyzersFolder()
+        {
+            var analyzers = FindAnalyzers(
+                "analyzers/dotnet/cs/Analyzer.dll",
+                "lib/netstandard2.0/Library.dll",
+                "ref/netstandard2.0/Library.dll",
+                "notanalyzers/Foo.dll");
+
+            Assert.Equal(new[] { "analyzers/dotnet/cs/Analyzer.dll" }, analyzers);
+        }
+
+        [Fact]
+        public void AnalyzerAssemblies_MatchesAnalyzersFolderCaseInsensitively()
+        {
+            // The content model matches literal path segments case-insensitively, so an 'Analyzers/' folder
+            // (capital A) is detected. This differs from the previous hand-rolled detection, which matched the
+            // 'analyzers/' prefix with StringComparison.Ordinal (case-sensitive).
+            var analyzers = FindAnalyzers(
+                "analyzers/dotnet/cs/Lower.dll",
+                "Analyzers/dotnet/cs/Upper.dll");
+
+            Assert.Equal(
+                new[]
+                {
+                    "Analyzers/dotnet/cs/Upper.dll",
+                    "analyzers/dotnet/cs/Lower.dll",
+                },
+                analyzers);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -607,6 +607,24 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal(firstHash, secondHash);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GetHash_WithDifferentRestoreEnableAnalyzerAssetsValues_ReturnsDifferentHashes(bool useLegacyHashFunction)
+        {
+            // Arrange
+            DependencyGraphSpec first = CreateDependencyGraphSpec();
+            DependencyGraphSpec second = CreateDependencyGraphSpec();
+            second.GetProjectSpec("a").RestoreMetadata.RestoreEnableAnalyzerAssets = true;
+
+            // Act
+            string firstHash = GetHash(first, useLegacyHashFunction);
+            string secondHash = GetHash(second, useLegacyHashFunction);
+
+            // Assert
+            Assert.NotEqual(firstHash, secondHash);
+        }
+
         [Fact]
         public void AddProject_WhenRestoreMetadataIsNull_AddsProject()
         {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -615,7 +615,8 @@ namespace NuGet.ProjectModel.Test
             // Arrange
             DependencyGraphSpec first = CreateDependencyGraphSpec();
             DependencyGraphSpec second = CreateDependencyGraphSpec();
-            second.GetProjectSpec("a").RestoreMetadata.RestoreEnableAnalyzerAssets = true;
+            first.GetProjectSpec("a").TargetFrameworks.Add(new TargetFrameworkInformation { FrameworkName = NuGetFramework.Parse("net5.0") });
+            second.GetProjectSpec("a").TargetFrameworks.Add(new TargetFrameworkInformation { FrameworkName = NuGetFramework.Parse("net5.0"), RestoreEnableAnalyzerAssets = true });
 
             // Act
             string firstHash = GetHash(first, useLegacyHashFunction);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -616,7 +616,8 @@ namespace NuGet.ProjectModel.Test
             DependencyGraphSpec first = CreateDependencyGraphSpec();
             DependencyGraphSpec second = CreateDependencyGraphSpec();
             first.GetProjectSpec("a").TargetFrameworks.Add(new TargetFrameworkInformation { FrameworkName = NuGetFramework.Parse("net5.0") });
-            second.GetProjectSpec("a").TargetFrameworks.Add(new TargetFrameworkInformation { FrameworkName = NuGetFramework.Parse("net5.0"), RestoreEnableAnalyzerAssets = true });
+            second.GetProjectSpec("a").TargetFrameworks.Add(new TargetFrameworkInformation { FrameworkName = NuGetFramework.Parse("net5.0") });
+            second.GetProjectSpec("a").RestoreMetadata.RestoreEnableAnalyzerAssets = true;
 
             // Act
             string firstHash = GetHash(first, useLegacyHashFunction);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -198,6 +198,35 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        public void PackageSpecReader_ReadsAnalyzerDependencyAssetFlags()
+        {
+            // Arrange
+            var json = @"{
+                           ""frameworks"": {
+                             ""net46"": {
+                               ""dependencies"": {
+                                 ""analyzerPackage"": {
+                                   ""version"": ""1.0.0"",
+                                   ""include"": ""compile, analyzers"",
+                                   ""exclude"": ""compile"",
+                                   ""suppressParent"": ""analyzers""
+                                 }
+                               }
+                             }
+                            }
+                        }";
+
+            // Act
+            var actual = GetPackageSpec(json, "TestProject", "project.json", null);
+
+            // Assert
+            var dep = actual.TargetFrameworks[0].Dependencies.FirstOrDefault(d => d.Name.Equals("analyzerPackage"));
+            Assert.NotNull(dep);
+            Assert.Equal(LibraryIncludeFlags.Analyzers, dep.IncludeType);
+            Assert.Equal(LibraryIncludeFlags.Analyzers, dep.SuppressParent);
+        }
+
+        [Fact]
         public void PackageSpecReader_ReadsDependencyWithMultipleNoWarn()
         {
             // Arrange
@@ -2954,6 +2983,35 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             packageSpec.RestoreMetadata.UseLegacyDependencyResolver.Should().Be(useLegacyDependencyResolver);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetPackageSpec_WithRestoreEnableAnalyzerAssets_ReturnsRestoreEnableAnalyzerAssets(
+            bool restoreEnableAnalyzerAssets)
+        {
+            // Arrange
+            var json = $"{{\"restore\":{{\"restoreEnableAnalyzerAssets\":{restoreEnableAnalyzerAssets.ToString().ToLowerInvariant()}}}}}";
+
+            // Act
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            // Assert
+            packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().Be(restoreEnableAnalyzerAssets);
+        }
+
+        [Fact]
+        public void GetPackageSpec_WithNoRestoreEnableAnalyzerAssetsValuePassed_DefaultsFalse()
+        {
+            // Arrange
+            var json = "{\"restore\":{}}";
+
+            // Act
+            PackageSpec packageSpec = GetPackageSpec(json);
+
+            // Assert
+            packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -2992,26 +2992,26 @@ namespace NuGet.ProjectModel.Test
             bool restoreEnableAnalyzerAssets)
         {
             // Arrange
-            var json = $"{{\"frameworks\":{{\"net5.0\":{{\"restoreEnableAnalyzerAssets\":{restoreEnableAnalyzerAssets.ToString().ToLowerInvariant()}}}}}}}";
+            var json = $"{{\"restore\":{{\"restoreEnableAnalyzerAssets\":{restoreEnableAnalyzerAssets.ToString().ToLowerInvariant()}}}}}";
 
             // Act
             PackageSpec packageSpec = GetPackageSpec(json);
 
             // Assert
-            packageSpec.TargetFrameworks.Single().RestoreEnableAnalyzerAssets.Should().Be(restoreEnableAnalyzerAssets);
+            packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().Be(restoreEnableAnalyzerAssets);
         }
 
         [Fact]
         public void GetPackageSpec_WithNoRestoreEnableAnalyzerAssetsValuePassed_DefaultsFalse()
         {
             // Arrange
-            var json = "{\"frameworks\":{\"net5.0\":{}}}";
+            var json = "{\"restore\":{}}";
 
             // Act
             PackageSpec packageSpec = GetPackageSpec(json);
 
             // Assert
-            packageSpec.TargetFrameworks.Single().RestoreEnableAnalyzerAssets.Should().BeFalse();
+            packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -2992,26 +2992,26 @@ namespace NuGet.ProjectModel.Test
             bool restoreEnableAnalyzerAssets)
         {
             // Arrange
-            var json = $"{{\"restore\":{{\"restoreEnableAnalyzerAssets\":{restoreEnableAnalyzerAssets.ToString().ToLowerInvariant()}}}}}";
+            var json = $"{{\"frameworks\":{{\"net5.0\":{{\"restoreEnableAnalyzerAssets\":{restoreEnableAnalyzerAssets.ToString().ToLowerInvariant()}}}}}}}";
 
             // Act
             PackageSpec packageSpec = GetPackageSpec(json);
 
             // Assert
-            packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().Be(restoreEnableAnalyzerAssets);
+            packageSpec.TargetFrameworks.Single().RestoreEnableAnalyzerAssets.Should().Be(restoreEnableAnalyzerAssets);
         }
 
         [Fact]
         public void GetPackageSpec_WithNoRestoreEnableAnalyzerAssetsValuePassed_DefaultsFalse()
         {
             // Arrange
-            var json = "{\"restore\":{}}";
+            var json = "{\"frameworks\":{\"net5.0\":{}}}";
 
             // Act
             PackageSpec packageSpec = GetPackageSpec(json);
 
             // Assert
-            packageSpec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
+            packageSpec.TargetFrameworks.Single().RestoreEnableAnalyzerAssets.Should().BeFalse();
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -366,6 +366,63 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        public void LockFileFormat_WithAnalyzerAssets_WritesAndReadsAnalyzerAssets()
+        {
+            // Arrange
+            const string AnalyzerAssetPath = "analyzers/dotnet/cs/MyAnalyzer.dll";
+
+            var lockFile = new LockFile()
+            {
+                Version = 5,
+                PackageSpec = new PackageSpec(new[]
+                {
+                    new TargetFrameworkInformation
+                    {
+                        FrameworkName = FrameworkConstants.CommonFrameworks.DotNet,
+                        TargetAlias = "dotnet"
+                    }
+                })
+            };
+
+            var target = new LockFileTarget()
+            {
+                TargetFramework = FrameworkConstants.CommonFrameworks.DotNet,
+                TargetAlias = "dotnet",
+                Name = "dotnet"
+            };
+
+            var targetLibrary = new LockFileTargetLibrary()
+            {
+                Name = "MyAnalyzerPackage",
+                Version = NuGetVersion.Parse("1.0.0"),
+                Type = LibraryType.Package
+            };
+            var analyzerAsset = new LockFileItem(AnalyzerAssetPath);
+            analyzerAsset.Properties["codeLanguage"] = "cs";
+            analyzerAsset.Properties["compilerApiVersion"] = "roslyn4.0";
+            targetLibrary.AnalyzerAssets.Add(analyzerAsset);
+            target.Libraries.Add(targetLibrary);
+            lockFile.Targets.Add(target);
+
+            var lockFileFormat = new LockFileFormat();
+
+            // Act
+            var renderedJson = lockFileFormat.Render(lockFile);
+            var parsedLockFile = Parse(renderedJson, "In Memory");
+
+            // Assert
+            Assert.Contains(@"""version"": 5", renderedJson);
+            Assert.Contains(@"""analyzers"": {", renderedJson);
+            Assert.Contains(@"""codeLanguage"": ""cs""", renderedJson);
+            Assert.Contains(@"""compilerApiVersion"": ""roslyn4.0""", renderedJson);
+
+            var parsedAsset = parsedLockFile.Targets.Single().Libraries.Single().AnalyzerAssets.Single();
+            Assert.Equal(AnalyzerAssetPath, parsedAsset.Path);
+            Assert.Equal("cs", parsedAsset.Properties["codeLanguage"]);
+            Assert.Equal("roslyn4.0", parsedAsset.Properties["compilerApiVersion"]);
+        }
+
+        [Fact]
         public void LockFileFormat_WritesPackageSpec()
         {
             // Arrange
@@ -393,6 +450,57 @@ namespace NuGet.ProjectModel.Test
                         FrameworkName = FrameworkConstants.CommonFrameworks.DotNet
                     }
                 })
+            };
+
+            // Act
+            var lockFileFormat = new LockFileFormat();
+            var output = JObject.Parse(lockFileFormat.Render(lockFile));
+            var expected = JObject.Parse(lockFileContent);
+
+            // Assert
+            Assert.Equal(expected.ToString(), output.ToString());
+        }
+
+        [Fact]
+        public void LockFileFormat_WithRestoreEnableAnalyzerAssets_WritesPackageSpecRestoreMetadata()
+        {
+            // Arrange
+            var lockFileContent = @"{
+  ""version"": 2,
+  ""targets"": {},
+  ""libraries"": {},
+  ""projectFileDependencyGroups"": {},
+  ""project"": {
+    ""restore"": {
+      ""projectUniqueName"": ""projectUniqueName"",
+      ""restoreEnableAnalyzerAssets"": true
+    },
+    ""frameworks"": {
+      ""dotnet"": {
+        ""framework"": ""dotnet""
+        }
+    }
+  }
+}";
+            var lockFile = new LockFile()
+            {
+                Version = 2,
+
+                PackageSpec = new PackageSpec(new[]
+                {
+                    new TargetFrameworkInformation
+                    {
+                        FrameworkName = FrameworkConstants.CommonFrameworks.DotNet
+                    }
+                })
+                {
+                    RestoreMetadata = new ProjectRestoreMetadata
+                    {
+                        ProjectUniqueName = "projectUniqueName",
+                        UsingMicrosoftNETSdk = true,
+                        RestoreEnableAnalyzerAssets = true
+                    }
+                }
             };
 
             // Act

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -462,7 +462,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
-        public void LockFileFormat_WithRestoreEnableAnalyzerAssets_WritesPackageSpecRestoreMetadata()
+        public void LockFileFormat_WithRestoreEnableAnalyzerAssets_WritesPackageSpecFramework()
         {
             // Arrange
             var lockFileContent = @"{
@@ -472,12 +472,12 @@ namespace NuGet.ProjectModel.Test
   ""projectFileDependencyGroups"": {},
   ""project"": {
     ""restore"": {
-      ""projectUniqueName"": ""projectUniqueName"",
-      ""restoreEnableAnalyzerAssets"": true
+      ""projectUniqueName"": ""projectUniqueName""
     },
     ""frameworks"": {
       ""dotnet"": {
-        ""framework"": ""dotnet""
+        ""framework"": ""dotnet"",
+        ""restoreEnableAnalyzerAssets"": true
         }
     }
   }
@@ -490,15 +490,15 @@ namespace NuGet.ProjectModel.Test
                 {
                     new TargetFrameworkInformation
                     {
-                        FrameworkName = FrameworkConstants.CommonFrameworks.DotNet
+                        FrameworkName = FrameworkConstants.CommonFrameworks.DotNet,
+                        RestoreEnableAnalyzerAssets = true
                     }
                 })
                 {
                     RestoreMetadata = new ProjectRestoreMetadata
                     {
                         ProjectUniqueName = "projectUniqueName",
-                        UsingMicrosoftNETSdk = true,
-                        RestoreEnableAnalyzerAssets = true
+                        UsingMicrosoftNETSdk = true
                     }
                 }
             };

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -462,7 +462,7 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
-        public void LockFileFormat_WithRestoreEnableAnalyzerAssets_WritesPackageSpecFramework()
+        public void LockFileFormat_WithRestoreEnableAnalyzerAssets_WritesPackageSpecRestoreMetadata()
         {
             // Arrange
             var lockFileContent = @"{
@@ -472,12 +472,12 @@ namespace NuGet.ProjectModel.Test
   ""projectFileDependencyGroups"": {},
   ""project"": {
     ""restore"": {
-      ""projectUniqueName"": ""projectUniqueName""
+      ""projectUniqueName"": ""projectUniqueName"",
+      ""restoreEnableAnalyzerAssets"": true
     },
     ""frameworks"": {
       ""dotnet"": {
-        ""framework"": ""dotnet"",
-        ""restoreEnableAnalyzerAssets"": true
+        ""framework"": ""dotnet""
         }
     }
   }
@@ -490,15 +490,15 @@ namespace NuGet.ProjectModel.Test
                 {
                     new TargetFrameworkInformation
                     {
-                        FrameworkName = FrameworkConstants.CommonFrameworks.DotNet,
-                        RestoreEnableAnalyzerAssets = true
+                        FrameworkName = FrameworkConstants.CommonFrameworks.DotNet
                     }
                 })
                 {
                     RestoreMetadata = new ProjectRestoreMetadata
                     {
                         ProjectUniqueName = "projectUniqueName",
-                        UsingMicrosoftNETSdk = true
+                        UsingMicrosoftNETSdk = true,
+                        RestoreEnableAnalyzerAssets = true
                     }
                 }
             };

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileTargetLibraryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileTargetLibraryTests.cs
@@ -293,6 +293,34 @@ namespace NuGet.ProjectModel.Test
         [InlineData("A;b", "a;B", true)]
         [InlineData("a;b;c", "c;a;B", true)]
         [InlineData("a;b;c;d", "c;a;B", false)]
+        public void Equals_WithAnalyzerAssets_ReturnsExpectedResult(string left, string right, bool expected)
+        {
+            var leftSide = new LockFileTargetLibrary()
+            {
+                AnalyzerAssets = left.Split(';').Select(e => new LockFileItem(e)).ToList()
+            };
+
+            var rightSide = new LockFileTargetLibrary()
+            {
+                AnalyzerAssets = right.Split(';').Select(e => new LockFileItem(e)).ToList()
+            };
+
+            // Act & Assert
+            if (expected)
+            {
+                leftSide.Should().Be(rightSide);
+            }
+            else
+            {
+                leftSide.Should().NotBe(rightSide);
+            }
+        }
+
+        [Theory]
+        [InlineData("a", "a", true)]
+        [InlineData("A;b", "a;B", true)]
+        [InlineData("a;b;c", "c;a;B", true)]
+        [InlineData("a;b;c;d", "c;a;B", false)]
         public void Equals_WithNativeLibraries(string left, string right, bool expected)
         {
             var leftSide = new LockFileTargetLibrary()
@@ -763,6 +791,34 @@ namespace NuGet.ProjectModel.Test
             var rightSide = new LockFileTargetLibrary()
             {
                 CompileTimeAssemblies = right.Split(';').Select(e => new LockFileItem(e)).ToList()
+            };
+
+            // Act & Assert
+            if (expected)
+            {
+                leftSide.GetHashCode().Should().Be(rightSide.GetHashCode());
+            }
+            else
+            {
+                leftSide.GetHashCode().Should().NotBe(rightSide.GetHashCode());
+            }
+        }
+
+        [Theory]
+        [InlineData("a", "a", true)]
+        [InlineData("A;b", "a;B", true)]
+        [InlineData("a;b;c", "c;a;B", true)]
+        [InlineData("a;b;c;d", "c;a;B", false)]
+        public void HashCode_WithAnalyzerAssets_ReturnsExpectedResult(string left, string right, bool expected)
+        {
+            var leftSide = new LockFileTargetLibrary()
+            {
+                AnalyzerAssets = left.Split(';').Select(e => new LockFileItem(e)).ToList()
+            };
+
+            var rightSide = new LockFileTargetLibrary()
+            {
+                AnalyzerAssets = right.Split(';').Select(e => new LockFileItem(e)).ToList()
             };
 
             // Act & Assert

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -227,6 +227,61 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        public void Write_ReadWrite_RestoreEnableAnalyzerAssets_True()
+        {
+            // Arrange
+            var json = @"{
+                            ""restore"": {
+    ""projectUniqueName"": ""projectUniqueName"",
+    ""projectName"": ""projectName"",
+    ""projectPath"": ""projectPath"",
+    ""packagesPath"": ""packagesPath"",
+    ""outputPath"": ""outputPath"",
+    ""projectStyle"": ""PackageReference"",
+    ""restoreEnableAnalyzerAssets"": true,
+    ""frameworks"": {
+      ""net45"": {
+        ""framework"": ""net45"",
+        ""projectReferences"": {}
+      }
+    }
+  }
+}";
+            // Act & Assert
+            VerifyJsonPackageSpecRoundTrip(json);
+        }
+
+        [Fact]
+        public void Write_ReadWrite_RestoreEnableAnalyzerAssets_DefaultFalse_NotWritten()
+        {
+            // Arrange
+            var json = @"{
+                            ""restore"": {
+    ""projectUniqueName"": ""projectUniqueName"",
+    ""projectName"": ""projectName"",
+    ""projectPath"": ""projectPath"",
+    ""packagesPath"": ""packagesPath"",
+    ""outputPath"": ""outputPath"",
+    ""projectStyle"": ""PackageReference"",
+    ""frameworks"": {
+      ""net45"": {
+        ""framework"": ""net45"",
+        ""projectReferences"": {}
+      }
+    }
+  }
+}";
+            // Act
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.csproj");
+
+            // Assert
+            spec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
+
+            var output = GetJsonString(spec);
+            output.Should().NotContain("restoreEnableAnalyzerAssets");
+        }
+
+        [Fact]
         public void Write_SerializesMembersAsJson()
         {
             // Arrange && Act

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -230,54 +230,57 @@ namespace NuGet.ProjectModel.Test
         public void Write_ReadWrite_RestoreEnableAnalyzerAssets_True()
         {
             // Arrange
-            var json = @"{
-                            ""restore"": {
-    ""projectUniqueName"": ""projectUniqueName"",
-    ""projectName"": ""projectName"",
-    ""projectPath"": ""projectPath"",
-    ""packagesPath"": ""packagesPath"",
-    ""outputPath"": ""outputPath"",
-    ""projectStyle"": ""PackageReference"",
-    ""restoreEnableAnalyzerAssets"": true,
-    ""frameworks"": {
-      ""net45"": {
-        ""framework"": ""net45"",
-        ""projectReferences"": {}
-      }
-    }
-  }
-}";
-            // Act & Assert
-            VerifyJsonPackageSpecRoundTrip(json);
+            var spec = new PackageSpec(new[]
+            {
+                new TargetFrameworkInformation
+                {
+                    FrameworkName = NuGetFramework.Parse("net45"),
+                    RestoreEnableAnalyzerAssets = true
+                }
+            })
+            {
+                RestoreMetadata = new ProjectRestoreMetadata
+                {
+                    ProjectUniqueName = "projectUniqueName",
+                    ProjectName = "projectName",
+                    ProjectStyle = ProjectStyle.PackageReference
+                }
+            };
+
+            // Act
+            var json = GetJsonString(spec);
+            var roundTripped = JsonPackageSpecReader.GetPackageSpec(json, "projectName", "project.csproj");
+
+            // Assert
+            json.Should().Contain("restoreEnableAnalyzerAssets");
+            roundTripped.TargetFrameworks[0].RestoreEnableAnalyzerAssets.Should().BeTrue();
         }
 
         [Fact]
         public void Write_ReadWrite_RestoreEnableAnalyzerAssets_DefaultFalse_NotWritten()
         {
             // Arrange
-            var json = @"{
-                            ""restore"": {
-    ""projectUniqueName"": ""projectUniqueName"",
-    ""projectName"": ""projectName"",
-    ""projectPath"": ""projectPath"",
-    ""packagesPath"": ""packagesPath"",
-    ""outputPath"": ""outputPath"",
-    ""projectStyle"": ""PackageReference"",
-    ""frameworks"": {
-      ""net45"": {
-        ""framework"": ""net45"",
-        ""projectReferences"": {}
-      }
-    }
-  }
-}";
+            var spec = new PackageSpec(new[]
+            {
+                new TargetFrameworkInformation
+                {
+                    FrameworkName = NuGetFramework.Parse("net45")
+                }
+            })
+            {
+                RestoreMetadata = new ProjectRestoreMetadata
+                {
+                    ProjectUniqueName = "projectUniqueName",
+                    ProjectName = "projectName",
+                    ProjectStyle = ProjectStyle.PackageReference
+                }
+            };
+
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.csproj");
+            var output = GetJsonString(spec);
 
             // Assert
-            spec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
-
-            var output = GetJsonString(spec);
+            spec.TargetFrameworks[0].RestoreEnableAnalyzerAssets.Should().BeFalse();
             output.Should().NotContain("restoreEnableAnalyzerAssets");
         }
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -234,8 +234,7 @@ namespace NuGet.ProjectModel.Test
             {
                 new TargetFrameworkInformation
                 {
-                    FrameworkName = NuGetFramework.Parse("net45"),
-                    RestoreEnableAnalyzerAssets = true
+                    FrameworkName = NuGetFramework.Parse("net45")
                 }
             })
             {
@@ -243,7 +242,8 @@ namespace NuGet.ProjectModel.Test
                 {
                     ProjectUniqueName = "projectUniqueName",
                     ProjectName = "projectName",
-                    ProjectStyle = ProjectStyle.PackageReference
+                    ProjectStyle = ProjectStyle.PackageReference,
+                    RestoreEnableAnalyzerAssets = true
                 }
             };
 
@@ -253,7 +253,7 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             json.Should().Contain("restoreEnableAnalyzerAssets");
-            roundTripped.TargetFrameworks[0].RestoreEnableAnalyzerAssets.Should().BeTrue();
+            roundTripped.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeTrue();
         }
 
         [Fact]
@@ -280,7 +280,7 @@ namespace NuGet.ProjectModel.Test
             var output = GetJsonString(spec);
 
             // Assert
-            spec.TargetFrameworks[0].RestoreEnableAnalyzerAssets.Should().BeFalse();
+            spec.RestoreMetadata.RestoreEnableAnalyzerAssets.Should().BeFalse();
             output.Should().NotContain("restoreEnableAnalyzerAssets");
         }
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
@@ -868,5 +868,40 @@ namespace NuGet.ProjectModel.Test
             clone.RestoreDoNotWriteDependencyGraphSpec.Should().Be(true);
             AssertEquality(true, original, clone);
         }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(false, false, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        public void Equals_WithRestoreEnableAnalyzerAssets(bool left, bool right, bool expected)
+        {
+            var leftSide = new ProjectRestoreMetadata
+            {
+                RestoreEnableAnalyzerAssets = left
+            };
+
+            var rightSide = new ProjectRestoreMetadata
+            {
+                RestoreEnableAnalyzerAssets = right
+            };
+
+            AssertEquality(expected, leftSide, rightSide);
+            AssertHashCode(expected, leftSide, rightSide);
+        }
+
+        [Fact]
+        public void Clone_WithAnalyzerAssetRestoreMetadata_CopiesValues()
+        {
+            var original = new ProjectRestoreMetadata
+            {
+                RestoreEnableAnalyzerAssets = true
+            };
+
+            var clone = original.Clone();
+
+            clone.RestoreEnableAnalyzerAssets.Should().BeTrue();
+            AssertEquality(true, original, clone);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ProjectRestoreMetadataTests.cs
@@ -868,40 +868,5 @@ namespace NuGet.ProjectModel.Test
             clone.RestoreDoNotWriteDependencyGraphSpec.Should().Be(true);
             AssertEquality(true, original, clone);
         }
-
-        [Theory]
-        [InlineData(true, true, true)]
-        [InlineData(false, false, true)]
-        [InlineData(true, false, false)]
-        [InlineData(false, true, false)]
-        public void Equals_WithRestoreEnableAnalyzerAssets(bool left, bool right, bool expected)
-        {
-            var leftSide = new ProjectRestoreMetadata
-            {
-                RestoreEnableAnalyzerAssets = left
-            };
-
-            var rightSide = new ProjectRestoreMetadata
-            {
-                RestoreEnableAnalyzerAssets = right
-            };
-
-            AssertEquality(expected, leftSide, rightSide);
-            AssertHashCode(expected, leftSide, rightSide);
-        }
-
-        [Fact]
-        public void Clone_WithAnalyzerAssetRestoreMetadata_CopiesValues()
-        {
-            var original = new ProjectRestoreMetadata
-            {
-                RestoreEnableAnalyzerAssets = true
-            };
-
-            var clone = original.Clone();
-
-            clone.RestoreEnableAnalyzerAssets.Should().BeTrue();
-            AssertEquality(true, original, clone);
-        }
     }
 }


### PR DESCRIPTION
# Bug

Progress: https://github.com/NuGet/Home/issues/6279
SDK PR (draft): https://github.com/dotnet/sdk/pull/54646

## Description

Today `project.assets.json` does not record which analyzers a package contributes, and analyzers are applied regardless of `PrivateAssets` / `ExcludeAssets` / `IncludeAssets`. This PR implements the **NuGet restore** half of the "indicate analyzer assets in project.assets.json" feature ([spec: NuGet/Home#14455](https://github.com/NuGet/Home/pull/14455)). The SDK consumption half ships as a separate dotnet/sdk PR.

When a project opts in with `<RestoreEnableAnalyzerAssets>true</RestoreEnableAnalyzerAssets>`, restore now:

- **Emits an `analyzers` group** under each package in the assets file, listing every analyzer assembly. Detection uses a new `AnalyzerAssemblies` pattern in `ManagedCodeConventions` (any `.dll` under `analyzers/` at any depth, excluding satellite `.resources.dll`), so the layout isn't assumed to be fixed and analyzer discovery is shared with the rest of the content model.
- **Respects asset filtering.** `PrivateAssets`, `ExcludeAssets`, and `IncludeAssets` filter analyzers like any other asset type. Analyzers excluded or transitively suppressed are written as a `_._` placeholder (consistent with `compile` / `runtime` / `native`).
- **Attaches selection metadata** to each entry: `codeLanguage` (`cs`/`vb`/`fs`/`any`) and, when present in the path, `compilerApiVersion` (`roslynX.Y`) — mirroring how content files carry `codeLanguage` — so the SDK selects applicable analyzers from metadata instead of parsing paths. The metadata is derived by scanning the path segments, since real packages place the language at a variable depth (for example `analyzers/dotnet/roslynX.Y/cs/`).

**Gating.** The feature is opt-in and only honored for projects targeting **.NET 11 or greater**. The `.NET 11+` gate is applied at evaluation time in `NuGet.targets` (mirroring `NuGetAuditMode`), and the resulting value is honored **per target framework**: it flows through `TargetFrameworkInformation.RestoreEnableAnalyzerAssets` and is read in code by every restore entry point — CLI/DG-spec (`MSBuildRestoreUtility`), VS nomination (`PackageSpecFactory`), and static-graph restore (`MSBuildStaticGraphRestore`, which previously did not honor the property at all). A multi-targeted `net10.0;net11.0` project therefore emits the `analyzers` group only for `net11.0`.

**Telemetry.** `ProjectRestoreInformation` reports `AnalyzerAssets.Enabled` (opt-in state) and `AnalyzerAssets.Count` (number of analyzer assets emitted, excluding `_._` placeholders). Richer adoption/impact telemetry to inform the default-on rollout ships as a follow-up.

**Public API & serialization.** Adds `TargetFrameworkInformation.RestoreEnableAnalyzerAssets`, `LockFileTargetLibrary.AnalyzerAssets`, `LockFileItem.CompilerApiVersionProperty`, and the `ManagedCodeConventions.ManagedCodePatterns.AnalyzerAssemblies` pattern (with the `AnalyzerAssembly` property name). The Newtonsoft.Json and System.Text.Json paths round-trip the new `analyzers` group and its metadata; the per-framework restore property round-trips through `PackageSpecWriter` and the streaming reader. The lock-file cache key includes the per-framework flag so toggling it invalidates correctly.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
