### PR TITLE
Enable nullable annotations for NuGet.Protocol service index, repository signature, and registration types

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageVulnerabilityMetadata.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Text.Json.Serialization;
 using Newtonsoft.Json;
@@ -11,10 +9,14 @@ namespace NuGet.Protocol
 {
     public class PackageVulnerabilityMetadata
     {
+        /// <summary>
+        /// NULL_INC: The advisory URL for this vulnerability.
+        /// Guaranteed non-null by the protocol: https://learn.microsoft.com/en-us/nuget/api/registration-base-url-resource#vulnerabilities
+        /// </summary>
         [JsonProperty(PropertyName = JsonProperties.AdvisoryUrl, ItemConverterType = typeof(SafeUriConverter))]
         [JsonPropertyName(JsonProperties.AdvisoryUrl)]
         [JsonInclude]
-        public Uri AdvisoryUrl { get; internal set; }
+        public Uri AdvisoryUrl { get; internal set; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.Severity)]
         [JsonPropertyName(JsonProperties.Severity)]
@@ -24,10 +26,11 @@ namespace NuGet.Protocol
 
         public PackageVulnerabilityMetadata(Uri advisoryUrl, int severity)
         {
-            AdvisoryUrl = advisoryUrl;
+            AdvisoryUrl = advisoryUrl ?? throw new ArgumentNullException(nameof(advisoryUrl));
             Severity = severity;
         }
 
+        // Parameterless constructor for JSON deserialization.
         public PackageVulnerabilityMetadata()
         {
         }

--- a/src/NuGet.Core/NuGet.Protocol/Model/RegistrationIndex.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/RegistrationIndex.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Newtonsoft.Json;
@@ -16,6 +14,6 @@ namespace NuGet.Protocol.Model
     {
         [JsonProperty("items")]
         [JsonPropertyName("items")]
-        public List<RegistrationPage> Items { get; set; }
+        public List<RegistrationPage>? Items { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/RegistrationLeafItem.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/RegistrationLeafItem.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Text.Json.Serialization;
 using Newtonsoft.Json;
@@ -16,10 +14,10 @@ namespace NuGet.Protocol.Model
     {
         [JsonProperty("catalogEntry")]
         [JsonPropertyName("catalogEntry")]
-        public PackageSearchMetadataRegistration CatalogEntry { get; set; }
+        public PackageSearchMetadataRegistration? CatalogEntry { get; set; }
 
         [JsonProperty(PropertyName = JsonProperties.PackageContent)]
         [JsonPropertyName(JsonProperties.PackageContent)]
-        public Uri PackageContent { get; set; }
+        public Uri? PackageContent { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/RegistrationPage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/RegistrationPage.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Newtonsoft.Json;
@@ -16,9 +14,11 @@ namespace NuGet.Protocol.Model
     /// </summary>
     internal class RegistrationPage
     {
+        // NULL_INC: Annotated as non-null per protocol spec (link above). JSON deserialization may leave these
+        // as null if the server sends malformed data, but existing code assumes non-null without checks.
         [JsonProperty("@id")]
         [JsonPropertyName("@id")]
-        public string Url { get; set; }
+        public string Url { get; set; } = null!;
 
         /// <summary>
         /// This property can be null when this model is used as an item in <see cref="RegistrationIndex.Items"/> when
@@ -27,14 +27,18 @@ namespace NuGet.Protocol.Model
         /// </summary>
         [JsonProperty("items")]
         [JsonPropertyName("items")]
-        public List<RegistrationLeafItem> Items { get; set; }
+        public List<RegistrationLeafItem>? Items { get; set; }
 
+        // NULL_INC: Annotated as non-null per protocol spec (link above). JSON deserialization may leave these
+        // as null if the server sends malformed data, but existing code assumes non-null without checks.
         [JsonProperty("lower")]
         [JsonPropertyName("lower")]
-        public string Lower { get; set; }
+        public string Lower { get; set; } = null!;
 
+        // NULL_INC: Annotated as non-null per protocol spec (link above). JSON deserialization may leave these
+        // as null if the server sends malformed data, but existing code assumes non-null without checks.
         [JsonProperty("upper")]
         [JsonPropertyName("upper")]
-        public string Upper { get; set; }
+        public string Upper { get; set; } = null!;
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using System.Linq;
@@ -18,11 +16,11 @@ namespace NuGet.Protocol
 {
     public class RepositorySignatureResourceProvider : ResourceProvider
     {
-        private readonly IEnvironmentVariableReader _environmentVariableReader;
+        private readonly IEnvironmentVariableReader? _environmentVariableReader;
 
         public RepositorySignatureResourceProvider() : this(null) { }
 
-        internal RepositorySignatureResourceProvider(IEnvironmentVariableReader environmentVariableReader)
+        internal RepositorySignatureResourceProvider(IEnvironmentVariableReader? environmentVariableReader)
            : base(typeof(RepositorySignatureResource),
                  nameof(RepositorySignatureResource),
                  NuGetResourceProviderPositions.Last)
@@ -30,9 +28,9 @@ namespace NuGet.Protocol
             _environmentVariableReader = environmentVariableReader;
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            RepositorySignatureResource resource = null;
+            RepositorySignatureResource? resource = null;
             var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
             if (serviceIndex != null)
             {
@@ -44,10 +42,10 @@ namespace NuGet.Protocol
                 }
             }
 
-            return new Tuple<bool, INuGetResource>(resource != null, resource);
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
         }
 
-        private async Task<RepositorySignatureResource> GetRepositorySignatureResourceAsync(
+        private async Task<RepositorySignatureResource?> GetRepositorySignatureResourceAsync(
             SourceRepository source,
             ServiceIndexEntry serviceEntry,
             ILogger log,
@@ -62,7 +60,8 @@ namespace NuGet.Protocol
                 throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.RepositorySignaturesResourceMustBeHttps, source.PackageSource.Source));
             }
 
-            var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
+            var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token)
+                ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
             var client = httpSourceResource.HttpSource;
             var cacheKey = GenerateCacheKey(serviceEntry);
 
@@ -91,9 +90,10 @@ namespace NuGet.Protocol
                                 async httpSourceResult =>
                                 {
                                     var model = await JsonSerializer.DeserializeAsync(
-                                        httpSourceResult.Stream,
+                                        httpSourceResult.Stream!,
                                         RepositorySignatureJsonContext.Default.RepositorySignatureModel,
-                                        token);
+                                        token)
+                                        ?? throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToReadRepositorySignature, repositorySignaturesResourceUri.AbsoluteUri));
                                     return new RepositorySignatureResource(model, source);
                                 },
                                 log,
@@ -117,14 +117,15 @@ namespace NuGet.Protocol
                                     if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
                                     {
                                         var model = await JsonSerializer.DeserializeAsync(
-                                            httpSourceResult.Stream,
+                                            httpSourceResult.Stream!,
                                             RepositorySignatureJsonContext.Default.RepositorySignatureModel,
-                                            token);
+                                            token)
+                                            ?? throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToReadRepositorySignature, repositorySignaturesResourceUri.AbsoluteUri));
                                         return new RepositorySignatureResource(model, source);
                                     }
                                     else
                                     {
-                                        var json = await httpSourceResult.Stream.AsJObjectAsync(token);
+                                        var json = (await httpSourceResult.Stream!.AsJObjectAsync(token))!;
 #pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
                                         return new RepositorySignatureResource(json, source);
 #pragma warning restore IL2026, IL3050

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;
@@ -31,7 +29,7 @@ namespace NuGet.Protocol
         private readonly ConcurrentDictionary<string, ServiceIndexCacheInfo> _cache;
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
         private readonly EnhancedHttpRetryHelper _enhancedHttpRetryHelper;
-        private readonly IEnvironmentVariableReader _environmentVariableReader;
+        private readonly IEnvironmentVariableReader? _environmentVariableReader;
 
         /// <summary>
         /// Maximum amount of time to store index.json
@@ -40,7 +38,7 @@ namespace NuGet.Protocol
 
         public ServiceIndexResourceV3Provider() : this(environmentVariableReader: null) { }
 
-        internal ServiceIndexResourceV3Provider(IEnvironmentVariableReader environmentVariableReader)
+        internal ServiceIndexResourceV3Provider(IEnvironmentVariableReader? environmentVariableReader)
             : base(typeof(ServiceIndexResourceV3),
                   nameof(ServiceIndexResourceV3Provider),
                   NuGetResourceProviderPositions.Last)
@@ -51,10 +49,10 @@ namespace NuGet.Protocol
             _enhancedHttpRetryHelper = new EnhancedHttpRetryHelper(environmentVariableReader ?? EnvironmentVariableWrapper.Instance);
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            ServiceIndexResourceV3 index = null;
-            ServiceIndexCacheInfo cacheInfo = null;
+            ServiceIndexResourceV3? index = null;
+            ServiceIndexCacheInfo? cacheInfo = null;
             var url = source.PackageSource.Source;
 
             // the file type can easily rule out if we need to request the url
@@ -102,7 +100,7 @@ namespace NuGet.Protocol
                 index = cacheInfo.Index;
             }
 
-            return new Tuple<bool, INuGetResource>(index != null, index);
+            return new Tuple<bool, INuGetResource?>(index != null, index);
         }
 
         /// <summary>
@@ -116,14 +114,15 @@ namespace NuGet.Protocol
         /// <exception cref="OperationCanceledException">Logged to any provided <paramref name="log"/> as LogMinimal prior to throwing.</exception>
         /// <exception cref="FatalProtocolException">Encapsulates all other exceptions.</exception>
         /// <returns></returns>
-        private async Task<ServiceIndexResourceV3> GetServiceIndexResourceV3(
+        private async Task<ServiceIndexResourceV3?> GetServiceIndexResourceV3(
             SourceRepository source,
             DateTime utcNow,
             ILogger log,
             CancellationToken token)
         {
             var url = source.PackageSource.Source;
-            var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
+            var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token)
+                ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
             var client = httpSourceResource.HttpSource;
 
             int maxRetries = _enhancedHttpRetryHelper.RetryCountOrDefault;
@@ -149,7 +148,7 @@ namespace NuGet.Protocol
                             },
                             async httpSourceResult =>
                             {
-                                var result = await ConsumeServiceIndexStreamAsync(httpSourceResult.Stream, utcNow, source.PackageSource, token);
+                                var result = await ConsumeServiceIndexStreamAsync(httpSourceResult.Stream!, utcNow, source.PackageSource, token);
 
                                 return result;
                             },
@@ -211,7 +210,7 @@ namespace NuGet.Protocol
 
         private static async Task<ServiceIndexResourceV3> ConsumeServiceIndexStreamStjAsync(Stream stream, DateTime utcNow, PackageSource source, CancellationToken token)
         {
-            ServiceIndexModel index;
+            ServiceIndexModel? index;
             try
             {
                 index = await JsonSerializer.DeserializeAsync(stream, JsonContext.Default.ServiceIndexModel, token);
@@ -233,7 +232,7 @@ namespace NuGet.Protocol
             }
 
             // Use SemVer instead of NuGetVersion; the service index should always be in strict SemVer format.
-            if (!SemanticVersion.TryParse(index.Version, out SemanticVersion version) || version.Major != 3)
+            if (!SemanticVersion.TryParse(index.Version, out SemanticVersion? version) || version.Major != 3)
             {
                 throw new InvalidDataException(string.Format(
                     CultureInfo.CurrentCulture,
@@ -247,16 +246,16 @@ namespace NuGet.Protocol
         private static async Task<ServiceIndexResourceV3> ConsumeServiceIndexStreamNsjAsync(Stream stream, DateTime utcNow, PackageSource source, CancellationToken token)
         {
             // Parse the JSON
-            JObject json = await stream.AsJObjectAsync(token);
+            JObject json = (await stream.AsJObjectAsync(token))!;
 
             // Use SemVer instead of NuGetVersion, the service index should always be
             // in strict SemVer format
-            JToken versionToken;
+            JToken? versionToken;
             if (json.TryGetValue("version", out versionToken) &&
                 versionToken.Type == JTokenType.String)
             {
-                SemanticVersion version;
-                if (SemanticVersion.TryParse((string)versionToken, out version) &&
+                SemanticVersion? version;
+                if (SemanticVersion.TryParse((string)versionToken!, out version) &&
                     version.Major == 3)
                 {
 #pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
@@ -268,7 +267,7 @@ namespace NuGet.Protocol
                     string errorMessage = string.Format(
                         CultureInfo.CurrentCulture,
                         Strings.Protocol_UnsupportedVersion,
-                        (string)versionToken);
+                        (string?)versionToken);
                     throw new InvalidDataException(errorMessage);
                 }
             }
@@ -280,7 +279,7 @@ namespace NuGet.Protocol
 
         protected class ServiceIndexCacheInfo
         {
-            public ServiceIndexResourceV3 Index { get; set; }
+            public ServiceIndexResourceV3? Index { get; set; }
 
             public DateTime CachedTime { get; set; }
         }

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -832,9 +832,9 @@ NuGet.Protocol.PackageUpdateResourceV2Provider.PackageUpdateResourceV2Provider()
 NuGet.Protocol.PackageUpdateResourceV3Provider
 NuGet.Protocol.PackageUpdateResourceV3Provider.PackageUpdateResourceV3Provider() -> void
 NuGet.Protocol.PackageVulnerabilityMetadata
-~NuGet.Protocol.PackageVulnerabilityMetadata.AdvisoryUrl.get -> System.Uri
+NuGet.Protocol.PackageVulnerabilityMetadata.AdvisoryUrl.get -> System.Uri!
 NuGet.Protocol.PackageVulnerabilityMetadata.PackageVulnerabilityMetadata() -> void
-~NuGet.Protocol.PackageVulnerabilityMetadata.PackageVulnerabilityMetadata(System.Uri advisoryUrl, int severity) -> void
+NuGet.Protocol.PackageVulnerabilityMetadata.PackageVulnerabilityMetadata(System.Uri! advisoryUrl, int severity) -> void
 NuGet.Protocol.PackageVulnerabilityMetadata.Severity.get -> int
 NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.PackageVulnerabilitySeverity.Critical = 3 -> NuGet.Protocol.PackageVulnerabilitySeverity
@@ -1391,10 +1391,10 @@ NuGet.Protocol.RepositoryCertificateInfo.RepositoryCertificateInfo() -> void
 NuGet.Protocol.RepositoryCertificateInfo.Subject.get -> string!
 NuGet.Protocol.RepositorySignatureResource
 NuGet.Protocol.RepositorySignatureResource.AllRepositorySigned.get -> bool
-~NuGet.Protocol.RepositorySignatureResource.RepositoryCertificateInfos.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.IRepositoryCertificateInfo>
-~NuGet.Protocol.RepositorySignatureResource.RepositorySignatureResource(Newtonsoft.Json.Linq.JObject repoSignInformationContent, NuGet.Protocol.Core.Types.SourceRepository source) -> void
-~NuGet.Protocol.RepositorySignatureResource.RepositorySignatureResource(bool allRepositorySigned, System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.IRepositoryCertificateInfo> repositoryCertInfos) -> void
-~NuGet.Protocol.RepositorySignatureResource.Source.get -> string
+NuGet.Protocol.RepositorySignatureResource.RepositoryCertificateInfos.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.IRepositoryCertificateInfo!>!
+NuGet.Protocol.RepositorySignatureResource.RepositorySignatureResource(Newtonsoft.Json.Linq.JObject! repoSignInformationContent, NuGet.Protocol.Core.Types.SourceRepository! source) -> void
+NuGet.Protocol.RepositorySignatureResource.RepositorySignatureResource(bool allRepositorySigned, System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.IRepositoryCertificateInfo!>! repositoryCertInfos) -> void
+NuGet.Protocol.RepositorySignatureResource.Source.get -> string!
 NuGet.Protocol.RepositorySignatureResource.UpdateRepositorySignatureInfo() -> void
 NuGet.Protocol.RepositorySignatureResourceProvider
 NuGet.Protocol.RepositorySignatureResourceProvider.RepositorySignatureResourceProvider() -> void
@@ -1423,15 +1423,15 @@ NuGet.Protocol.ServiceIndexEntry.ServiceIndexEntry(System.Uri! serviceUri, strin
 NuGet.Protocol.ServiceIndexEntry.Type.get -> string!
 NuGet.Protocol.ServiceIndexEntry.Uri.get -> System.Uri!
 NuGet.Protocol.ServiceIndexResourceV3
-~NuGet.Protocol.ServiceIndexResourceV3.ServiceIndexResourceV3(Newtonsoft.Json.Linq.JObject index, System.DateTime requestTime) -> void
+NuGet.Protocol.ServiceIndexResourceV3.ServiceIndexResourceV3(Newtonsoft.Json.Linq.JObject! index, System.DateTime requestTime) -> void
 NuGet.Protocol.ServiceIndexResourceV3Provider
 NuGet.Protocol.ServiceIndexResourceV3Provider.MaxCacheDuration.get -> System.TimeSpan
 NuGet.Protocol.ServiceIndexResourceV3Provider.MaxCacheDuration.set -> void
 NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo
 NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.CachedTime.get -> System.DateTime
 NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.CachedTime.set -> void
-~NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.Index.get -> NuGet.Protocol.ServiceIndexResourceV3
-~NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.Index.set -> void
+NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.Index.get -> NuGet.Protocol.ServiceIndexResourceV3?
+NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.Index.set -> void
 NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.ServiceIndexCacheInfo() -> void
 NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexResourceV3Provider() -> void
 NuGet.Protocol.ServiceTypes
@@ -1859,7 +1859,7 @@ override NuGet.Protocol.ProxyAuthenticationHandler.SendAsync(System.Net.Http.Htt
 ~override NuGet.Protocol.RemoteV3FindPackageByIdResource.GetPackageDownloaderAsync(NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.IPackageDownloader>
 ~override NuGet.Protocol.RemoteV3FindPackageByIdResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository sourceRepository, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.ReportAbuseResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.RepositorySignatureResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.RepositorySignatureResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.SafeBoolConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.SafeBoolConverter.CanRead.get -> bool
 override NuGet.Protocol.SafeBoolConverter.CanWrite.get -> bool
@@ -1874,7 +1874,7 @@ override NuGet.Protocol.SemanticVersionConverter.CanConvert(System.Type! objectT
 override NuGet.Protocol.SemanticVersionConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.SemanticVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 override NuGet.Protocol.ServerWarningLogHandler.SendAsync(System.Net.Http.HttpRequestMessage! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
-~override NuGet.Protocol.ServiceIndexResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.ServiceIndexResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.StsAuthenticationHandler.SendAsync(System.Net.Http.HttpRequestMessage! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
 ~override NuGet.Protocol.SymbolPackageUpdateResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.V2FeedListResource.ListAsync(string searchTerm, bool prerelease, bool allVersions, bool includeDelisted, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Common.IEnumerableAsync<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
@@ -2128,11 +2128,11 @@ virtual NuGet.Protocol.Plugins.Receiver.Close() -> void
 ~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(NuGet.Packaging.Core.PackageIdentity package) -> System.Uri
 ~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string id, NuGet.Versioning.NuGetVersion version) -> System.Uri
 ~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string packageId) -> System.Uri
-~virtual NuGet.Protocol.ServiceIndexResourceV3.Entries.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry>
-~virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(NuGet.Versioning.NuGetVersion clientVersion, params string[] orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry>
-~virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(params string[] orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry>
-~virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUri(params string[] orderedTypes) -> System.Uri
-~virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUris(NuGet.Versioning.NuGetVersion clientVersion, params string[] orderedTypes) -> System.Collections.Generic.IReadOnlyList<System.Uri>
-~virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUris(params string[] orderedTypes) -> System.Collections.Generic.IReadOnlyList<System.Uri>
-~virtual NuGet.Protocol.ServiceIndexResourceV3.Json.get -> string
+virtual NuGet.Protocol.ServiceIndexResourceV3.Entries.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!
+virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(NuGet.Versioning.NuGetVersion! clientVersion, params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!
+virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!
+virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUri(params string![]! orderedTypes) -> System.Uri?
+virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUris(NuGet.Versioning.NuGetVersion! clientVersion, params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<System.Uri!>!
+virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUris(params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<System.Uri!>!
+virtual NuGet.Protocol.ServiceIndexResourceV3.Json.get -> string!
 virtual NuGet.Protocol.ServiceIndexResourceV3.RequestTime.get -> System.DateTime

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -832,9 +832,9 @@ NuGet.Protocol.PackageUpdateResourceV2Provider.PackageUpdateResourceV2Provider()
 NuGet.Protocol.PackageUpdateResourceV3Provider
 NuGet.Protocol.PackageUpdateResourceV3Provider.PackageUpdateResourceV3Provider() -> void
 NuGet.Protocol.PackageVulnerabilityMetadata
-~NuGet.Protocol.PackageVulnerabilityMetadata.AdvisoryUrl.get -> System.Uri
+NuGet.Protocol.PackageVulnerabilityMetadata.AdvisoryUrl.get -> System.Uri!
 NuGet.Protocol.PackageVulnerabilityMetadata.PackageVulnerabilityMetadata() -> void
-~NuGet.Protocol.PackageVulnerabilityMetadata.PackageVulnerabilityMetadata(System.Uri advisoryUrl, int severity) -> void
+NuGet.Protocol.PackageVulnerabilityMetadata.PackageVulnerabilityMetadata(System.Uri! advisoryUrl, int severity) -> void
 NuGet.Protocol.PackageVulnerabilityMetadata.Severity.get -> int
 NuGet.Protocol.PackageVulnerabilitySeverity
 NuGet.Protocol.PackageVulnerabilitySeverity.Critical = 3 -> NuGet.Protocol.PackageVulnerabilitySeverity
@@ -1391,10 +1391,10 @@ NuGet.Protocol.RepositoryCertificateInfo.RepositoryCertificateInfo() -> void
 NuGet.Protocol.RepositoryCertificateInfo.Subject.get -> string!
 NuGet.Protocol.RepositorySignatureResource
 NuGet.Protocol.RepositorySignatureResource.AllRepositorySigned.get -> bool
-~NuGet.Protocol.RepositorySignatureResource.RepositoryCertificateInfos.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.IRepositoryCertificateInfo>
-~NuGet.Protocol.RepositorySignatureResource.RepositorySignatureResource(Newtonsoft.Json.Linq.JObject repoSignInformationContent, NuGet.Protocol.Core.Types.SourceRepository source) -> void
-~NuGet.Protocol.RepositorySignatureResource.RepositorySignatureResource(bool allRepositorySigned, System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.IRepositoryCertificateInfo> repositoryCertInfos) -> void
-~NuGet.Protocol.RepositorySignatureResource.Source.get -> string
+NuGet.Protocol.RepositorySignatureResource.RepositoryCertificateInfos.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.IRepositoryCertificateInfo!>!
+NuGet.Protocol.RepositorySignatureResource.RepositorySignatureResource(Newtonsoft.Json.Linq.JObject! repoSignInformationContent, NuGet.Protocol.Core.Types.SourceRepository! source) -> void
+NuGet.Protocol.RepositorySignatureResource.RepositorySignatureResource(bool allRepositorySigned, System.Collections.Generic.IEnumerable<NuGet.Packaging.Core.IRepositoryCertificateInfo!>! repositoryCertInfos) -> void
+NuGet.Protocol.RepositorySignatureResource.Source.get -> string!
 NuGet.Protocol.RepositorySignatureResource.UpdateRepositorySignatureInfo() -> void
 NuGet.Protocol.RepositorySignatureResourceProvider
 NuGet.Protocol.RepositorySignatureResourceProvider.RepositorySignatureResourceProvider() -> void
@@ -1423,15 +1423,15 @@ NuGet.Protocol.ServiceIndexEntry.ServiceIndexEntry(System.Uri! serviceUri, strin
 NuGet.Protocol.ServiceIndexEntry.Type.get -> string!
 NuGet.Protocol.ServiceIndexEntry.Uri.get -> System.Uri!
 NuGet.Protocol.ServiceIndexResourceV3
-~NuGet.Protocol.ServiceIndexResourceV3.ServiceIndexResourceV3(Newtonsoft.Json.Linq.JObject index, System.DateTime requestTime) -> void
+NuGet.Protocol.ServiceIndexResourceV3.ServiceIndexResourceV3(Newtonsoft.Json.Linq.JObject! index, System.DateTime requestTime) -> void
 NuGet.Protocol.ServiceIndexResourceV3Provider
 NuGet.Protocol.ServiceIndexResourceV3Provider.MaxCacheDuration.get -> System.TimeSpan
 NuGet.Protocol.ServiceIndexResourceV3Provider.MaxCacheDuration.set -> void
 NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo
 NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.CachedTime.get -> System.DateTime
 NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.CachedTime.set -> void
-~NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.Index.get -> NuGet.Protocol.ServiceIndexResourceV3
-~NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.Index.set -> void
+NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.Index.get -> NuGet.Protocol.ServiceIndexResourceV3?
+NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.Index.set -> void
 NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexCacheInfo.ServiceIndexCacheInfo() -> void
 NuGet.Protocol.ServiceIndexResourceV3Provider.ServiceIndexResourceV3Provider() -> void
 NuGet.Protocol.ServiceTypes
@@ -1850,7 +1850,7 @@ override NuGet.Protocol.ProxyAuthenticationHandler.SendAsync(System.Net.Http.Htt
 ~override NuGet.Protocol.RemoteV3FindPackageByIdResource.GetPackageDownloaderAsync(NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.IPackageDownloader>
 ~override NuGet.Protocol.RemoteV3FindPackageByIdResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository sourceRepository, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.ReportAbuseResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.RepositorySignatureResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.RepositorySignatureResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.SafeBoolConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.SafeBoolConverter.CanRead.get -> bool
 override NuGet.Protocol.SafeBoolConverter.CanWrite.get -> bool
@@ -1865,7 +1865,7 @@ override NuGet.Protocol.SemanticVersionConverter.CanConvert(System.Type! objectT
 override NuGet.Protocol.SemanticVersionConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.SemanticVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 override NuGet.Protocol.ServerWarningLogHandler.SendAsync(System.Net.Http.HttpRequestMessage! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
-~override NuGet.Protocol.ServiceIndexResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.ServiceIndexResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 ~override NuGet.Protocol.SymbolPackageUpdateResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.V2FeedListResource.ListAsync(string searchTerm, bool prerelease, bool allVersions, bool includeDelisted, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Common.IEnumerableAsync<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
 ~override NuGet.Protocol.V2FeedListResource.Source.get -> string
@@ -2116,11 +2116,11 @@ virtual NuGet.Protocol.Plugins.Receiver.Close() -> void
 ~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(NuGet.Packaging.Core.PackageIdentity package) -> System.Uri
 ~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string id, NuGet.Versioning.NuGetVersion version) -> System.Uri
 ~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string packageId) -> System.Uri
-~virtual NuGet.Protocol.ServiceIndexResourceV3.Entries.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry>
-~virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(NuGet.Versioning.NuGetVersion clientVersion, params string[] orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry>
-~virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(params string[] orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry>
-~virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUri(params string[] orderedTypes) -> System.Uri
-~virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUris(NuGet.Versioning.NuGetVersion clientVersion, params string[] orderedTypes) -> System.Collections.Generic.IReadOnlyList<System.Uri>
-~virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUris(params string[] orderedTypes) -> System.Collections.Generic.IReadOnlyList<System.Uri>
-~virtual NuGet.Protocol.ServiceIndexResourceV3.Json.get -> string
+virtual NuGet.Protocol.ServiceIndexResourceV3.Entries.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!
+virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(NuGet.Versioning.NuGetVersion! clientVersion, params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!
+virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!
+virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUri(params string![]! orderedTypes) -> System.Uri?
+virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUris(NuGet.Versioning.NuGetVersion! clientVersion, params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<System.Uri!>!
+virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntryUris(params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<System.Uri!>!
+virtual NuGet.Protocol.ServiceIndexResourceV3.Json.get -> string!
 virtual NuGet.Protocol.ServiceIndexResourceV3.RequestTime.get -> System.DateTime

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RepositorySignatureResource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 #if NET5_0_OR_GREATER
@@ -38,12 +36,12 @@ namespace NuGet.Protocol
                 throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToParseRepoSignInfor, JsonProperties.SigningCertificates, source.PackageSource.Source));
 
             AllRepositorySigned = allRepositorySigned;
-            RepositoryCertificateInfos = data.OfType<JObject>().Select(p => p.FromJToken<RepositoryCertificateInfo>());
+            RepositoryCertificateInfos = data.OfType<JObject>().Select(p => p.FromJToken<RepositoryCertificateInfo>()!);
 
             foreach (var repositoryCertificateInfo in RepositoryCertificateInfos)
             {
-                var validUri = Uri.TryCreate(repositoryCertificateInfo.ContentUrl, UriKind.Absolute, out var repositoryContentUrl);
-                if (!validUri || !string.Equals(repositoryContentUrl.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+                if (!Uri.TryCreate(repositoryCertificateInfo.ContentUrl, UriKind.Absolute, out Uri? repositoryContentUrl)
+                    || !string.Equals(repositoryContentUrl.Scheme, "https", StringComparison.OrdinalIgnoreCase))
                 {
                     throw new FatalProtocolException(Strings.RepositoryContentUrlMustBeHttps);
                 }
@@ -54,6 +52,9 @@ namespace NuGet.Protocol
 
         internal RepositorySignatureResource(RepositorySignatureModel model, SourceRepository source)
         {
+            _ = model ?? throw new ArgumentNullException(nameof(model));
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+
             AllRepositorySigned = model.AllRepositorySigned ??
                 throw new FatalProtocolException(string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToParseRepoSignInfor, JsonProperties.AllRepositorySigned, source.PackageSource.Source));
 
@@ -62,7 +63,7 @@ namespace NuGet.Protocol
 
             foreach (RepositoryCertificateInfo cert in certs)
             {
-                if (!Uri.TryCreate(cert.ContentUrl, UriKind.Absolute, out Uri contentUrl)
+                if (!Uri.TryCreate(cert.ContentUrl, UriKind.Absolute, out Uri? contentUrl)
                     || !string.Equals(contentUrl.Scheme, "https", StringComparison.OrdinalIgnoreCase))
                 {
                     throw new FatalProtocolException(Strings.RepositoryContentUrlMustBeHttps);
@@ -78,6 +79,7 @@ namespace NuGet.Protocol
         {
             AllRepositorySigned = allRepositorySigned;
             RepositoryCertificateInfos = repositoryCertInfos;
+            Source = string.Empty;
         }
 
         public void UpdateRepositorySignatureInfo()

--- a/src/NuGet.Core/NuGet.Protocol/Resources/ServiceIndexResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/ServiceIndexResourceV3.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 #if NET5_0_OR_GREATER
@@ -26,8 +24,8 @@ namespace NuGet.Protocol
     /// </summary>
     public class ServiceIndexResourceV3 : INuGetResource
     {
-        private string _json;
-        private readonly ServiceIndexModel _model;
+        private string? _json;
+        private readonly ServiceIndexModel? _model;
         private readonly IDictionary<string, List<ServiceIndexEntry>> _index;
         private readonly DateTime _requestTime;
         private static readonly IReadOnlyList<ServiceIndexEntry> _emptyEntries = new List<ServiceIndexEntry>();
@@ -37,8 +35,9 @@ namespace NuGet.Protocol
         [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
         [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
 #endif
-        internal ServiceIndexResourceV3(JObject index, DateTime requestTime, PackageSource packageSource)
+        internal ServiceIndexResourceV3(JObject index, DateTime requestTime, PackageSource? packageSource)
         {
+            _ = index ?? throw new ArgumentNullException(nameof(index));
             _json = index.ToString();
             _index = MakeLookup(index, packageSource);
             _requestTime = requestTime;
@@ -48,10 +47,11 @@ namespace NuGet.Protocol
         [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
         [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
 #endif
-        public ServiceIndexResourceV3(JObject index, DateTime requestTime) : this(index, requestTime, null) { }
+        public ServiceIndexResourceV3(JObject index, DateTime requestTime) : this(index, requestTime, packageSource: null) { }
 
-        internal ServiceIndexResourceV3(ServiceIndexModel model, DateTime requestTime, PackageSource packageSource)
+        internal ServiceIndexResourceV3(ServiceIndexModel model, DateTime requestTime, PackageSource? packageSource)
         {
+            _ = model ?? throw new ArgumentNullException(nameof(model));
             _model = model;
             _index = MakeLookup(model, packageSource);
             _requestTime = requestTime;
@@ -78,7 +78,7 @@ namespace NuGet.Protocol
 
         public virtual string Json
         {
-            get { return _json ??= JsonSerializer.Serialize(_model, JsonContext.Default.ServiceIndexModel); }
+            get { return _json ??= JsonSerializer.Serialize(_model!, JsonContext.Default.ServiceIndexModel); }
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace NuGet.Protocol
 
             foreach (var type in orderedTypes)
             {
-                List<ServiceIndexEntry> entries;
+                List<ServiceIndexEntry>? entries;
                 if (_index.TryGetValue(type, out entries))
                 {
                     var compatible = GetBestVersionMatchForType(clientVersion, entries);
@@ -137,7 +137,7 @@ namespace NuGet.Protocol
         /// <summary>
         /// Get the best match service URI.
         /// </summary>
-        public virtual Uri GetServiceEntryUri(params string[] orderedTypes)
+        public virtual Uri? GetServiceEntryUri(params string[] orderedTypes)
         {
             var clientVersion = MinClientVersionUtility.GetNuGetClientVersion();
 
@@ -167,8 +167,7 @@ namespace NuGet.Protocol
             return GetServiceEntries(clientVersion, orderedTypes).Select(e => e.Uri).ToList();
         }
 
-#nullable enable
-        private static IDictionary<string, List<ServiceIndexEntry>> MakeLookup(ServiceIndexModel index, PackageSource packageSource)
+        private static IDictionary<string, List<ServiceIndexEntry>> MakeLookup(ServiceIndexModel index, PackageSource? packageSource)
         {
             var result = new Dictionary<string, List<ServiceIndexEntry>>(StringComparer.Ordinal);
 
@@ -233,20 +232,18 @@ namespace NuGet.Protocol
             return result;
         }
 
-#nullable disable
-
-        private static IDictionary<string, List<ServiceIndexEntry>> MakeLookup(JObject index, PackageSource packageSource)
+        private static IDictionary<string, List<ServiceIndexEntry>> MakeLookup(JObject index, PackageSource? packageSource)
         {
             var result = new Dictionary<string, List<ServiceIndexEntry>>(StringComparer.Ordinal);
 
-            JToken resources;
+            JToken? resources;
             if (index.TryGetValue("resources", out resources))
             {
                 foreach (var resource in resources)
                 {
                     var id = GetValues(resource["@id"]).SingleOrDefault();
 
-                    Uri uri;
+                    Uri? uri;
                     if (string.IsNullOrEmpty(id) || !Uri.TryCreate(id, UriKind.Absolute, out uri))
                     {
                         // Skip invalid or missing @ids
@@ -274,7 +271,7 @@ namespace NuGet.Protocol
                         // Parse supported versions
                         foreach (var versionString in GetValues(clientVersionToken))
                         {
-                            SemanticVersion version;
+                            SemanticVersion? version;
                             if (SemanticVersion.TryParse(versionString, out version))
                             {
                                 clientVersions.Add(version);
@@ -287,7 +284,7 @@ namespace NuGet.Protocol
                     {
                         foreach (var version in clientVersions)
                         {
-                            List<ServiceIndexEntry> entries;
+                            List<ServiceIndexEntry>? entries;
                             if (!result.TryGetValue(type, out entries))
                             {
                                 entries = new List<ServiceIndexEntry>();
@@ -317,7 +314,7 @@ namespace NuGet.Protocol
         [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Only called from JObject constructor which is annotated with [RUC]/[RDC].")]
         [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Only called from JObject constructor which is annotated with [RUC]/[RDC].")]
 #endif
-        private static IEnumerable<string> GetValues(JToken token)
+        private static IEnumerable<string> GetValues(JToken? token)
         {
             if (token?.Type == JTokenType.Array)
             {
@@ -325,13 +322,13 @@ namespace NuGet.Protocol
                 {
                     if (entry.Type == JTokenType.String)
                     {
-                        yield return entry.ToObject<string>();
+                        yield return entry.ToObject<string>()!;
                     }
                 }
             }
             else if (token?.Type == JTokenType.String)
             {
-                yield return token.ToObject<string>();
+                yield return token.ToObject<string>()!;
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/VulnerabilityInfoResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/VulnerabilityInfoResourceV3.cs
@@ -73,7 +73,8 @@ namespace NuGet.Protocol.Resources
             {
                 ServiceIndexResourceV3 serviceIndex = await _sourceRepository.GetResourceAsync<ServiceIndexResourceV3>(cancellationToken)
                     ?? throw new InvalidOperationException($"The source '{_sourceRepository.PackageSource.Source}' does not provide {nameof(ServiceIndexResourceV3)}.");
-                return serviceIndex.GetServiceEntryUri(ServiceTypes.VulnerabilityInfo);
+                return serviceIndex.GetServiceEntryUri(ServiceTypes.VulnerabilityInfo)
+                    ?? throw new InvalidOperationException($"The source '{_sourceRepository.PackageSource.Source}' does not provide {nameof(ServiceTypes.VulnerabilityInfo)}.");
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/MockServiceIndexResourceV3Provider.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/MockServiceIndexResourceV3Provider.cs
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Tests.Providers
                     new JProperty("comment", "http://www.w3.org/2000/01/rdf-schema#comment")));
 
             var serviceIndexResource = new ServiceIndexResourceV3(index, DateTime.UtcNow);
-            var tryCreateResult = new Tuple<bool, INuGetResource>(true, serviceIndexResource);
+            var tryCreateResult = new Tuple<bool, INuGetResource?>(true, serviceIndexResource);
 
             provider.Setup(x => x.TryCreate(It.IsAny<SourceRepository>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(tryCreateResult));

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/PackageDetailsUriResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/PackageDetailsUriResourceV3ProviderTests.cs
@@ -117,7 +117,7 @@ namespace NuGet.Protocol.Providers.Tests
                     new JProperty("comment", "http://www.w3.org/2000/01/rdf-schema#comment")));
 
             var serviceIndexResource = new ServiceIndexResourceV3(index, DateTime.UtcNow);
-            var tryCreateResult = new Tuple<bool, INuGetResource>(true, serviceIndexResource);
+            var tryCreateResult = new Tuple<bool, INuGetResource?>(true, serviceIndexResource);
 
             provider.Setup(x => x.TryCreate(It.IsAny<SourceRepository>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(tryCreateResult));

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReportAbuseResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReportAbuseResourceV3ProviderTests.cs
@@ -118,7 +118,7 @@ namespace NuGet.Protocol.Tests.Providers
                     new JProperty("comment", "http://www.w3.org/2000/01/rdf-schema#comment")));
 
             var serviceIndexResource = new ServiceIndexResourceV3(index, DateTime.UtcNow);
-            var tryCreateResult = new Tuple<bool, INuGetResource>(true, serviceIndexResource);
+            var tryCreateResult = new Tuple<bool, INuGetResource?>(true, serviceIndexResource);
 
             provider.Setup(x => x.TryCreate(It.IsAny<SourceRepository>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(tryCreateResult));


### PR DESCRIPTION
# Bug

Progress: https://github.com/NuGet/Home/issues/14851

## Description

Enable nullable annotations for NuGet.Protocol Phase 15 (Service index / repository signature resources) and Phase 16 (Search model leaves — registration types + vulnerability metadata).

### Files annotated (removed `#nullable disable`):

**Phase 15 — Public resource types + providers:**
- `ServiceIndexResourceV3.cs` — service index resource with JObject and STJ code paths
- `ServiceIndexResourceV3Provider.cs` — caching provider with retry logic
- `RepositorySignatureResource.cs` — repository signing resource
- `RepositorySignatureResourceProvider.cs` — provider with dual STJ/NSJ deserialization

**Phase 16 — Internal registration DTOs + public vulnerability metadata:**
- `RegistrationIndex.cs`, `RegistrationPage.cs`, `RegistrationLeafItem.cs` — internal JSON DTOs
- `PackageVulnerabilityMetadata.cs` — public vulnerability model

### Key decisions:

1. **`GetServiceEntryUri` returns `Uri?`** — `FirstOrDefault()` can genuinely return null when no matching service type is registered. Callers that need non-null use `?? throw`.

2. **`httpSourceResource` null checks with `InvalidOperationException`** — Instead of suppressing with `!`, both providers now throw explicitly if `GetResourceAsync<HttpSourceResource>()` returns null. This is a coding error (misconfigured source), not a user error, so inline interpolated strings are used (same pattern as `VulnerabilityInfoResourceV3`). No shared resx string needed.

3. **`RepositorySignatureResourceProvider` deserialization null checks** — `JsonSerializer.DeserializeAsync` returns `T?`. Instead of `model!`, we use `?? throw new FatalProtocolException(...)` to give a clear error at the deserialization boundary rather than an NRE later.

4. **`RegistrationPage` properties (`Url`, `Lower`, `Upper`) annotated non-null** — The [protocol spec](https://learn.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-page) guarantees these. Existing code already uses them without null checks (`NuGetVersion.Parse(page.Lower)`). `Items` stays nullable per its documented semantics. `NULL_INC` comment added to document the `= null!` initializers.

5. **`PackageVulnerabilityMetadata.AdvisoryUrl` annotated non-null** — The [protocol spec](https://learn.microsoft.com/en-us/nuget/api/registration-base-url-resource#vulnerabilities) guarantees `advisoryUrl` is always present. Using `= null!` with a doc comment linking to the spec. This avoids forcing callers to add unnecessary `!` or null checks.

6. **`RepositorySignatureResource` internal ctor** — Added `_ = model ?? throw` and `_ = source ?? throw` guard clauses. Without annotation, callers would NRE on `model.AllRepositorySigned` with no useful diagnostics. Explicit throws give clear failure messages.

7. **`ServiceIndexResourceV3` ctors** — Same pattern: `_ = index ?? throw` and `_ = model ?? throw` since the public ctor delegates to internal and external callers could pass null.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
