### PR TITLE
Remove suppression and Fix trim warnings

### DIFF
--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
@@ -5,9 +5,6 @@
 
 using System;
 using System.Diagnostics;
-#if NET5_0_OR_GREATER
-using System.Diagnostics.CodeAnalysis;
-#endif
 using System.Globalization;
 using System.Linq;
 using System.Net;

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
@@ -14,7 +14,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NuGet.Common;
 using NuGet.Configuration;
 
@@ -216,8 +216,10 @@ namespace NuGet.Credentials
             try
             {
                 // Mono will add utf-16 byte order mark to the start of stdOut, remove it here.
-                credentialResponse =
-                    JsonConvert.DeserializeObject<PluginCredentialResponse>(stdOut.Trim(new char[] { '\uFEFF' }))
+                var trimmedOutput = stdOut.Trim(new char[] { '\uFEFF' });
+                credentialResponse = string.IsNullOrWhiteSpace(trimmedOutput)
+                    ? new PluginCredentialResponse()
+                    : JsonSerializer.Deserialize(trimmedOutput, PluginCredentialResponseJsonContext.Default.PluginCredentialResponse)
                     ?? new PluginCredentialResponse();
             }
             catch (Exception)

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialProvider.cs
@@ -173,10 +173,6 @@ namespace NuGet.Credentials
         /// </summary>
         public int TimeoutSeconds { get; }
 
-#if NET5_0_OR_GREATER
-        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Legacy command-line credential provider infrastructure; Newtonsoft.Json deserializes the concrete PluginCredentialResponse type, which is preserved here.")]
-        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Legacy command-line credential provider infrastructure; Newtonsoft.Json deserializes the concrete PluginCredentialResponse type, which is preserved here.")]
-#endif
         private PluginCredentialResponse GetPluginResponse(PluginCredentialRequest request,
             CancellationToken cancellationToken)
         {

--- a/src/NuGet.Core/NuGet.Credentials/PluginCredentialResponseJsonContext.cs
+++ b/src/NuGet.Core/NuGet.Credentials/PluginCredentialResponseJsonContext.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace NuGet.Credentials
+{
+    [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+    [JsonSerializable(typeof(PluginCredentialResponse))]
+    internal partial class PluginCredentialResponseJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Credentials.Test/PluginCredentialResponseDeserializationTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Credentials.Test/PluginCredentialResponseDeserializationTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using Newtonsoft.Json;
 using Xunit;
 
@@ -10,17 +8,17 @@ namespace NuGet.Credentials.Test
 {
     public class PluginCredentialResponseDeserializationTests
     {
-        private static PluginCredentialResponse DeserializeWithStj(string json)
+        private static PluginCredentialResponse? DeserializeWithStj(string json)
         {
             return System.Text.Json.JsonSerializer.Deserialize(json, PluginCredentialResponseJsonContext.Default.PluginCredentialResponse);
         }
 
-        private static PluginCredentialResponse DeserializeWithNsj(string json)
+        private static PluginCredentialResponse? DeserializeWithNsj(string json)
         {
             return JsonConvert.DeserializeObject<PluginCredentialResponse>(json);
         }
 
-        private static void AssertResponsesEqual(PluginCredentialResponse nsj, PluginCredentialResponse stj)
+        private static void AssertResponsesEqual(PluginCredentialResponse? nsj, PluginCredentialResponse? stj)
         {
             Assert.Equal(nsj?.Username, stj?.Username);
             Assert.Equal(nsj?.Password, stj?.Password);
@@ -49,8 +47,8 @@ namespace NuGet.Credentials.Test
         [InlineData(@"{""Username"":""u"",""Password"":""p"",""AuthTypes"":[""basic"",""digest"",""negotiate"",""ntlm""]}")]
         public void StjAndNsjProduceSameResult(string json)
         {
-            var nsjResult = DeserializeWithNsj(json);
-            var stjResult = DeserializeWithStj(json);
+            PluginCredentialResponse? nsjResult = DeserializeWithNsj(json);
+            PluginCredentialResponse? stjResult = DeserializeWithStj(json);
 
             AssertResponsesEqual(nsjResult, stjResult);
         }
@@ -59,8 +57,8 @@ namespace NuGet.Credentials.Test
         [InlineData("null")]
         public void StjAndNsjBothReturnNull(string json)
         {
-            var nsjResult = DeserializeWithNsj(json);
-            var stjResult = DeserializeWithStj(json);
+            PluginCredentialResponse? nsjResult = DeserializeWithNsj(json);
+            PluginCredentialResponse? stjResult = DeserializeWithStj(json);
 
             Assert.Null(nsjResult);
             Assert.Null(stjResult);

--- a/test/NuGet.Core.Tests/NuGet.Credentials.Test/PluginCredentialResponseDeserializationTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Credentials.Test/PluginCredentialResponseDeserializationTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable disable
+
+using Newtonsoft.Json;
+using Xunit;
+
+namespace NuGet.Credentials.Test
+{
+    public class PluginCredentialResponseDeserializationTests
+    {
+        private static PluginCredentialResponse DeserializeWithStj(string json)
+        {
+            return System.Text.Json.JsonSerializer.Deserialize(json, PluginCredentialResponseJsonContext.Default.PluginCredentialResponse);
+        }
+
+        private static PluginCredentialResponse DeserializeWithNsj(string json)
+        {
+            return JsonConvert.DeserializeObject<PluginCredentialResponse>(json);
+        }
+
+        private static void AssertResponsesEqual(PluginCredentialResponse nsj, PluginCredentialResponse stj)
+        {
+            Assert.Equal(nsj?.Username, stj?.Username);
+            Assert.Equal(nsj?.Password, stj?.Password);
+            Assert.Equal(nsj?.Message, stj?.Message);
+            Assert.Equal(nsj?.AuthTypes, stj?.AuthTypes);
+            Assert.Equal(nsj?.IsValid, stj?.IsValid);
+        }
+
+        [Theory]
+        [InlineData(@"{""Username"":""user"",""Password"":""pass"",""Message"":""msg"",""AuthTypes"":[""basic"",""digest""]}")]
+        [InlineData(@"{""username"":""u"",""password"":""p"",""message"":""m"",""authTypes"":[""basic""]}")]
+        [InlineData(@"{""USERNAME"":""u"",""PassWord"":""p""}")]
+        [InlineData(@"{""Username"":""u""}")]
+        [InlineData(@"{}")]
+        [InlineData(@"{""Username"":null,""Password"":null,""AuthTypes"":null}")]
+        [InlineData(@"{""Username"":""u"",""Password"":""p"",""AuthTypes"":[]}")]
+        [InlineData(@"{""Username"":""u"",""Password"":""p"",""ExtraProp"":""val"",""Another"":123}")]
+        [InlineData(@"{""Username"":"""",""Password"":"""",""Message"":""""}")]
+        [InlineData(@"{""Username"":"" user "",""Password"":"" pass ""}")]
+        [InlineData(@"{""Username"":""\u0041\u0042"",""Password"":""\u00e9""}")]
+        [InlineData(@"{""Username"":""user"",""Password"":""p@$$w0rd!#%&*""}")]
+        [InlineData(@"{""Username"":""u"",""Password"":""p"",""Message"":""""}")]
+        [InlineData(@"   {""Username"":""u"",""Password"":""p""}   ")]
+        [InlineData(@"{""Message"":""Extra message.""}")]
+        [InlineData(@"{""username"":""u"", ""password"":""p"", ""Message"":""""}")]
+        [InlineData(@"{""Username"":""u"",""Password"":""p"",""AuthTypes"":[""basic"",""digest"",""negotiate"",""ntlm""]}")]
+        public void StjAndNsjProduceSameResult(string json)
+        {
+            var nsjResult = DeserializeWithNsj(json);
+            var stjResult = DeserializeWithStj(json);
+
+            AssertResponsesEqual(nsjResult, stjResult);
+        }
+
+        [Theory]
+        [InlineData("null")]
+        public void StjAndNsjBothReturnNull(string json)
+        {
+            var nsjResult = DeserializeWithNsj(json);
+            var stjResult = DeserializeWithStj(json);
+
+            Assert.Null(nsjResult);
+            Assert.Null(stjResult);
+        }
+
+        [Theory]
+        [InlineData("not json")]
+        [InlineData("{invalid}")]
+        public void StjAndNsjBothThrowOnInvalidJson(string json)
+        {
+            Assert.ThrowsAny<JsonReaderException>(() => DeserializeWithNsj(json));
+            Assert.ThrowsAny<System.Text.Json.JsonException>(() => DeserializeWithStj(json));
+        }
+
+        [Fact]
+        public void StjAndNsjBothThrowOnJsonArrayInput()
+        {
+            var json = "[1,2,3]";
+
+            Assert.ThrowsAny<JsonSerializationException>(() => DeserializeWithNsj(json));
+            Assert.ThrowsAny<System.Text.Json.JsonException>(() => DeserializeWithStj(json));
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/NuGet.Client/pull/7453#discussion_r3430123286

## Description

The `Newtonsoft.Json` version upgrade exposed `IL2026/IL3050` trimming/AOT warnings because the newer version annotates `JsonConvert.DeserializeObject<T>()` with `[RequiresUnreferencedCode]/[RequiresDynamicCode]`. Rather than cascading these attributes up the entire credential service call chain, this PR replaces the NSJ call in `PluginCredentialProvider` with `System.Text.Json` source-generated deserialization, eliminating the warnings at the source.

Unlike the dual NSJ/STJ code paths behind a feature switch in `NuGet.Protocol`, I don't see a reason to be that careful here `PluginCredentialResponse` is a trivial 4-property POCO with no custom converters or polymorphism, and I've added parity tests that deserialize the same inputs with both NSJ and STJ and assert equal results.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
