### PR TITLE
Ensure NuGet.Protocol is AOT/trim-warning-free with proper annotations and feature switch isolation

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/JsonExtensions.cs
@@ -15,6 +15,10 @@ using NuGet.Protocol.Converters;
 
 namespace NuGet.Protocol
 {
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Legacy Newtonsoft.Json infrastructure; not used in AOT code paths.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Legacy Newtonsoft.Json infrastructure; not used in AOT code paths.")]
+#endif
     public static class JsonExtensions
     {
         public const int JsonSerializationMaxDepth = 512;

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -87,26 +87,42 @@ namespace NuGet.Protocol
             Common.ILogger logger,
             CancellationToken token)
         {
-            return await _httpSource.ProcessStreamAsync(
-                new HttpSourceRequest(apiEndpointUri, logger),
-                async stream =>
-                {
-                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                        || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+            {
+                return await _httpSource.ProcessStreamAsync(
+                    new HttpSourceRequest(apiEndpointUri, logger),
+                    async stream =>
                     {
                         var seekableStream = await stream.AsSeekableStreamAsync(token);
                         return await System.Text.Json.JsonSerializer.DeserializeAsync(seekableStream, JsonContext.Default.StringArray, token);
-                    }
-                    else
+                    },
+                    logger,
+                    token);
+            }
+            else
+            {
+                return await _httpSource.ProcessStreamAsync(
+                    new HttpSourceRequest(apiEndpointUri, logger),
+                    async stream =>
                     {
-                        using var reader = new StreamReader(await stream.AsSeekableStreamAsync(token));
-                        using var jsonReader = new JsonTextReader(reader);
-                        var serializer = Newtonsoft.Json.JsonSerializer.Create();
-                        return serializer.Deserialize<string[]>(jsonReader);
-                    }
-                },
-                logger,
-                token);
+                        if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+                        {
+                            var seekableStream = await stream.AsSeekableStreamAsync(token);
+                            return await System.Text.Json.JsonSerializer.DeserializeAsync(seekableStream, JsonContext.Default.StringArray, token);
+                        }
+                        else
+                        {
+                            using var reader = new StreamReader(await stream.AsSeekableStreamAsync(token));
+                            using var jsonReader = new JsonTextReader(reader);
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
+                            var serializer = Newtonsoft.Json.JsonSerializer.Create();
+                            return serializer.Deserialize<string[]>(jsonReader);
+#pragma warning restore IL2026, IL3050
+                        }
+                    },
+                    logger,
+                    token);
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/JsonSerializationUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/JsonSerializationUtilities.cs
@@ -17,6 +17,10 @@ namespace NuGet.Protocol.Plugins
     /// <summary>
     /// JSON serialization/deserialization utilities.
     /// </summary>
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Legacy Newtonsoft.Json infrastructure; methods on this class are already annotated with [RUC]/[RDC].")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Legacy Newtonsoft.Json infrastructure; methods on this class are already annotated with [RUC]/[RDC].")]
+#endif
     public static class JsonSerializationUtilities
     {
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogMessage.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -9,6 +12,10 @@ using Newtonsoft.Json.Linq;
 
 namespace NuGet.Protocol.Plugins
 {
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Legacy Newtonsoft.Json infrastructure; plugin logging is not used in AOT code paths.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Legacy Newtonsoft.Json infrastructure; plugin logging is not used in AOT code paths.")]
+#endif
     internal abstract class PluginLogMessage : IPluginLogMessage
     {
         private static readonly StringEnumConverter _enumConverter = new StringEnumConverter();

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
@@ -5,6 +5,9 @@
 
 using System;
 using System.Collections.Concurrent;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -598,6 +601,10 @@ namespace NuGet.Protocol.Plugins
             }
         }
 
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+#endif
         private void HandleInboundFault(Message fault)
         {
             if (fault == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageUtilities.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using Newtonsoft.Json.Linq;
 
 namespace NuGet.Protocol.Plugins
@@ -72,6 +75,10 @@ namespace NuGet.Protocol.Plugins
         /// <param name="message">The message.</param>
         /// <returns>A JSON string, or <see langword="null" /> if no payload exists.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <see langword="null" />.</exception>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based serialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based serialization.")]
+#endif
         public static string? SerializePayload(Message message)
         {
             if (message == null)
@@ -92,9 +99,7 @@ namespace NuGet.Protocol.Plugins
             using (var stringWriter = new System.IO.StringWriter())
             using (var jsonWriter = new Newtonsoft.Json.JsonTextWriter(stringWriter))
             {
-#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
                 JsonSerializationUtilities.Serialize(jsonWriter, message.PayloadObject);
-#pragma warning restore IL2026, IL3050
                 return stringWriter.ToString();
             }
         }
@@ -107,6 +112,10 @@ namespace NuGet.Protocol.Plugins
         /// <returns>The deserialized message payload of type <typeparamref name="TPayload" />
         /// or <see langword="null" /> if no payload exists.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="message" /> is <see langword="null" />.</exception>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         public static TPayload? DeserializePayload<TPayload>(Message message)
         {
             if (message == null)
@@ -121,9 +130,7 @@ namespace NuGet.Protocol.Plugins
 
             if (message.PayloadObject is Newtonsoft.Json.Linq.JObject jobj)
             {
-#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
                 return JsonSerializationUtilities.ToObject<TPayload>(jobj);
-#pragma warning restore IL2026, IL3050
             }
 
             return (TPayload)message.PayloadObject;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
@@ -5,6 +5,9 @@
 
 using System;
 using System.Diagnostics;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -149,6 +152,10 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="progress">A progress notification.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="progress" /> is <see langword="null" />.</exception>
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+#endif
         public override void HandleProgress(Message progress)
         {
             if (progress == null)
@@ -169,6 +176,10 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="response">A response.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="response" /> is <see langword="null" />.</exception>
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+#endif
         public override void HandleResponse(Message response)
         {
             if (response == null)
@@ -186,6 +197,10 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="fault">A fault response.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="fault" /> is <see langword="null" />.</exception>
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+#endif
         public override void HandleFault(Message fault)
         {
             if (fault == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetCredentialsRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetCredentialsRequestHandler.cs
@@ -5,6 +5,9 @@
 
 using System;
 using System.Collections.Concurrent;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using System.Net;
 using System.Threading;
@@ -109,6 +112,10 @@ namespace NuGet.Protocol.Plugins
         /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+#endif
         public async Task HandleResponseAsync(
             IConnection connection,
             Message request,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetServiceIndexRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetServiceIndexRequestHandler.cs
@@ -5,6 +5,9 @@
 
 using System;
 using System.Collections.Concurrent;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
@@ -93,6 +96,10 @@ namespace NuGet.Protocol.Plugins
         /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+#endif
         public async Task HandleResponseAsync(
             IConnection connection,
             Message request,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/LogRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/LogRequestHandler.cs
@@ -4,6 +4,9 @@
 #nullable disable
 
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -53,6 +56,10 @@ namespace NuGet.Protocol.Plugins
         /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+#endif
         public async Task HandleResponseAsync(
             IConnection connection,
             Message request,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandler.cs
@@ -6,6 +6,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -69,6 +72,10 @@ namespace NuGet.Protocol.Plugins
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseHandler" />
         /// is <see langword="null" />.</exception>
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+#endif
         public async Task HandleResponseAsync(
             IConnection connection,
             Message request,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/SymmetricHandshake.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/SymmetricHandshake.cs
@@ -4,6 +4,9 @@
 #nullable disable
 
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Versioning;
@@ -154,6 +157,10 @@ namespace NuGet.Protocol.Plugins
         /// is <see langword="null" />.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "PayloadObject is always a typed object (not JObject) in these scenarios; the reflection code path is not reached.")]
+#endif
         public async Task HandleResponseAsync(
             IConnection connection,
             Message request,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
@@ -139,8 +139,13 @@ namespace NuGet.Protocol.Plugins
             {
                 lock (_sendLock)
                 {
-                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                        || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+                    {
+                        string json = System.Text.Json.JsonSerializer.Serialize(message, PluginJsonContext.Default.Message);
+                        _textWriter.WriteLine(json);
+                        _textWriter.Flush();
+                    }
+                    else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
                     {
                         string json = System.Text.Json.JsonSerializer.Serialize(message, PluginJsonContext.Default.Message);
                         _textWriter.WriteLine(json);
@@ -149,7 +154,7 @@ namespace NuGet.Protocol.Plugins
                     else
                     {
                         using var jsonWriter = new Newtonsoft.Json.JsonTextWriter(_textWriter) { CloseOutput = false };
-#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
+#pragma warning disable IL2026, IL3050 // NSJ code path is unreachable when feature switch is true; ILC trims this branch in AOT
                         JsonSerializationUtilities.Serialize(jsonWriter, message);
 #pragma warning restore IL2026, IL3050
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
@@ -154,7 +154,7 @@ namespace NuGet.Protocol.Plugins
                     else
                     {
                         using var jsonWriter = new Newtonsoft.Json.JsonTextWriter(_textWriter) { CloseOutput = false };
-#pragma warning disable IL2026, IL3050 // NSJ code path is unreachable when feature switch is true; ILC trims this branch in AOT
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
                         JsonSerializationUtilities.Serialize(jsonWriter, message);
 #pragma warning restore IL2026, IL3050
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/StandardInputReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/StandardInputReceiver.cs
@@ -127,14 +127,17 @@ namespace NuGet.Protocol.Plugins
 
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                        || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+                    {
+                        message = System.Text.Json.JsonSerializer.Deserialize(line, PluginJsonContext.Default.Message);
+                    }
+                    else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
                     {
                         message = System.Text.Json.JsonSerializer.Deserialize(line, PluginJsonContext.Default.Message);
                     }
                     else
                     {
-#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
+#pragma warning disable IL2026, IL3050 // NSJ code path is unreachable when feature switch is true; ILC trims this branch in AOT
                         message = JsonSerializationUtilities.Deserialize<Message>(line);
 #pragma warning restore IL2026, IL3050
                     }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/StandardInputReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/StandardInputReceiver.cs
@@ -137,7 +137,7 @@ namespace NuGet.Protocol.Plugins
                     }
                     else
                     {
-#pragma warning disable IL2026, IL3050 // NSJ code path is unreachable when feature switch is true; ILC trims this branch in AOT
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
                         message = JsonSerializationUtilities.Deserialize<Message>(line);
 #pragma warning restore IL2026, IL3050
                     }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
@@ -109,14 +109,17 @@ namespace NuGet.Protocol.Plugins
             {
                 if (!IsClosed && !string.IsNullOrEmpty(e.Line))
                 {
-                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                        || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+                    {
+                        message = System.Text.Json.JsonSerializer.Deserialize(e.Line, PluginJsonContext.Default.Message);
+                    }
+                    else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
                     {
                         message = System.Text.Json.JsonSerializer.Deserialize(e.Line, PluginJsonContext.Default.Message);
                     }
                     else
                     {
-#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
+#pragma warning disable IL2026, IL3050 // NSJ code path is unreachable when feature switch is true; ILC trims this branch in AOT
                         message = JsonSerializationUtilities.Deserialize<Message>(e.Line);
 #pragma warning restore IL2026, IL3050
                     }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
@@ -119,7 +119,7 @@ namespace NuGet.Protocol.Plugins
                     }
                     else
                     {
-#pragma warning disable IL2026, IL3050 // NSJ code path is unreachable when feature switch is true; ILC trims this branch in AOT
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
                         message = JsonSerializationUtilities.Deserialize<Message>(e.Line);
 #pragma warning restore IL2026, IL3050
                     }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
@@ -75,36 +75,64 @@ namespace NuGet.Protocol
 
                     try
                     {
-                        return await client.GetAsync(
-                            new HttpSourceCachedRequest(
-                                serviceEntry.Uri.AbsoluteUri,
-                                cacheKey,
-                                cacheContext)
-                            {
-                                EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(repositorySignaturesResourceUri.AbsoluteUri, stream),
-                                MaxTries = 1,
-                                IsRetry = retry > 1,
-                                IsLastAttempt = retry == maxRetries
-                            },
-                            async httpSourceResult =>
-                            {
-                                if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                                    || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+                        if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+                        {
+                            return await client.GetAsync(
+                                new HttpSourceCachedRequest(
+                                    serviceEntry.Uri.AbsoluteUri,
+                                    cacheKey,
+                                    cacheContext)
+                                {
+                                    EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(repositorySignaturesResourceUri.AbsoluteUri, stream),
+                                    MaxTries = 1,
+                                    IsRetry = retry > 1,
+                                    IsLastAttempt = retry == maxRetries
+                                },
+                                async httpSourceResult =>
                                 {
                                     var model = await JsonSerializer.DeserializeAsync(
                                         httpSourceResult.Stream,
                                         RepositorySignatureJsonContext.Default.RepositorySignatureModel,
                                         token);
                                     return new RepositorySignatureResource(model, source);
-                                }
-                                else
+                                },
+                                log,
+                                token);
+                        }
+                        else
+                        {
+                            return await client.GetAsync(
+                                new HttpSourceCachedRequest(
+                                    serviceEntry.Uri.AbsoluteUri,
+                                    cacheKey,
+                                    cacheContext)
                                 {
-                                    var json = await httpSourceResult.Stream.AsJObjectAsync(token);
-                                    return new RepositorySignatureResource(json, source);
-                                }
-                            },
-                            log,
-                            token);
+                                    EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(repositorySignaturesResourceUri.AbsoluteUri, stream),
+                                    MaxTries = 1,
+                                    IsRetry = retry > 1,
+                                    IsLastAttempt = retry == maxRetries
+                                },
+                                async httpSourceResult =>
+                                {
+                                    if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+                                    {
+                                        var model = await JsonSerializer.DeserializeAsync(
+                                            httpSourceResult.Stream,
+                                            RepositorySignatureJsonContext.Default.RepositorySignatureModel,
+                                            token);
+                                        return new RepositorySignatureResource(model, source);
+                                    }
+                                    else
+                                    {
+                                        var json = await httpSourceResult.Stream.AsJObjectAsync(token);
+#pragma warning disable IL2026, IL3050 // NSJ code path is unreachable when feature switch is true; ILC trims this branch in AOT
+                                        return new RepositorySignatureResource(json, source);
+#pragma warning restore IL2026, IL3050
+                                    }
+                                },
+                                log,
+                                token);
+                        }
                     }
                     catch (Exception ex) when (retry < maxRetries)
                     {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
@@ -125,7 +125,7 @@ namespace NuGet.Protocol
                                     else
                                     {
                                         var json = await httpSourceResult.Stream.AsJObjectAsync(token);
-#pragma warning disable IL2026, IL3050 // NSJ code path is unreachable when feature switch is true; ILC trims this branch in AOT
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
                                         return new RepositorySignatureResource(json, source);
 #pragma warning restore IL2026, IL3050
                                     }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
@@ -195,8 +195,11 @@ namespace NuGet.Protocol
 
         private async Task<ServiceIndexResourceV3> ConsumeServiceIndexStreamAsync(Stream stream, DateTime utcNow, PackageSource source, CancellationToken token)
         {
-            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+            {
+                return await ConsumeServiceIndexStreamStjAsync(stream, utcNow, source, token);
+            }
+            else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
             {
                 return await ConsumeServiceIndexStreamStjAsync(stream, utcNow, source, token);
             }
@@ -256,7 +259,9 @@ namespace NuGet.Protocol
                 if (SemanticVersion.TryParse((string)versionToken, out version) &&
                     version.Major == 3)
                 {
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
                     return new ServiceIndexResourceV3(json, utcNow, source);
+#pragma warning restore IL2026, IL3050
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
@@ -48,7 +48,11 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+            {
+                return await IdStartsWithStjAsync(packageIdPrefix, includePrerelease, log, token);
+            }
+            else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
             {
                 return await IdStartsWithStjAsync(packageIdPrefix, includePrerelease, log, token);
             }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -181,8 +181,11 @@ namespace NuGet.Protocol
                 return default(T);
             }
 
-            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+            {
+                return await DeserializeStreamDataWithStjAsync<T>(stream, token);
+            }
+            else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
             {
                 return await DeserializeStreamDataWithStjAsync<T>(stream, token);
             }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -264,8 +264,11 @@ namespace NuGet.Protocol
                 return null;
             }
 
-            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch
-                || NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+            {
+                return await ProcessHttpStreamWithStjAsync(httpInitialResponse, take, token);
+            }
+            else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
             {
                 return await ProcessHttpStreamWithStjAsync(httpInitialResponse, take, token);
             }
@@ -294,8 +297,10 @@ namespace NuGet.Protocol
 
         private static async Task<V3SearchResults> ProcessHttpStreamWithNsjAsync(HttpResponseMessage httpInitialResponse, uint take, CancellationToken token)
         {
+#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
             var _newtonsoftConvertersSerializer = JsonSerializer.Create(JsonExtensions.ObjectSerializationSettings);
             _newtonsoftConvertersSerializer.Converters.Add(new Converters.V3SearchResultsConverter(take));
+#pragma warning restore IL2026, IL3050
 
 #if NETCOREAPP2_0_OR_GREATER
             using (var stream = await httpInitialResponse.Content.ReadAsStreamAsync(token))

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
@@ -5,6 +5,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json.Linq;
@@ -23,6 +26,10 @@ namespace NuGet.Protocol
 
         public IEnumerable<IRepositoryCertificateInfo> RepositoryCertificateInfos { get; }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         public RepositorySignatureResource(JObject repoSignInformationContent, SourceRepository source)
         {
             var allRepositorySigned = repoSignInformationContent.GetBoolean(JsonProperties.AllRepositorySigned) ??
@@ -31,9 +38,7 @@ namespace NuGet.Protocol
                 throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToParseRepoSignInfor, JsonProperties.SigningCertificates, source.PackageSource.Source));
 
             AllRepositorySigned = allRepositorySigned;
-#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path
             RepositoryCertificateInfos = data.OfType<JObject>().Select(p => p.FromJToken<RepositoryCertificateInfo>());
-#pragma warning restore IL2026, IL3050
 
             foreach (var repositoryCertificateInfo in RepositoryCertificateInfos)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/ServiceIndexResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/ServiceIndexResourceV3.cs
@@ -5,6 +5,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Linq;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
@@ -30,6 +33,10 @@ namespace NuGet.Protocol
         private static readonly IReadOnlyList<ServiceIndexEntry> _emptyEntries = new List<ServiceIndexEntry>();
         private static readonly SemanticVersion _defaultVersion = new SemanticVersion(0, 0, 0);
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         internal ServiceIndexResourceV3(JObject index, DateTime requestTime, PackageSource packageSource)
         {
             _json = index.ToString();
@@ -37,6 +44,10 @@ namespace NuGet.Protocol
             _requestTime = requestTime;
         }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         public ServiceIndexResourceV3(JObject index, DateTime requestTime) : this(index, requestTime, null) { }
 
         internal ServiceIndexResourceV3(ServiceIndexModel model, DateTime requestTime, PackageSource packageSource)
@@ -302,6 +313,10 @@ namespace NuGet.Protocol
         /// Read string values from an array or string.
         /// Returns an empty enumerable if the value is null.
         /// </summary>
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Only called from JObject constructor which is annotated with [RUC]/[RDC].")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Only called from JObject constructor which is annotated with [RUC]/[RDC].")]
+#endif
         private static IEnumerable<string> GetValues(JToken token)
         {
             if (token?.Type == JTokenType.Array)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14944

## Description

Annotate `NuGet.Protocol`'s AOT-incompatible code paths with proper trim/AOT attributes to ensure zero ILC warnings when consuming the library from a `PublishAot` application.


 - Added `[RequiresUnreferencedCode]`/`[RequiresDynamicCode]` on `MessageUtilities.SerializePayload`, `MessageUtilities.DeserializePayload<T>`, and the `RepositorySignatureResource(JObject, SourceRepository)` constructor
 - Added `[UnconditionalSuppressMessage]` on internal plugin request handlers where `DeserializePayload` is called but the reflection path is unreachable (payload is always a pre-deserialized typed object from STJ's `MessageConverter`)
 - Restructured feature-switch-guarded code in `Sender`, `StandardInputReceiver`, `StandardOutputReceiver`, and `RepositorySignatureResourceProvider` to use `if/else if` pattern instead of `||`. In the issue attached I have another link reporting an issue in the runtime repo. The repro I attached there, shows that the trimmer warns when the condition statement that contains a feature switch contains a runtime condition even if it is guaranteed the logic evaluates to always one vlaue. In our case we have `FeatureSwitch || getenvVariable()`. However, even if `FeatureSwitch` is true. we still get a warning from the else block of code which should have been trimmed out. I was able to fix this by making the FeatureSwitch the singular condition.
 
## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
           I tested this by adding NuGet.protocl as a dependency in a native app that would call all its public APIs and publishing it https://github.com/Nigusu-Allehu/NuGetAotTest
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
