### PR TITLE
Stop using consumption

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,7 +60,7 @@
     <PackageVersion Include="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
     <!-- Microsoft.TeamFoundationServer.ExtendedClient has vulnerable dependencies Microsoft.IdentityModel.JsonWebTokens and System.IdentityModel.Tokens.Jwt . When it's upgraded, try removing the pinned packages -->
     <PackageVersion Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="16.153.0" />
-    <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="18.0.0-preview-1-10723-180" />
+    <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="18.0.0-preview-1-10827-020" />
     <PackageVersion Include="Microsoft.TestPlatform.Portable" Version="17.1.0" />
     <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost" Version="18.8.850" />
     <PackageVersion Include="Microsoft.VisualStudio.Copilot" Version="18.0.848-alpha" />
@@ -99,7 +99,7 @@
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-    <PackageVersion Include="VsWebSite.Interop" Version="17.10.40173" />
+    <PackageVersion Include="VsWebSite.Interop" Version="17.10.40459" />
     <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Xunit.StaFact" Version="1.1.11" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -90,13 +90,8 @@
       <package pattern="Microsoft.VSSDK.*" />
     </packageSource>
     <packageSource key="vssdk">
-      <package pattern="envdte" />
-      <package pattern="envdte100" />
-      <package pattern="envdte80" />
-      <package pattern="envdte90" />
-      <package pattern="envdte90a" />
+      <package pattern="envdte*" />
       <package pattern="Microsoft.Build.Framework" />
-      <package pattern="Microsoft.DataAI.NuGetRecommender.Contracts" />
       <package pattern="Microsoft.Internal.VisualStudio.*" />
       <package pattern="Microsoft.NET.StringTools" />
       <package pattern="microsoft.servicehub.*" />
@@ -104,17 +99,7 @@
       <package pattern="Microsoft.VSSDK.*" />
       <package pattern="stdole" />
       <package pattern="streamjsonrpc" />
-      <package pattern="vslangproj" />
-      <package pattern="vslangproj100" />
-      <package pattern="vslangproj110" />
-      <package pattern="vslangproj140" />
-      <package pattern="vslangproj150" />
-      <package pattern="vslangproj157" />
-      <package pattern="vslangproj158" />
-      <package pattern="vslangproj165" />
-      <package pattern="vslangproj2" />
-      <package pattern="vslangproj80" />
-      <package pattern="vslangproj90" />
+      <package pattern="vslangproj*" />
       <package pattern="vswebsite.interop" />
     </packageSource>
     <packageSource key="vssdk-archived">

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -82,36 +82,12 @@
       <package pattern="nuget.client.endtoend.testdata" />
       <package pattern="nugetvalidator" />
     </packageSource>
-    <!-- It is not always easiest to figure out which packages come from vs-impl and which packages come from vssdk, so for simplicity we can duplicate the mappings.
-    There are redundant mappings this way, but probably easier to maintain this way. -->
     <packageSource key="vs-impl">
-      <package pattern="envdte" />
-      <package pattern="envdte100" />
-      <package pattern="envdte80" />
-      <package pattern="envdte90" />
-      <package pattern="envdte90a" />
-      <package pattern="Microsoft.Build.Framework" />
-      <package pattern="Microsoft.DataAI.NuGetRecommender.Contracts" />
       <package pattern="Microsoft.Internal.VisualStudio.*" />
-      <package pattern="Microsoft.NET.StringTools" />
       <package pattern="microsoft.servicehub.*" />
-      <package pattern="Microsoft.TeamFoundationServer.ExtendedClient" />
       <package pattern="microsoft.test.apex.visualstudio" />
       <package pattern="Microsoft.VisualStudio.*" />
       <package pattern="Microsoft.VSSDK.*" />
-      <package pattern="stdole" />
-      <package pattern="streamjsonrpc" />
-      <package pattern="vslangproj" />
-      <package pattern="vslangproj100" />
-      <package pattern="vslangproj110" />
-      <package pattern="vslangproj140" />
-      <package pattern="vslangproj150" />
-      <package pattern="vslangproj157" />
-      <package pattern="vslangproj158" />
-      <package pattern="vslangproj165" />
-      <package pattern="vslangproj2" />
-      <package pattern="vslangproj80" />
-      <package pattern="vslangproj90" />
     </packageSource>
     <packageSource key="vssdk">
       <package pattern="envdte" />
@@ -124,8 +100,6 @@
       <package pattern="Microsoft.Internal.VisualStudio.*" />
       <package pattern="Microsoft.NET.StringTools" />
       <package pattern="microsoft.servicehub.*" />
-      <package pattern="Microsoft.TeamFoundationServer.ExtendedClient" />
-      <package pattern="microsoft.test.apex.visualstudio" />
       <package pattern="Microsoft.VisualStudio.*" />
       <package pattern="Microsoft.VSSDK.*" />
       <package pattern="stdole" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,7 +6,10 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
-    <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption%40Local/nuget/v3/index.json" />
+    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vssdk-archived" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk-archived/nuget/v3/index.json" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+    <add key="vs-impl-archived" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl-archived/nuget/v3/index.json" />
   </packageSources>
   <auditSources>
     <clear />
@@ -38,6 +41,7 @@
       <package pattern="Microsoft.*" />
       <package pattern="Microsoft.Build.Framework" />
       <package pattern="Microsoft.NET.StringTools" />
+      <package pattern="Microsoft.VisualStudioEng.MicroBuild.Core" />      
       <package pattern="Microsoft.VisualStudio.TemplateWizardInterface" />
       <package pattern="moq" />
       <package pattern="MSTest.TestAdapter" />
@@ -59,6 +63,17 @@
       <package pattern="xunit.*" />
       <package pattern="xunitxml.testlogger" />
       <package pattern="Microsoft.DotNet.PlatformAbstractions" />
+      <package pattern="Microsoft.VisualStudio.SDK.EmbedInteropTypes" />
+      <package pattern="Microsoft.DataAI.NuGetRecommender.Contracts" />
+      <package pattern="Microsoft.TeamFoundationServer.ExtendedClient" />
+      <package pattern="Microsoft.VisualStudio.TaskRunnerExplorer.14.0" />
+      <package pattern="Microsoft.VisualStudio.Web.BrowserLink.12.0" />
+      <package pattern="Microsoft.VisualStudio.LanguageServices" />
+      <package pattern="Microsoft.VisualStudio.Services.Client" />
+      <package pattern="Microsoft.VisualStudio.Services.InteractiveClient" />
+      <package pattern="Microsoft.VsSDK.CompatibilityAnalyzer" /> <!-- This is odd one. This version exists on nuget.org, but not in the vssdk feed. It is very likely we need to change this one at some point. Microsoft.VSSDK.BuildTools Microsoft.VSSDK.BuildTools 17.4.2116 needs to be updated -->
+      <package pattern="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" />
+      <package pattern="Microsoft.VisualStudio.Sdk.TestFramework" />
     </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="Microsoft.DotNet.*" />
@@ -67,7 +82,9 @@
       <package pattern="nuget.client.endtoend.testdata" />
       <package pattern="nugetvalidator" />
     </packageSource>
-    <packageSource key="vside">
+    <!-- It is not always easiest to figure out which packages come from vs-impl and which packages come from vssdk, so for simplicity we can duplicate the mappings.
+    There are redundant mappings this way, but probably easier to maintain this way. -->
+    <packageSource key="vs-impl">
       <package pattern="envdte" />
       <package pattern="envdte100" />
       <package pattern="envdte80" />
@@ -75,15 +92,41 @@
       <package pattern="envdte90a" />
       <package pattern="Microsoft.Build.Framework" />
       <package pattern="Microsoft.DataAI.NuGetRecommender.Contracts" />
-      <package pattern="microsoft.internal.visualstudio.*" />
-      <package pattern="Microsoft.Internal.VisualStudio.Shell.Framework" />
+      <package pattern="Microsoft.Internal.VisualStudio.*" />
       <package pattern="Microsoft.NET.StringTools" />
       <package pattern="microsoft.servicehub.*" />
-      <package pattern="Microsoft.ServiceHub.Framework" />
       <package pattern="Microsoft.TeamFoundationServer.ExtendedClient" />
       <package pattern="microsoft.test.apex.visualstudio" />
       <package pattern="Microsoft.VisualStudio.*" />
-      <package pattern="Microsoft.VisualStudioEng.MicroBuild.Core" />
+      <package pattern="Microsoft.VSSDK.*" />
+      <package pattern="stdole" />
+      <package pattern="streamjsonrpc" />
+      <package pattern="vslangproj" />
+      <package pattern="vslangproj100" />
+      <package pattern="vslangproj110" />
+      <package pattern="vslangproj140" />
+      <package pattern="vslangproj150" />
+      <package pattern="vslangproj157" />
+      <package pattern="vslangproj158" />
+      <package pattern="vslangproj165" />
+      <package pattern="vslangproj2" />
+      <package pattern="vslangproj80" />
+      <package pattern="vslangproj90" />
+    </packageSource>
+    <packageSource key="vssdk">
+      <package pattern="envdte" />
+      <package pattern="envdte100" />
+      <package pattern="envdte80" />
+      <package pattern="envdte90" />
+      <package pattern="envdte90a" />
+      <package pattern="Microsoft.Build.Framework" />
+      <package pattern="Microsoft.DataAI.NuGetRecommender.Contracts" />
+      <package pattern="Microsoft.Internal.VisualStudio.*" />
+      <package pattern="Microsoft.NET.StringTools" />
+      <package pattern="microsoft.servicehub.*" />
+      <package pattern="Microsoft.TeamFoundationServer.ExtendedClient" />
+      <package pattern="microsoft.test.apex.visualstudio" />
+      <package pattern="Microsoft.VisualStudio.*" />
       <package pattern="Microsoft.VSSDK.*" />
       <package pattern="stdole" />
       <package pattern="streamjsonrpc" />
@@ -99,6 +142,16 @@
       <package pattern="vslangproj80" />
       <package pattern="vslangproj90" />
       <package pattern="vswebsite.interop" />
+    </packageSource>
+    <packageSource key="vssdk-archived">
+      <package pattern="Microsoft.VisualStudio.*" />
+      <package pattern="Microsoft.VSSDK.*" />
+      <package pattern="Microsoft.Internal.VisualStudio.*" />
+    </packageSource>
+    <packageSource key="vs-impl-archived">
+      <package pattern="Microsoft.VisualStudio.*" />
+      <package pattern="Microsoft.VSSDK.*" />
+      <package pattern="Microsoft.Internal.VisualStudio.*" />
     </packageSource>
     <packageSource key="VS">
       <package pattern="Microsoft.DevDiv.Validation.TestPlatform.Settings.Tasks" />


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/nuget/client.engineering/issues/2877

## Description

Follow up to the challenges in https://github.com/NuGet/NuGet.Client/pull/7036. 
The consumption feed needs to be managed to bring in new packages and for that reason we have been using the local view of it.  
What this means is we don't see new packages coming in.

The better solution and what other public products like roslyn are doing is referencing the vs-impl and vssdk feeds: https://github.com/dotnet/roslyn/blob/main/NuGet.config. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
