### PR TITLE
Update test cases to use TestConstants

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetListPackageTests.cs
@@ -1107,19 +1107,19 @@ namespace Dotnet.Integration.Test
 
         [PlatformTheory(Platform.Windows)]
         [InlineData(" --include-transitive", true)]
-        [InlineData(" --include-transitive --framework net10.0", false)]
+        [InlineData(" --include-transitive --framework " + TestConstants.ProjectTargetFramework, false)]
         [InlineData(" --include-transitive --framework net472", true)]
         [InlineData("", false)]
         public async Task DeprecatedOption_WithMultiTargetedProjectsAndDeprecatedPackages_Succeeds(string additionalOptions, bool shouldReportTransitivePackages)
         {
             // Arrange
             using var pathContext = _fixture.CreateSimpleTestPathContext();
-            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net472;net10.0");
+            var projectA = XPlatTestUtils.CreateProject("ProjectA", pathContext, "net472;" + TestConstants.ProjectTargetFramework);
 
             var packageA100 = new SimpleTestPackageContext("A", "1.0.0");
             var packageB100 = new SimpleTestPackageContext("B", "1.0.0");
             packageA100.PerFrameworkDependencies.Add(FrameworkConstants.CommonFrameworks.Net472, [packageB100]);
-            packageA100.PerFrameworkDependencies.Add(FrameworkConstants.CommonFrameworks.Net10_0, []);
+            packageA100.PerFrameworkDependencies.Add(TestConstants.DefaultTargetFramework, []);
 
             await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, packageA100, packageB100);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: recent failures in https://dev.azure.com/dnceng-public/public/_build?definitionId=289&_a=summary

## Description

Replace hardcoded net10.0 with TestConstants.ProjectTargetFramework so the test targets the framework matching the SDK under test, fixing NU1101 failures

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
