### PR TITLE
Allow string values for int and bool properties in STJ path

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -51,6 +51,7 @@ namespace NuGet.Protocol
 
         [JsonProperty(PropertyName = JsonProperties.DownloadCount)]
         [JsonPropertyName(JsonProperties.DownloadCount)]
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
         [JsonInclude]
         public long? DownloadCount { get; internal set; }
 
@@ -201,6 +202,7 @@ namespace NuGet.Protocol
 
         [JsonProperty(PropertyName = JsonProperties.PrefixReserved)]
         [JsonPropertyName(JsonProperties.PrefixReserved)]
+        [System.Text.Json.Serialization.JsonConverter(typeof(SafeBoolStjConverter))]
         [JsonInclude]
         public bool PrefixReserved { get; internal set; }
 
@@ -302,6 +304,7 @@ namespace NuGet.Protocol
 
         [JsonProperty(PropertyName = JsonProperties.Listed)]
         [JsonPropertyName(JsonProperties.Listed)]
+        [System.Text.Json.Serialization.JsonConverter(typeof(SafeBoolStjConverter))]
         [JsonInclude]
         public bool IsListed { get; internal set; } = true;
 

--- a/src/NuGet.Core/NuGet.Protocol/Model/V3SearchResults.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/V3SearchResults.cs
@@ -11,6 +11,7 @@ namespace NuGet.Protocol.Model
     {
         [JsonProperty("totalHits")]
         [JsonPropertyName("totalHits")]
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
         public long TotalHits { get; set; }
 
         [JsonProperty("data")]

--- a/src/NuGet.Core/NuGet.Protocol/Model/VersionInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/VersionInfo.cs
@@ -35,6 +35,7 @@ namespace NuGet.Protocol.Core.Types
         public NuGetVersion Version { get; private set; }
 
         [JsonPropertyName("downloads")]
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
         public long? DownloadCount { get; private set; }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearch.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearch.json
@@ -36,6 +36,7 @@
       ],
       "totalDownloads": 248620082,
       "verified": true,
+      "listed": true,
       "packageTypes": [
         {
           "name": "Dependency"

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearch.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearch.json
@@ -3,7 +3,7 @@
     "@vocab": "http://schema.nuget.org/schema#",
     "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
   },
-  "totalHits": 5385,
+  "totalHits": "5385",
   "data": [
     {
       "@id": "https://api.nuget.org/v3/registration5-gz-semver2/entityframework/index.json",
@@ -34,8 +34,8 @@
         "EntityFramework",
         "Microsoft"
       ],
-      "totalDownloads": 248620082,
-      "verified": true,
+      "totalDownloads": "248620082",
+      "verified": "true",
       "packageTypes": [
         {
           "name": "Dependency"
@@ -44,7 +44,7 @@
       "versions": [
         {
           "version": "4.1.10331",
-          "downloads": 1267747,
+          "downloads": "1267747",
           "@id": "https://api.nuget.org/v3/registration5-gz-semver2/entityframework/4.1.10331.json"
         },
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearch.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearch.json
@@ -3,7 +3,7 @@
     "@vocab": "http://schema.nuget.org/schema#",
     "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
   },
-  "totalHits": "5385",
+  "totalHits": 5385,
   "data": [
     {
       "@id": "https://api.nuget.org/v3/registration5-gz-semver2/entityframework/index.json",
@@ -34,8 +34,8 @@
         "EntityFramework",
         "Microsoft"
       ],
-      "totalDownloads": "248620082",
-      "verified": "true",
+      "totalDownloads": 248620082,
+      "verified": true,
       "packageTypes": [
         {
           "name": "Dependency"
@@ -44,7 +44,7 @@
       "versions": [
         {
           "version": "4.1.10331",
-          "downloads": "1267747",
+          "downloads": 1267747,
           "@id": "https://api.nuget.org/v3/registration5-gz-semver2/entityframework/4.1.10331.json"
         },
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearchWithStringTypes.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearchWithStringTypes.json
@@ -3,7 +3,7 @@
         "@vocab": "http://schema.nuget.org/schema#",
         "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
     },
-    "totalHits": 5385,
+    "totalHits": "5385",
     "data": [
         {
             "@id": "https://api.nuget.org/v3/registration5-gz-semver2/entityframework/index.json",
@@ -20,8 +20,8 @@
             "tags": "Microsoft, EntityFramework, EF, Database, Data, O/RM, ADO.NET",
             "authors": "Microsoft",
             "owners": "aspnet, EntityFramework, Microsoft",
-            "totalDownloads": 248620082,
-            "verified": true,
+            "totalDownloads": "248620082",
+            "verified": "true",
             "packageTypes": [
                 {
                     "name": "Dependency"
@@ -30,7 +30,7 @@
             "versions": [
                 {
                     "version": "4.1.10331",
-                    "downloads": 1267747,
+                    "downloads": "1267747",
                     "@id": "https://api.nuget.org/v3/registration5-gz-semver2/entityframework/4.1.10331.json"
                 },
                 {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearchWithStringTypes.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/compiler/resources/EntityFrameworkSearchWithStringTypes.json
@@ -22,6 +22,7 @@
             "owners": "aspnet, EntityFramework, Microsoft",
             "totalDownloads": "248620082",
             "verified": "true",
+            "listed": "true",
             "packageTypes": [
                 {
                     "name": "Dependency"


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14943

## Description

Fixes STJ deserialization parity issues that crash when NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION=true and a feed returns numeric or boolean values as strings.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
