### PR TITLE
Allow string vuln severity in STJ code path

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/PackageDependencyGroupStjConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/PackageDependencyGroupStjConverter.cs
@@ -67,7 +67,10 @@ namespace NuGet.Protocol.Converters
                 }
                 else
                 {
-                    reader.Skip();
+                    if (!reader.TrySkip())
+                    {
+                        throw new JsonException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnexpectedJsonToken, reader.TokenType));
+                    }
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityMetadata.cs
@@ -18,6 +18,7 @@ namespace NuGet.Protocol
 
         [JsonProperty(PropertyName = JsonProperties.Severity)]
         [JsonPropertyName(JsonProperties.Severity)]
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
         [JsonInclude]
         public int Severity { get; internal set; }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/PackageDependencyGroupStjConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Converters/PackageDependencyGroupStjConverterTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Protocol.Converters;
+using Xunit;
+
+namespace NuGet.Protocol.Tests.Converters
+{
+    public class PackageDependencyGroupStjConverterTests
+    {
+        private static readonly JsonSerializerOptions Options = PackageSearchJsonContext.Default.Options;
+
+        [Fact]
+        public void Read_WithIsFinalBlockFalse_UnknownPropertyDoesNotThrow()
+        {
+            byte[] json = Encoding.UTF8.GetBytes(
+                @"{""unknownProperty"": {""nested"": true}, ""targetFramework"": ""net8.0""}");
+
+            var reader = new Utf8JsonReader(json, isFinalBlock: false, new JsonReaderState());
+            reader.Read();
+
+            var converter = new PackageDependencyGroupStjConverter();
+            var result = converter.Read(ref reader, typeof(PackageDependencyGroup), Options);
+
+            result.Should().NotBeNull();
+            result.TargetFramework.Should().Be(NuGetFramework.Parse("net8.0"));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -72,6 +72,10 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(string.Join(", ", "deepequal", "deep", "equal"), result.Tags);
                 Assert.Equal("DeepEqual", result.Title);
                 Assert.True(result.IsListed);
+
+                var vulnerability = Assert.Single(result.Vulnerabilities);
+                Assert.Equal(2, vulnerability.Severity);
+                Assert.Equal("https://contoso.test/advisory/1", vulnerability.AdvisoryUrl.OriginalString);
             }
         }
 

--- a/test/TestUtilities/Test.Utility/JsonData.cs
+++ b/test/TestUtilities/Test.Utility/JsonData.cs
@@ -525,7 +525,13 @@ namespace Test.Utility
               ""equal""
             ],
             ""title"": ""DeepEqual"",
-            ""version"": ""0.9.0""
+            ""version"": ""0.9.0"",
+            ""vulnerabilities"": [
+              {
+                ""advisoryUrl"": ""https://contoso.test/advisory/1"",
+                ""severity"": ""2""
+              }
+            ]
           },
           ""packageContent"": ""https://api.nuget.org/packages/deepequal.0.9.0.nupkg"",
           ""registration"": ""https://api.nuget.org/v3/registration0/deepequal/index.json""


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14938

## Description

Fixes two bugs in the System.Text.Json deserialization path 

 1. Severity crash: nuget.org's registration API returns vulnerability severity as a string ("2"), but `PackageVulnerabilityMetadata.Severity` is int. STJ rejects this by default.
 2. Streaming TrySkip crash: `PackageDependencyGroupStjConverter` called `reader.Skip()` which throws on streaming readers. Fix: use reader.TrySkip() instead.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
