### PR TITLE
Show inner exceptions on binding redirect failures

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
@@ -522,7 +522,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         NuGetProjectContext.Log(level,
                             Strings.FailedToUpdateBindingRedirects,
                             fileName,
-                            ex.Message);
+                            ExceptionUtilities.DisplayMessage(ex));
 
                         if (behavior.FailOperations)
                         {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14940

## Description

Use a helper method that includes inner exceptions, when logging failures during binding redirect calculations.  This will help both customers, and the NuGet team, have a better idea about what might have gone wrong. Currently we don't have any information, and usually can't even guess how to fix the problem.

The product code depends on EnvDTE, so it's not practical to write unit tests. I wasn't able to figure out how to create a package that installs successfully, but then triggers the binding redirect failure, so I wasn't able to manually test this either.  But I think it's a low risk change, because `ExceptionUtilities.DisplayMessage` is already being used elsewhere, so we should have confidence that it already works.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~  See description above
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
