### PR TITLE
Enable nullable for NuGet.Protocol Plugins runtime

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/AutomaticProgressReporter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/AutomaticProgressReporter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -144,7 +142,7 @@ namespace NuGet.Protocol.Plugins
                 cancellationToken);
         }
 
-        private void OnTimer(object state)
+        private void OnTimer(object? state)
         {
             try
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Connection.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Connection.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,12 +28,12 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Occurs when an unrecoverable fault has been caught.
         /// </summary>
-        public event EventHandler<ProtocolErrorEventArgs> Faulted;
+        public event EventHandler<ProtocolErrorEventArgs>? Faulted;
 
         /// <summary>
         /// Occurs when a message has been received.
         /// </summary>
-        public event EventHandler<MessageEventArgs> MessageReceived;
+        public event EventHandler<MessageEventArgs>? MessageReceived;
 
         /// <summary>
         /// Gets the message dispatcher.
@@ -50,7 +48,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Gets the negotiated protocol version, or <see langword="null" /> if not yet connected.
         /// </summary>
-        public SemanticVersion ProtocolVersion { get; private set; }
+        public SemanticVersion? ProtocolVersion { get; private set; }
 
         /// <summary>
         /// Instantiates a new instance of the <see cref="Connection" /> class.
@@ -271,7 +269,7 @@ namespace NuGet.Protocol.Plugins
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         /// <exception cref="InvalidOperationException">Thrown if not connected.</exception>
-        public Task<TInbound> SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(
+        public Task<TInbound?> SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(
             MessageMethod method,
             TOutbound payload,
             CancellationToken cancellationToken)
@@ -294,7 +292,7 @@ namespace NuGet.Protocol.Plugins
             return MessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(method, payload, cancellationToken);
         }
 
-        private void OnMessageReceived(object sender, MessageEventArgs e)
+        private void OnMessageReceived(object? sender, MessageEventArgs e)
         {
             if (_logger.IsEnabled)
             {
@@ -304,7 +302,7 @@ namespace NuGet.Protocol.Plugins
             MessageReceived?.Invoke(this, e);
         }
 
-        private void OnFaulted(object sender, ProtocolErrorEventArgs e)
+        private void OnFaulted(object? sender, ProtocolErrorEventArgs e)
         {
             Faulted?.Invoke(this, e);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IConnection.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IConnection.cs
@@ -16,12 +16,12 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Occurs when an unrecoverable fault has been caught.
         /// </summary>
-        event EventHandler<ProtocolErrorEventArgs> Faulted;
+        event EventHandler<ProtocolErrorEventArgs>? Faulted;
 
         /// <summary>
         /// Occurs when a message has been received.
         /// </summary>
-        event EventHandler<MessageEventArgs> MessageReceived;
+        event EventHandler<MessageEventArgs>? MessageReceived;
 
         /// <summary>
         /// Gets the message dispatcher.
@@ -70,7 +70,7 @@ namespace NuGet.Protocol.Plugins
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         /// <exception cref="InvalidOperationException">Thrown if not connected.</exception>
-        Task<TInbound> SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(
+        Task<TInbound?> SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(
             MessageMethod method,
             TOutbound payload,
             CancellationToken cancellationToken)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IMessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IMessageDispatcher.cs
@@ -80,7 +80,7 @@ namespace NuGet.Protocol.Plugins
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <typeparamref name="TInbound" />
         /// from the target.</returns>
-        Task<TInbound> DispatchRequestAsync<TOutbound, TInbound>(
+        Task<TInbound?> DispatchRequestAsync<TOutbound, TInbound>(
             MessageMethod method,
             TOutbound payload,
             CancellationToken cancellationToken)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPlugin.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPlugin.cs
@@ -13,12 +13,12 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Occurs before the plugin closes.
         /// </summary>
-        event EventHandler BeforeClose;
+        event EventHandler? BeforeClose;
 
         /// <summary>
         /// Occurs when the plugin has closed.
         /// </summary>
-        event EventHandler Closed;
+        event EventHandler? Closed;
 
         /// <summary>
         /// Gets the connection for the plugin.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IPluginManager.cs
@@ -37,6 +37,6 @@ namespace NuGet.Protocol.Plugins
         /// <param name="pluginDiscoveryResult"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>A PluginCreationResult</returns>
-        Task<Tuple<bool, PluginCreationResult>> TryGetSourceAgnosticPluginAsync(PluginDiscoveryResult pluginDiscoveryResult, OperationClaim requestedOperationClaim, CancellationToken cancellationToken);
+        Task<Tuple<bool, PluginCreationResult?>> TryGetSourceAgnosticPluginAsync(PluginDiscoveryResult pluginDiscoveryResult, OperationClaim requestedOperationClaim, CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IReceiver.cs
@@ -13,12 +13,12 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Occurs when an unrecoverable fault has been caught.
         /// </summary>
-        event EventHandler<ProtocolErrorEventArgs> Faulted;
+        event EventHandler<ProtocolErrorEventArgs>? Faulted;
 
         /// <summary>
         /// Occurs when a message has been received.
         /// </summary>
-        event EventHandler<MessageEventArgs> MessageReceived;
+        event EventHandler<MessageEventArgs>? MessageReceived;
 
         /// <summary>
         /// Closes the connection.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/JsonSerializationUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/JsonSerializationUtilities.cs
@@ -53,11 +53,7 @@ namespace NuGet.Protocol.Plugins
         [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
         [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
 #endif
-<<<<<<< HEAD
-        public static T Deserialize<T>(string json)
-=======
         public static T? Deserialize<T>(string json)
->>>>>>> 0c62525b82 (Enable nullable for NuGet.Protocol Plugins runtime)
             where T : class
         {
             if (string.IsNullOrEmpty(json))

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/JsonSerializationUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/JsonSerializationUtilities.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 #if NET5_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -48,14 +46,18 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <typeparam name="T">The deserialization type.</typeparam>
         /// <param name="json">JSON to deserialize.</param>
-        /// <returns>An instance of <typeparamref name="T" />.</returns>
+        /// <returns>An instance of <typeparamref name="T" />, or <see langword="null" /> if the JSON represents a null value.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="json" />
         /// is either <see langword="null" /> or an empty string.</exception>
 #if NET5_0_OR_GREATER
         [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
         [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
 #endif
+<<<<<<< HEAD
         public static T Deserialize<T>(string json)
+=======
+        public static T? Deserialize<T>(string json)
+>>>>>>> 0c62525b82 (Enable nullable for NuGet.Protocol Plugins runtime)
             where T : class
         {
             if (string.IsNullOrEmpty(json))
@@ -115,13 +117,13 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <typeparam name="T">The deserialization type.</typeparam>
         /// <param name="jObject">A JSON object.</param>
-        /// <returns>An instance of <typeparamref name="T" />.</returns>
+        /// <returns>An instance of <typeparamref name="T" />, or <see langword="null" /> if the JSON represents a null value.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="jObject" /> is <see langword="null" />.</exception>
 #if NET5_0_OR_GREATER
         [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
         [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
 #endif
-        public static T ToObject<T>(JObject jObject)
+        public static T? ToObject<T>(JObject jObject)
         {
             if (jObject == null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageDispatcher.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 #if NET5_0_OR_GREATER
@@ -20,7 +18,7 @@ namespace NuGet.Protocol.Plugins
     /// </summary>
     public sealed class MessageDispatcher : IMessageDispatcher, IResponseHandler
     {
-        private IConnection _connection;
+        private IConnection? _connection;
         private readonly IIdGenerator _idGenerator;
         private bool _isClosed;
         private bool _isDisposed;
@@ -279,7 +277,7 @@ namespace NuGet.Protocol.Plugins
         /// from the target.</returns>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
-        public Task<TInbound> DispatchRequestAsync<TOutbound, TInbound>(
+        public Task<TInbound?> DispatchRequestAsync<TOutbound, TInbound>(
             MessageMethod method,
             TOutbound payload,
             CancellationToken cancellationToken)
@@ -349,7 +347,7 @@ namespace NuGet.Protocol.Plugins
         /// Sets the connection to be used for dispatching messages.
         /// </summary>
         /// <param name="connection">A connection instance.  Can be <see langword="null" />.</param>
-        public void SetConnection(IConnection connection)
+        public void SetConnection(IConnection? connection)
         {
             if (_connection == connection)
             {
@@ -385,9 +383,7 @@ namespace NuGet.Protocol.Plugins
             CancellationToken cancellationToken)
             where TOutgoing : class
         {
-            InboundRequestContext requestContext;
-
-            if (!_inboundRequestContexts.TryGetValue(request.RequestId, out requestContext))
+            if (!_inboundRequestContexts.TryGetValue(request.RequestId, out _))
             {
                 return;
             }
@@ -459,7 +455,7 @@ namespace NuGet.Protocol.Plugins
             await connection.SendAsync(response, cancellationToken);
         }
 
-        private async Task<TIncoming> DispatchWithNewContextAsync<TOutgoing, TIncoming>(
+        private async Task<TIncoming?> DispatchWithNewContextAsync<TOutgoing, TIncoming>(
             IConnection connection,
             MessageType type,
             MessageMethod method,
@@ -525,7 +521,7 @@ namespace NuGet.Protocol.Plugins
             return null;
         }
 
-        private void OnMessageReceived(object sender, MessageEventArgs e)
+        private void OnMessageReceived(object? sender, MessageEventArgs e)
         {
             // Capture _connection as SetConnection(...) could null it out later.
             var connection = _connection;
@@ -535,9 +531,7 @@ namespace NuGet.Protocol.Plugins
                 return;
             }
 
-            OutboundRequestContext requestContext;
-
-            if (_outboundRequestContexts.TryGetValue(e.Message.RequestId, out requestContext))
+            if (_outboundRequestContexts.TryGetValue(e.Message.RequestId, out var requestContext))
             {
                 switch (e.Message.Type)
                 {
@@ -593,9 +587,7 @@ namespace NuGet.Protocol.Plugins
 
         private void HandleInboundCancel(Message message)
         {
-            InboundRequestContext requestContext;
-
-            if (_inboundRequestContexts.TryGetValue(message.RequestId, out requestContext))
+            if (_inboundRequestContexts.TryGetValue(message.RequestId, out var requestContext))
             {
                 requestContext.Cancel();
             }
@@ -614,14 +606,14 @@ namespace NuGet.Protocol.Plugins
 
             var payload = MessageUtilities.DeserializePayload<Fault>(fault);
 
-            throw new ProtocolException(payload.Message);
+            throw new ProtocolException(payload?.Message);
         }
 
         private void HandleInboundRequest(Message message)
         {
             var cancellationToken = CancellationToken.None;
-            IRequestHandler requestHandler = null;
-            ProtocolException exception = null;
+            IRequestHandler? requestHandler = null;
+            ProtocolException? exception = null;
 
             try
             {
@@ -643,15 +635,13 @@ namespace NuGet.Protocol.Plugins
             }
             else
             {
-                requestContext.BeginFaultAsync(message, exception);
+                requestContext.BeginFaultAsync(message, exception!);
             }
         }
 
         private IRequestHandler GetInboundRequestHandler(MessageMethod method)
         {
-            IRequestHandler handler;
-
-            if (!RequestHandlers.TryGet(method, out handler))
+            if (!RequestHandlers.TryGet(method, out var handler))
             {
                 throw new ProtocolException(
                     string.Format(CultureInfo.CurrentCulture, Strings.Plugin_RequestHandlerDoesNotExist, method));
@@ -662,9 +652,7 @@ namespace NuGet.Protocol.Plugins
 
         private OutboundRequestContext GetOutboundRequestContext(string requestId)
         {
-            OutboundRequestContext requestContext;
-
-            if (!_outboundRequestContexts.TryGetValue(requestId, out requestContext))
+            if (!_outboundRequestContexts.TryGetValue(requestId, out var requestContext))
             {
                 throw new ProtocolException(
                     string.Format(CultureInfo.CurrentCulture, Strings.Plugin_RequestContextDoesNotExist, requestId));
@@ -675,9 +663,7 @@ namespace NuGet.Protocol.Plugins
 
         private void RemoveInboundRequestContext(string requestId)
         {
-            InboundRequestContext requestContext;
-
-            if (_inboundRequestContexts.TryRemove(requestId, out requestContext))
+            if (_inboundRequestContexts.TryRemove(requestId, out var requestContext))
             {
                 requestContext.Dispose();
             }
@@ -685,9 +671,7 @@ namespace NuGet.Protocol.Plugins
 
         private void RemoveOutboundRequestContext(string requestId)
         {
-            OutboundRequestContext requestContext;
-
-            if (_outboundRequestContexts.TryRemove(requestId, out requestContext))
+            if (_outboundRequestContexts.TryRemove(requestId, out var requestContext))
             {
                 requestContext.Dispose();
             }
@@ -698,7 +682,7 @@ namespace NuGet.Protocol.Plugins
             CancellationToken cancellationToken)
         {
             return new InboundRequestContext(
-                _connection,
+                _connection!,
                 message.RequestId,
                 cancellationToken,
                 _inboundRequestProcessingContext,
@@ -713,7 +697,7 @@ namespace NuGet.Protocol.Plugins
             where TIncoming : class
         {
             return new OutboundRequestContext<TIncoming>(
-                _connection,
+                _connection!,
                 message,
                 timeout,
                 isKeepAlive,

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetOperationClaimsResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetOperationClaimsResponse.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/HandshakeRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/HandshakeRequest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using Newtonsoft.Json;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/HandshakeResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/HandshakeResponse.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Newtonsoft.Json;
 using NuGet.Versioning;
@@ -25,6 +26,13 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         [System.Text.Json.Serialization.JsonConverter(typeof(StjSemanticVersionConverter))]
         public SemanticVersion? ProtocolVersion { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the handshake succeeded. When <see langword="true" />,
+        /// <see cref="ProtocolVersion" /> is guaranteed to be non-<see langword="null" />.
+        /// </summary>
+        [MemberNotNullWhen(true, nameof(ProtocolVersion))]
+        internal bool IsSuccess => ResponseCode == MessageResponseCode.Success;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HandshakeResponse" /> class.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/NoOpDisposePlugin.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/NoOpDisposePlugin.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins
@@ -17,7 +15,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Occurs before the plugin closes.
         /// </summary>
-        public event EventHandler BeforeClose
+        public event EventHandler? BeforeClose
         {
             add
             {
@@ -32,7 +30,7 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Occurs when the plugin has closed.
         /// </summary>
-        public event EventHandler Closed
+        public event EventHandler? Closed
         {
             add
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/NsjRawJsonStringConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/NsjRawJsonStringConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using Newtonsoft.Json;
@@ -14,7 +12,7 @@ namespace NuGet.Protocol.Plugins
     {
         public override bool CanConvert(Type objectType) => objectType == typeof(string);
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             if (reader.TokenType == JsonToken.Null)
             {
@@ -31,7 +29,7 @@ namespace NuGet.Protocol.Plugins
             return obj.ToString(Formatting.None);
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             if (value is string s)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 
@@ -19,9 +17,9 @@ namespace NuGet.Protocol.Plugins
         public CancellationToken CancellationToken { get; protected set; }
 
         /// <summary>
-        /// Gets the request ID.
+        /// Gets the request ID. Never null, protected constructor sets it.
         /// </summary>
-        public string RequestId { get; protected set; }
+        public string RequestId { get; protected set; } = null!;
 
         /// <summary>
         /// Disposes of this instance.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 #if NET5_0_OR_GREATER
@@ -28,14 +26,14 @@ namespace NuGet.Protocol.Plugins
         private bool _isKeepAlive;
         private readonly IPluginLogger _logger;
         private readonly Message _request;
-        private readonly TaskCompletionSource<TResult> _taskCompletionSource;
+        private readonly TaskCompletionSource<TResult?> _taskCompletionSource;
         private readonly TimeSpan? _timeout;
-        private readonly Timer _timer;
+        private readonly Timer? _timer;
 
         /// <summary>
         /// Gets the completion task.
         /// </summary>
-        public Task<TResult> CompletionTask => _taskCompletionSource.Task;
+        public Task<TResult?> CompletionTask => _taskCompletionSource.Task;
 
         /// <summary>
         /// Initializes a new <see cref="OutboundRequestContext{TResult}" /> class.
@@ -105,7 +103,7 @@ namespace NuGet.Protocol.Plugins
 
             _connection = connection;
             _request = request;
-            _taskCompletionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _taskCompletionSource = new TaskCompletionSource<TResult?>(TaskCreationOptions.RunContinuationsAsynchronously);
             _timeout = timeout;
             _isKeepAlive = isKeepAlive;
             RequestId = request.RequestId;
@@ -167,7 +165,8 @@ namespace NuGet.Protocol.Plugins
 
             if (_timeout.HasValue && _isKeepAlive)
             {
-                _timer.Change(_timeout.Value, Timeout.InfiniteTimeSpan);
+                // _timer is non-null whenever _timeout.HasValue (see constructor).
+                _timer!.Change(_timeout.Value, Timeout.InfiniteTimeSpan);
             }
         }
 
@@ -210,7 +209,7 @@ namespace NuGet.Protocol.Plugins
 
             var payload = MessageUtilities.DeserializePayload<Fault>(fault);
 
-            throw new ProtocolException(payload.Message);
+            throw new ProtocolException(payload?.Message);
         }
 
         protected override void Dispose(bool disposing)
@@ -256,7 +255,7 @@ namespace NuGet.Protocol.Plugins
             }
         }
 
-        private void OnTimeout(object state)
+        private void OnTimeout(object? state)
         {
             Debug.WriteLine($"Request {_request.RequestId} timed out.");
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Plugin.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Plugin.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Threading;
@@ -16,7 +14,7 @@ namespace NuGet.Protocol.Plugins
     {
         private bool _isClosed;
         private readonly TimeSpan _idleTimeout;
-        private readonly Timer _idleTimer;
+        private readonly Timer? _idleTimer;
         private readonly object _idleTimerLock;
         private bool _isDisposed;
         private readonly bool _isOwnProcess;
@@ -25,27 +23,27 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Occurs before the plugin closes.
         /// </summary>
-        public event EventHandler BeforeClose;
+        public event EventHandler? BeforeClose;
 
         /// <summary>
         /// Occurs when the plugin has closed.
         /// </summary>
-        public event EventHandler Closed;
+        public event EventHandler? Closed;
 
         /// <summary>
         /// Occurs when a plugin process has exited.
         /// </summary>
-        public event EventHandler<PluginEventArgs> Exited;
+        public event EventHandler<PluginEventArgs>? Exited;
 
         /// <summary>
         /// Occurs when a plugin or plugin connection has faulted.
         /// </summary>
-        public event EventHandler<FaultedPluginEventArgs> Faulted;
+        public event EventHandler<FaultedPluginEventArgs>? Faulted;
 
         /// <summary>
         /// Occurs when a plugin has been idle for the configured idle timeout period.
         /// </summary>
-        public event EventHandler<PluginEventArgs> Idle;
+        public event EventHandler<PluginEventArgs>? Idle;
 
         /// <summary>
         /// Gets the connection for the plugin
@@ -87,7 +85,7 @@ namespace NuGet.Protocol.Plugins
         {
         }
 
-        internal Plugin(string filePath, IConnection connection, IPluginProcess process, bool isOwnProcess, TimeSpan idleTimeout, string id)
+        internal Plugin(string filePath, IConnection connection, IPluginProcess process, bool isOwnProcess, TimeSpan idleTimeout, string? id)
         {
             if (string.IsNullOrEmpty(filePath))
             {
@@ -216,22 +214,22 @@ namespace NuGet.Protocol.Plugins
             }
         }
 
-        private void OnExited(object sender, IPluginProcess pluginProcess)
+        private void OnExited(object? sender, IPluginProcess pluginProcess)
         {
             Exited?.Invoke(this, new PluginEventArgs(this));
         }
 
-        private void OnFaulted(object sender, ProtocolErrorEventArgs e)
+        private void OnFaulted(object? sender, ProtocolErrorEventArgs e)
         {
             Faulted?.Invoke(this, new FaultedPluginEventArgs(this, e.Exception));
         }
 
-        private void OnIdleTimer(object state)
+        private void OnIdleTimer(object? state)
         {
             Idle?.Invoke(this, new PluginEventArgs(this));
         }
 
-        private void OnMessageReceived(object sender, MessageEventArgs e)
+        private void OnMessageReceived(object? sender, MessageEventArgs e)
         {
             lock (_idleTimerLock)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoverer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -20,10 +18,10 @@ namespace NuGet.Protocol.Plugins
     public sealed class PluginDiscoverer : IPluginDiscoverer
     {
         private bool _isDisposed;
-        private List<PluginFile> _pluginFiles;
-        private readonly string _netCoreOrNetFXPluginPaths;
-        private readonly string _nuGetPluginPaths;
-        private IEnumerable<PluginDiscoveryResult> _results;
+        private List<PluginFile>? _pluginFiles;
+        private readonly string? _netCoreOrNetFXPluginPaths;
+        private readonly string? _nuGetPluginPaths;
+        private IEnumerable<PluginDiscoveryResult>? _results;
         private readonly SemaphoreSlim _semaphore;
         private readonly IEnvironmentVariableReader _environmentVariableReader;
 
@@ -96,7 +94,7 @@ namespace NuGet.Protocol.Plugins
                 if (!string.IsNullOrEmpty(_netCoreOrNetFXPluginPaths))
                 {
                     // NUGET_NETFX_PLUGIN_PATHS, NUGET_NETCORE_PLUGIN_PATHS have been set.
-                    var filePaths = _netCoreOrNetFXPluginPaths.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+                    var filePaths = _netCoreOrNetFXPluginPaths!.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
                     _pluginFiles = GetPluginFiles(filePaths, cancellationToken);
                 }
                 else if (!string.IsNullOrEmpty(_nuGetPluginPaths))
@@ -111,7 +109,11 @@ namespace NuGet.Protocol.Plugins
                     var directories = new List<string> { PluginDiscoveryUtility.GetNuGetHomePluginsPath() };
 #if IS_DESKTOP
                     // Internal plugins are only supported for .NET Framework scenarios, namely msbuild.exe
-                    directories.Add(PluginDiscoveryUtility.GetInternalPlugins());
+                    var internalPlugins = PluginDiscoveryUtility.GetInternalPlugins();
+                    if (internalPlugins != null)
+                    {
+                        directories.Add(internalPlugins);
+                    }
 #endif
                     var filePaths = PluginDiscoveryUtility.GetConventionBasedPlugins(directories);
                     _pluginFiles = GetPluginFiles(filePaths, cancellationToken);
@@ -148,7 +150,7 @@ namespace NuGet.Protocol.Plugins
             return _results;
         }
 
-        private static List<PluginFile> GetPluginFiles(IEnumerable<string> filePaths, CancellationToken cancellationToken)
+        private static List<PluginFile> GetPluginFiles(IEnumerable<string>? filePaths, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -210,7 +212,7 @@ namespace NuGet.Protocol.Plugins
                     }
                     else if (Directory.Exists(path))
                     {
-                        List<PluginFile> plugins = GetNetToolsPluginsInDirectory(path);
+                        List<PluginFile>? plugins = GetNetToolsPluginsInDirectory(path);
 
                         if (plugins != null)
                         {
@@ -241,7 +243,7 @@ namespace NuGet.Protocol.Plugins
             {
                 if (PathValidator.IsValidLocalPath(path) || PathValidator.IsValidUncPath(path))
                 {
-                    List<PluginFile> plugins = GetNetToolsPluginsInDirectory(path);
+                    List<PluginFile>? plugins = GetNetToolsPluginsInDirectory(path);
 
                     if (plugins != null)
                     {
@@ -253,9 +255,9 @@ namespace NuGet.Protocol.Plugins
             return pluginFiles;
         }
 
-        private static List<PluginFile> GetNetToolsPluginsInDirectory(string directoryPath)
+        private static List<PluginFile>? GetNetToolsPluginsInDirectory(string directoryPath)
         {
-            List<PluginFile> pluginFiles = null;
+            List<PluginFile>? pluginFiles = null;
 
             if (!Directory.Exists(directoryPath))
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginDiscoveryUtility.cs
@@ -1,6 +1,4 @@
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,7 +9,7 @@ namespace NuGet.Protocol.Plugins
 {
     public static class PluginDiscoveryUtility
     {
-        public static Lazy<string> InternalPluginDiscoveryRoot { get; set; }
+        public static Lazy<string>? InternalPluginDiscoveryRoot { get; set; }
 
         private static string NuGetPluginsDirectory = "Plugins";
 
@@ -20,7 +18,7 @@ namespace NuGet.Protocol.Plugins
         /// The internal plugins located next to the NuGet assemblies.
         /// </summary>
         /// <returns>Internal plugins</returns>
-        public static string GetInternalPlugins()
+        public static string? GetInternalPlugins()
         {
             return InternalPluginDiscoveryRoot?.Value ??
                 GetNuGetPluginsDirectoryRelativeToNuGetAssembly(typeof(PluginDiscoveryUtility).Assembly.Location); // NuGet.*.dll
@@ -32,7 +30,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="msbuildDirectoryPath">The MsBuildExe directory path. Needs to be a valid path. file:// not supported.</param>
         /// <returns>The NuGet plugins directory, null if <paramref name="msbuildDirectoryPath"/> is null</returns>
         /// <remarks>The MSBuild.exe is in MSBuild\Current\Bin, the Plugins directory is in Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins</remarks>
-        public static string GetInternalPluginRelativeToMSBuildDirectory(string msbuildDirectoryPath)
+        public static string? GetInternalPluginRelativeToMSBuildDirectory(string msbuildDirectoryPath)
         {
             if (string.IsNullOrEmpty(msbuildDirectoryPath))
             {
@@ -53,11 +51,11 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="nugetAssemblyPath">The path to a NuGet assembly in CommonExtensions\NuGet, needs to be a valid path. file:// not supported</param>
         /// <returns>The NuGet plugins directory in CommonExtensions\NuGet\Plugins, null if the <paramref name="nugetAssemblyPath"/> is null</returns>
-        public static string GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string nugetAssemblyPath)
+        public static string? GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string nugetAssemblyPath)
         {
             return !string.IsNullOrEmpty(nugetAssemblyPath) ?
                     Path.Combine(
-                        Path.GetDirectoryName(nugetAssemblyPath),
+                        Path.GetDirectoryName(nugetAssemblyPath)!,
                         NuGetPluginsDirectory
                         ) :
                     null;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -38,6 +38,7 @@ namespace NuGet.Protocol.Plugins
         }
 
         // Parameterless constructor used by Moq to mock this type.
+        [Obsolete("This constructor exists only for Moq via reflection. Do not call directly.", error: true)]
         internal PluginFactory()
         {
             _logger = null!;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -27,8 +25,6 @@ namespace NuGet.Protocol.Plugins
         private readonly TimeSpan _pluginIdleTimeout;
         private readonly ConcurrentDictionary<string, Lazy<Task<IPlugin>>> _plugins;
         private readonly IEnvironmentVariableReader _environmentVariableReader;
-
-        internal PluginFactory() { }
 
         /// <summary>
         /// Instantiates a new <see cref="PluginFactory" /> class.
@@ -207,10 +203,10 @@ namespace NuGet.Protocol.Plugins
             {
                 // Process ID is unavailable until we start the process; however, we want to wire up this event before
                 // attempting to start the process in case the process immediately exits.
-                EventHandler<IPluginProcess> onExited = null;
-                Connection connection = null;
+                EventHandler<IPluginProcess>? onExited = null;
+                Connection? connection = null;
 
-                onExited = (object eventSender, IPluginProcess exitedProcess) =>
+                onExited = (object? eventSender, IPluginProcess exitedProcess) =>
                 {
                     exitedProcess.Exited -= onExited;
 
@@ -381,9 +377,7 @@ namespace NuGet.Protocol.Plugins
 
             UnregisterEventHandlers(plugin as Plugin);
 
-            Lazy<Task<IPlugin>> lazyTask;
-
-            if (_plugins.TryRemove(plugin.FilePath, out lazyTask))
+            if (_plugins.TryRemove(plugin.FilePath, out Lazy<Task<IPlugin>>? lazyTask))
             {
                 if (lazyTask.IsValueCreated && lazyTask.Value.Status == TaskStatus.RanToCompletion)
                 {
@@ -402,7 +396,7 @@ namespace NuGet.Protocol.Plugins
             }
         }
 
-        private void OnPluginFaulted(object sender, FaultedPluginEventArgs e)
+        private void OnPluginFaulted(object? sender, FaultedPluginEventArgs e)
         {
             var message = string.Format(
                 CultureInfo.CurrentCulture,
@@ -415,12 +409,12 @@ namespace NuGet.Protocol.Plugins
             Dispose(e.Plugin);
         }
 
-        private void OnPluginExited(object sender, PluginEventArgs e)
+        private void OnPluginExited(object? sender, PluginEventArgs e)
         {
             Dispose(e.Plugin);
         }
 
-        private void OnPluginIdle(object sender, PluginEventArgs e)
+        private void OnPluginIdle(object? sender, PluginEventArgs e)
         {
             if (_logger.IsEnabled)
             {
@@ -458,7 +452,7 @@ namespace NuGet.Protocol.Plugins
             }
         }
 
-        private void UnregisterEventHandlers(Plugin plugin)
+        private void UnregisterEventHandlers(Plugin? plugin)
         {
             if (plugin != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginFactory.cs
@@ -37,6 +37,14 @@ namespace NuGet.Protocol.Plugins
         {
         }
 
+        // Parameterless constructor used by Moq to mock this type.
+        internal PluginFactory()
+        {
+            _logger = null!;
+            _plugins = null!;
+            _environmentVariableReader = null!;
+        }
+
         internal PluginFactory(TimeSpan pluginIdleTimeout, IEnvironmentVariableReader environmentVariableReader)
         {
             _environmentVariableReader = environmentVariableReader ?? throw new ArgumentNullException(nameof(environmentVariableReader));

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
@@ -1,12 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -137,7 +136,7 @@ namespace NuGet.Protocol.Plugins
 
                         if (pluginCreationResult.Item1)
                         {
-                            pluginCreationResults.Add(pluginCreationResult.Item2);
+                            pluginCreationResults.Add(pluginCreationResult.Item2!);
                         }
                     }
                 }
@@ -154,7 +153,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="requestedOperationClaim">The requested operation claim</param>
         /// <param name="cancellationToken">cancellation token</param>
         /// <returns>A plugin creation result, null if the requested plugin cannot handle the given operation claim</returns>
-        public Task<Tuple<bool, PluginCreationResult>> TryGetSourceAgnosticPluginAsync(PluginDiscoveryResult pluginDiscoveryResult, OperationClaim requestedOperationClaim, CancellationToken cancellationToken)
+        public Task<Tuple<bool, PluginCreationResult?>> TryGetSourceAgnosticPluginAsync(PluginDiscoveryResult pluginDiscoveryResult, OperationClaim requestedOperationClaim, CancellationToken cancellationToken)
         {
             if (pluginDiscoveryResult == null)
             {
@@ -184,12 +183,12 @@ namespace NuGet.Protocol.Plugins
         /// <param name="serviceIndex">service index</param>
         /// <param name="cancellationToken">cancellation token</param>
         /// <returns>A plugin creation result, null if the requested plugin cannot handle the given operation claim</returns>
-        private async Task<Tuple<bool, PluginCreationResult>> TryCreatePluginAsync(
+        private async Task<Tuple<bool, PluginCreationResult?>> TryCreatePluginAsync(
             PluginDiscoveryResult result,
             OperationClaim requestedOperationClaim,
             PluginRequestKey requestKey,
-            string packageSourceRepository,
-            string serviceIndex,
+            string? packageSourceRepository,
+            string? serviceIndex,
             CancellationToken cancellationToken)
         {
             // This is a non cancellable task.
@@ -200,7 +199,7 @@ namespace NuGet.Protocol.Plugins
             // We could consider handling each of this operations more cleverly, 
             // but simplicity and readability is prioritized           
             cancellationToken = CancellationToken.None;
-            PluginCreationResult pluginCreationResult = null;
+            PluginCreationResult? pluginCreationResult = null;
             var cacheEntry = new PluginCacheEntry(_pluginsCacheDirectoryPath.Value, result.PluginFile.Path, requestKey.PackageSourceRepository);
 
             ConcurrencyUtilities.ExecuteWithFileLocked(cacheEntry.CacheFileName, cacheEntry.LoadFromFile);
@@ -255,7 +254,7 @@ namespace NuGet.Protocol.Plugins
                     }
                     else
                     {
-                        pluginCreationResult = new PluginCreationResult(result.Message);
+                        pluginCreationResult = new PluginCreationResult(result.Message!);
                     }
                 }
                 catch (Exception e)
@@ -269,7 +268,7 @@ namespace NuGet.Protocol.Plugins
                 }
             }
 
-            return new Tuple<bool, PluginCreationResult>(pluginCreationResult != null, pluginCreationResult);
+            return new Tuple<bool, PluginCreationResult?>(pluginCreationResult != null, pluginCreationResult);
         }
 
         private async Task<Lazy<IPluginMulticlientUtilities>> PerformOneTimePluginInitializationAsync(IPlugin plugin, CancellationToken cancellationToken)
@@ -297,6 +296,13 @@ namespace NuGet.Protocol.Plugins
             return utilities;
         }
 
+        [MemberNotNull(nameof(EnvironmentVariableReader))]
+        [MemberNotNull(nameof(_discoverer))]
+        [MemberNotNull(nameof(_pluginsCacheDirectoryPath))]
+        [MemberNotNull(nameof(_connectionOptions))]
+        [MemberNotNull(nameof(_pluginFactory))]
+        [MemberNotNull(nameof(_pluginOperationClaims))]
+        [MemberNotNull(nameof(_pluginUtilities))]
         private void Initialize(IEnvironmentVariableReader reader,
             Lazy<IPluginDiscoverer> pluginDiscoverer,
             Func<TimeSpan, IPluginFactory> pluginFactoryCreator,
@@ -324,11 +330,11 @@ namespace NuGet.Protocol.Plugins
 
         private static async Task<IReadOnlyList<OperationClaim>> GetPluginOperationClaimsAsync(
             IPlugin plugin,
-            string packageSourceRepository,
-            string serviceIndex,
+            string? packageSourceRepository,
+            string? serviceIndex,
             CancellationToken cancellationToken)
         {
-            if (plugin.Connection.ProtocolVersion.Equals(Plugins.ProtocolConstants.Version100) && (string.IsNullOrEmpty(packageSourceRepository) || serviceIndex == null))
+            if (plugin.Connection.ProtocolVersion?.Equals(Plugins.ProtocolConstants.Version100) == true && (string.IsNullOrEmpty(packageSourceRepository) || serviceIndex == null))
             {
                 throw new ArgumentException("Cannot invoke get operation claims with null arguments on a " + Plugins.ProtocolConstants.Version100 + " plugin");
             }
@@ -354,7 +360,7 @@ namespace NuGet.Protocol.Plugins
 
         private bool IsPluginPossiblyAvailable()
         {
-            string pluginEnvVariable;
+            string? pluginEnvVariable;
 
 #if IS_DESKTOP
             pluginEnvVariable = EnvironmentVariableReader.GetEnvironmentVariable(EnvironmentVariableConstants.DesktopPluginPaths);
@@ -365,13 +371,13 @@ namespace NuGet.Protocol.Plugins
             return !string.IsNullOrEmpty(pluginEnvVariable);
         }
 
-        private void OnPluginClosed(object sender, EventArgs e)
+        private void OnPluginClosed(object? sender, EventArgs e)
         {
             if (sender is IPlugin plugin)
             {
                 plugin.Closed -= OnPluginClosed;
 
-                _pluginUtilities.TryRemove(plugin.Id, out Lazy<IPluginMulticlientUtilities> utilities);
+                _pluginUtilities.TryRemove(plugin.Id, out _);
             }
         }
 
@@ -437,7 +443,7 @@ namespace NuGet.Protocol.Plugins
                 PackageSourceRepository = packageSourceRepository;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return Equals(obj as PluginRequestKey);
             }
@@ -447,7 +453,7 @@ namespace NuGet.Protocol.Plugins
                 return HashCodeCombiner.GetHashCode(PluginFilePath, PackageSourceRepository);
             }
 
-            public bool Equals(PluginRequestKey other)
+            public bool Equals(PluginRequestKey? other)
             {
                 if (ReferenceEquals(this, other))
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginMulticlientUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginMulticlientUtilities.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Threading;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -152,7 +150,7 @@ namespace NuGet.Protocol.Plugins
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            string filePath = null;
+            string? filePath = null;
 
             try
             {
@@ -206,10 +204,10 @@ namespace NuGet.Protocol.Plugins
 
             if (response != null && response.ResponseCode == MessageResponseCode.Success)
             {
-                return response.Hash;
+                return response.Hash!;
             }
 
-            return null;
+            return null!; // This is a fallback in case the plugin fails to provide a hash. This should never happen in practice. It is not worth the risk to annotate this method as null.
         }
 
         /// <summary>
@@ -236,7 +234,7 @@ namespace NuGet.Protocol.Plugins
         /// Sets a throttle for package downloads.
         /// </summary>
         /// <param name="throttle">A throttle.  Can be <see langword="null" />.</param>
-        public void SetThrottle(SemaphoreSlim throttle)
+        public void SetThrottle(SemaphoreSlim? throttle)
         {
             // Do nothing.  Plugins are not implemented on macOS.
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageReader.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -25,12 +23,12 @@ namespace NuGet.Protocol.Plugins
     /// </summary>
     public sealed class PluginPackageReader : PackageReaderBase
     {
-        private readonly ConcurrentDictionary<string, Lazy<Task<FileStreamCreator>>> _fileStreams;
-        private IEnumerable<string> _files;
+        private readonly ConcurrentDictionary<string, Lazy<Task<FileStreamCreator?>>> _fileStreams;
+        private IEnumerable<string>? _files;
         private readonly SemaphoreSlim _getFilesSemaphore;
         private readonly SemaphoreSlim _getNuspecReaderSemaphore;
         private bool _isDisposed;
-        private NuspecReader _nuspecReader;
+        private NuspecReader? _nuspecReader;
         private readonly PackageIdentity _packageIdentity;
         private readonly string _packageSourceRepository;
         private readonly IPlugin _plugin;
@@ -70,7 +68,7 @@ namespace NuGet.Protocol.Plugins
             _packageSourceRepository = packageSourceRepository;
             _getFilesSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
             _getNuspecReaderSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
-            _fileStreams = new ConcurrentDictionary<string, Lazy<Task<FileStreamCreator>>>(StringComparer.OrdinalIgnoreCase);
+            _fileStreams = new ConcurrentDictionary<string, Lazy<Task<FileStreamCreator?>>>(StringComparer.OrdinalIgnoreCase);
             _tempDirectoryPath = new Lazy<string>(GetTemporaryDirectoryPath);
         }
 
@@ -107,14 +105,14 @@ namespace NuGet.Protocol.Plugins
 
             var lazyCreator = _fileStreams.GetOrAdd(
                 path,
-                p => new Lazy<Task<FileStreamCreator>>(
+                p => new Lazy<Task<FileStreamCreator?>>(
                     () => GetStreamInternalAsync(p)));
 
             await lazyCreator.Value;
 
             if (lazyCreator.Value.Result == null)
             {
-                return null;
+                return null!;
             }
 
             return lazyCreator.Value.Result.Create();
@@ -293,7 +291,7 @@ namespace NuGet.Protocol.Plugins
                 switch (response.ResponseCode)
                 {
                     case MessageResponseCode.Success:
-                        return response.CopiedFiles;
+                        return response.CopiedFiles!;
 
                     case MessageResponseCode.Error:
                         throw new PluginException(
@@ -364,7 +362,7 @@ namespace NuGet.Protocol.Plugins
         /// <see cref="NuGetVersion" />.</returns>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
-        public override async Task<NuGetVersion> GetMinClientVersionAsync(CancellationToken cancellationToken)
+        public override async Task<NuGetVersion?> GetMinClientVersionAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -952,7 +950,7 @@ namespace NuGet.Protocol.Plugins
                 }
             }
 
-            return null;
+            return null!;
         }
 
         protected override void Dispose(bool disposing)
@@ -1002,7 +1000,7 @@ namespace NuGet.Protocol.Plugins
                 // Use the known framework or if the folder did not parse, use the Any framework and consider it a sub folder
                 var framework = GetFrameworkFromPath(path, allowSubFolders);
 
-                List<string> items = null;
+                List<string>? items = null;
                 if (!groups.TryGetValue(framework, out items))
                 {
                     items = new List<string>();
@@ -1017,7 +1015,7 @@ namespace NuGet.Protocol.Plugins
                 .Select(framework => new FrameworkSpecificGroup(framework, groups[framework].OrderBy(e => e, StringComparer.OrdinalIgnoreCase)));
         }
 
-        private async Task<FileStreamCreator> GetStreamInternalAsync(
+        private async Task<FileStreamCreator?> GetStreamInternalAsync(
             string pathInPackage)
         {
             var packageId = _packageIdentity.Id;
@@ -1040,7 +1038,7 @@ namespace NuGet.Protocol.Plugins
                 switch (response.ResponseCode)
                 {
                     case MessageResponseCode.Success:
-                        return new FileStreamCreator(response.CopiedFiles.Single());
+                        return new FileStreamCreator(response.CopiedFiles!.Single());
 
                     case MessageResponseCode.Error:
                         throw new PluginException(
@@ -1079,7 +1077,7 @@ namespace NuGet.Protocol.Plugins
                 switch (response.ResponseCode)
                 {
                     case MessageResponseCode.Success:
-                        return response.Files;
+                        return response.Files!;
 
                     case MessageResponseCode.Error:
                         throw new PluginException(
@@ -1105,7 +1103,7 @@ namespace NuGet.Protocol.Plugins
 
         private void CreatePackageDownloadMarkerFile(string nupkgFilePath)
         {
-            var directory = Path.GetDirectoryName(nupkgFilePath);
+            var directory = Path.GetDirectoryName(nupkgFilePath)!;
             var resolver = new VersionFolderPathResolver(directory);
             var fileName = resolver.GetPackageDownloadMarkerFileName(_packageIdentity.Id);
             var filePath = Path.Combine(directory, fileName);
@@ -1122,7 +1120,7 @@ namespace NuGet.Protocol.Plugins
             return tempDirectoryPath;
         }
 
-        public override Task<PrimarySignature> GetPrimarySignatureAsync(CancellationToken token)
+        public override Task<PrimarySignature?> GetPrimarySignatureAsync(CancellationToken token)
         {
             return TaskResult.Null<PrimarySignature>();
         }
@@ -1151,10 +1149,10 @@ namespace NuGet.Protocol.Plugins
             return false;
         }
 
-        public override string GetContentHash(CancellationToken token, Func<string> GetUnsignedPackageHash = null)
+        public override string GetContentHash(CancellationToken token, Func<string>? GetUnsignedPackageHash = null)
         {
             // Plugin Download doesn't support signed packages so simply return null... and even then they aren't always packages.
-            return null;
+            return null!;
         }
 
         private sealed class FileStreamCreator : IDisposable

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginProcess.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginProcess.cs
@@ -1,10 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace NuGet.Protocol.Plugins
@@ -15,21 +14,26 @@ namespace NuGet.Protocol.Plugins
     public sealed class PluginProcess : IPluginProcess
     {
         private int? _exitCode;
-        private bool _hasStarted;
         private int? _id;
         private bool _isDisposed;
         private readonly Process _process;
-        private readonly ProcessStartInfo _startInfo;
+        private readonly ProcessStartInfo? _startInfo;
+
+        // When HasStarted is false, _startInfo is guaranteed non-null
+        // (parameterless ctor sets HasStarted=true; the only way it can be false is the
+        // ProcessStartInfo ctor, which assigns _startInfo).
+        [MemberNotNullWhen(false, nameof(_startInfo))]
+        private bool HasStarted { get; set; }
 
         /// <summary>
         /// Occurs when a process exits.
         /// </summary>
-        public event EventHandler<IPluginProcess> Exited;
+        public event EventHandler<IPluginProcess>? Exited;
 
         /// <summary>
         /// Occurs when a line of output has been received.
         /// </summary>
-        public event EventHandler<LineReadEventArgs> LineRead;
+        public event EventHandler<LineReadEventArgs>? LineRead;
 
         public int? ExitCode
         {
@@ -41,7 +45,7 @@ namespace NuGet.Protocol.Plugins
             }
         }
 
-        internal string FilePath => _process.MainModule.FileName;
+        internal string FilePath => _process.MainModule!.FileName;
 
         /// <summary>
         /// Gets the process ID if the process was started; otherwise, <see langword="null" />.
@@ -64,7 +68,7 @@ namespace NuGet.Protocol.Plugins
         public PluginProcess()
         {
             _process = Process.GetCurrentProcess();
-            _hasStarted = true;
+            HasStarted = true;
         }
 
         /// <summary>
@@ -140,7 +144,7 @@ namespace NuGet.Protocol.Plugins
 
         public void Start()
         {
-            if (_hasStarted)
+            if (HasStarted)
             {
                 throw new InvalidOperationException();
             }
@@ -151,17 +155,17 @@ namespace NuGet.Protocol.Plugins
             _process.EnableRaisingEvents = true;
             _process.StartInfo = _startInfo;
 
-            _hasStarted = true;
+            HasStarted = true;
 
             _process.Start();
         }
 
-        private void OnOutputDataReceived(object sender, DataReceivedEventArgs e)
+        private void OnOutputDataReceived(object? sender, DataReceivedEventArgs e)
         {
             LineRead?.Invoke(sender, new LineReadEventArgs(e.Data));
         }
 
-        private void OnProcessExited(object sender, EventArgs e)
+        private void OnProcessExited(object? sender, EventArgs e)
         {
             if (sender is Process process)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Receiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Receiver.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins
@@ -25,12 +23,12 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Occurs when an unrecoverable fault has been caught.
         /// </summary>
-        public event EventHandler<ProtocolErrorEventArgs> Faulted;
+        public event EventHandler<ProtocolErrorEventArgs>? Faulted;
 
         /// <summary>
         /// Occurs when a message has been received.
         /// </summary>
-        public event EventHandler<MessageEventArgs> MessageReceived;
+        public event EventHandler<MessageEventArgs>? MessageReceived;
 
         /// <summary>
         /// Closes the connection.
@@ -60,7 +58,7 @@ namespace NuGet.Protocol.Plugins
 
         protected abstract void Dispose(bool disposing);
 
-        protected void FireFaultEvent(Exception exception, Message message)
+        protected void FireFaultEvent(Exception exception, Message? message)
         {
             var ex = new ProtocolException(Strings.Plugin_ProtocolException, exception);
             var eventArgs = message == null

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers.cs
@@ -1,10 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -74,7 +73,7 @@ namespace NuGet.Protocol.Plugins
         /// <param name="method">A message method.</param>
         /// <param name="handler">An existing request handler.</param>
         /// <returns><see langword="true" /> if the request handler exists; otherwise, <see langword="false" />.</returns>
-        public bool TryGet(MessageMethod method, out IRequestHandler handler)
+        public bool TryGet(MessageMethod method, [NotNullWhen(true)] out IRequestHandler? handler)
         {
             return _handlers.TryGetValue(method, out handler);
         }
@@ -86,9 +85,7 @@ namespace NuGet.Protocol.Plugins
         /// <returns><see langword="true" /> if a request handler was removed; otherwise, <see langword="false" />.</returns>
         public bool TryRemove(MessageMethod method)
         {
-            IRequestHandler handler;
-
-            return _handlers.TryRemove(method, out handler);
+            return _handlers.TryRemove(method, out _);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/CloseRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/CloseRequestHandler.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetCredentialsRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetCredentialsRequestHandler.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 #if NET5_0_OR_GREATER
@@ -25,10 +23,10 @@ namespace NuGet.Protocol.Plugins
     {
         private const string _basicAuthenticationType = "Basic";
 
-        private readonly ICredentialService _credentialService;
+        private readonly ICredentialService? _credentialService;
         private bool _isDisposed;
         private readonly IPlugin _plugin;
-        private readonly IWebProxy _proxy;
+        private readonly IWebProxy? _proxy;
         private readonly ConcurrentDictionary<string, SourceRepository> _repositories;
 
         /// <summary>
@@ -46,8 +44,8 @@ namespace NuGet.Protocol.Plugins
         /// is <see langword="null" />.</exception>
         public GetCredentialsRequestHandler(
             IPlugin plugin,
-            IWebProxy proxy,
-            ICredentialService credentialService)
+            IWebProxy? proxy,
+            ICredentialService? credentialService)
         {
             if (plugin == null)
             {
@@ -139,10 +137,11 @@ namespace NuGet.Protocol.Plugins
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var requestPayload = MessageUtilities.DeserializePayload<GetCredentialsRequest>(request);
+            // Deserialized payload is non-null for well-formed handler requests.
+            var requestPayload = MessageUtilities.DeserializePayload<GetCredentialsRequest>(request)!;
             var packageSource = GetPackageSource(requestPayload.PackageSourceRepository);
 
-            GetCredentialsResponse responsePayload = null;
+            GetCredentialsResponse responsePayload;
 
             if (packageSource.IsHttp &&
                 string.Equals(
@@ -150,7 +149,7 @@ namespace NuGet.Protocol.Plugins
                     packageSource.Source,
                     StringComparison.OrdinalIgnoreCase))
             {
-                ICredentials credential = null;
+                ICredentials? credential;
 
                 using (var progressReporter = AutomaticProgressReporter.Create(
                     _plugin.Connection,
@@ -181,12 +180,13 @@ namespace NuGet.Protocol.Plugins
                 }
                 else
                 {
-                    networkCredential = credential?.GetCredential(packageSource.SourceUri, null);
+                    // authType is documented as nullable in implementations even though BCL types it as non-null.
+                    var resolvedCredential = credential?.GetCredential(packageSource.SourceUri, authType: null!);
 
                     responsePayload = new GetCredentialsResponse(
-                        networkCredential != null ? MessageResponseCode.Success : MessageResponseCode.NotFound,
-                        networkCredential?.UserName,
-                        networkCredential?.Password);
+                        resolvedCredential != null ? MessageResponseCode.Success : MessageResponseCode.NotFound,
+                        resolvedCredential?.UserName,
+                        resolvedCredential?.Password);
                 }
             }
             else
@@ -200,7 +200,7 @@ namespace NuGet.Protocol.Plugins
             await responseHandler.SendResponseAsync(request, responsePayload, cancellationToken);
         }
 
-        private async Task<ICredentials> GetCredentialAsync(
+        private async Task<ICredentials?> GetCredentialAsync(
             PackageSource packageSource,
             HttpStatusCode statusCode,
             CancellationToken cancellationToken)
@@ -215,7 +215,7 @@ namespace NuGet.Protocol.Plugins
             return await GetPackageSourceCredential(requestType, packageSource, cancellationToken);
         }
 
-        private async Task<ICredentials> GetPackageSourceCredential(
+        private async Task<ICredentials?> GetPackageSourceCredential(
             CredentialRequestType requestType,
             PackageSource packageSource,
             CancellationToken cancellationToken)
@@ -257,7 +257,7 @@ namespace NuGet.Protocol.Plugins
             return credentials;
         }
 
-        private async Task<ICredentials> GetProxyCredentialAsync(
+        private async Task<ICredentials?> GetProxyCredentialAsync(
             PackageSource packageSource,
             CancellationToken cancellationToken)
         {
@@ -276,7 +276,8 @@ namespace NuGet.Protocol.Plugins
                     message,
                     cancellationToken);
 
-                return proxyCredentials?.GetCredential(proxyUri, _basicAuthenticationType);
+                // IWebProxy.GetProxy returns non-null in practice when proxy resolution succeeds.
+                return proxyCredentials?.GetCredential(proxyUri!, _basicAuthenticationType);
             }
 
             return null;
@@ -300,9 +301,7 @@ namespace NuGet.Protocol.Plugins
 
         private PackageSource GetPackageSource(string packageSourceRepository)
         {
-            SourceRepository sourceRepository;
-
-            if (_repositories.TryGetValue(packageSourceRepository, out sourceRepository))
+            if (_repositories.TryGetValue(packageSourceRepository, out var sourceRepository))
             {
                 return sourceRepository.PackageSource;
             }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetServiceIndexRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetServiceIndexRequestHandler.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 #if NET5_0_OR_GREATER
@@ -123,19 +121,19 @@ namespace NuGet.Protocol.Plugins
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var getRequest = MessageUtilities.DeserializePayload<GetServiceIndexRequest>(request);
-            SourceRepository sourceRepository;
-            ServiceIndexResourceV3 serviceIndex = null;
+            // Deserialized payload is non-null for well-formed handler requests.
+            var getRequest = MessageUtilities.DeserializePayload<GetServiceIndexRequest>(request)!;
+            ServiceIndexResourceV3? serviceIndex = null;
             GetServiceIndexResponse responsePayload;
 
-            if (_repositories.TryGetValue(getRequest.PackageSourceRepository, out sourceRepository))
+            if (_repositories.TryGetValue(getRequest.PackageSourceRepository, out var sourceRepository))
             {
                 serviceIndex = await sourceRepository.GetResourceAsync<ServiceIndexResourceV3>(cancellationToken);
             }
 
             if (serviceIndex == null)
             {
-                responsePayload = new GetServiceIndexResponse(MessageResponseCode.NotFound, serviceIndexJson: (string)null);
+                responsePayload = new GetServiceIndexResponse(MessageResponseCode.NotFound, serviceIndexJson: (string?)null);
             }
             else
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/LogRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/LogRequestHandler.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-#if NET5_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
-#endif
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/LogRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/LogRequestHandler.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 #if NET5_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -83,7 +81,8 @@ namespace NuGet.Protocol.Plugins
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var logRequest = MessageUtilities.DeserializePayload<LogRequest>(request);
+            // Deserialized payload is non-null for well-formed handler requests.
+            var logRequest = MessageUtilities.DeserializePayload<LogRequest>(request)!;
             MessageResponseCode responseCode;
 
             if (logRequest.LogLevel >= _logLevel)
@@ -107,6 +106,7 @@ namespace NuGet.Protocol.Plugins
         /// </summary>
         /// <param name="logger">A logger.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
+        [MemberNotNull(nameof(_logger))]
         public void SetLogger(ILogger logger)
         {
             if (logger == null)

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandler.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -99,9 +97,10 @@ namespace NuGet.Protocol.Plugins
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var monitorRequest = MessageUtilities.DeserializePayload<MonitorNuGetProcessExitRequest>(request);
+            // Deserialized payload is non-null for well-formed handler requests.
+            var monitorRequest = MessageUtilities.DeserializePayload<MonitorNuGetProcessExitRequest>(request)!;
 
-            Process process = null;
+            Process? process = null;
 
             try
             {
@@ -131,7 +130,7 @@ namespace NuGet.Protocol.Plugins
             await responseHandler.SendResponseAsync(request, response, cancellationToken);
         }
 
-        private void OnProcessExited(object sender, EventArgs e)
+        private void OnProcessExited(object? sender, EventArgs e)
         {
             _plugin.Close();
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/SymmetricHandshake.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/SymmetricHandshake.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 #if NET5_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -23,9 +21,9 @@ namespace NuGet.Protocol.Plugins
         private readonly TimeSpan _handshakeTimeout;
         private bool _isDisposed;
         private readonly SemanticVersion _minimumProtocolVersion;
-        private HandshakeRequest _outboundHandshakeRequest;
+        private HandshakeRequest? _outboundHandshakeRequest;
         private readonly SemanticVersion _protocolVersion;
-        private TaskCompletionSource<int> _responseSentTaskCompletionSource;
+        private readonly TaskCompletionSource<int> _responseSentTaskCompletionSource;
         private readonly CancellationTokenSource _timeoutCancellationTokenSource;
 
         /// <summary>
@@ -116,7 +114,7 @@ namespace NuGet.Protocol.Plugins
         /// if the handshake was successful; otherwise, <see langword="null" />.</returns>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
-        public async Task<SemanticVersion> HandshakeAsync(CancellationToken cancellationToken)
+        public async Task<SemanticVersion?> HandshakeAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -127,7 +125,7 @@ namespace NuGet.Protocol.Plugins
                 _outboundHandshakeRequest,
                 cancellationToken);
 
-            if (response != null && response.ResponseCode == MessageResponseCode.Success)
+            if (response?.IsSuccess == true)
             {
                 if (IsSupportedVersion(response.ProtocolVersion))
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestIdGenerator.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestIdGenerator.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 
 namespace NuGet.Protocol.Plugins

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Sender.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Threading;
@@ -26,7 +24,7 @@ namespace NuGet.Protocol.Plugins
         private bool _isDisposed;
         private readonly object _sendLock;
         private readonly TextWriter _textWriter;
-        private readonly IEnvironmentVariableReader _environmentVariableReader;
+        private readonly IEnvironmentVariableReader? _environmentVariableReader;
 
         /// <summary>
         /// Instantiates a new <see cref="Sender" /> class.
@@ -38,7 +36,7 @@ namespace NuGet.Protocol.Plugins
         {
         }
 
-        internal Sender(TextWriter writer, IEnvironmentVariableReader environmentVariableReader)
+        internal Sender(TextWriter writer, IEnvironmentVariableReader? environmentVariableReader)
         {
             if (writer == null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/StandardInputReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/StandardInputReceiver.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Threading;
@@ -23,8 +21,8 @@ namespace NuGet.Protocol.Plugins
     {
         private readonly TextReader _reader;
         private readonly CancellationTokenSource _receiveCancellationTokenSource;
-        private Task _receiveThread;
-        private readonly IEnvironmentVariableReader _environmentVariableReader;
+        private Task? _receiveThread;
+        private readonly IEnvironmentVariableReader? _environmentVariableReader;
 
         /// <summary>
         /// Instantiates a new <see cref="StandardInputReceiver" /> class.
@@ -36,7 +34,7 @@ namespace NuGet.Protocol.Plugins
         {
         }
 
-        internal StandardInputReceiver(TextReader reader, IEnvironmentVariableReader environmentVariableReader)
+        internal StandardInputReceiver(TextReader reader, IEnvironmentVariableReader? environmentVariableReader)
         {
             if (reader == null)
             {
@@ -109,15 +107,15 @@ namespace NuGet.Protocol.Plugins
                 TaskScheduler.Default);
         }
 
-        private void Receive(object state)
+        private void Receive(object? state)
         {
-            Message message = null;
+            Message? message = null;
 
             try
             {
-                var cancellationToken = (CancellationToken)state;
+                var cancellationToken = (CancellationToken)state!;
 
-                string line;
+                string? line;
 
                 // Reading from the standard input stream is a blocking call; while we're
                 // in a read call we can't respond to cancellation requests.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using NuGet.Common;
 using NuGet.Shared;
@@ -20,7 +18,7 @@ namespace NuGet.Protocol.Plugins
     {
         private bool _hasConnected;
         private readonly IPluginProcess _process;
-        private readonly IEnvironmentVariableReader _environmentVariableReader;
+        private readonly IEnvironmentVariableReader? _environmentVariableReader;
 
         /// <summary>
         /// Instantiates a new <see cref="StandardOutputReceiver" /> class.
@@ -32,7 +30,7 @@ namespace NuGet.Protocol.Plugins
         {
         }
 
-        internal StandardOutputReceiver(IPluginProcess process, IEnvironmentVariableReader environmentVariableReader)
+        internal StandardOutputReceiver(IPluginProcess process, IEnvironmentVariableReader? environmentVariableReader)
         {
             if (process == null)
             {
@@ -100,14 +98,15 @@ namespace NuGet.Protocol.Plugins
             _hasConnected = true;
         }
 
-        private void OnLineRead(object sender, LineReadEventArgs e)
+        private void OnLineRead(object? sender, LineReadEventArgs e)
         {
-            Message message = null;
+            Message? message = null;
 
             // Top-level exception handler for a worker pool thread.
             try
             {
-                if (!IsClosed && !string.IsNullOrEmpty(e.Line))
+                string? line = e.Line;
+                if (!IsClosed && line != null && line.Length > 0)
                 {
                     if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
                     {
@@ -115,7 +114,7 @@ namespace NuGet.Protocol.Plugins
                     }
                     else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
                     {
-                        message = System.Text.Json.JsonSerializer.Deserialize(e.Line, PluginJsonContext.Default.Message);
+                        message = System.Text.Json.JsonSerializer.Deserialize(line, PluginJsonContext.Default.Message);
                     }
                     else
                     {

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/StandardOutputReceiver.cs
@@ -110,7 +110,7 @@ namespace NuGet.Protocol.Plugins
                 {
                     if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
                     {
-                        message = System.Text.Json.JsonSerializer.Deserialize(e.Line, PluginJsonContext.Default.Message);
+                        message = System.Text.Json.JsonSerializer.Deserialize(line, PluginJsonContext.Default.Message);
                     }
                     else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
                     {
@@ -119,7 +119,7 @@ namespace NuGet.Protocol.Plugins
                     else
                     {
 #pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
-                        message = JsonSerializationUtilities.Deserialize<Message>(e.Line);
+                        message = JsonSerializationUtilities.Deserialize<Message>(line);
 #pragma warning restore IL2026, IL3050
                     }
 

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -848,21 +848,21 @@ NuGet.Protocol.Plugins.AutomaticProgressReporter
 NuGet.Protocol.Plugins.AutomaticProgressReporter.Dispose() -> void
 NuGet.Protocol.Plugins.CloseRequestHandler
 NuGet.Protocol.Plugins.CloseRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
-~NuGet.Protocol.Plugins.CloseRequestHandler.CloseRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin) -> void
+NuGet.Protocol.Plugins.CloseRequestHandler.CloseRequestHandler(NuGet.Protocol.Plugins.IPlugin! plugin) -> void
 NuGet.Protocol.Plugins.CloseRequestHandler.Dispose() -> void
-~NuGet.Protocol.Plugins.CloseRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.CloseRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.Connection
 NuGet.Protocol.Plugins.Connection.Close() -> void
-~NuGet.Protocol.Plugins.Connection.ConnectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.Connection.Connection(NuGet.Protocol.Plugins.IMessageDispatcher dispatcher, NuGet.Protocol.Plugins.ISender sender, NuGet.Protocol.Plugins.IReceiver receiver, NuGet.Protocol.Plugins.ConnectionOptions options) -> void
+NuGet.Protocol.Plugins.Connection.ConnectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.Connection.Connection(NuGet.Protocol.Plugins.IMessageDispatcher! dispatcher, NuGet.Protocol.Plugins.ISender! sender, NuGet.Protocol.Plugins.IReceiver! receiver, NuGet.Protocol.Plugins.ConnectionOptions! options) -> void
 NuGet.Protocol.Plugins.Connection.Dispose() -> void
-NuGet.Protocol.Plugins.Connection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs>
-~NuGet.Protocol.Plugins.Connection.MessageDispatcher.get -> NuGet.Protocol.Plugins.IMessageDispatcher
-NuGet.Protocol.Plugins.Connection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs>
-~NuGet.Protocol.Plugins.Connection.Options.get -> NuGet.Protocol.Plugins.ConnectionOptions
-~NuGet.Protocol.Plugins.Connection.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
-~NuGet.Protocol.Plugins.Connection.SendAsync(NuGet.Protocol.Plugins.Message message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.Connection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound>
+NuGet.Protocol.Plugins.Connection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>?
+NuGet.Protocol.Plugins.Connection.MessageDispatcher.get -> NuGet.Protocol.Plugins.IMessageDispatcher!
+NuGet.Protocol.Plugins.Connection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>?
+NuGet.Protocol.Plugins.Connection.Options.get -> NuGet.Protocol.Plugins.ConnectionOptions!
+NuGet.Protocol.Plugins.Connection.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion?
+NuGet.Protocol.Plugins.Connection.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.Connection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound?>!
 NuGet.Protocol.Plugins.Connection.State.get -> NuGet.Protocol.Plugins.ConnectionState
 NuGet.Protocol.Plugins.ConnectionOptions
 NuGet.Protocol.Plugins.ConnectionOptions.ConnectionOptions(NuGet.Versioning.SemanticVersion! protocolVersion, NuGet.Versioning.SemanticVersion! minimumProtocolVersion, System.TimeSpan handshakeTimeout, System.TimeSpan requestTimeout) -> void
@@ -925,11 +925,11 @@ NuGet.Protocol.Plugins.GetCredentialsRequest.GetCredentialsRequest(string! packa
 NuGet.Protocol.Plugins.GetCredentialsRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.GetCredentialsRequest.StatusCode.get -> System.Net.HttpStatusCode
 NuGet.Protocol.Plugins.GetCredentialsRequestHandler
-~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository sourceRepository) -> void
+NuGet.Protocol.Plugins.GetCredentialsRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository! sourceRepository) -> void
 NuGet.Protocol.Plugins.GetCredentialsRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
 NuGet.Protocol.Plugins.GetCredentialsRequestHandler.Dispose() -> void
-~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.GetCredentialsRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin, System.Net.IWebProxy proxy, NuGet.Configuration.ICredentialService credentialService) -> void
-~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.GetCredentialsRequestHandler.GetCredentialsRequestHandler(NuGet.Protocol.Plugins.IPlugin! plugin, System.Net.IWebProxy? proxy, NuGet.Configuration.ICredentialService? credentialService) -> void
+NuGet.Protocol.Plugins.GetCredentialsRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.GetCredentialsResponse
 NuGet.Protocol.Plugins.GetCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IReadOnlyList<string!>?
 NuGet.Protocol.Plugins.GetCredentialsResponse.GetCredentialsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string? username, string? password, System.Collections.Generic.IReadOnlyList<string!>? authenticationTypes = null) -> void
@@ -950,8 +950,8 @@ NuGet.Protocol.Plugins.GetOperationClaimsRequest.GetOperationClaimsRequest(strin
 NuGet.Protocol.Plugins.GetOperationClaimsRequest.PackageSourceRepository.get -> string?
 NuGet.Protocol.Plugins.GetOperationClaimsRequest.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject?
 NuGet.Protocol.Plugins.GetOperationClaimsResponse
-~NuGet.Protocol.Plugins.GetOperationClaimsResponse.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>
-~NuGet.Protocol.Plugins.GetOperationClaimsResponse.GetOperationClaimsResponse(System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.OperationClaim> claims) -> void
+NuGet.Protocol.Plugins.GetOperationClaimsResponse.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>!
+NuGet.Protocol.Plugins.GetOperationClaimsResponse.GetOperationClaimsResponse(System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.OperationClaim>! claims) -> void
 NuGet.Protocol.Plugins.GetPackageHashRequest
 NuGet.Protocol.Plugins.GetPackageHashRequest.GetPackageHashRequest(string! packageSourceRepository, string! packageId, string! packageVersion, string! hashAlgorithm) -> void
 NuGet.Protocol.Plugins.GetPackageHashRequest.HashAlgorithm.get -> string!
@@ -974,32 +974,32 @@ NuGet.Protocol.Plugins.GetServiceIndexRequest
 NuGet.Protocol.Plugins.GetServiceIndexRequest.GetServiceIndexRequest(string! packageSourceRepository) -> void
 NuGet.Protocol.Plugins.GetServiceIndexRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.GetServiceIndexRequestHandler
-~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository sourceRepository) -> void
+NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository! sourceRepository) -> void
 NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
 NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.Dispose() -> void
-~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.GetServiceIndexRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin) -> void
-~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.GetServiceIndexRequestHandler(NuGet.Protocol.Plugins.IPlugin! plugin) -> void
+NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.GetServiceIndexResponse
 NuGet.Protocol.Plugins.GetServiceIndexResponse.GetServiceIndexResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, Newtonsoft.Json.Linq.JObject? serviceIndex) -> void
 NuGet.Protocol.Plugins.GetServiceIndexResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetServiceIndexResponse.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject?
 NuGet.Protocol.Plugins.HandshakeRequest
-~NuGet.Protocol.Plugins.HandshakeRequest.HandshakeRequest(NuGet.Versioning.SemanticVersion protocolVersion, NuGet.Versioning.SemanticVersion minimumProtocolVersion) -> void
-~NuGet.Protocol.Plugins.HandshakeRequest.MinimumProtocolVersion.get -> NuGet.Versioning.SemanticVersion
-~NuGet.Protocol.Plugins.HandshakeRequest.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
+NuGet.Protocol.Plugins.HandshakeRequest.HandshakeRequest(NuGet.Versioning.SemanticVersion! protocolVersion, NuGet.Versioning.SemanticVersion! minimumProtocolVersion) -> void
+NuGet.Protocol.Plugins.HandshakeRequest.MinimumProtocolVersion.get -> NuGet.Versioning.SemanticVersion!
+NuGet.Protocol.Plugins.HandshakeRequest.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion!
 NuGet.Protocol.Plugins.HandshakeResponse
 NuGet.Protocol.Plugins.HandshakeResponse.HandshakeResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, NuGet.Versioning.SemanticVersion? protocolVersion) -> void
 NuGet.Protocol.Plugins.HandshakeResponse.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion?
 NuGet.Protocol.Plugins.HandshakeResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.IConnection
 NuGet.Protocol.Plugins.IConnection.Close() -> void
-NuGet.Protocol.Plugins.IConnection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>!
+NuGet.Protocol.Plugins.IConnection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>?
 NuGet.Protocol.Plugins.IConnection.MessageDispatcher.get -> NuGet.Protocol.Plugins.IMessageDispatcher!
-NuGet.Protocol.Plugins.IConnection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>!
+NuGet.Protocol.Plugins.IConnection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>?
 NuGet.Protocol.Plugins.IConnection.Options.get -> NuGet.Protocol.Plugins.ConnectionOptions!
 NuGet.Protocol.Plugins.IConnection.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion?
 NuGet.Protocol.Plugins.IConnection.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-NuGet.Protocol.Plugins.IConnection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound!>!
+NuGet.Protocol.Plugins.IConnection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound?>!
 NuGet.Protocol.Plugins.IIdGenerator
 NuGet.Protocol.Plugins.IIdGenerator.GenerateUniqueId() -> string!
 NuGet.Protocol.Plugins.IMessageDispatcher
@@ -1009,14 +1009,14 @@ NuGet.Protocol.Plugins.IMessageDispatcher.CreateMessage<TPayload>(NuGet.Protocol
 NuGet.Protocol.Plugins.IMessageDispatcher.DispatchCancelAsync(NuGet.Protocol.Plugins.Message! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IMessageDispatcher.DispatchFaultAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Fault! fault, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IMessageDispatcher.DispatchProgressAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Progress! progress, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-NuGet.Protocol.Plugins.IMessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound!>!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound?>!
 NuGet.Protocol.Plugins.IMessageDispatcher.DispatchResponseAsync<TOutbound>(NuGet.Protocol.Plugins.Message! request, TOutbound! responsePayload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IMessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers!
 NuGet.Protocol.Plugins.IMessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection? connection) -> void
 NuGet.Protocol.Plugins.IPlugin
-NuGet.Protocol.Plugins.IPlugin.BeforeClose -> System.EventHandler!
+NuGet.Protocol.Plugins.IPlugin.BeforeClose -> System.EventHandler?
 NuGet.Protocol.Plugins.IPlugin.Close() -> void
-NuGet.Protocol.Plugins.IPlugin.Closed -> System.EventHandler!
+NuGet.Protocol.Plugins.IPlugin.Closed -> System.EventHandler?
 NuGet.Protocol.Plugins.IPlugin.Connection.get -> NuGet.Protocol.Plugins.IConnection!
 NuGet.Protocol.Plugins.IPlugin.FilePath.get -> string!
 NuGet.Protocol.Plugins.IPlugin.Id.get -> string!
@@ -1026,7 +1026,7 @@ NuGet.Protocol.Plugins.IPluginDiscoverer.DiscoverAsync(System.Threading.Cancella
 NuGet.Protocol.Plugins.IPluginManager
 NuGet.Protocol.Plugins.IPluginManager.CreatePluginsAsync(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginCreationResult!>!>!
 NuGet.Protocol.Plugins.IPluginManager.FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult!>!>!
-NuGet.Protocol.Plugins.IPluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult! pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult!>!>!
+NuGet.Protocol.Plugins.IPluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult! pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult?>!>!
 NuGet.Protocol.Plugins.IPluginMulticlientUtilities
 NuGet.Protocol.Plugins.IPluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(string! key, System.Func<System.Threading.Tasks.Task!>! taskFunc, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IPluginProcess
@@ -1040,8 +1040,8 @@ NuGet.Protocol.Plugins.IPluginProcess.LineRead -> System.EventHandler<NuGet.Prot
 NuGet.Protocol.Plugins.IReceiver
 NuGet.Protocol.Plugins.IReceiver.Close() -> void
 NuGet.Protocol.Plugins.IReceiver.Connect() -> void
-NuGet.Protocol.Plugins.IReceiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>!
-NuGet.Protocol.Plugins.IReceiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>!
+NuGet.Protocol.Plugins.IReceiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>?
+NuGet.Protocol.Plugins.IReceiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>?
 NuGet.Protocol.Plugins.IRequestHandler
 NuGet.Protocol.Plugins.IRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
 NuGet.Protocol.Plugins.IRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
@@ -1057,12 +1057,12 @@ NuGet.Protocol.Plugins.ISender.Close() -> void
 NuGet.Protocol.Plugins.ISender.Connect() -> void
 NuGet.Protocol.Plugins.ISender.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.InboundRequestContext
-~NuGet.Protocol.Plugins.InboundRequestContext.BeginFaultAsync(NuGet.Protocol.Plugins.Message request, System.Exception exception) -> void
-~NuGet.Protocol.Plugins.InboundRequestContext.BeginResponseAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IRequestHandler requestHandler, NuGet.Protocol.Plugins.IResponseHandler responseHandler) -> void
+NuGet.Protocol.Plugins.InboundRequestContext.BeginFaultAsync(NuGet.Protocol.Plugins.Message! request, System.Exception! exception) -> void
+NuGet.Protocol.Plugins.InboundRequestContext.BeginResponseAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IRequestHandler! requestHandler, NuGet.Protocol.Plugins.IResponseHandler! responseHandler) -> void
 NuGet.Protocol.Plugins.InboundRequestContext.Cancel() -> void
 NuGet.Protocol.Plugins.InboundRequestContext.Dispose() -> void
-~NuGet.Protocol.Plugins.InboundRequestContext.InboundRequestContext(NuGet.Protocol.Plugins.IConnection connection, string requestId, System.Threading.CancellationToken cancellationToken) -> void
-~NuGet.Protocol.Plugins.InboundRequestContext.RequestId.get -> string
+NuGet.Protocol.Plugins.InboundRequestContext.InboundRequestContext(NuGet.Protocol.Plugins.IConnection! connection, string! requestId, System.Threading.CancellationToken cancellationToken) -> void
+NuGet.Protocol.Plugins.InboundRequestContext.RequestId.get -> string!
 NuGet.Protocol.Plugins.InitializeRequest
 NuGet.Protocol.Plugins.InitializeRequest.ClientVersion.get -> string!
 NuGet.Protocol.Plugins.InitializeRequest.Culture.get -> string!
@@ -1081,9 +1081,9 @@ NuGet.Protocol.Plugins.LogRequest.LogRequest(NuGet.Common.LogLevel logLevel, str
 NuGet.Protocol.Plugins.LogRequest.Message.get -> string!
 NuGet.Protocol.Plugins.LogRequestHandler
 NuGet.Protocol.Plugins.LogRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
-~NuGet.Protocol.Plugins.LogRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.LogRequestHandler.LogRequestHandler(NuGet.Common.ILogger logger) -> void
-~NuGet.Protocol.Plugins.LogRequestHandler.SetLogger(NuGet.Common.ILogger logger) -> void
+NuGet.Protocol.Plugins.LogRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.LogRequestHandler.LogRequestHandler(NuGet.Common.ILogger! logger) -> void
+NuGet.Protocol.Plugins.LogRequestHandler.SetLogger(NuGet.Common.ILogger! logger) -> void
 NuGet.Protocol.Plugins.LogResponse
 NuGet.Protocol.Plugins.LogResponse.LogResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.LogResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
@@ -1095,17 +1095,17 @@ NuGet.Protocol.Plugins.Message.RequestId.get -> string!
 NuGet.Protocol.Plugins.Message.Type.get -> NuGet.Protocol.Plugins.MessageType
 NuGet.Protocol.Plugins.MessageDispatcher
 NuGet.Protocol.Plugins.MessageDispatcher.Close() -> void
-~NuGet.Protocol.Plugins.MessageDispatcher.CreateMessage(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.MessageDispatcher.CreateMessage<TPayload>(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload payload) -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.MessageDispatcher.DispatchCancelAsync(NuGet.Protocol.Plugins.Message request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.MessageDispatcher.DispatchFaultAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.Fault fault, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.MessageDispatcher.DispatchProgressAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.Progress progress, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.MessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound>
-~NuGet.Protocol.Plugins.MessageDispatcher.DispatchResponseAsync<TOutbound>(NuGet.Protocol.Plugins.Message request, TOutbound responsePayload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.MessageDispatcher.CreateMessage(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message!
+NuGet.Protocol.Plugins.MessageDispatcher.CreateMessage<TPayload>(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload! payload) -> NuGet.Protocol.Plugins.Message!
+NuGet.Protocol.Plugins.MessageDispatcher.DispatchCancelAsync(NuGet.Protocol.Plugins.Message! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.MessageDispatcher.DispatchFaultAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Fault! fault, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.MessageDispatcher.DispatchProgressAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Progress! progress, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.MessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound?>!
+NuGet.Protocol.Plugins.MessageDispatcher.DispatchResponseAsync<TOutbound>(NuGet.Protocol.Plugins.Message! request, TOutbound! responsePayload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.MessageDispatcher.Dispose() -> void
-~NuGet.Protocol.Plugins.MessageDispatcher.MessageDispatcher(NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.IIdGenerator idGenerator) -> void
-~NuGet.Protocol.Plugins.MessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers
-~NuGet.Protocol.Plugins.MessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection connection) -> void
+NuGet.Protocol.Plugins.MessageDispatcher.MessageDispatcher(NuGet.Protocol.Plugins.IRequestHandlers! requestHandlers, NuGet.Protocol.Plugins.IIdGenerator! idGenerator) -> void
+NuGet.Protocol.Plugins.MessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers!
+NuGet.Protocol.Plugins.MessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection? connection) -> void
 NuGet.Protocol.Plugins.MessageEventArgs
 NuGet.Protocol.Plugins.MessageEventArgs.Message.get -> NuGet.Protocol.Plugins.Message!
 NuGet.Protocol.Plugins.MessageEventArgs.MessageEventArgs(NuGet.Protocol.Plugins.Message! message) -> void
@@ -1145,21 +1145,21 @@ NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequest.ProcessId.get -> int
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.Dispose() -> void
-~NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.MonitorNuGetProcessExitRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin) -> void
+NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.MonitorNuGetProcessExitRequestHandler(NuGet.Protocol.Plugins.IPlugin! plugin) -> void
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitResponse
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitResponse.MonitorNuGetProcessExitResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.NoOpDisposePlugin
-NuGet.Protocol.Plugins.NoOpDisposePlugin.BeforeClose -> System.EventHandler
+NuGet.Protocol.Plugins.NoOpDisposePlugin.BeforeClose -> System.EventHandler?
 NuGet.Protocol.Plugins.NoOpDisposePlugin.Close() -> void
-NuGet.Protocol.Plugins.NoOpDisposePlugin.Closed -> System.EventHandler
-~NuGet.Protocol.Plugins.NoOpDisposePlugin.Connection.get -> NuGet.Protocol.Plugins.IConnection
+NuGet.Protocol.Plugins.NoOpDisposePlugin.Closed -> System.EventHandler?
+NuGet.Protocol.Plugins.NoOpDisposePlugin.Connection.get -> NuGet.Protocol.Plugins.IConnection!
 NuGet.Protocol.Plugins.NoOpDisposePlugin.Dispose() -> void
-~NuGet.Protocol.Plugins.NoOpDisposePlugin.FilePath.get -> string
-~NuGet.Protocol.Plugins.NoOpDisposePlugin.Id.get -> string
-~NuGet.Protocol.Plugins.NoOpDisposePlugin.Name.get -> string
-~NuGet.Protocol.Plugins.NoOpDisposePlugin.NoOpDisposePlugin(NuGet.Protocol.Plugins.IPlugin plugin) -> void
+NuGet.Protocol.Plugins.NoOpDisposePlugin.FilePath.get -> string!
+NuGet.Protocol.Plugins.NoOpDisposePlugin.Id.get -> string!
+NuGet.Protocol.Plugins.NoOpDisposePlugin.Name.get -> string!
+NuGet.Protocol.Plugins.NoOpDisposePlugin.NoOpDisposePlugin(NuGet.Protocol.Plugins.IPlugin! plugin) -> void
 NuGet.Protocol.Plugins.OperationClaim
 NuGet.Protocol.Plugins.OperationClaim.Authentication = 1 -> NuGet.Protocol.Plugins.OperationClaim
 NuGet.Protocol.Plugins.OperationClaim.DownloadPackage = 0 -> NuGet.Protocol.Plugins.OperationClaim
@@ -1168,24 +1168,24 @@ NuGet.Protocol.Plugins.OutboundRequestContext.CancellationToken.get -> System.Th
 NuGet.Protocol.Plugins.OutboundRequestContext.CancellationToken.set -> void
 NuGet.Protocol.Plugins.OutboundRequestContext.Dispose() -> void
 NuGet.Protocol.Plugins.OutboundRequestContext.OutboundRequestContext() -> void
-~NuGet.Protocol.Plugins.OutboundRequestContext.RequestId.get -> string
-~NuGet.Protocol.Plugins.OutboundRequestContext.RequestId.set -> void
+NuGet.Protocol.Plugins.OutboundRequestContext.RequestId.get -> string!
+NuGet.Protocol.Plugins.OutboundRequestContext.RequestId.set -> void
 NuGet.Protocol.Plugins.OutboundRequestContext<TResult>
-~NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.CompletionTask.get -> System.Threading.Tasks.Task<TResult>
-~NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.OutboundRequestContext(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, System.TimeSpan? timeout, bool isKeepAlive, System.Threading.CancellationToken cancellationToken) -> void
+NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.CompletionTask.get -> System.Threading.Tasks.Task<TResult?>!
+NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.OutboundRequestContext(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, System.TimeSpan? timeout, bool isKeepAlive, System.Threading.CancellationToken cancellationToken) -> void
 NuGet.Protocol.Plugins.Plugin
-NuGet.Protocol.Plugins.Plugin.BeforeClose -> System.EventHandler
+NuGet.Protocol.Plugins.Plugin.BeforeClose -> System.EventHandler?
 NuGet.Protocol.Plugins.Plugin.Close() -> void
-NuGet.Protocol.Plugins.Plugin.Closed -> System.EventHandler
-~NuGet.Protocol.Plugins.Plugin.Connection.get -> NuGet.Protocol.Plugins.IConnection
+NuGet.Protocol.Plugins.Plugin.Closed -> System.EventHandler?
+NuGet.Protocol.Plugins.Plugin.Connection.get -> NuGet.Protocol.Plugins.IConnection!
 NuGet.Protocol.Plugins.Plugin.Dispose() -> void
-NuGet.Protocol.Plugins.Plugin.Exited -> System.EventHandler<NuGet.Protocol.Plugins.PluginEventArgs>
-NuGet.Protocol.Plugins.Plugin.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.FaultedPluginEventArgs>
-~NuGet.Protocol.Plugins.Plugin.FilePath.get -> string
-~NuGet.Protocol.Plugins.Plugin.Id.get -> string
-NuGet.Protocol.Plugins.Plugin.Idle -> System.EventHandler<NuGet.Protocol.Plugins.PluginEventArgs>
-~NuGet.Protocol.Plugins.Plugin.Name.get -> string
-~NuGet.Protocol.Plugins.Plugin.Plugin(string filePath, NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.IPluginProcess process, bool isOwnProcess, System.TimeSpan idleTimeout) -> void
+NuGet.Protocol.Plugins.Plugin.Exited -> System.EventHandler<NuGet.Protocol.Plugins.PluginEventArgs!>?
+NuGet.Protocol.Plugins.Plugin.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.FaultedPluginEventArgs!>?
+NuGet.Protocol.Plugins.Plugin.FilePath.get -> string!
+NuGet.Protocol.Plugins.Plugin.Id.get -> string!
+NuGet.Protocol.Plugins.Plugin.Idle -> System.EventHandler<NuGet.Protocol.Plugins.PluginEventArgs!>?
+NuGet.Protocol.Plugins.Plugin.Name.get -> string!
+NuGet.Protocol.Plugins.Plugin.Plugin(string! filePath, NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.IPluginProcess! process, bool isOwnProcess, System.TimeSpan idleTimeout) -> void
 NuGet.Protocol.Plugins.PluginCacheEntry
 NuGet.Protocol.Plugins.PluginCacheEntry.LoadFromFile() -> void
 NuGet.Protocol.Plugins.PluginCacheEntry.OperationClaims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>?
@@ -1203,7 +1203,7 @@ NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string! message
 NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string! message, System.Exception! exception) -> void
 NuGet.Protocol.Plugins.PluginCreationResult.PluginMulticlientUtilities.get -> NuGet.Protocol.Plugins.IPluginMulticlientUtilities?
 NuGet.Protocol.Plugins.PluginDiscoverer
-~NuGet.Protocol.Plugins.PluginDiscoverer.DiscoverAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult>>
+NuGet.Protocol.Plugins.PluginDiscoverer.DiscoverAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult!>!>!
 NuGet.Protocol.Plugins.PluginDiscoverer.Dispose() -> void
 NuGet.Protocol.Plugins.PluginDiscoverer.PluginDiscoverer() -> void
 NuGet.Protocol.Plugins.PluginDiscoveryResult
@@ -1230,39 +1230,39 @@ NuGet.Protocol.Plugins.PluginFileState.InvalidFilePath = 2 -> NuGet.Protocol.Plu
 NuGet.Protocol.Plugins.PluginFileState.NotFound = 1 -> NuGet.Protocol.Plugins.PluginFileState
 NuGet.Protocol.Plugins.PluginFileState.Valid = 0 -> NuGet.Protocol.Plugins.PluginFileState
 NuGet.Protocol.Plugins.PluginManager
-~NuGet.Protocol.Plugins.PluginManager.CreatePluginsAsync(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginCreationResult>>
+NuGet.Protocol.Plugins.PluginManager.CreatePluginsAsync(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginCreationResult!>!>!
 NuGet.Protocol.Plugins.PluginManager.Dispose() -> void
-~NuGet.Protocol.Plugins.PluginManager.EnvironmentVariableReader.get -> NuGet.Common.IEnvironmentVariableReader
-~NuGet.Protocol.Plugins.PluginManager.FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult>>
-~NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) -> void
-~NuGet.Protocol.Plugins.PluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult>>
+NuGet.Protocol.Plugins.PluginManager.EnvironmentVariableReader.get -> NuGet.Common.IEnvironmentVariableReader!
+NuGet.Protocol.Plugins.PluginManager.FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult!>!>!
+NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader! reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer!>! pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory!>! pluginFactoryCreator, System.Lazy<string!>! pluginsCacheDirectoryPath) -> void
+NuGet.Protocol.Plugins.PluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult! pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult?>!>!
 NuGet.Protocol.Plugins.PluginMulticlientUtilities
-~NuGet.Protocol.Plugins.PluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(string key, System.Func<System.Threading.Tasks.Task> taskFunc, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.PluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(string! key, System.Func<System.Threading.Tasks.Task!>! taskFunc, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.PluginMulticlientUtilities.PluginMulticlientUtilities() -> void
 NuGet.Protocol.Plugins.PluginPackageDownloader
-~NuGet.Protocol.Plugins.PluginPackageDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader
-~NuGet.Protocol.Plugins.PluginPackageDownloader.CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.Plugins.PluginPackageDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader
+NuGet.Protocol.Plugins.PluginPackageDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader!
+NuGet.Protocol.Plugins.PluginPackageDownloader.CopyNupkgFileToAsync(string! destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.Plugins.PluginPackageDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader!
 NuGet.Protocol.Plugins.PluginPackageDownloader.Dispose() -> void
-~NuGet.Protocol.Plugins.PluginPackageDownloader.GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
-~NuGet.Protocol.Plugins.PluginPackageDownloader.PluginPackageDownloader(NuGet.Protocol.Plugins.IPlugin plugin, NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Protocol.Plugins.PluginPackageReader packageReader, string packageSourceRepository) -> void
-~NuGet.Protocol.Plugins.PluginPackageDownloader.SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) -> void
-~NuGet.Protocol.Plugins.PluginPackageDownloader.SetThrottle(System.Threading.SemaphoreSlim throttle) -> void
-~NuGet.Protocol.Plugins.PluginPackageDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader
-~NuGet.Protocol.Plugins.PluginPackageDownloader.Source.get -> string
+NuGet.Protocol.Plugins.PluginPackageDownloader.GetPackageHashAsync(string! hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+NuGet.Protocol.Plugins.PluginPackageDownloader.PluginPackageDownloader(NuGet.Protocol.Plugins.IPlugin! plugin, NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Protocol.Plugins.PluginPackageReader! packageReader, string! packageSourceRepository) -> void
+NuGet.Protocol.Plugins.PluginPackageDownloader.SetExceptionHandler(System.Func<System.Exception!, System.Threading.Tasks.Task<bool>!>! handleExceptionAsync) -> void
+NuGet.Protocol.Plugins.PluginPackageDownloader.SetThrottle(System.Threading.SemaphoreSlim? throttle) -> void
+NuGet.Protocol.Plugins.PluginPackageDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader!
+NuGet.Protocol.Plugins.PluginPackageDownloader.Source.get -> string!
 NuGet.Protocol.Plugins.PluginPackageReader
-~NuGet.Protocol.Plugins.PluginPackageReader.PluginPackageReader(NuGet.Protocol.Plugins.IPlugin plugin, NuGet.Packaging.Core.PackageIdentity packageIdentity, string packageSourceRepository) -> void
+NuGet.Protocol.Plugins.PluginPackageReader.PluginPackageReader(NuGet.Protocol.Plugins.IPlugin! plugin, NuGet.Packaging.Core.PackageIdentity! packageIdentity, string! packageSourceRepository) -> void
 NuGet.Protocol.Plugins.PluginProcess
 NuGet.Protocol.Plugins.PluginProcess.BeginReadLine() -> void
 NuGet.Protocol.Plugins.PluginProcess.CancelRead() -> void
 NuGet.Protocol.Plugins.PluginProcess.Dispose() -> void
 NuGet.Protocol.Plugins.PluginProcess.ExitCode.get -> int?
-NuGet.Protocol.Plugins.PluginProcess.Exited -> System.EventHandler<NuGet.Protocol.Plugins.IPluginProcess>
+NuGet.Protocol.Plugins.PluginProcess.Exited -> System.EventHandler<NuGet.Protocol.Plugins.IPluginProcess!>?
 NuGet.Protocol.Plugins.PluginProcess.Id.get -> int?
 NuGet.Protocol.Plugins.PluginProcess.Kill() -> void
-NuGet.Protocol.Plugins.PluginProcess.LineRead -> System.EventHandler<NuGet.Protocol.Plugins.LineReadEventArgs>
+NuGet.Protocol.Plugins.PluginProcess.LineRead -> System.EventHandler<NuGet.Protocol.Plugins.LineReadEventArgs!>?
 NuGet.Protocol.Plugins.PluginProcess.PluginProcess() -> void
-~NuGet.Protocol.Plugins.PluginProcess.PluginProcess(System.Diagnostics.ProcessStartInfo startInfo) -> void
+NuGet.Protocol.Plugins.PluginProcess.PluginProcess(System.Diagnostics.ProcessStartInfo! startInfo) -> void
 NuGet.Protocol.Plugins.PluginProcess.Start() -> void
 NuGet.Protocol.Plugins.PrefetchPackageRequest
 NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageId.get -> string!
@@ -1286,31 +1286,31 @@ NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string? message) -> v
 NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string? message, System.Exception? innerException) -> void
 NuGet.Protocol.Plugins.Receiver
 NuGet.Protocol.Plugins.Receiver.Dispose() -> void
-NuGet.Protocol.Plugins.Receiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs>
-~NuGet.Protocol.Plugins.Receiver.FireFaultEvent(System.Exception exception, NuGet.Protocol.Plugins.Message message) -> void
-~NuGet.Protocol.Plugins.Receiver.FireMessageReceivedEvent(NuGet.Protocol.Plugins.Message message) -> void
+NuGet.Protocol.Plugins.Receiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>?
+NuGet.Protocol.Plugins.Receiver.FireFaultEvent(System.Exception! exception, NuGet.Protocol.Plugins.Message? message) -> void
+NuGet.Protocol.Plugins.Receiver.FireMessageReceivedEvent(NuGet.Protocol.Plugins.Message! message) -> void
 NuGet.Protocol.Plugins.Receiver.IsClosed.get -> bool
 NuGet.Protocol.Plugins.Receiver.IsDisposed.get -> bool
 NuGet.Protocol.Plugins.Receiver.IsDisposed.set -> void
-NuGet.Protocol.Plugins.Receiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs>
+NuGet.Protocol.Plugins.Receiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>?
 NuGet.Protocol.Plugins.Receiver.Receiver() -> void
 NuGet.Protocol.Plugins.Receiver.ThrowIfClosed() -> void
 NuGet.Protocol.Plugins.Receiver.ThrowIfDisposed() -> void
 NuGet.Protocol.Plugins.RequestHandlers
-~NuGet.Protocol.Plugins.RequestHandlers.AddOrUpdate(NuGet.Protocol.Plugins.MessageMethod method, System.Func<NuGet.Protocol.Plugins.IRequestHandler> addHandlerFunc, System.Func<NuGet.Protocol.Plugins.IRequestHandler, NuGet.Protocol.Plugins.IRequestHandler> updateHandlerFunc) -> void
+NuGet.Protocol.Plugins.RequestHandlers.AddOrUpdate(NuGet.Protocol.Plugins.MessageMethod method, System.Func<NuGet.Protocol.Plugins.IRequestHandler!>! addHandlerFunc, System.Func<NuGet.Protocol.Plugins.IRequestHandler!, NuGet.Protocol.Plugins.IRequestHandler!>! updateHandlerFunc) -> void
 NuGet.Protocol.Plugins.RequestHandlers.RequestHandlers() -> void
-~NuGet.Protocol.Plugins.RequestHandlers.TryAdd(NuGet.Protocol.Plugins.MessageMethod method, NuGet.Protocol.Plugins.IRequestHandler handler) -> bool
-~NuGet.Protocol.Plugins.RequestHandlers.TryGet(NuGet.Protocol.Plugins.MessageMethod method, out NuGet.Protocol.Plugins.IRequestHandler handler) -> bool
+NuGet.Protocol.Plugins.RequestHandlers.TryAdd(NuGet.Protocol.Plugins.MessageMethod method, NuGet.Protocol.Plugins.IRequestHandler! handler) -> bool
+NuGet.Protocol.Plugins.RequestHandlers.TryGet(NuGet.Protocol.Plugins.MessageMethod method, out NuGet.Protocol.Plugins.IRequestHandler? handler) -> bool
 NuGet.Protocol.Plugins.RequestHandlers.TryRemove(NuGet.Protocol.Plugins.MessageMethod method) -> bool
 NuGet.Protocol.Plugins.RequestIdGenerator
-~NuGet.Protocol.Plugins.RequestIdGenerator.GenerateUniqueId() -> string
+NuGet.Protocol.Plugins.RequestIdGenerator.GenerateUniqueId() -> string!
 NuGet.Protocol.Plugins.RequestIdGenerator.RequestIdGenerator() -> void
 NuGet.Protocol.Plugins.Sender
 NuGet.Protocol.Plugins.Sender.Close() -> void
 NuGet.Protocol.Plugins.Sender.Connect() -> void
 NuGet.Protocol.Plugins.Sender.Dispose() -> void
-~NuGet.Protocol.Plugins.Sender.SendAsync(NuGet.Protocol.Plugins.Message message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.Sender.Sender(System.IO.TextWriter writer) -> void
+NuGet.Protocol.Plugins.Sender.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.Sender.Sender(System.IO.TextWriter! writer) -> void
 NuGet.Protocol.Plugins.SetCredentialsRequest
 NuGet.Protocol.Plugins.SetCredentialsRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.SetCredentialsRequest.Password.get -> string?
@@ -1328,15 +1328,15 @@ NuGet.Protocol.Plugins.SetLogLevelResponse
 NuGet.Protocol.Plugins.SetLogLevelResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.SetLogLevelResponse.SetLogLevelResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.StandardInputReceiver
-~NuGet.Protocol.Plugins.StandardInputReceiver.StandardInputReceiver(System.IO.TextReader reader) -> void
+NuGet.Protocol.Plugins.StandardInputReceiver.StandardInputReceiver(System.IO.TextReader! reader) -> void
 NuGet.Protocol.Plugins.StandardOutputReceiver
-~NuGet.Protocol.Plugins.StandardOutputReceiver.StandardOutputReceiver(NuGet.Protocol.Plugins.IPluginProcess process) -> void
+NuGet.Protocol.Plugins.StandardOutputReceiver.StandardOutputReceiver(NuGet.Protocol.Plugins.IPluginProcess! process) -> void
 NuGet.Protocol.Plugins.SymmetricHandshake
 NuGet.Protocol.Plugins.SymmetricHandshake.CancellationToken.get -> System.Threading.CancellationToken
 NuGet.Protocol.Plugins.SymmetricHandshake.Dispose() -> void
-~NuGet.Protocol.Plugins.SymmetricHandshake.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.SymmetricHandshake.HandshakeAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Versioning.SemanticVersion>
-~NuGet.Protocol.Plugins.SymmetricHandshake.SymmetricHandshake(NuGet.Protocol.Plugins.IConnection connection, System.TimeSpan handshakeTimeout, NuGet.Versioning.SemanticVersion protocolVersion, NuGet.Versioning.SemanticVersion minimumProtocolVersion) -> void
+NuGet.Protocol.Plugins.SymmetricHandshake.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.SymmetricHandshake.HandshakeAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Versioning.SemanticVersion?>!
+NuGet.Protocol.Plugins.SymmetricHandshake.SymmetricHandshake(NuGet.Protocol.Plugins.IConnection! connection, System.TimeSpan handshakeTimeout, NuGet.Versioning.SemanticVersion! protocolVersion, NuGet.Versioning.SemanticVersion! minimumProtocolVersion) -> void
 NuGet.Protocol.Plugins.TimeoutUtilities
 NuGet.Protocol.ProtocolConstants
 NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider
@@ -1567,9 +1567,9 @@ abstract NuGet.Protocol.Core.Types.ResourceProvider.TryCreate(NuGet.Protocol.Cor
 ~abstract NuGet.Protocol.FindLocalPackagesResource.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
 abstract NuGet.Protocol.Plugins.OutboundRequestContext.Dispose(bool disposing) -> void
 abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleCancelResponse() -> void
-~abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleFault(NuGet.Protocol.Plugins.Message fault) -> void
-~abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleProgress(NuGet.Protocol.Plugins.Message progress) -> void
-~abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleResponse(NuGet.Protocol.Plugins.Message response) -> void
+abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleFault(NuGet.Protocol.Plugins.Message! fault) -> void
+abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleProgress(NuGet.Protocol.Plugins.Message! progress) -> void
+abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleResponse(NuGet.Protocol.Plugins.Message! response) -> void
 abstract NuGet.Protocol.Plugins.Receiver.Connect() -> void
 abstract NuGet.Protocol.Plugins.Receiver.Dispose(bool disposing) -> void
 const NuGet.Protocol.CachingUtility.BufferSize = 8192 -> int
@@ -1785,59 +1785,59 @@ override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWrit
 ~override NuGet.Protocol.PackageUpdateResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.PluginFindPackageByIdResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleCancelResponse() -> void
-~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleFault(NuGet.Protocol.Plugins.Message fault) -> void
-~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleProgress(NuGet.Protocol.Plugins.Message progress) -> void
-~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleResponse(NuGet.Protocol.Plugins.Message response) -> void
+override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleFault(NuGet.Protocol.Plugins.Message! fault) -> void
+override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleProgress(NuGet.Protocol.Plugins.Message! progress) -> void
+override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleResponse(NuGet.Protocol.Plugins.Message! response) -> void
 override NuGet.Protocol.Plugins.PluginFile.ToString() -> string!
-~override NuGet.Protocol.Plugins.PluginPackageReader.CanVerifySignedPackages(NuGet.Packaging.Signing.SignedPackageVerifierSettings verifierSettings) -> bool
-~override NuGet.Protocol.Plugins.PluginPackageReader.CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate extractFile, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<string>
-~override NuGet.Protocol.Plugins.PluginPackageReader.CopyFilesAsync(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate extractFile, NuGet.Common.ILogger logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.CopyNupkgAsync(string nupkgFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetArchiveHashAsync(NuGet.Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<byte[]>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetBuildItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetBuildItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null) -> string
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetContentItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetContentItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
+override NuGet.Protocol.Plugins.PluginPackageReader.CanVerifySignedPackages(NuGet.Packaging.Signing.SignedPackageVerifierSettings! verifierSettings) -> bool
+override NuGet.Protocol.Plugins.PluginPackageReader.CopyFiles(string! destination, System.Collections.Generic.IEnumerable<string!>! packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate! extractFile, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<string!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.CopyFilesAsync(string! destination, System.Collections.Generic.IEnumerable<string!>! packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate! extractFile, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.CopyNupkgAsync(string! nupkgFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetArchiveHashAsync(NuGet.Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<byte[]!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetBuildItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetBuildItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetContentHash(System.Threading.CancellationToken token, System.Func<string!>? GetUnsignedPackageHash = null) -> string!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetContentItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetContentItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
 override NuGet.Protocol.Plugins.PluginPackageReader.GetDevelopmentDependency() -> bool
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetDevelopmentDependencyAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFiles() -> System.Collections.Generic.IEnumerable<string>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFiles(string folder) -> System.Collections.Generic.IEnumerable<string>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFilesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFilesAsync(string folder, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFrameworkItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFrameworkItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetIdentity() -> NuGet.Packaging.Core.PackageIdentity
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetIdentityAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.Core.PackageIdentity>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetItems(string folderName) -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetItemsAsync(string folderName, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetLibItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetLibItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetMinClientVersion() -> NuGet.Versioning.NuGetVersion
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetMinClientVersionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Versioning.NuGetVersion>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspec() -> System.IO.Stream
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecFile() -> string
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecFileAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecReaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.NuspecReader>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageDependencies() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageDependenciesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageTypes() -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageType>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageTypesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageType>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetPrimarySignatureAsync(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Packaging.Signing.PrimarySignature>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetReferenceItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetReferenceItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetStream(string path) -> System.IO.Stream
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetStreamAsync(string path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworks() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworksAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetToolItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetToolItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
+override NuGet.Protocol.Plugins.PluginPackageReader.GetDevelopmentDependencyAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFiles() -> System.Collections.Generic.IEnumerable<string!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFiles(string! folder) -> System.Collections.Generic.IEnumerable<string!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFilesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFilesAsync(string! folder, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFrameworkItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFrameworkItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetIdentity() -> NuGet.Packaging.Core.PackageIdentity!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetIdentityAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.Core.PackageIdentity!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetItems(string! folderName) -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetItemsAsync(string! folderName, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetLibItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetLibItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetMinClientVersion() -> NuGet.Versioning.NuGetVersion!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetMinClientVersionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Versioning.NuGetVersion?>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspec() -> System.IO.Stream!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecFile() -> string!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecFileAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecReaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.NuspecReader!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageDependencies() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageDependenciesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageTypes() -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageType!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageTypesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageType!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetPrimarySignatureAsync(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Packaging.Signing.PrimarySignature?>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetReferenceItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetReferenceItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetStream(string! path) -> System.IO.Stream!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetStreamAsync(string! path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworks() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworksAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetToolItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetToolItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
 override NuGet.Protocol.Plugins.PluginPackageReader.IsServiceable() -> bool
-~override NuGet.Protocol.Plugins.PluginPackageReader.IsServiceableAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.Plugins.PluginPackageReader.IsSignedAsync(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.Plugins.PluginPackageReader.NuspecReader.get -> NuGet.Packaging.NuspecReader
-~override NuGet.Protocol.Plugins.PluginPackageReader.ValidateIntegrityAsync(NuGet.Packaging.Signing.SignatureContent signatureContent, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
+override NuGet.Protocol.Plugins.PluginPackageReader.IsServiceableAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.Plugins.PluginPackageReader.IsSignedAsync(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.Plugins.PluginPackageReader.NuspecReader.get -> NuGet.Packaging.NuspecReader!
+override NuGet.Protocol.Plugins.PluginPackageReader.ValidateIntegrityAsync(NuGet.Packaging.Signing.SignatureContent! signatureContent, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
 override NuGet.Protocol.Plugins.StandardInputReceiver.Connect() -> void
 override NuGet.Protocol.Plugins.StandardOutputReceiver.Close() -> void
 override NuGet.Protocol.Plugins.StandardOutputReceiver.Connect() -> void
@@ -2001,26 +2001,26 @@ static NuGet.Protocol.LocalFolderUtility.IsPossiblePackageMatch(System.IO.FileIn
 static NuGet.Protocol.LocalFolderUtility.ResolvePackageFromPath(string! packagePath, bool isSnupkg = false) -> System.Collections.Generic.IEnumerable<string!>!
 static NuGet.Protocol.NullThrottle.Instance.get -> NuGet.Protocol.NullThrottle!
 ~static NuGet.Protocol.PackageDetailsUriResourceV3.CreateOrNull(string uriTemplate) -> NuGet.Protocol.PackageDetailsUriResourceV3
-~static NuGet.Protocol.Plugins.AutomaticProgressReporter.Create(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Plugins.AutomaticProgressReporter
+static NuGet.Protocol.Plugins.AutomaticProgressReporter.Create(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Plugins.AutomaticProgressReporter!
 static NuGet.Protocol.Plugins.ConnectionOptions.CreateDefault(NuGet.Common.IEnvironmentVariableReader? reader = null) -> NuGet.Protocol.Plugins.ConnectionOptions!
-~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Deserialize<T>(string json) -> T
-~static NuGet.Protocol.Plugins.JsonSerializationUtilities.FromObject(object value) -> Newtonsoft.Json.Linq.JObject
-~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serialize(Newtonsoft.Json.JsonWriter writer, object value) -> void
-~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serializer.get -> Newtonsoft.Json.JsonSerializer
-~static NuGet.Protocol.Plugins.JsonSerializationUtilities.ToObject<T>(Newtonsoft.Json.Linq.JObject jObject) -> T
-~static NuGet.Protocol.Plugins.LogRequestHandler.GetLogLevel(NuGet.Common.ILogger logger) -> NuGet.Common.LogLevel
+static NuGet.Protocol.Plugins.JsonSerializationUtilities.Deserialize<T>(string! json) -> T?
+static NuGet.Protocol.Plugins.JsonSerializationUtilities.FromObject(object! value) -> Newtonsoft.Json.Linq.JObject!
+static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serialize(Newtonsoft.Json.JsonWriter! writer, object! value) -> void
+static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serializer.get -> Newtonsoft.Json.JsonSerializer!
+static NuGet.Protocol.Plugins.JsonSerializationUtilities.ToObject<T>(Newtonsoft.Json.Linq.JObject! jObject) -> T?
+static NuGet.Protocol.Plugins.LogRequestHandler.GetLogLevel(NuGet.Common.ILogger! logger) -> NuGet.Common.LogLevel
 static NuGet.Protocol.Plugins.MessageUtilities.Create(string! requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message!
 static NuGet.Protocol.Plugins.MessageUtilities.Create<TPayload>(string! requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload! payload) -> NuGet.Protocol.Plugins.Message!
 static NuGet.Protocol.Plugins.MessageUtilities.DeserializePayload<TPayload>(NuGet.Protocol.Plugins.Message! message) -> TPayload?
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetConventionBasedPlugins(System.Collections.Generic.IEnumerable<string> directories) -> System.Collections.Generic.IEnumerable<string>
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildDirectory(string msbuildDirectoryPath) -> string
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetInternalPlugins() -> string
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetNuGetHomePluginsPath() -> string
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string nugetAssemblyPath) -> string
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot.get -> System.Lazy<string>
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot.set -> void
-~static NuGet.Protocol.Plugins.PluginFactory.CreateFromCurrentProcessAsync(NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>
-~static NuGet.Protocol.Plugins.PluginManager.Instance.get -> NuGet.Protocol.Plugins.IPluginManager
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetConventionBasedPlugins(System.Collections.Generic.IEnumerable<string!>! directories) -> System.Collections.Generic.IEnumerable<string!>!
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildDirectory(string! msbuildDirectoryPath) -> string?
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetInternalPlugins() -> string?
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetNuGetHomePluginsPath() -> string!
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string! nugetAssemblyPath) -> string?
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot.get -> System.Lazy<string!>?
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot.set -> void
+static NuGet.Protocol.Plugins.PluginFactory.CreateFromCurrentProcessAsync(NuGet.Protocol.Plugins.IRequestHandlers! requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions! options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin!>!
+static NuGet.Protocol.Plugins.PluginManager.Instance.get -> NuGet.Protocol.Plugins.IPluginManager!
 static NuGet.Protocol.Plugins.TimeoutUtilities.GetTimeout(string? timeoutInSeconds, System.TimeSpan fallbackTimeout) -> System.TimeSpan
 static NuGet.Protocol.Plugins.TimeoutUtilities.IsValid(System.TimeSpan timeout) -> bool
 static NuGet.Protocol.RegistrationUtility.CreateVersionRange(string! stringToParse) -> NuGet.Versioning.VersionRange!
@@ -2117,7 +2117,7 @@ virtual NuGet.Protocol.LocalPackageInfo.LastWriteTimeUtc.get -> System.DateTime
 ~virtual NuGet.Protocol.LocalPackageInfo.Path.get -> string
 virtual NuGet.Protocol.ODataServiceDocumentResourceV2.RequestTime.get -> System.DateTime
 virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
-~virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile pluginFile, System.Collections.Generic.IEnumerable<string> arguments, NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>
+virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile! pluginFile, System.Collections.Generic.IEnumerable<string!>! arguments, NuGet.Protocol.Plugins.IRequestHandlers! requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions! options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin!>!
 virtual NuGet.Protocol.Plugins.Receiver.Close() -> void
 ~virtual NuGet.Protocol.RawSearchResourceV3.Search(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>>
 ~virtual NuGet.Protocol.RawSearchResourceV3.SearchPage(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject>

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -848,21 +848,21 @@ NuGet.Protocol.Plugins.AutomaticProgressReporter
 NuGet.Protocol.Plugins.AutomaticProgressReporter.Dispose() -> void
 NuGet.Protocol.Plugins.CloseRequestHandler
 NuGet.Protocol.Plugins.CloseRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
-~NuGet.Protocol.Plugins.CloseRequestHandler.CloseRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin) -> void
+NuGet.Protocol.Plugins.CloseRequestHandler.CloseRequestHandler(NuGet.Protocol.Plugins.IPlugin! plugin) -> void
 NuGet.Protocol.Plugins.CloseRequestHandler.Dispose() -> void
-~NuGet.Protocol.Plugins.CloseRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.CloseRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.Connection
 NuGet.Protocol.Plugins.Connection.Close() -> void
-~NuGet.Protocol.Plugins.Connection.ConnectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.Connection.Connection(NuGet.Protocol.Plugins.IMessageDispatcher dispatcher, NuGet.Protocol.Plugins.ISender sender, NuGet.Protocol.Plugins.IReceiver receiver, NuGet.Protocol.Plugins.ConnectionOptions options) -> void
+NuGet.Protocol.Plugins.Connection.ConnectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.Connection.Connection(NuGet.Protocol.Plugins.IMessageDispatcher! dispatcher, NuGet.Protocol.Plugins.ISender! sender, NuGet.Protocol.Plugins.IReceiver! receiver, NuGet.Protocol.Plugins.ConnectionOptions! options) -> void
 NuGet.Protocol.Plugins.Connection.Dispose() -> void
-NuGet.Protocol.Plugins.Connection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs>
-~NuGet.Protocol.Plugins.Connection.MessageDispatcher.get -> NuGet.Protocol.Plugins.IMessageDispatcher
-NuGet.Protocol.Plugins.Connection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs>
-~NuGet.Protocol.Plugins.Connection.Options.get -> NuGet.Protocol.Plugins.ConnectionOptions
-~NuGet.Protocol.Plugins.Connection.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
-~NuGet.Protocol.Plugins.Connection.SendAsync(NuGet.Protocol.Plugins.Message message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.Connection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound>
+NuGet.Protocol.Plugins.Connection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>?
+NuGet.Protocol.Plugins.Connection.MessageDispatcher.get -> NuGet.Protocol.Plugins.IMessageDispatcher!
+NuGet.Protocol.Plugins.Connection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>?
+NuGet.Protocol.Plugins.Connection.Options.get -> NuGet.Protocol.Plugins.ConnectionOptions!
+NuGet.Protocol.Plugins.Connection.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion?
+NuGet.Protocol.Plugins.Connection.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.Connection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound?>!
 NuGet.Protocol.Plugins.Connection.State.get -> NuGet.Protocol.Plugins.ConnectionState
 NuGet.Protocol.Plugins.ConnectionOptions
 NuGet.Protocol.Plugins.ConnectionOptions.ConnectionOptions(NuGet.Versioning.SemanticVersion! protocolVersion, NuGet.Versioning.SemanticVersion! minimumProtocolVersion, System.TimeSpan handshakeTimeout, System.TimeSpan requestTimeout) -> void
@@ -925,11 +925,11 @@ NuGet.Protocol.Plugins.GetCredentialsRequest.GetCredentialsRequest(string! packa
 NuGet.Protocol.Plugins.GetCredentialsRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.GetCredentialsRequest.StatusCode.get -> System.Net.HttpStatusCode
 NuGet.Protocol.Plugins.GetCredentialsRequestHandler
-~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository sourceRepository) -> void
+NuGet.Protocol.Plugins.GetCredentialsRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository! sourceRepository) -> void
 NuGet.Protocol.Plugins.GetCredentialsRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
 NuGet.Protocol.Plugins.GetCredentialsRequestHandler.Dispose() -> void
-~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.GetCredentialsRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin, System.Net.IWebProxy proxy, NuGet.Configuration.ICredentialService credentialService) -> void
-~NuGet.Protocol.Plugins.GetCredentialsRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.GetCredentialsRequestHandler.GetCredentialsRequestHandler(NuGet.Protocol.Plugins.IPlugin! plugin, System.Net.IWebProxy? proxy, NuGet.Configuration.ICredentialService? credentialService) -> void
+NuGet.Protocol.Plugins.GetCredentialsRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.GetCredentialsResponse
 NuGet.Protocol.Plugins.GetCredentialsResponse.AuthenticationTypes.get -> System.Collections.Generic.IReadOnlyList<string!>?
 NuGet.Protocol.Plugins.GetCredentialsResponse.GetCredentialsResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, string? username, string? password, System.Collections.Generic.IReadOnlyList<string!>? authenticationTypes = null) -> void
@@ -950,8 +950,8 @@ NuGet.Protocol.Plugins.GetOperationClaimsRequest.GetOperationClaimsRequest(strin
 NuGet.Protocol.Plugins.GetOperationClaimsRequest.PackageSourceRepository.get -> string?
 NuGet.Protocol.Plugins.GetOperationClaimsRequest.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject?
 NuGet.Protocol.Plugins.GetOperationClaimsResponse
-~NuGet.Protocol.Plugins.GetOperationClaimsResponse.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>
-~NuGet.Protocol.Plugins.GetOperationClaimsResponse.GetOperationClaimsResponse(System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.OperationClaim> claims) -> void
+NuGet.Protocol.Plugins.GetOperationClaimsResponse.Claims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>!
+NuGet.Protocol.Plugins.GetOperationClaimsResponse.GetOperationClaimsResponse(System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.OperationClaim>! claims) -> void
 NuGet.Protocol.Plugins.GetPackageHashRequest
 NuGet.Protocol.Plugins.GetPackageHashRequest.GetPackageHashRequest(string! packageSourceRepository, string! packageId, string! packageVersion, string! hashAlgorithm) -> void
 NuGet.Protocol.Plugins.GetPackageHashRequest.HashAlgorithm.get -> string!
@@ -974,32 +974,32 @@ NuGet.Protocol.Plugins.GetServiceIndexRequest
 NuGet.Protocol.Plugins.GetServiceIndexRequest.GetServiceIndexRequest(string! packageSourceRepository) -> void
 NuGet.Protocol.Plugins.GetServiceIndexRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.GetServiceIndexRequestHandler
-~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository sourceRepository) -> void
+NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.AddOrUpdateSourceRepository(NuGet.Protocol.Core.Types.SourceRepository! sourceRepository) -> void
 NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
 NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.Dispose() -> void
-~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.GetServiceIndexRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin) -> void
-~NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.GetServiceIndexRequestHandler(NuGet.Protocol.Plugins.IPlugin! plugin) -> void
+NuGet.Protocol.Plugins.GetServiceIndexRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.GetServiceIndexResponse
 NuGet.Protocol.Plugins.GetServiceIndexResponse.GetServiceIndexResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, Newtonsoft.Json.Linq.JObject? serviceIndex) -> void
 NuGet.Protocol.Plugins.GetServiceIndexResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.GetServiceIndexResponse.ServiceIndex.get -> Newtonsoft.Json.Linq.JObject?
 NuGet.Protocol.Plugins.HandshakeRequest
-~NuGet.Protocol.Plugins.HandshakeRequest.HandshakeRequest(NuGet.Versioning.SemanticVersion protocolVersion, NuGet.Versioning.SemanticVersion minimumProtocolVersion) -> void
-~NuGet.Protocol.Plugins.HandshakeRequest.MinimumProtocolVersion.get -> NuGet.Versioning.SemanticVersion
-~NuGet.Protocol.Plugins.HandshakeRequest.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion
+NuGet.Protocol.Plugins.HandshakeRequest.HandshakeRequest(NuGet.Versioning.SemanticVersion! protocolVersion, NuGet.Versioning.SemanticVersion! minimumProtocolVersion) -> void
+NuGet.Protocol.Plugins.HandshakeRequest.MinimumProtocolVersion.get -> NuGet.Versioning.SemanticVersion!
+NuGet.Protocol.Plugins.HandshakeRequest.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion!
 NuGet.Protocol.Plugins.HandshakeResponse
 NuGet.Protocol.Plugins.HandshakeResponse.HandshakeResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode, NuGet.Versioning.SemanticVersion? protocolVersion) -> void
 NuGet.Protocol.Plugins.HandshakeResponse.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion?
 NuGet.Protocol.Plugins.HandshakeResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.IConnection
 NuGet.Protocol.Plugins.IConnection.Close() -> void
-NuGet.Protocol.Plugins.IConnection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>!
+NuGet.Protocol.Plugins.IConnection.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>?
 NuGet.Protocol.Plugins.IConnection.MessageDispatcher.get -> NuGet.Protocol.Plugins.IMessageDispatcher!
-NuGet.Protocol.Plugins.IConnection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>!
+NuGet.Protocol.Plugins.IConnection.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>?
 NuGet.Protocol.Plugins.IConnection.Options.get -> NuGet.Protocol.Plugins.ConnectionOptions!
 NuGet.Protocol.Plugins.IConnection.ProtocolVersion.get -> NuGet.Versioning.SemanticVersion?
 NuGet.Protocol.Plugins.IConnection.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-NuGet.Protocol.Plugins.IConnection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound!>!
+NuGet.Protocol.Plugins.IConnection.SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound?>!
 NuGet.Protocol.Plugins.IIdGenerator
 NuGet.Protocol.Plugins.IIdGenerator.GenerateUniqueId() -> string!
 NuGet.Protocol.Plugins.IMessageDispatcher
@@ -1009,14 +1009,14 @@ NuGet.Protocol.Plugins.IMessageDispatcher.CreateMessage<TPayload>(NuGet.Protocol
 NuGet.Protocol.Plugins.IMessageDispatcher.DispatchCancelAsync(NuGet.Protocol.Plugins.Message! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IMessageDispatcher.DispatchFaultAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Fault! fault, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IMessageDispatcher.DispatchProgressAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Progress! progress, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-NuGet.Protocol.Plugins.IMessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound!>!
+NuGet.Protocol.Plugins.IMessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound?>!
 NuGet.Protocol.Plugins.IMessageDispatcher.DispatchResponseAsync<TOutbound>(NuGet.Protocol.Plugins.Message! request, TOutbound! responsePayload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IMessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers!
 NuGet.Protocol.Plugins.IMessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection? connection) -> void
 NuGet.Protocol.Plugins.IPlugin
-NuGet.Protocol.Plugins.IPlugin.BeforeClose -> System.EventHandler!
+NuGet.Protocol.Plugins.IPlugin.BeforeClose -> System.EventHandler?
 NuGet.Protocol.Plugins.IPlugin.Close() -> void
-NuGet.Protocol.Plugins.IPlugin.Closed -> System.EventHandler!
+NuGet.Protocol.Plugins.IPlugin.Closed -> System.EventHandler?
 NuGet.Protocol.Plugins.IPlugin.Connection.get -> NuGet.Protocol.Plugins.IConnection!
 NuGet.Protocol.Plugins.IPlugin.FilePath.get -> string!
 NuGet.Protocol.Plugins.IPlugin.Id.get -> string!
@@ -1026,7 +1026,7 @@ NuGet.Protocol.Plugins.IPluginDiscoverer.DiscoverAsync(System.Threading.Cancella
 NuGet.Protocol.Plugins.IPluginManager
 NuGet.Protocol.Plugins.IPluginManager.CreatePluginsAsync(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginCreationResult!>!>!
 NuGet.Protocol.Plugins.IPluginManager.FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult!>!>!
-NuGet.Protocol.Plugins.IPluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult! pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult!>!>!
+NuGet.Protocol.Plugins.IPluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult! pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult?>!>!
 NuGet.Protocol.Plugins.IPluginMulticlientUtilities
 NuGet.Protocol.Plugins.IPluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(string! key, System.Func<System.Threading.Tasks.Task!>! taskFunc, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.IPluginProcess
@@ -1040,8 +1040,8 @@ NuGet.Protocol.Plugins.IPluginProcess.LineRead -> System.EventHandler<NuGet.Prot
 NuGet.Protocol.Plugins.IReceiver
 NuGet.Protocol.Plugins.IReceiver.Close() -> void
 NuGet.Protocol.Plugins.IReceiver.Connect() -> void
-NuGet.Protocol.Plugins.IReceiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>!
-NuGet.Protocol.Plugins.IReceiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>!
+NuGet.Protocol.Plugins.IReceiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>?
+NuGet.Protocol.Plugins.IReceiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>?
 NuGet.Protocol.Plugins.IRequestHandler
 NuGet.Protocol.Plugins.IRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
 NuGet.Protocol.Plugins.IRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
@@ -1057,12 +1057,12 @@ NuGet.Protocol.Plugins.ISender.Close() -> void
 NuGet.Protocol.Plugins.ISender.Connect() -> void
 NuGet.Protocol.Plugins.ISender.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.InboundRequestContext
-~NuGet.Protocol.Plugins.InboundRequestContext.BeginFaultAsync(NuGet.Protocol.Plugins.Message request, System.Exception exception) -> void
-~NuGet.Protocol.Plugins.InboundRequestContext.BeginResponseAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IRequestHandler requestHandler, NuGet.Protocol.Plugins.IResponseHandler responseHandler) -> void
+NuGet.Protocol.Plugins.InboundRequestContext.BeginFaultAsync(NuGet.Protocol.Plugins.Message! request, System.Exception! exception) -> void
+NuGet.Protocol.Plugins.InboundRequestContext.BeginResponseAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IRequestHandler! requestHandler, NuGet.Protocol.Plugins.IResponseHandler! responseHandler) -> void
 NuGet.Protocol.Plugins.InboundRequestContext.Cancel() -> void
 NuGet.Protocol.Plugins.InboundRequestContext.Dispose() -> void
-~NuGet.Protocol.Plugins.InboundRequestContext.InboundRequestContext(NuGet.Protocol.Plugins.IConnection connection, string requestId, System.Threading.CancellationToken cancellationToken) -> void
-~NuGet.Protocol.Plugins.InboundRequestContext.RequestId.get -> string
+NuGet.Protocol.Plugins.InboundRequestContext.InboundRequestContext(NuGet.Protocol.Plugins.IConnection! connection, string! requestId, System.Threading.CancellationToken cancellationToken) -> void
+NuGet.Protocol.Plugins.InboundRequestContext.RequestId.get -> string!
 NuGet.Protocol.Plugins.InitializeRequest
 NuGet.Protocol.Plugins.InitializeRequest.ClientVersion.get -> string!
 NuGet.Protocol.Plugins.InitializeRequest.Culture.get -> string!
@@ -1081,9 +1081,9 @@ NuGet.Protocol.Plugins.LogRequest.LogRequest(NuGet.Common.LogLevel logLevel, str
 NuGet.Protocol.Plugins.LogRequest.Message.get -> string!
 NuGet.Protocol.Plugins.LogRequestHandler
 NuGet.Protocol.Plugins.LogRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
-~NuGet.Protocol.Plugins.LogRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.LogRequestHandler.LogRequestHandler(NuGet.Common.ILogger logger) -> void
-~NuGet.Protocol.Plugins.LogRequestHandler.SetLogger(NuGet.Common.ILogger logger) -> void
+NuGet.Protocol.Plugins.LogRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.LogRequestHandler.LogRequestHandler(NuGet.Common.ILogger! logger) -> void
+NuGet.Protocol.Plugins.LogRequestHandler.SetLogger(NuGet.Common.ILogger! logger) -> void
 NuGet.Protocol.Plugins.LogResponse
 NuGet.Protocol.Plugins.LogResponse.LogResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.LogResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
@@ -1095,17 +1095,17 @@ NuGet.Protocol.Plugins.Message.RequestId.get -> string!
 NuGet.Protocol.Plugins.Message.Type.get -> NuGet.Protocol.Plugins.MessageType
 NuGet.Protocol.Plugins.MessageDispatcher
 NuGet.Protocol.Plugins.MessageDispatcher.Close() -> void
-~NuGet.Protocol.Plugins.MessageDispatcher.CreateMessage(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.MessageDispatcher.CreateMessage<TPayload>(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload payload) -> NuGet.Protocol.Plugins.Message
-~NuGet.Protocol.Plugins.MessageDispatcher.DispatchCancelAsync(NuGet.Protocol.Plugins.Message request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.MessageDispatcher.DispatchFaultAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.Fault fault, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.MessageDispatcher.DispatchProgressAsync(NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.Progress progress, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.MessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound>
-~NuGet.Protocol.Plugins.MessageDispatcher.DispatchResponseAsync<TOutbound>(NuGet.Protocol.Plugins.Message request, TOutbound responsePayload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.MessageDispatcher.CreateMessage(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message!
+NuGet.Protocol.Plugins.MessageDispatcher.CreateMessage<TPayload>(NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload! payload) -> NuGet.Protocol.Plugins.Message!
+NuGet.Protocol.Plugins.MessageDispatcher.DispatchCancelAsync(NuGet.Protocol.Plugins.Message! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.MessageDispatcher.DispatchFaultAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Fault! fault, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.MessageDispatcher.DispatchProgressAsync(NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.Progress! progress, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.MessageDispatcher.DispatchRequestAsync<TOutbound, TInbound>(NuGet.Protocol.Plugins.MessageMethod method, TOutbound! payload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TInbound?>!
+NuGet.Protocol.Plugins.MessageDispatcher.DispatchResponseAsync<TOutbound>(NuGet.Protocol.Plugins.Message! request, TOutbound! responsePayload, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.MessageDispatcher.Dispose() -> void
-~NuGet.Protocol.Plugins.MessageDispatcher.MessageDispatcher(NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.IIdGenerator idGenerator) -> void
-~NuGet.Protocol.Plugins.MessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers
-~NuGet.Protocol.Plugins.MessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection connection) -> void
+NuGet.Protocol.Plugins.MessageDispatcher.MessageDispatcher(NuGet.Protocol.Plugins.IRequestHandlers! requestHandlers, NuGet.Protocol.Plugins.IIdGenerator! idGenerator) -> void
+NuGet.Protocol.Plugins.MessageDispatcher.RequestHandlers.get -> NuGet.Protocol.Plugins.IRequestHandlers!
+NuGet.Protocol.Plugins.MessageDispatcher.SetConnection(NuGet.Protocol.Plugins.IConnection? connection) -> void
 NuGet.Protocol.Plugins.MessageEventArgs
 NuGet.Protocol.Plugins.MessageEventArgs.Message.get -> NuGet.Protocol.Plugins.Message!
 NuGet.Protocol.Plugins.MessageEventArgs.MessageEventArgs(NuGet.Protocol.Plugins.Message! message) -> void
@@ -1145,21 +1145,21 @@ NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequest.ProcessId.get -> int
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.CancellationToken.get -> System.Threading.CancellationToken
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.Dispose() -> void
-~NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.MonitorNuGetProcessExitRequestHandler(NuGet.Protocol.Plugins.IPlugin plugin) -> void
+NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.MonitorNuGetProcessExitRequestHandler.MonitorNuGetProcessExitRequestHandler(NuGet.Protocol.Plugins.IPlugin! plugin) -> void
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitResponse
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitResponse.MonitorNuGetProcessExitResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.MonitorNuGetProcessExitResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.NoOpDisposePlugin
-NuGet.Protocol.Plugins.NoOpDisposePlugin.BeforeClose -> System.EventHandler
+NuGet.Protocol.Plugins.NoOpDisposePlugin.BeforeClose -> System.EventHandler?
 NuGet.Protocol.Plugins.NoOpDisposePlugin.Close() -> void
-NuGet.Protocol.Plugins.NoOpDisposePlugin.Closed -> System.EventHandler
-~NuGet.Protocol.Plugins.NoOpDisposePlugin.Connection.get -> NuGet.Protocol.Plugins.IConnection
+NuGet.Protocol.Plugins.NoOpDisposePlugin.Closed -> System.EventHandler?
+NuGet.Protocol.Plugins.NoOpDisposePlugin.Connection.get -> NuGet.Protocol.Plugins.IConnection!
 NuGet.Protocol.Plugins.NoOpDisposePlugin.Dispose() -> void
-~NuGet.Protocol.Plugins.NoOpDisposePlugin.FilePath.get -> string
-~NuGet.Protocol.Plugins.NoOpDisposePlugin.Id.get -> string
-~NuGet.Protocol.Plugins.NoOpDisposePlugin.Name.get -> string
-~NuGet.Protocol.Plugins.NoOpDisposePlugin.NoOpDisposePlugin(NuGet.Protocol.Plugins.IPlugin plugin) -> void
+NuGet.Protocol.Plugins.NoOpDisposePlugin.FilePath.get -> string!
+NuGet.Protocol.Plugins.NoOpDisposePlugin.Id.get -> string!
+NuGet.Protocol.Plugins.NoOpDisposePlugin.Name.get -> string!
+NuGet.Protocol.Plugins.NoOpDisposePlugin.NoOpDisposePlugin(NuGet.Protocol.Plugins.IPlugin! plugin) -> void
 NuGet.Protocol.Plugins.OperationClaim
 NuGet.Protocol.Plugins.OperationClaim.Authentication = 1 -> NuGet.Protocol.Plugins.OperationClaim
 NuGet.Protocol.Plugins.OperationClaim.DownloadPackage = 0 -> NuGet.Protocol.Plugins.OperationClaim
@@ -1168,24 +1168,24 @@ NuGet.Protocol.Plugins.OutboundRequestContext.CancellationToken.get -> System.Th
 NuGet.Protocol.Plugins.OutboundRequestContext.CancellationToken.set -> void
 NuGet.Protocol.Plugins.OutboundRequestContext.Dispose() -> void
 NuGet.Protocol.Plugins.OutboundRequestContext.OutboundRequestContext() -> void
-~NuGet.Protocol.Plugins.OutboundRequestContext.RequestId.get -> string
-~NuGet.Protocol.Plugins.OutboundRequestContext.RequestId.set -> void
+NuGet.Protocol.Plugins.OutboundRequestContext.RequestId.get -> string!
+NuGet.Protocol.Plugins.OutboundRequestContext.RequestId.set -> void
 NuGet.Protocol.Plugins.OutboundRequestContext<TResult>
-~NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.CompletionTask.get -> System.Threading.Tasks.Task<TResult>
-~NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.OutboundRequestContext(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, System.TimeSpan? timeout, bool isKeepAlive, System.Threading.CancellationToken cancellationToken) -> void
+NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.CompletionTask.get -> System.Threading.Tasks.Task<TResult?>!
+NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.OutboundRequestContext(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, System.TimeSpan? timeout, bool isKeepAlive, System.Threading.CancellationToken cancellationToken) -> void
 NuGet.Protocol.Plugins.Plugin
-NuGet.Protocol.Plugins.Plugin.BeforeClose -> System.EventHandler
+NuGet.Protocol.Plugins.Plugin.BeforeClose -> System.EventHandler?
 NuGet.Protocol.Plugins.Plugin.Close() -> void
-NuGet.Protocol.Plugins.Plugin.Closed -> System.EventHandler
-~NuGet.Protocol.Plugins.Plugin.Connection.get -> NuGet.Protocol.Plugins.IConnection
+NuGet.Protocol.Plugins.Plugin.Closed -> System.EventHandler?
+NuGet.Protocol.Plugins.Plugin.Connection.get -> NuGet.Protocol.Plugins.IConnection!
 NuGet.Protocol.Plugins.Plugin.Dispose() -> void
-NuGet.Protocol.Plugins.Plugin.Exited -> System.EventHandler<NuGet.Protocol.Plugins.PluginEventArgs>
-NuGet.Protocol.Plugins.Plugin.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.FaultedPluginEventArgs>
-~NuGet.Protocol.Plugins.Plugin.FilePath.get -> string
-~NuGet.Protocol.Plugins.Plugin.Id.get -> string
-NuGet.Protocol.Plugins.Plugin.Idle -> System.EventHandler<NuGet.Protocol.Plugins.PluginEventArgs>
-~NuGet.Protocol.Plugins.Plugin.Name.get -> string
-~NuGet.Protocol.Plugins.Plugin.Plugin(string filePath, NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.IPluginProcess process, bool isOwnProcess, System.TimeSpan idleTimeout) -> void
+NuGet.Protocol.Plugins.Plugin.Exited -> System.EventHandler<NuGet.Protocol.Plugins.PluginEventArgs!>?
+NuGet.Protocol.Plugins.Plugin.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.FaultedPluginEventArgs!>?
+NuGet.Protocol.Plugins.Plugin.FilePath.get -> string!
+NuGet.Protocol.Plugins.Plugin.Id.get -> string!
+NuGet.Protocol.Plugins.Plugin.Idle -> System.EventHandler<NuGet.Protocol.Plugins.PluginEventArgs!>?
+NuGet.Protocol.Plugins.Plugin.Name.get -> string!
+NuGet.Protocol.Plugins.Plugin.Plugin(string! filePath, NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.IPluginProcess! process, bool isOwnProcess, System.TimeSpan idleTimeout) -> void
 NuGet.Protocol.Plugins.PluginCacheEntry
 NuGet.Protocol.Plugins.PluginCacheEntry.LoadFromFile() -> void
 NuGet.Protocol.Plugins.PluginCacheEntry.OperationClaims.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.Plugins.OperationClaim>?
@@ -1203,7 +1203,7 @@ NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string! message
 NuGet.Protocol.Plugins.PluginCreationResult.PluginCreationResult(string! message, System.Exception! exception) -> void
 NuGet.Protocol.Plugins.PluginCreationResult.PluginMulticlientUtilities.get -> NuGet.Protocol.Plugins.IPluginMulticlientUtilities?
 NuGet.Protocol.Plugins.PluginDiscoverer
-~NuGet.Protocol.Plugins.PluginDiscoverer.DiscoverAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult>>
+NuGet.Protocol.Plugins.PluginDiscoverer.DiscoverAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult!>!>!
 NuGet.Protocol.Plugins.PluginDiscoverer.Dispose() -> void
 NuGet.Protocol.Plugins.PluginDiscoverer.PluginDiscoverer() -> void
 NuGet.Protocol.Plugins.PluginDiscoveryResult
@@ -1230,39 +1230,39 @@ NuGet.Protocol.Plugins.PluginFileState.InvalidFilePath = 2 -> NuGet.Protocol.Plu
 NuGet.Protocol.Plugins.PluginFileState.NotFound = 1 -> NuGet.Protocol.Plugins.PluginFileState
 NuGet.Protocol.Plugins.PluginFileState.Valid = 0 -> NuGet.Protocol.Plugins.PluginFileState
 NuGet.Protocol.Plugins.PluginManager
-~NuGet.Protocol.Plugins.PluginManager.CreatePluginsAsync(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginCreationResult>>
+NuGet.Protocol.Plugins.PluginManager.CreatePluginsAsync(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginCreationResult!>!>!
 NuGet.Protocol.Plugins.PluginManager.Dispose() -> void
-~NuGet.Protocol.Plugins.PluginManager.EnvironmentVariableReader.get -> NuGet.Common.IEnvironmentVariableReader
-~NuGet.Protocol.Plugins.PluginManager.FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult>>
-~NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) -> void
-~NuGet.Protocol.Plugins.PluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult>>
+NuGet.Protocol.Plugins.PluginManager.EnvironmentVariableReader.get -> NuGet.Common.IEnvironmentVariableReader!
+NuGet.Protocol.Plugins.PluginManager.FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Plugins.PluginDiscoveryResult!>!>!
+NuGet.Protocol.Plugins.PluginManager.PluginManager(NuGet.Common.IEnvironmentVariableReader! reader, System.Lazy<NuGet.Protocol.Plugins.IPluginDiscoverer!>! pluginDiscoverer, System.Func<System.TimeSpan, NuGet.Protocol.Plugins.PluginFactory!>! pluginFactoryCreator, System.Lazy<string!>! pluginsCacheDirectoryPath) -> void
+NuGet.Protocol.Plugins.PluginManager.TryGetSourceAgnosticPluginAsync(NuGet.Protocol.Plugins.PluginDiscoveryResult! pluginDiscoveryResult, NuGet.Protocol.Plugins.OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Plugins.PluginCreationResult?>!>!
 NuGet.Protocol.Plugins.PluginMulticlientUtilities
-~NuGet.Protocol.Plugins.PluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(string key, System.Func<System.Threading.Tasks.Task> taskFunc, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+NuGet.Protocol.Plugins.PluginMulticlientUtilities.DoOncePerPluginLifetimeAsync(string! key, System.Func<System.Threading.Tasks.Task!>! taskFunc, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 NuGet.Protocol.Plugins.PluginMulticlientUtilities.PluginMulticlientUtilities() -> void
 NuGet.Protocol.Plugins.PluginPackageDownloader
-~NuGet.Protocol.Plugins.PluginPackageDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader
-~NuGet.Protocol.Plugins.PluginPackageDownloader.CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.Plugins.PluginPackageDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader
+NuGet.Protocol.Plugins.PluginPackageDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader!
+NuGet.Protocol.Plugins.PluginPackageDownloader.CopyNupkgFileToAsync(string! destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.Plugins.PluginPackageDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader!
 NuGet.Protocol.Plugins.PluginPackageDownloader.Dispose() -> void
-~NuGet.Protocol.Plugins.PluginPackageDownloader.GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
-~NuGet.Protocol.Plugins.PluginPackageDownloader.PluginPackageDownloader(NuGet.Protocol.Plugins.IPlugin plugin, NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Protocol.Plugins.PluginPackageReader packageReader, string packageSourceRepository) -> void
-~NuGet.Protocol.Plugins.PluginPackageDownloader.SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) -> void
-~NuGet.Protocol.Plugins.PluginPackageDownloader.SetThrottle(System.Threading.SemaphoreSlim throttle) -> void
-~NuGet.Protocol.Plugins.PluginPackageDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader
-~NuGet.Protocol.Plugins.PluginPackageDownloader.Source.get -> string
+NuGet.Protocol.Plugins.PluginPackageDownloader.GetPackageHashAsync(string! hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+NuGet.Protocol.Plugins.PluginPackageDownloader.PluginPackageDownloader(NuGet.Protocol.Plugins.IPlugin! plugin, NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Protocol.Plugins.PluginPackageReader! packageReader, string! packageSourceRepository) -> void
+NuGet.Protocol.Plugins.PluginPackageDownloader.SetExceptionHandler(System.Func<System.Exception!, System.Threading.Tasks.Task<bool>!>! handleExceptionAsync) -> void
+NuGet.Protocol.Plugins.PluginPackageDownloader.SetThrottle(System.Threading.SemaphoreSlim? throttle) -> void
+NuGet.Protocol.Plugins.PluginPackageDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader!
+NuGet.Protocol.Plugins.PluginPackageDownloader.Source.get -> string!
 NuGet.Protocol.Plugins.PluginPackageReader
-~NuGet.Protocol.Plugins.PluginPackageReader.PluginPackageReader(NuGet.Protocol.Plugins.IPlugin plugin, NuGet.Packaging.Core.PackageIdentity packageIdentity, string packageSourceRepository) -> void
+NuGet.Protocol.Plugins.PluginPackageReader.PluginPackageReader(NuGet.Protocol.Plugins.IPlugin! plugin, NuGet.Packaging.Core.PackageIdentity! packageIdentity, string! packageSourceRepository) -> void
 NuGet.Protocol.Plugins.PluginProcess
 NuGet.Protocol.Plugins.PluginProcess.BeginReadLine() -> void
 NuGet.Protocol.Plugins.PluginProcess.CancelRead() -> void
 NuGet.Protocol.Plugins.PluginProcess.Dispose() -> void
 NuGet.Protocol.Plugins.PluginProcess.ExitCode.get -> int?
-NuGet.Protocol.Plugins.PluginProcess.Exited -> System.EventHandler<NuGet.Protocol.Plugins.IPluginProcess>
+NuGet.Protocol.Plugins.PluginProcess.Exited -> System.EventHandler<NuGet.Protocol.Plugins.IPluginProcess!>?
 NuGet.Protocol.Plugins.PluginProcess.Id.get -> int?
 NuGet.Protocol.Plugins.PluginProcess.Kill() -> void
-NuGet.Protocol.Plugins.PluginProcess.LineRead -> System.EventHandler<NuGet.Protocol.Plugins.LineReadEventArgs>
+NuGet.Protocol.Plugins.PluginProcess.LineRead -> System.EventHandler<NuGet.Protocol.Plugins.LineReadEventArgs!>?
 NuGet.Protocol.Plugins.PluginProcess.PluginProcess() -> void
-~NuGet.Protocol.Plugins.PluginProcess.PluginProcess(System.Diagnostics.ProcessStartInfo startInfo) -> void
+NuGet.Protocol.Plugins.PluginProcess.PluginProcess(System.Diagnostics.ProcessStartInfo! startInfo) -> void
 NuGet.Protocol.Plugins.PluginProcess.Start() -> void
 NuGet.Protocol.Plugins.PrefetchPackageRequest
 NuGet.Protocol.Plugins.PrefetchPackageRequest.PackageId.get -> string!
@@ -1286,31 +1286,31 @@ NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string? message) -> v
 NuGet.Protocol.Plugins.ProtocolException.ProtocolException(string? message, System.Exception? innerException) -> void
 NuGet.Protocol.Plugins.Receiver
 NuGet.Protocol.Plugins.Receiver.Dispose() -> void
-NuGet.Protocol.Plugins.Receiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs>
-~NuGet.Protocol.Plugins.Receiver.FireFaultEvent(System.Exception exception, NuGet.Protocol.Plugins.Message message) -> void
-~NuGet.Protocol.Plugins.Receiver.FireMessageReceivedEvent(NuGet.Protocol.Plugins.Message message) -> void
+NuGet.Protocol.Plugins.Receiver.Faulted -> System.EventHandler<NuGet.Protocol.Plugins.ProtocolErrorEventArgs!>?
+NuGet.Protocol.Plugins.Receiver.FireFaultEvent(System.Exception! exception, NuGet.Protocol.Plugins.Message? message) -> void
+NuGet.Protocol.Plugins.Receiver.FireMessageReceivedEvent(NuGet.Protocol.Plugins.Message! message) -> void
 NuGet.Protocol.Plugins.Receiver.IsClosed.get -> bool
 NuGet.Protocol.Plugins.Receiver.IsDisposed.get -> bool
 NuGet.Protocol.Plugins.Receiver.IsDisposed.set -> void
-NuGet.Protocol.Plugins.Receiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs>
+NuGet.Protocol.Plugins.Receiver.MessageReceived -> System.EventHandler<NuGet.Protocol.Plugins.MessageEventArgs!>?
 NuGet.Protocol.Plugins.Receiver.Receiver() -> void
 NuGet.Protocol.Plugins.Receiver.ThrowIfClosed() -> void
 NuGet.Protocol.Plugins.Receiver.ThrowIfDisposed() -> void
 NuGet.Protocol.Plugins.RequestHandlers
-~NuGet.Protocol.Plugins.RequestHandlers.AddOrUpdate(NuGet.Protocol.Plugins.MessageMethod method, System.Func<NuGet.Protocol.Plugins.IRequestHandler> addHandlerFunc, System.Func<NuGet.Protocol.Plugins.IRequestHandler, NuGet.Protocol.Plugins.IRequestHandler> updateHandlerFunc) -> void
+NuGet.Protocol.Plugins.RequestHandlers.AddOrUpdate(NuGet.Protocol.Plugins.MessageMethod method, System.Func<NuGet.Protocol.Plugins.IRequestHandler!>! addHandlerFunc, System.Func<NuGet.Protocol.Plugins.IRequestHandler!, NuGet.Protocol.Plugins.IRequestHandler!>! updateHandlerFunc) -> void
 NuGet.Protocol.Plugins.RequestHandlers.RequestHandlers() -> void
-~NuGet.Protocol.Plugins.RequestHandlers.TryAdd(NuGet.Protocol.Plugins.MessageMethod method, NuGet.Protocol.Plugins.IRequestHandler handler) -> bool
-~NuGet.Protocol.Plugins.RequestHandlers.TryGet(NuGet.Protocol.Plugins.MessageMethod method, out NuGet.Protocol.Plugins.IRequestHandler handler) -> bool
+NuGet.Protocol.Plugins.RequestHandlers.TryAdd(NuGet.Protocol.Plugins.MessageMethod method, NuGet.Protocol.Plugins.IRequestHandler! handler) -> bool
+NuGet.Protocol.Plugins.RequestHandlers.TryGet(NuGet.Protocol.Plugins.MessageMethod method, out NuGet.Protocol.Plugins.IRequestHandler? handler) -> bool
 NuGet.Protocol.Plugins.RequestHandlers.TryRemove(NuGet.Protocol.Plugins.MessageMethod method) -> bool
 NuGet.Protocol.Plugins.RequestIdGenerator
-~NuGet.Protocol.Plugins.RequestIdGenerator.GenerateUniqueId() -> string
+NuGet.Protocol.Plugins.RequestIdGenerator.GenerateUniqueId() -> string!
 NuGet.Protocol.Plugins.RequestIdGenerator.RequestIdGenerator() -> void
 NuGet.Protocol.Plugins.Sender
 NuGet.Protocol.Plugins.Sender.Close() -> void
 NuGet.Protocol.Plugins.Sender.Connect() -> void
 NuGet.Protocol.Plugins.Sender.Dispose() -> void
-~NuGet.Protocol.Plugins.Sender.SendAsync(NuGet.Protocol.Plugins.Message message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.Sender.Sender(System.IO.TextWriter writer) -> void
+NuGet.Protocol.Plugins.Sender.SendAsync(NuGet.Protocol.Plugins.Message! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.Sender.Sender(System.IO.TextWriter! writer) -> void
 NuGet.Protocol.Plugins.SetCredentialsRequest
 NuGet.Protocol.Plugins.SetCredentialsRequest.PackageSourceRepository.get -> string!
 NuGet.Protocol.Plugins.SetCredentialsRequest.Password.get -> string?
@@ -1328,15 +1328,15 @@ NuGet.Protocol.Plugins.SetLogLevelResponse
 NuGet.Protocol.Plugins.SetLogLevelResponse.ResponseCode.get -> NuGet.Protocol.Plugins.MessageResponseCode
 NuGet.Protocol.Plugins.SetLogLevelResponse.SetLogLevelResponse(NuGet.Protocol.Plugins.MessageResponseCode responseCode) -> void
 NuGet.Protocol.Plugins.StandardInputReceiver
-~NuGet.Protocol.Plugins.StandardInputReceiver.StandardInputReceiver(System.IO.TextReader reader) -> void
+NuGet.Protocol.Plugins.StandardInputReceiver.StandardInputReceiver(System.IO.TextReader! reader) -> void
 NuGet.Protocol.Plugins.StandardOutputReceiver
-~NuGet.Protocol.Plugins.StandardOutputReceiver.StandardOutputReceiver(NuGet.Protocol.Plugins.IPluginProcess process) -> void
+NuGet.Protocol.Plugins.StandardOutputReceiver.StandardOutputReceiver(NuGet.Protocol.Plugins.IPluginProcess! process) -> void
 NuGet.Protocol.Plugins.SymmetricHandshake
 NuGet.Protocol.Plugins.SymmetricHandshake.CancellationToken.get -> System.Threading.CancellationToken
 NuGet.Protocol.Plugins.SymmetricHandshake.Dispose() -> void
-~NuGet.Protocol.Plugins.SymmetricHandshake.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, NuGet.Protocol.Plugins.IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-~NuGet.Protocol.Plugins.SymmetricHandshake.HandshakeAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Versioning.SemanticVersion>
-~NuGet.Protocol.Plugins.SymmetricHandshake.SymmetricHandshake(NuGet.Protocol.Plugins.IConnection connection, System.TimeSpan handshakeTimeout, NuGet.Versioning.SemanticVersion protocolVersion, NuGet.Versioning.SemanticVersion minimumProtocolVersion) -> void
+NuGet.Protocol.Plugins.SymmetricHandshake.HandleResponseAsync(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, NuGet.Protocol.Plugins.IResponseHandler! responseHandler, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NuGet.Protocol.Plugins.SymmetricHandshake.HandshakeAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Versioning.SemanticVersion?>!
+NuGet.Protocol.Plugins.SymmetricHandshake.SymmetricHandshake(NuGet.Protocol.Plugins.IConnection! connection, System.TimeSpan handshakeTimeout, NuGet.Versioning.SemanticVersion! protocolVersion, NuGet.Versioning.SemanticVersion! minimumProtocolVersion) -> void
 NuGet.Protocol.Plugins.TimeoutUtilities
 NuGet.Protocol.ProtocolConstants
 NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider
@@ -1563,9 +1563,9 @@ abstract NuGet.Protocol.Core.Types.ResourceProvider.TryCreate(NuGet.Protocol.Cor
 ~abstract NuGet.Protocol.FindLocalPackagesResource.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
 abstract NuGet.Protocol.Plugins.OutboundRequestContext.Dispose(bool disposing) -> void
 abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleCancelResponse() -> void
-~abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleFault(NuGet.Protocol.Plugins.Message fault) -> void
-~abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleProgress(NuGet.Protocol.Plugins.Message progress) -> void
-~abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleResponse(NuGet.Protocol.Plugins.Message response) -> void
+abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleFault(NuGet.Protocol.Plugins.Message! fault) -> void
+abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleProgress(NuGet.Protocol.Plugins.Message! progress) -> void
+abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleResponse(NuGet.Protocol.Plugins.Message! response) -> void
 abstract NuGet.Protocol.Plugins.Receiver.Connect() -> void
 abstract NuGet.Protocol.Plugins.Receiver.Dispose(bool disposing) -> void
 const NuGet.Protocol.CachingUtility.BufferSize = 8192 -> int
@@ -1776,59 +1776,59 @@ override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWrit
 ~override NuGet.Protocol.PackageUpdateResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.PluginFindPackageByIdResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleCancelResponse() -> void
-~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleFault(NuGet.Protocol.Plugins.Message fault) -> void
-~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleProgress(NuGet.Protocol.Plugins.Message progress) -> void
-~override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleResponse(NuGet.Protocol.Plugins.Message response) -> void
+override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleFault(NuGet.Protocol.Plugins.Message! fault) -> void
+override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleProgress(NuGet.Protocol.Plugins.Message! progress) -> void
+override NuGet.Protocol.Plugins.OutboundRequestContext<TResult>.HandleResponse(NuGet.Protocol.Plugins.Message! response) -> void
 override NuGet.Protocol.Plugins.PluginFile.ToString() -> string!
-~override NuGet.Protocol.Plugins.PluginPackageReader.CanVerifySignedPackages(NuGet.Packaging.Signing.SignedPackageVerifierSettings verifierSettings) -> bool
-~override NuGet.Protocol.Plugins.PluginPackageReader.CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate extractFile, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<string>
-~override NuGet.Protocol.Plugins.PluginPackageReader.CopyFilesAsync(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate extractFile, NuGet.Common.ILogger logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.CopyNupkgAsync(string nupkgFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetArchiveHashAsync(NuGet.Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<byte[]>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetBuildItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetBuildItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null) -> string
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetContentItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetContentItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
+override NuGet.Protocol.Plugins.PluginPackageReader.CanVerifySignedPackages(NuGet.Packaging.Signing.SignedPackageVerifierSettings! verifierSettings) -> bool
+override NuGet.Protocol.Plugins.PluginPackageReader.CopyFiles(string! destination, System.Collections.Generic.IEnumerable<string!>! packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate! extractFile, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<string!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.CopyFilesAsync(string! destination, System.Collections.Generic.IEnumerable<string!>! packageFiles, NuGet.Packaging.Core.ExtractPackageFileDelegate! extractFile, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.CopyNupkgAsync(string! nupkgFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetArchiveHashAsync(NuGet.Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<byte[]!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetBuildItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetBuildItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetContentHash(System.Threading.CancellationToken token, System.Func<string!>? GetUnsignedPackageHash = null) -> string!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetContentItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetContentItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
 override NuGet.Protocol.Plugins.PluginPackageReader.GetDevelopmentDependency() -> bool
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetDevelopmentDependencyAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFiles() -> System.Collections.Generic.IEnumerable<string>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFiles(string folder) -> System.Collections.Generic.IEnumerable<string>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFilesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFilesAsync(string folder, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFrameworkItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetFrameworkItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetIdentity() -> NuGet.Packaging.Core.PackageIdentity
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetIdentityAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.Core.PackageIdentity>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetItems(string folderName) -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetItemsAsync(string folderName, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetLibItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetLibItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetMinClientVersion() -> NuGet.Versioning.NuGetVersion
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetMinClientVersionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Versioning.NuGetVersion>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspec() -> System.IO.Stream
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecFile() -> string
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecFileAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecReaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.NuspecReader>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageDependencies() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageDependenciesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageTypes() -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageType>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageTypesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageType>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetPrimarySignatureAsync(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Packaging.Signing.PrimarySignature>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetReferenceItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetReferenceItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetStream(string path) -> System.IO.Stream
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetStreamAsync(string path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworks() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworksAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework>>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetToolItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>
-~override NuGet.Protocol.Plugins.PluginPackageReader.GetToolItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup>>
+override NuGet.Protocol.Plugins.PluginPackageReader.GetDevelopmentDependencyAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFiles() -> System.Collections.Generic.IEnumerable<string!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFiles(string! folder) -> System.Collections.Generic.IEnumerable<string!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFilesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFilesAsync(string! folder, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFrameworkItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetFrameworkItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetIdentity() -> NuGet.Packaging.Core.PackageIdentity!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetIdentityAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.Core.PackageIdentity!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetItems(string! folderName) -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetItemsAsync(string! folderName, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetLibItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetLibItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetMinClientVersion() -> NuGet.Versioning.NuGetVersion!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetMinClientVersionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Versioning.NuGetVersion?>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspec() -> System.IO.Stream!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecFile() -> string!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecFileAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetNuspecReaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.NuspecReader!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageDependencies() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageDependenciesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageTypes() -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageType!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetPackageTypesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Packaging.Core.PackageType!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetPrimarySignatureAsync(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Packaging.Signing.PrimarySignature?>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetReferenceItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetReferenceItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetStream(string! path) -> System.IO.Stream!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetStreamAsync(string! path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworks() -> System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetSupportedFrameworksAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework!>!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetToolItems() -> System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!
+override NuGet.Protocol.Plugins.PluginPackageReader.GetToolItemsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Packaging.FrameworkSpecificGroup!>!>!
 override NuGet.Protocol.Plugins.PluginPackageReader.IsServiceable() -> bool
-~override NuGet.Protocol.Plugins.PluginPackageReader.IsServiceableAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.Plugins.PluginPackageReader.IsSignedAsync(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.Plugins.PluginPackageReader.NuspecReader.get -> NuGet.Packaging.NuspecReader
-~override NuGet.Protocol.Plugins.PluginPackageReader.ValidateIntegrityAsync(NuGet.Packaging.Signing.SignatureContent signatureContent, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
+override NuGet.Protocol.Plugins.PluginPackageReader.IsServiceableAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.Plugins.PluginPackageReader.IsSignedAsync(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.Plugins.PluginPackageReader.NuspecReader.get -> NuGet.Packaging.NuspecReader!
+override NuGet.Protocol.Plugins.PluginPackageReader.ValidateIntegrityAsync(NuGet.Packaging.Signing.SignatureContent! signatureContent, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
 override NuGet.Protocol.Plugins.StandardInputReceiver.Connect() -> void
 override NuGet.Protocol.Plugins.StandardOutputReceiver.Close() -> void
 override NuGet.Protocol.Plugins.StandardOutputReceiver.Connect() -> void
@@ -1991,24 +1991,24 @@ static NuGet.Protocol.LocalFolderUtility.IsPossiblePackageMatch(System.IO.FileIn
 static NuGet.Protocol.LocalFolderUtility.ResolvePackageFromPath(string! packagePath, bool isSnupkg = false) -> System.Collections.Generic.IEnumerable<string!>!
 static NuGet.Protocol.NullThrottle.Instance.get -> NuGet.Protocol.NullThrottle!
 ~static NuGet.Protocol.PackageDetailsUriResourceV3.CreateOrNull(string uriTemplate) -> NuGet.Protocol.PackageDetailsUriResourceV3
-~static NuGet.Protocol.Plugins.AutomaticProgressReporter.Create(NuGet.Protocol.Plugins.IConnection connection, NuGet.Protocol.Plugins.Message request, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Plugins.AutomaticProgressReporter
+static NuGet.Protocol.Plugins.AutomaticProgressReporter.Create(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Plugins.AutomaticProgressReporter!
 static NuGet.Protocol.Plugins.ConnectionOptions.CreateDefault(NuGet.Common.IEnvironmentVariableReader? reader = null) -> NuGet.Protocol.Plugins.ConnectionOptions!
-~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Deserialize<T>(string json) -> T
-~static NuGet.Protocol.Plugins.JsonSerializationUtilities.FromObject(object value) -> Newtonsoft.Json.Linq.JObject
-~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serialize(Newtonsoft.Json.JsonWriter writer, object value) -> void
-~static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serializer.get -> Newtonsoft.Json.JsonSerializer
-~static NuGet.Protocol.Plugins.JsonSerializationUtilities.ToObject<T>(Newtonsoft.Json.Linq.JObject jObject) -> T
-~static NuGet.Protocol.Plugins.LogRequestHandler.GetLogLevel(NuGet.Common.ILogger logger) -> NuGet.Common.LogLevel
+static NuGet.Protocol.Plugins.JsonSerializationUtilities.Deserialize<T>(string! json) -> T?
+static NuGet.Protocol.Plugins.JsonSerializationUtilities.FromObject(object! value) -> Newtonsoft.Json.Linq.JObject!
+static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serialize(Newtonsoft.Json.JsonWriter! writer, object! value) -> void
+static NuGet.Protocol.Plugins.JsonSerializationUtilities.Serializer.get -> Newtonsoft.Json.JsonSerializer!
+static NuGet.Protocol.Plugins.JsonSerializationUtilities.ToObject<T>(Newtonsoft.Json.Linq.JObject! jObject) -> T?
+static NuGet.Protocol.Plugins.LogRequestHandler.GetLogLevel(NuGet.Common.ILogger! logger) -> NuGet.Common.LogLevel
 static NuGet.Protocol.Plugins.MessageUtilities.Create(string! requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method) -> NuGet.Protocol.Plugins.Message!
 static NuGet.Protocol.Plugins.MessageUtilities.Create<TPayload>(string! requestId, NuGet.Protocol.Plugins.MessageType type, NuGet.Protocol.Plugins.MessageMethod method, TPayload! payload) -> NuGet.Protocol.Plugins.Message!
 static NuGet.Protocol.Plugins.MessageUtilities.DeserializePayload<TPayload>(NuGet.Protocol.Plugins.Message! message) -> TPayload?
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetConventionBasedPlugins(System.Collections.Generic.IEnumerable<string> directories) -> System.Collections.Generic.IEnumerable<string>
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetNuGetHomePluginsPath() -> string
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string nugetAssemblyPath) -> string
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot.get -> System.Lazy<string>
-~static NuGet.Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot.set -> void
-~static NuGet.Protocol.Plugins.PluginFactory.CreateFromCurrentProcessAsync(NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>
-~static NuGet.Protocol.Plugins.PluginManager.Instance.get -> NuGet.Protocol.Plugins.IPluginManager
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetConventionBasedPlugins(System.Collections.Generic.IEnumerable<string!>! directories) -> System.Collections.Generic.IEnumerable<string!>!
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetNuGetHomePluginsPath() -> string!
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string! nugetAssemblyPath) -> string?
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot.get -> System.Lazy<string!>?
+static NuGet.Protocol.Plugins.PluginDiscoveryUtility.InternalPluginDiscoveryRoot.set -> void
+static NuGet.Protocol.Plugins.PluginFactory.CreateFromCurrentProcessAsync(NuGet.Protocol.Plugins.IRequestHandlers! requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions! options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin!>!
+static NuGet.Protocol.Plugins.PluginManager.Instance.get -> NuGet.Protocol.Plugins.IPluginManager!
 static NuGet.Protocol.Plugins.TimeoutUtilities.GetTimeout(string? timeoutInSeconds, System.TimeSpan fallbackTimeout) -> System.TimeSpan
 static NuGet.Protocol.Plugins.TimeoutUtilities.IsValid(System.TimeSpan timeout) -> bool
 static NuGet.Protocol.RegistrationUtility.CreateVersionRange(string! stringToParse) -> NuGet.Versioning.VersionRange!
@@ -2105,7 +2105,7 @@ virtual NuGet.Protocol.LocalPackageInfo.LastWriteTimeUtc.get -> System.DateTime
 ~virtual NuGet.Protocol.LocalPackageInfo.Path.get -> string
 virtual NuGet.Protocol.ODataServiceDocumentResourceV2.RequestTime.get -> System.DateTime
 virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
-~virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile pluginFile, System.Collections.Generic.IEnumerable<string> arguments, NuGet.Protocol.Plugins.IRequestHandlers requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin>
+virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile! pluginFile, System.Collections.Generic.IEnumerable<string!>! arguments, NuGet.Protocol.Plugins.IRequestHandlers! requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions! options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin!>!
 virtual NuGet.Protocol.Plugins.Receiver.Close() -> void
 ~virtual NuGet.Protocol.RawSearchResourceV3.Search(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>>
 ~virtual NuGet.Protocol.RawSearchResourceV3.SearchPage(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -1107,19 +1107,19 @@ namespace Dotnet.Integration.Test
 
         [PlatformTheory(Platform.Windows)]
         [InlineData(" --include-transitive", true)]
-        [InlineData(" --include-transitive --framework net10.0", false)]
+        [InlineData(" --include-transitive --framework " + TestConstants.ProjectTargetFramework, false)]
         [InlineData(" --include-transitive --framework net472", true)]
         [InlineData("", false)]
         public async Task DeprecatedOption_WithMultiTargetedProjectsAndDeprecatedPackages_Succeeds(string additionalOptions, bool shouldReportTransitivePackages)
         {
             // Arrange
             using var pathContext = _fixture.CreateSimpleTestPathContext();
-            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net472;net10.0");
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net472;" + TestConstants.ProjectTargetFramework);
 
             var packageA100 = new SimpleTestPackageContext("A", "1.0.0");
             var packageB100 = new SimpleTestPackageContext("B", "1.0.0");
             packageA100.PerFrameworkDependencies.Add(FrameworkConstants.CommonFrameworks.Net472, [packageB100]);
-            packageA100.PerFrameworkDependencies.Add(FrameworkConstants.CommonFrameworks.Net10_0, []);
+            packageA100.PerFrameworkDependencies.Add(TestConstants.DefaultTargetFramework, []);
 
             await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageA100, packageB100);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/AutomaticProgressReporterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/AutomaticProgressReporterTests.cs
@@ -18,7 +18,7 @@ namespace NuGet.Protocol.Plugins.Tests
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => AutomaticProgressReporter.Create(
-                        connection: null,
+                        connection: null!,
                         request: test.Request,
                         interval: test.Interval,
                         cancellationToken: CancellationToken.None));
@@ -35,7 +35,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => AutomaticProgressReporter.Create(
                         test.Connection.Object,
-                        request: null,
+                        request: null!,
                         interval: test.Interval,
                         cancellationToken: CancellationToken.None));
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/JsonSerializationUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/JsonSerializationUtilitiesTests.cs
@@ -40,7 +40,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Deserialize_ThrowsForNullJson()
         {
             var exception = Assert.Throws<ArgumentException>(
-                () => JsonSerializationUtilities.Deserialize<A>(json: null));
+                () => JsonSerializationUtilities.Deserialize<A>(json: null!));
 
             Assert.Equal("json", exception.ParamName);
         }
@@ -59,14 +59,14 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             var a = JsonSerializationUtilities.Deserialize<A>(_expectedJson);
 
-            Assert.Equal(3, a.B);
+            Assert.Equal(3, a!.B);
         }
 
         [Fact]
         public void FromObject_ThrowsForNullValue()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => JsonSerializationUtilities.FromObject(value: null));
+                () => JsonSerializationUtilities.FromObject(value: null!));
 
             Assert.Equal("value", exception.ParamName);
         }
@@ -83,7 +83,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Serialize_ThrowsForNullWriter()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => JsonSerializationUtilities.Serialize(writer: null, value: _expectedObject));
+                () => JsonSerializationUtilities.Serialize(writer: null!, value: _expectedObject));
 
             Assert.Equal("writer", exception.ParamName);
         }
@@ -106,7 +106,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void ToObject_ThrowsForNullValue()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => JsonSerializationUtilities.ToObject<A>(jObject: null));
+                () => JsonSerializationUtilities.ToObject<A>(jObject: null!));
 
             Assert.Equal("jObject", exception.ParamName);
         }
@@ -117,7 +117,7 @@ namespace NuGet.Protocol.Plugins.Tests
             var jObject = JObject.FromObject(_expectedObject);
             var a = JsonSerializationUtilities.ToObject<A>(jObject);
 
-            Assert.Equal(3, a.B);
+            Assert.Equal(3, a!.B);
         }
 
         private sealed class A

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/CopyFilesInPackageRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/CopyFilesInPackageRequestTests.cs
@@ -137,7 +137,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObject()
         {
             var json = "{\"DestinationFolderPath\":\"a\",\"FilesInPackage\":[\"b\"],\"PackageId\":\"c\",\"PackageSourceRepository\":\"d\",\"PackageVersion\":\"e\"}";
-            var request = JsonSerializationUtilities.Deserialize<CopyFilesInPackageRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<CopyFilesInPackageRequest>(json)!;
 
             Assert.Equal("d", request.PackageSourceRepository);
             Assert.Equal("c", request.PackageId);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/CopyFilesInPackageResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/CopyFilesInPackageResponseTests.cs
@@ -59,7 +59,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObjectForSuccess()
         {
             var json = "{\"CopiedFiles\":[\"a\"],\"ResponseCode\":\"Success\"}";
-            var response = JsonSerializationUtilities.Deserialize<CopyFilesInPackageResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<CopyFilesInPackageResponse>(json)!;
 
             Assert.Equal(MessageResponseCode.Success, response.ResponseCode);
             Assert.Equal(new[] { "a" }, response.CopiedFiles);
@@ -69,7 +69,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObjectForNotFound()
         {
             var json = "{\"ResponseCode\":\"NotFound\"}";
-            var response = JsonSerializationUtilities.Deserialize<CopyFilesInPackageResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<CopyFilesInPackageResponse>(json)!;
 
             Assert.Equal(MessageResponseCode.NotFound, response.ResponseCode);
             Assert.Null(response.CopiedFiles);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/CopyNupkgFileRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/CopyNupkgFileRequestTests.cs
@@ -101,7 +101,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObject()
         {
             var json = "{\"DestinationFilePath\":\"a\",\"PackageId\":\"b\",\"PackageSourceRepository\":\"c\",\"PackageVersion\":\"d\"}";
-            var request = JsonSerializationUtilities.Deserialize<CopyNupkgFileRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<CopyNupkgFileRequest>(json)!;
 
             Assert.Equal("c", request.PackageSourceRepository);
             Assert.Equal("b", request.PackageId);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/CopyNupkgFileResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/CopyNupkgFileResponseTests.cs
@@ -40,7 +40,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObject()
         {
             var json = "{\"ResponseCode\":\"Success\"}";
-            var response = JsonSerializationUtilities.Deserialize<CopyNupkgFileResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<CopyNupkgFileResponse>(json)!;
 
             Assert.Equal(MessageResponseCode.Success, response.ResponseCode);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/FaultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/FaultTests.cs
@@ -39,7 +39,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObject()
         {
             var json = "{\"Message\":\"a\"}";
-            var fault = JsonSerializationUtilities.Deserialize<Fault>(json);
+            var fault = JsonSerializationUtilities.Deserialize<Fault>(json)!;
 
             Assert.Equal("a", fault.Message);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetAuthenticationCredentialsResponseTests.cs
@@ -60,7 +60,7 @@ namespace NuGet.Protocol.Tests.Plugins
             string[] authenticationTypes,
             MessageResponseCode messageResponseCode)
         {
-            var response = JsonSerializationUtilities.Deserialize<GetAuthenticationCredentialsResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<GetAuthenticationCredentialsResponse>(json)!;
             Assert.Equal(response.Username, username);
             Assert.Equal(response.Password, password);
             Assert.Equal(response.Message, message);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsRequestTests.cs
@@ -61,7 +61,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObject()
         {
             var json = "{\"PackageSourceRepository\":\"a\",\"StatusCode\":\"Unauthorized\"}";
-            var request = JsonSerializationUtilities.Deserialize<GetCredentialsRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<GetCredentialsRequest>(json)!;
 
             Assert.Equal("a", request.PackageSourceRepository);
             Assert.Equal(HttpStatusCode.Unauthorized, request.StatusCode);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsResponseTests.cs
@@ -96,7 +96,7 @@ namespace NuGet.Protocol.Plugins.Tests
             string password,
             string[] authTypes)
         {
-            var response = JsonSerializationUtilities.Deserialize<GetCredentialsResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<GetCredentialsResponse>(json)!;
 
             Assert.Equal(responseCode, response.ResponseCode);
             Assert.Equal(username, response.Username);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetFilesInPackageRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetFilesInPackageRequestTests.cs
@@ -80,7 +80,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObject()
         {
             var json = "{\"PackageId\":\"a\",\"PackageSourceRepository\":\"b\",\"PackageVersion\":\"c\"}";
-            var request = JsonSerializationUtilities.Deserialize<GetFilesInPackageRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<GetFilesInPackageRequest>(json)!;
 
             Assert.Equal("b", request.PackageSourceRepository);
             Assert.Equal("a", request.PackageId);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetFilesInPackageResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetFilesInPackageResponseTests.cs
@@ -59,7 +59,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObjectForSuccess()
         {
             var json = "{\"Files\":[\"a\"],\"ResponseCode\":\"Success\"}";
-            var response = JsonSerializationUtilities.Deserialize<GetFilesInPackageResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<GetFilesInPackageResponse>(json)!;
 
             Assert.Equal(MessageResponseCode.Success, response.ResponseCode);
             Assert.Equal(new[] { "a" }, response.Files);
@@ -69,7 +69,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObjectForNotFound()
         {
             var json = "{\"ResponseCode\":\"NotFound\"}";
-            var response = JsonSerializationUtilities.Deserialize<GetFilesInPackageResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<GetFilesInPackageResponse>(json)!;
 
             Assert.Equal(MessageResponseCode.NotFound, response.ResponseCode);
             Assert.Null(response.Files);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetOperationClaimsResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetOperationClaimsResponseTests.cs
@@ -12,7 +12,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [Fact]
         public void Constructor_ThrowsForNullClaims()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => new GetOperationClaimsResponse(claims: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => new GetOperationClaimsResponse(claims: null!));
 
             Assert.Equal("claims", exception.ParamName);
         }
@@ -60,7 +60,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [InlineData("{\"Claims\":[\"DownloadPackage\"]}", new[] { OperationClaim.DownloadPackage })]
         public void JsonDeserialization_ReturnsCorrectObject(string json, OperationClaim[] claims)
         {
-            var response = JsonSerializationUtilities.Deserialize<GetOperationClaimsResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<GetOperationClaimsResponse>(json)!;
 
             Assert.Equal(claims.Length, response.Claims.Count);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetPackageHashRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetPackageHashRequestTests.cs
@@ -101,7 +101,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObject()
         {
             var json = "{\"HashAlgorithm\":\"a\",\"PackageId\":\"b\",\"PackageSourceRepository\":\"c\",\"PackageVersion\":\"d\"}";
-            var request = JsonSerializationUtilities.Deserialize<GetPackageHashRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<GetPackageHashRequest>(json)!;
 
             Assert.Equal("a", request.HashAlgorithm);
             Assert.Equal("b", request.PackageId);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetPackageHashResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetPackageHashResponseTests.cs
@@ -63,7 +63,7 @@ namespace NuGet.Protocol.Plugins.Tests
             MessageResponseCode responseCode,
             string hash)
         {
-            var response = JsonSerializationUtilities.Deserialize<GetPackageHashResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<GetPackageHashResponse>(json)!;
 
             Assert.Equal(responseCode, response.ResponseCode);
             Assert.Equal(hash, response.Hash);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetPackageVersionsRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetPackageVersionsRequestTests.cs
@@ -61,7 +61,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObject()
         {
             var json = "{\"PackageId\":\"a\",\"PackageSourceRepository\":\"b\"}";
-            var request = JsonSerializationUtilities.Deserialize<GetPackageVersionsRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<GetPackageVersionsRequest>(json)!;
 
             Assert.Equal("b", request.PackageSourceRepository);
             Assert.Equal("a", request.PackageId);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetPackageVersionsResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetPackageVersionsResponseTests.cs
@@ -59,7 +59,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObjectForSuccess()
         {
             var json = "{\"ResponseCode\":\"Success\",\"Versions\":[\"a\"]}";
-            var response = JsonSerializationUtilities.Deserialize<GetPackageVersionsResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<GetPackageVersionsResponse>(json)!;
 
             Assert.Equal(MessageResponseCode.Success, response.ResponseCode);
             Assert.Equal(new[] { "a" }, response.Versions);
@@ -69,7 +69,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObjectForNotFound()
         {
             var json = "{\"ResponseCode\":\"NotFound\"}";
-            var response = JsonSerializationUtilities.Deserialize<GetPackageVersionsResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<GetPackageVersionsResponse>(json)!;
 
             Assert.Equal(MessageResponseCode.NotFound, response.ResponseCode);
             Assert.Null(response.Versions);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetServiceIndexRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetServiceIndexRequestTests.cs
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObject()
         {
             var json = "{\"PackageSourceRepository\":\"a\"}";
-            var request = JsonSerializationUtilities.Deserialize<GetServiceIndexRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<GetServiceIndexRequest>(json)!;
 
             Assert.Equal("a", request.PackageSourceRepository);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetServiceIndexResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetServiceIndexResponseTests.cs
@@ -51,7 +51,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObjectForSuccess()
         {
             var json = "{\"ResponseCode\":\"Success\",\"ServiceIndex\":{\"a\":\"b\"}}";
-            var response = JsonSerializationUtilities.Deserialize<GetServiceIndexResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<GetServiceIndexResponse>(json)!;
 
             Assert.Equal(MessageResponseCode.Success, response.ResponseCode);
             Assert.Equal("{\"a\":\"b\"}", response.ServiceIndexJson);
@@ -61,7 +61,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObjectForNotFound()
         {
             var json = "{\"ResponseCode\":\"NotFound\"}";
-            var response = JsonSerializationUtilities.Deserialize<GetServiceIndexResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<GetServiceIndexResponse>(json)!;
 
             Assert.Equal(MessageResponseCode.NotFound, response.ResponseCode);
             Assert.Null(response.ServiceIndexJson);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/HandshakeRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/HandshakeRequestTests.cs
@@ -17,7 +17,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_ThrowsForNullProtocolVersion()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new HandshakeRequest(protocolVersion: null, minimumProtocolVersion: _version1_0_0));
+                () => new HandshakeRequest(protocolVersion: null!, minimumProtocolVersion: _version1_0_0));
 
             Assert.Equal("protocolVersion", exception.ParamName);
         }
@@ -26,7 +26,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_ThrowsForNullMinimumProtocolVersion()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new HandshakeRequest(_version1_0_0, minimumProtocolVersion: null));
+                () => new HandshakeRequest(_version1_0_0, minimumProtocolVersion: null!));
 
             Assert.Equal("minimumProtocolVersion", exception.ParamName);
         }
@@ -65,7 +65,7 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             var json = "{\"ProtocolVersion\":\"2.0.0\",\"MinimumProtocolVersion\":\"1.0.0\"}";
 
-            var request = JsonSerializationUtilities.Deserialize<HandshakeRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<HandshakeRequest>(json)!;
 
             Assert.Equal(_version2_0_0, request.ProtocolVersion);
             Assert.Equal(_version1_0_0, request.MinimumProtocolVersion);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/HandshakeResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/HandshakeResponseTests.cs
@@ -77,7 +77,7 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             var version = versionString == null ? null : SemanticVersion.Parse(versionString);
 
-            var response = JsonSerializationUtilities.Deserialize<HandshakeResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<HandshakeResponse>(json)!;
 
             Assert.Equal(responseCode, response.ResponseCode);
             Assert.Equal(version, response.ProtocolVersion);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/InitializeResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/InitializeResponseTests.cs
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [InlineData("{\"ResponseCode\":\"Error\"}", MessageResponseCode.Error)]
         public void JsonDeserialization_ReturnsCorrectObject(string json, MessageResponseCode responseCode)
         {
-            var response = JsonSerializationUtilities.Deserialize<InitializeResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<InitializeResponse>(json)!;
 
             Assert.Equal(responseCode, response.ResponseCode);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/LogRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/LogRequestTests.cs
@@ -54,7 +54,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [InlineData("{\"LogLevel\":\"Warning\",\"Message\":3}", "3")]
         public void JsonDeserialization_ReturnsCorrectObject(string json, string message)
         {
-            var request = JsonSerializationUtilities.Deserialize<LogRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<LogRequest>(json)!;
 
             Assert.Equal(LogLevel.Warning, request.LogLevel);
             Assert.Equal(message, request.Message);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/LogResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/LogResponseTests.cs
@@ -40,7 +40,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [InlineData("{\"ResponseCode\":\"Error\"}", MessageResponseCode.Error)]
         public void JsonDeserialization_ReturnsCorrectObject(string json, MessageResponseCode responseCode)
         {
-            var response = JsonSerializationUtilities.Deserialize<LogResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<LogResponse>(json)!;
 
             Assert.Equal(responseCode, response.ResponseCode);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/MessageConverterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/MessageConverterTests.cs
@@ -37,7 +37,7 @@ namespace NuGet.Protocol.Plugins.Tests
             System.Text.Json.JsonSerializer.Deserialize(json, PluginJsonContext.Default.Message)!;
 
         private static Message DeserializeWithNsj(string json) =>
-            JsonSerializationUtilities.Deserialize<Message>(json);
+            JsonSerializationUtilities.Deserialize<Message>(json)!;
 
         private static object[] Msg(MessageType type, MessageMethod method, object payload) =>
             new object[] { MessageUtilities.Create("test-id", type, method, payload) };

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/MonitorNuGetProcessExitRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/MonitorNuGetProcessExitRequestTests.cs
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObject()
         {
             var json = $"{{\"ProcessId\":{_processId}}}";
-            var request = JsonSerializationUtilities.Deserialize<MonitorNuGetProcessExitRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<MonitorNuGetProcessExitRequest>(json)!;
 
             Assert.Equal(_processId, request.ProcessId);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/MonitorNuGetProcessExitResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/MonitorNuGetProcessExitResponseTests.cs
@@ -42,7 +42,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [InlineData("{\"ResponseCode\":\"Error\"}", MessageResponseCode.Error)]
         public void JsonDeserialization_ReturnsCorrectObject(string json, MessageResponseCode responseCode)
         {
-            var response = JsonSerializationUtilities.Deserialize<MonitorNuGetProcessExitResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<MonitorNuGetProcessExitResponse>(json)!;
 
             Assert.Equal(responseCode, response.ResponseCode);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/PrefetchPackageRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/PrefetchPackageRequestTests.cs
@@ -80,7 +80,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void JsonDeserialization_ReturnsCorrectObject()
         {
             var json = "{\"PackageId\":\"a\",\"PackageSourceRepository\":\"b\",\"PackageVersion\":\"c\"}";
-            var request = JsonSerializationUtilities.Deserialize<PrefetchPackageRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<PrefetchPackageRequest>(json)!;
 
             Assert.Equal("a", request.PackageId);
             Assert.Equal("b", request.PackageSourceRepository);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/PrefetchPackageResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/PrefetchPackageResponseTests.cs
@@ -42,7 +42,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [InlineData("{\"ResponseCode\":\"Error\"}", MessageResponseCode.Error)]
         public void JsonDeserialization_ReturnsCorrectObject(string json, MessageResponseCode responseCode)
         {
-            var response = JsonSerializationUtilities.Deserialize<PrefetchPackageResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<PrefetchPackageResponse>(json)!;
 
             Assert.Equal(responseCode, response.ResponseCode);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/ProgressTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/ProgressTests.cs
@@ -53,7 +53,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [InlineData("{\"Percentage\":1}", 1D)]
         public void JsonDeserialization_ReturnsCorrectObject(string json, double? percentage)
         {
-            var progress = JsonSerializationUtilities.Deserialize<Progress>(json);
+            var progress = JsonSerializationUtilities.Deserialize<Progress>(json)!;
 
             Assert.Equal(percentage, progress.Percentage);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/SetCredentialsRequestTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/SetCredentialsRequestTests.cs
@@ -78,7 +78,7 @@ namespace NuGet.Protocol.Plugins.Tests
             string username,
             string password)
         {
-            var request = JsonSerializationUtilities.Deserialize<SetCredentialsRequest>(json);
+            var request = JsonSerializationUtilities.Deserialize<SetCredentialsRequest>(json)!;
 
             Assert.Equal(packageSourceRepository, request.PackageSourceRepository);
             Assert.Equal(proxyUsername, request.ProxyUsername);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/SetCredentialsResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/SetCredentialsResponseTests.cs
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [InlineData("{\"ResponseCode\":\"Error\"}", MessageResponseCode.Error)]
         public void JsonDeserialization_ReturnsCorrectObject(string json, MessageResponseCode responseCode)
         {
-            var response = JsonSerializationUtilities.Deserialize<SetCredentialsResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<SetCredentialsResponse>(json)!;
 
             Assert.Equal(responseCode, response.ResponseCode);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/SetLogLevelResponseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/SetLogLevelResponseTests.cs
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [InlineData("{\"ResponseCode\":\"Error\"}", MessageResponseCode.Error)]
         public void JsonDeserialization_ReturnsCorrectObject(string json, MessageResponseCode responseCode)
         {
-            var response = JsonSerializationUtilities.Deserialize<SetLogLevelResponse>(json);
+            var response = JsonSerializationUtilities.Deserialize<SetLogLevelResponse>(json)!;
 
             Assert.Equal(responseCode, response.ResponseCode);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/OutboundRequestContextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/OutboundRequestContextTests.cs
@@ -16,7 +16,7 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new OutboundRequestContext<HandshakeResponse>(
-                    connection: null,
+                    connection: null!,
                     request: MessageUtilities.Create(
                         requestId: "a",
                         type: MessageType.Request,
@@ -34,7 +34,7 @@ namespace NuGet.Protocol.Plugins.Tests
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new OutboundRequestContext<HandshakeResponse>(
                     Mock.Of<IConnection>(),
-                    request: null,
+                    request: null!,
                     timeout: TimeSpan.FromMinutes(1),
                     isKeepAlive: true,
                     cancellationToken: CancellationToken.None));
@@ -55,7 +55,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     TimeSpan.FromMinutes(1),
                     isKeepAlive: true,
                     cancellationToken: CancellationToken.None,
-                    logger: null));
+                    logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
         }
@@ -176,7 +176,7 @@ namespace NuGet.Protocol.Plugins.Tests
             using (var test = new OutboundRequestContextTest())
             {
                 var exception = Assert.Throws<ArgumentNullException>(
-                    () => test.Context.HandleProgress(progress: null));
+                    () => test.Context.HandleProgress(progress: null!));
 
                 Assert.Equal("progress", exception.ParamName);
             }
@@ -188,7 +188,7 @@ namespace NuGet.Protocol.Plugins.Tests
             using (var test = new OutboundRequestContextTest())
             {
                 var exception = Assert.Throws<ArgumentNullException>(
-                    () => test.Context.HandleResponse(response: null));
+                    () => test.Context.HandleResponse(response: null!));
 
                 Assert.Equal("response", exception.ParamName);
             }
@@ -210,8 +210,8 @@ namespace NuGet.Protocol.Plugins.Tests
 
                 Assert.Equal(TaskStatus.RanToCompletion, test.Context.CompletionTask.Status);
 #pragma warning disable xUnit1031 // Do not use blocking task operations in test method
-                Assert.Equal(MessageResponseCode.Error, test.Context.CompletionTask.Result.ResponseCode);
-                Assert.Null(test.Context.CompletionTask.Result.ProtocolVersion);
+                Assert.Equal(MessageResponseCode.Error, test.Context.CompletionTask.Result!.ResponseCode);
+                Assert.Null(test.Context.CompletionTask.Result!.ProtocolVersion);
 #pragma warning restore xUnit1031 // Do not use blocking task operations in test method
             }
         }
@@ -255,7 +255,7 @@ namespace NuGet.Protocol.Plugins.Tests
             using (var test = new OutboundRequestContextTest())
             {
                 var exception = Assert.Throws<ArgumentNullException>(
-                    () => test.Context.HandleFault(fault: null));
+                    () => test.Context.HandleFault(fault: null!));
 
                 Assert.Equal("fault", exception.ParamName);
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginFactoryTests.cs
@@ -65,7 +65,7 @@ namespace NuGet.Protocol.Plugins.Tests
             var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => factory.GetOrCreateAsync(
                     new PluginFile(filePath: "a", state: new Lazy<PluginFileState>(() => PluginFileState.Valid)),
-                    arguments: null,
+                    arguments: null!,
                     requestHandlers: new RequestHandlers(),
                     options: ConnectionOptions.CreateDefault(),
                     sessionCancellationToken: CancellationToken.None));
@@ -82,7 +82,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 () => factory.GetOrCreateAsync(
                     new PluginFile(filePath: "a", state: new Lazy<PluginFileState>(() => PluginFileState.Valid)),
                     arguments: PluginConstants.PluginArguments,
-                    requestHandlers: null,
+                    requestHandlers: null!,
                     options: ConnectionOptions.CreateDefault(),
                     sessionCancellationToken: CancellationToken.None));
 
@@ -99,7 +99,7 @@ namespace NuGet.Protocol.Plugins.Tests
                     new PluginFile(filePath: "a", state: new Lazy<PluginFileState>(() => PluginFileState.Valid)),
                     arguments: PluginConstants.PluginArguments,
                     requestHandlers: new RequestHandlers(),
-                    options: null,
+                    options: null!,
                     sessionCancellationToken: CancellationToken.None));
 
             Assert.Equal("options", exception.ParamName);
@@ -170,7 +170,7 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => PluginFactory.CreateFromCurrentProcessAsync(
-                    requestHandlers: null,
+                    requestHandlers: null!,
                     options: ConnectionOptions.CreateDefault(),
                     sessionCancellationToken: CancellationToken.None));
 
@@ -183,7 +183,7 @@ namespace NuGet.Protocol.Plugins.Tests
             var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => PluginFactory.CreateFromCurrentProcessAsync(
                     requestHandlers: new RequestHandlers(),
-                    options: null,
+                    options: null!,
                     sessionCancellationToken: CancellationToken.None));
 
             Assert.Equal("options", exception.ParamName);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginMulticlientUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginMulticlientUtilitiesTests.cs
@@ -37,7 +37,7 @@ namespace NuGet.Protocol.Plugins.Tests
             var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => _utilities.DoOncePerPluginLifetimeAsync(
                     key: "a",
-                    taskFunc: null,
+                    taskFunc: null!,
                     cancellationToken: CancellationToken.None));
 
             Assert.Equal("taskFunc", exception.ParamName);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginPackageDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginPackageDownloaderTests.cs
@@ -34,7 +34,7 @@ namespace NuGet.Protocol.Plugins.Tests
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new PluginPackageDownloader(
-                        plugin: null,
+                        plugin: null!,
                         packageIdentity: _packageIdentity,
                         packageReader: packageReader,
                         packageSourceRepository: _packageSourceRepository));
@@ -54,7 +54,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new PluginPackageDownloader(
                         Mock.Of<IPlugin>(),
-                        packageIdentity: null,
+                        packageIdentity: null!,
                         packageReader: packageReader,
                         packageSourceRepository: _packageSourceRepository));
 
@@ -69,7 +69,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 () => new PluginPackageDownloader(
                     Mock.Of<IPlugin>(),
                     _packageIdentity,
-                    packageReader: null,
+                    packageReader: null!,
                     packageSourceRepository: _packageSourceRepository));
 
             Assert.Equal("packageReader", exception.ParamName);
@@ -428,7 +428,7 @@ namespace NuGet.Protocol.Plugins.Tests
             using (var test = PluginPackageDownloaderTest.Create())
             {
                 var exception = Assert.Throws<ArgumentNullException>(
-                    () => test.Downloader.SetExceptionHandler(handleExceptionAsync: null));
+                    () => test.Downloader.SetExceptionHandler(handleExceptionAsync: null!));
 
                 Assert.Equal("handleExceptionAsync", exception.ParamName);
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/CloseRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/CloseRequestHandlerTests.cs
@@ -15,7 +15,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_ThrowsForNullPlugin()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new CloseRequestHandler(plugin: null));
+                () => new CloseRequestHandler(plugin: null!));
 
             Assert.Equal("plugin", exception.ParamName);
         }
@@ -53,7 +53,7 @@ namespace NuGet.Protocol.Plugins.Tests
             {
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                     () => test.Handler.HandleResponseAsync(
-                        connection: null,
+                        connection: null!,
                         request: MessageUtilities.Create(
                             requestId: "a",
                             type: MessageType.Request,
@@ -73,7 +73,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                     () => test.Handler.HandleResponseAsync(
                         Mock.Of<IConnection>(),
-                        request: null,
+                        request: null!,
                         responseHandler: Mock.Of<IResponseHandler>(),
                         cancellationToken: CancellationToken.None));
 
@@ -93,7 +93,7 @@ namespace NuGet.Protocol.Plugins.Tests
                             requestId: "a",
                             type: MessageType.Request,
                             method: MessageMethod.Close),
-                        responseHandler: null,
+                        responseHandler: null!,
                         cancellationToken: CancellationToken.None));
 
                 Assert.Equal("responseHandler", exception.ParamName);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/LogRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/LogRequestHandlerTests.cs
@@ -17,7 +17,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_ThrowsForNullLogger()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new LogRequestHandler(logger: null));
+                () => new LogRequestHandler(logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
         }
@@ -37,7 +37,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
             var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => test.Handler.HandleResponseAsync(
-                    connection: null,
+                    connection: null!,
                     request: test.Request,
                     responseHandler: Mock.Of<IResponseHandler>(),
                     cancellationToken: CancellationToken.None));
@@ -53,7 +53,7 @@ namespace NuGet.Protocol.Plugins.Tests
             var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => test.Handler.HandleResponseAsync(
                     Mock.Of<IConnection>(),
-                    request: null,
+                    request: null!,
                     responseHandler: Mock.Of<IResponseHandler>(),
                     cancellationToken: CancellationToken.None));
 
@@ -69,7 +69,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 () => test.Handler.HandleResponseAsync(
                     Mock.Of<IConnection>(),
                     test.Request,
-                    responseHandler: null,
+                    responseHandler: null!,
                     cancellationToken: CancellationToken.None));
 
             Assert.Equal("responseHandler", exception.ParamName);
@@ -170,7 +170,7 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             var test = new LogRequestHandlerTest();
             var exception = Assert.Throws<ArgumentNullException>(
-                () => test.Handler.SetLogger(logger: null));
+                () => test.Handler.SetLogger(logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
         }
@@ -206,7 +206,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void GetLogLevel_ThrowsForNullLogger()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => LogRequestHandler.GetLogLevel(logger: null));
+                () => LogRequestHandler.GetLogLevel(logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandlerTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_ThrowsForNullPlugin()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new MonitorNuGetProcessExitRequestHandler(plugin: null));
+                () => new MonitorNuGetProcessExitRequestHandler(plugin: null!));
 
             Assert.Equal("plugin", exception.ParamName);
         }
@@ -51,7 +51,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
             var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => _handler.HandleResponseAsync(
-                    connection: null,
+                    connection: null!,
                     request: request,
                     responseHandler: Mock.Of<IResponseHandler>(),
                     cancellationToken: CancellationToken.None));
@@ -65,7 +65,7 @@ namespace NuGet.Protocol.Plugins.Tests
             var exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => _handler.HandleResponseAsync(
                     Mock.Of<IConnection>(),
-                    request: null,
+                    request: null!,
                     responseHandler: Mock.Of<IResponseHandler>(),
                     cancellationToken: CancellationToken.None));
 
@@ -81,7 +81,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 () => _handler.HandleResponseAsync(
                     Mock.Of<IConnection>(),
                     request,
-                    responseHandler: null,
+                    responseHandler: null!,
                     cancellationToken: CancellationToken.None));
 
             Assert.Equal("responseHandler", exception.ParamName);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlersTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlersTests.cs
@@ -24,7 +24,7 @@ namespace NuGet.Protocol.Plugins.Tests
             var exception = Assert.Throws<ArgumentNullException>(
                 () => _handlers.AddOrUpdate(
                     MessageMethod.Handshake,
-                    addHandlerFunc: null,
+                    addHandlerFunc: null!,
                     updateHandlerFunc: oldHandler => oldHandler));
 
             Assert.Equal("addHandlerFunc", exception.ParamName);
@@ -37,7 +37,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 () => _handlers.AddOrUpdate(
                     MessageMethod.Handshake,
                     () => Mock.Of<IRequestHandler>(),
-                    updateHandlerFunc: null));
+                    updateHandlerFunc: null!));
 
             Assert.Equal("updateHandlerFunc", exception.ParamName);
         }
@@ -49,8 +49,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
             _handlers.AddOrUpdate(MessageMethod.Handshake, () => handler, oldHandler => handler);
 
-            IRequestHandler actualHandler;
-            var wasAdded = _handlers.TryGet(MessageMethod.Handshake, out actualHandler);
+            var wasAdded = _handlers.TryGet(MessageMethod.Handshake, out var actualHandler);
 
             Assert.True(wasAdded);
             Assert.Same(handler, actualHandler);
@@ -65,8 +64,7 @@ namespace NuGet.Protocol.Plugins.Tests
             _handlers.AddOrUpdate(MessageMethod.Handshake, () => firstHandler, h => firstHandler);
             _handlers.AddOrUpdate(MessageMethod.Handshake, () => secondHandler, h => secondHandler);
 
-            IRequestHandler actualHandler;
-            var wasUpdated = _handlers.TryGet(MessageMethod.Handshake, out actualHandler);
+            var wasUpdated = _handlers.TryGet(MessageMethod.Handshake, out var actualHandler);
 
             Assert.True(wasUpdated);
             Assert.Same(secondHandler, actualHandler);
@@ -76,7 +74,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void TryAdd_ThrowsForNullHandler()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => _handlers.TryAdd(MessageMethod.Handshake, handler: null));
+                () => _handlers.TryAdd(MessageMethod.Handshake, handler: null!));
 
             Assert.Equal("handler", exception.ParamName);
         }
@@ -103,8 +101,7 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             _handlers.TryAdd(MessageMethod.Handshake, _handler);
 
-            IRequestHandler handler;
-            var wasGotten = _handlers.TryGet(MessageMethod.Handshake, out handler);
+            var wasGotten = _handlers.TryGet(MessageMethod.Handshake, out var handler);
 
             Assert.True(wasGotten);
             Assert.Same(_handler, handler);
@@ -113,8 +110,7 @@ namespace NuGet.Protocol.Plugins.Tests
         [Fact]
         public void TryGet_ReturnsFalseIfNotGotten()
         {
-            IRequestHandler handler;
-            var wasGotten = _handlers.TryGet(MessageMethod.Handshake, out handler);
+            var wasGotten = _handlers.TryGet(MessageMethod.Handshake, out var handler);
 
             Assert.False(wasGotten);
             Assert.Null(handler);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/SenderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/SenderTests.cs
@@ -27,7 +27,7 @@ namespace NuGet.Protocol.Plugins.Tests
         public void Constructor_ThrowsForNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new Sender(writer: null));
+                () => new Sender(writer: null!));
 
             Assert.Equal("writer", exception.ParamName);
         }
@@ -110,7 +110,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 sender.Connect();
 
                 var exception = await Assert.ThrowsAsync<ArgumentNullException>(
-                    () => sender.SendAsync(message: null, cancellationToken: CancellationToken.None));
+                    () => sender.SendAsync(message: null!, cancellationToken: CancellationToken.None));
 
                 Assert.Equal("message", exception.ParamName);
             }


### PR DESCRIPTION
# Bug

Progress: https://github.com/NuGet/Home/issues/14851

## Description

`Plugins/` runtime — serialization utilities, request contexts, connection/dispatcher, handlers, orchestration (Plugin/PluginFactory/PluginManager/PluginDiscoverer), and the package-operation readers/downloaders.

Most changes are mechanical: removing `#nullable disable`, annotating fields/parameters/returns, replacing `~` entries in `PublicAPI.Shipped.txt` for both `net472` and `net8.0`, and adding `null!` in tests that assert `ArgumentNullException`.

Points worth flagging for review:

- **`PluginPackageReader.CopyNupkgAsync` returns `null!`.** The base `PackageReaderBase.CopyNupkgAsync` is declared `Task<string!>!`, but this override has three null-return paths that pre-date nullable enablement: (1) `response == null`, (2) `MessageResponseCode.NotFound` (writes a download-marker file), (3) default/error. `PackageExtractor` already handles the empty/null result, so the real contract is nullable. Making the base honest (`Task<string?>`) is an API change in `NuGet.Packaging` and out of scope here; left as `null!` for now.
- **`HandshakeResponse.IsSuccess` added as `internal`.** Replaces the previous `null!` field-init suppression on `ProtocolVersion`/`MessageDispatcher` after a successful handshake, using a `[MemberNotNullWhen(true, …)]` pattern similar to `PluginCreationResult.IsSuccess`.
- **`PluginPackageReader.GetMinClientVersion()` keeps a non-null return (`NuGetVersion!`)** even though the base is `NuGetVersion?` — covariant return narrowing, since this override always throws `NotSupportedException`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
