### PR TITLE
[7.0.x] Disable optimization profiling in pipeline

### DIFF
--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -89,11 +89,7 @@ stages:
         swix:
           enabled: true
         optprof:
-          enabled: ${{ variables['isOfficialBuild'] }}
-          OptimizationInputsLookupMethod: DropPrefix
-          DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
-          ShouldSkipOptimize: $(ShouldSkipOptimize)
-          AccessToken: $(System.AccessToken)
+          enabled: false
       outputParentDirectory: '$(Build.StagingDirectory)'
       outputs:
       - output: pipelineArtifact
@@ -120,16 +116,6 @@ stages:
         dropMetadataContainerName: 'DropMetadata-RunSettings'
         # need to make daily Apex test pipeline build its own tests, and remove this from official pipeline
         codeSignValidationEnabled: false
-
-      - output: artifactsDrop
-        displayName: 'OptProfV2:  publish profiling inputs to artifact services'
-        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
-        dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: '$(ProfilingInputsDropName)'
-        sourcePath: '$(Build.StagingDirectory)\OptProf\ProfilingInputs'
-        toLowerCase: false
-        usePat: true
-        dropMetadataContainerName: 'DropMetadata-ProfilingInputs'
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe and VSIX as artifact'


### PR DESCRIPTION
This branch is no longer running OptProf, so the build no longer needs to check for optimization inputs.
7.0 is no longer supported in VS, only in .NET SDK.