### PR TITLE
Pin MessagePack package version to fix restore audit warning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -109,7 +109,7 @@
     Once the packages depending on these packages are upgraded, these PackageVersions can be removed.
   -->
   <ItemGroup>
-    <PackageVersion Include="MessagePack" Version="2.5.301" />
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.7.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -109,6 +109,7 @@
     Once the packages depending on these packages are upgraded, these PackageVersions can be removed.
   -->
   <ItemGroup>
+    <PackageVersion Include="MessagePack" Version="2.5.301" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.7.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
   </ItemGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGet.VisualStudio.Contracts.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Contracts/NuGet.VisualStudio.Contracts.csproj
@@ -22,6 +22,8 @@
       These packages are dependencies of directly referenced PackageReferences.
       When the above PackageReferences are upgraded to newer versions, try deleting the below PackageReferences
       -->
+    <!-- Microsoft.ServiceHub.Framework has a dependency on a vulnerable version of MessagePack. Once it no longer has a transitive dependency on a vulnerable version, this can be removed -->
+    <PackageReference Include="MessagePack" />
     <!-- We do this to avoid the warning our build raises about keeping a consistent newtonsoft.json version. We don't need newtonsonft.json type in here, we don't use it. -->
     <PackageReference Include="Newtonsoft.Json" PrivateAssets="all" ExcludeAssets="all" />
   </ItemGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGet.VisualStudio.Internal.Contracts.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/NuGet.VisualStudio.Internal.Contracts.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Sdk" />
+    <!-- Microsoft.VisualStudio.Sdk has a dependency on a vulnerable version of MessagePack. Once it no longer has a transitive dependency on a vulnerable version, this can be removed -->
+    <PackageReference Include="MessagePack" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Styles" />
+    <!-- Microsoft.VisualStudio.Shell.15.0 has a dependency on a vulnerable version of MessagePack. Once it no longer has a transitive dependency on a vulnerable version, this can be removed -->
+    <PackageReference Include="MessagePack" />
     <PackageReference Include="Newtonsoft.Json" ExcludeAssets="all" />
   </ItemGroup>
 

--- a/test/NuGet.Tests.Apex/NuGet.OptProf/NuGet.OptProf.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.OptProf/NuGet.OptProf.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" ExcludeAssets="Compile" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualStudio.Sdk" />
+    <!-- Microsoft.VisualStudio.Sdk has a dependency on a vulnerable version of MessagePack. Once it no longer has a transitive dependency on a vulnerable version, this can be removed -->
+    <PackageReference Include="MessagePack" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: Engineering

## Description
Restore in my local machine is failing with the below warnings. Pinned the package reference MessagePack version to `2.5.302` as per the guidance in the advisory.

> warning NU1903: Package 'MessagePack' 2.5.198 has a known high severity vulnerability, https://github.com/advisories/GHSA-hv8m-jj95-wg3x

## PR Checklist

- ~[ ] Meaningful title, helpful description and a linked NuGet/Home issue~
- ~[ ] Added tests~
- ~[ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
