### PR TITLE
Enable nullable on local repository types in NuGet.Protocol

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +13,7 @@ namespace NuGet.Protocol
 {
     public abstract class FindLocalPackagesResource : INuGetResource
     {
-        public string Root { get; protected set; }
+        public string Root { get; protected set; } = null!;
 
         public virtual bool Exists(PackageIdentity identity, ILogger logger, CancellationToken token)
         {
@@ -27,9 +25,9 @@ namespace NuGet.Protocol
             return FindPackagesById(packageId, logger, token).Any();
         }
 
-        public abstract LocalPackageInfo GetPackage(Uri path, ILogger logger, CancellationToken token);
+        public abstract LocalPackageInfo? GetPackage(Uri path, ILogger logger, CancellationToken token);
 
-        public abstract LocalPackageInfo GetPackage(PackageIdentity identity, ILogger logger, CancellationToken token);
+        public abstract LocalPackageInfo? GetPackage(PackageIdentity identity, ILogger logger, CancellationToken token);
 
         public abstract IEnumerable<LocalPackageInfo> FindPackagesById(string id, ILogger logger, CancellationToken token);
 

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourcePackagesConfig.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourcePackagesConfig.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -18,7 +16,7 @@ namespace NuGet.Protocol
     {
         public FindLocalPackagesResourcePackagesConfig(string root)
         {
-            Root = root;
+            Root = root ?? throw new ArgumentNullException(nameof(root));
         }
 
         public override IEnumerable<LocalPackageInfo> FindPackagesById(string id, ILogger logger, CancellationToken token)
@@ -29,12 +27,12 @@ namespace NuGet.Protocol
             return LocalFolderUtility.GetDistinctPackages(packages);
         }
 
-        public override LocalPackageInfo GetPackage(Uri path, ILogger logger, CancellationToken token)
+        public override LocalPackageInfo? GetPackage(Uri path, ILogger logger, CancellationToken token)
         {
             return LocalFolderUtility.GetPackage(path, logger);
         }
 
-        public override LocalPackageInfo GetPackage(PackageIdentity identity, ILogger logger, CancellationToken token)
+        public override LocalPackageInfo? GetPackage(PackageIdentity identity, ILogger logger, CancellationToken token)
         {
             return LocalFolderUtility.GetPackagesConfigFolderPackage(Root, identity, logger);
         }

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourcePackagesConfigProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourcePackagesConfigProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,9 +19,9 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            FindLocalPackagesResource curResource = null;
+            FindLocalPackagesResource? curResource = null;
             var feedType = await source.GetFeedType(token);
 
             if (feedType == FeedType.FileSystemPackagesConfig)
@@ -31,7 +29,7 @@ namespace NuGet.Protocol
                 curResource = new FindLocalPackagesResourcePackagesConfig(source.PackageSource.Source);
             }
 
-            return new Tuple<bool, INuGetResource>(curResource != null, curResource);
+            return new Tuple<bool, INuGetResource?>(curResource != null, curResource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceUnzipped.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceUnzipped.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -26,7 +24,7 @@ namespace NuGet.Protocol
 
         public FindLocalPackagesResourceUnzipped(string root)
         {
-            Root = root;
+            Root = root ?? throw new ArgumentNullException(nameof(root));
             _packages = new Lazy<IReadOnlyList<LocalPackageInfo>>(() => GetPackagesCore(root));
             _index = new Lazy<Dictionary<PackageIdentity, LocalPackageInfo>>(() => GetIndex(_packages));
             _pathIndex = new Lazy<Dictionary<Uri, LocalPackageInfo>>(() => GetPathIndex(_packages));
@@ -37,17 +35,15 @@ namespace NuGet.Protocol
             return _packages.Value.Where(package => StringComparer.OrdinalIgnoreCase.Equals(id, package.Identity.Id)).ToArray();
         }
 
-        public override LocalPackageInfo GetPackage(Uri path, ILogger logger, CancellationToken token)
+        public override LocalPackageInfo? GetPackage(Uri path, ILogger logger, CancellationToken token)
         {
-            LocalPackageInfo package;
-            _pathIndex.Value.TryGetValue(path, out package);
+            _pathIndex.Value.TryGetValue(path, out LocalPackageInfo? package);
             return package;
         }
 
-        public override LocalPackageInfo GetPackage(PackageIdentity identity, ILogger logger, CancellationToken token)
+        public override LocalPackageInfo? GetPackage(PackageIdentity identity, ILogger logger, CancellationToken token)
         {
-            LocalPackageInfo package;
-            _index.Value.TryGetValue(identity, out package);
+            _index.Value.TryGetValue(identity, out LocalPackageInfo? package);
             return package;
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceUnzippedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceUnzippedProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -23,9 +21,9 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            FindLocalPackagesResource curResource = null;
+            FindLocalPackagesResource? curResource = null;
 
             if (await source.GetFeedType(token) == FeedType.FileSystemUnzipped)
             {
@@ -33,7 +31,7 @@ namespace NuGet.Protocol
                     (packageSource) => new FindLocalPackagesResourceUnzipped(packageSource.Source));
             }
 
-            return new Tuple<bool, INuGetResource>(curResource != null, curResource);
+            return new Tuple<bool, INuGetResource?>(curResource != null, curResource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceV2.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceV2.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -15,7 +13,7 @@ namespace NuGet.Protocol
     {
         public FindLocalPackagesResourceV2(string root)
         {
-            Root = root;
+            Root = root ?? throw new ArgumentNullException(nameof(root));
         }
 
         public override IEnumerable<LocalPackageInfo> FindPackagesById(string id, ILogger logger, CancellationToken token)
@@ -28,14 +26,14 @@ namespace NuGet.Protocol
             return LocalFolderUtility.GetDistinctPackages(packages);
         }
 
-        public override LocalPackageInfo GetPackage(Uri path, ILogger logger, CancellationToken token)
+        public override LocalPackageInfo? GetPackage(Uri path, ILogger logger, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
             return LocalFolderUtility.GetPackage(path, logger);
         }
 
-        public override LocalPackageInfo GetPackage(PackageIdentity identity, ILogger logger, CancellationToken token)
+        public override LocalPackageInfo? GetPackage(PackageIdentity identity, ILogger logger, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceV2Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceV2Provider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,9 +15,9 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            FindLocalPackagesResource curResource = null;
+            FindLocalPackagesResource? curResource = null;
             var feedType = await source.GetFeedType(token);
 
             if (feedType == FeedType.FileSystemV2
@@ -28,7 +26,7 @@ namespace NuGet.Protocol
                 curResource = new FindLocalPackagesResourceV2(source.PackageSource.Source);
             }
 
-            return new Tuple<bool, INuGetResource>(curResource != null, curResource);
+            return new Tuple<bool, INuGetResource?>(curResource != null, curResource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceV3.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -18,7 +16,7 @@ namespace NuGet.Protocol
     {
         public FindLocalPackagesResourceV3(string root)
         {
-            Root = root;
+            Root = root ?? throw new ArgumentNullException(nameof(root));
         }
 
         public override IEnumerable<LocalPackageInfo> FindPackagesById(string id, ILogger logger, CancellationToken token)
@@ -28,14 +26,14 @@ namespace NuGet.Protocol
             return LocalFolderUtility.GetPackagesV3(Root, id, logger, token);
         }
 
-        public override LocalPackageInfo GetPackage(Uri path, ILogger logger, CancellationToken token)
+        public override LocalPackageInfo? GetPackage(Uri path, ILogger logger, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
             return LocalFolderUtility.GetPackage(path, logger);
         }
 
-        public override LocalPackageInfo GetPackage(PackageIdentity identity, ILogger logger, CancellationToken token)
+        public override LocalPackageInfo? GetPackage(PackageIdentity identity, ILogger logger, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/FindLocalPackagesResourceV3Provider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,16 +15,16 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            FindLocalPackagesResource curResource = null;
+            FindLocalPackagesResource? curResource = null;
 
             if (await source.GetFeedType(token) == FeedType.FileSystemV3)
             {
                 curResource = new FindLocalPackagesResourceV3(source.PackageSource.Source);
             }
 
-            return new Tuple<bool, INuGetResource>(curResource != null, curResource);
+            return new Tuple<bool, INuGetResource?>(curResource != null, curResource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -11,8 +9,8 @@ namespace NuGet.Protocol
 {
     public class LocalPackageInfo
     {
-        private readonly Lazy<NuspecReader> _nuspecHelper;
-        private readonly Func<PackageReaderBase> _getPackageReader;
+        private readonly Lazy<NuspecReader> _nuspecHelper = null!;
+        private readonly Func<PackageReaderBase> _getPackageReader = null!;
 
         /// <summary>
         /// Local nuget package.
@@ -52,7 +50,7 @@ namespace NuGet.Protocol
             {
                 if (useFolder)
                 {
-                    var directoryName = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(Path), System.IO.Path.GetFileNameWithoutExtension(Path));
+                    var directoryName = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(Path)!, System.IO.Path.GetFileNameWithoutExtension(Path));
                     return new PackageFolderReader(directoryName);
                 }
                 else
@@ -62,20 +60,20 @@ namespace NuGet.Protocol
             });
         }
 
+        // Protected ctor for subclass override patterns; virtual members must be overridden.
         protected LocalPackageInfo()
         {
-
         }
 
         /// <summary>
         /// Package id and version.
         /// </summary>
-        public virtual PackageIdentity Identity { get; }
+        public virtual PackageIdentity Identity { get; } = null!;
 
         /// <summary>
         /// Nupkg or folder path.
         /// </summary>
-        public virtual string Path { get; }
+        public virtual string Path { get; } = null!;
 
         /// <summary>
         /// Last file write time. This is used for the publish date.

--- a/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/LocalPackageSearchMetadata.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -27,28 +25,28 @@ namespace NuGet.Protocol
             _nuspec = package.Nuspec;
         }
 
-        public string Authors => _nuspec.GetAuthors();
+        public string? Authors => _nuspec.GetAuthors();
 
         public IEnumerable<PackageDependencyGroup> DependencySets => _nuspec.GetDependencyGroups().ToArray();
 
-        public string Description => _nuspec.GetDescription();
+        public string? Description => _nuspec.GetDescription();
 
         /// <remarks>
         /// Local package sources never provide a download count.
         /// </remarks>
         public long? DownloadCount => null;
 
-        public Uri IconUrl => GetIconUri();
+        public Uri? IconUrl => GetIconUri();
 
-        public string ReadmeFileUrl => GetReadmeUri();
+        public string? ReadmeFileUrl => GetReadmeUri();
 
         public PackageIdentity Identity => _nuspec.GetIdentity();
 
-        public Uri LicenseUrl => Convert(_nuspec.GetLicenseUrl());
+        public Uri? LicenseUrl => Convert(_nuspec.GetLicenseUrl());
 
-        private IReadOnlyList<string> _ownersList;
+        private IReadOnlyList<string>? _ownersList;
 
-        public IReadOnlyList<string> OwnersList
+        public IReadOnlyList<string>? OwnersList
         {
             get
             {
@@ -61,27 +59,27 @@ namespace NuGet.Protocol
             }
         }
 
-        public string Owners => _nuspec.GetOwners();
+        public string? Owners => _nuspec.GetOwners();
 
-        public Uri ProjectUrl => Convert(_nuspec.GetProjectUrl());
+        public Uri? ProjectUrl => Convert(_nuspec.GetProjectUrl());
 
         public DateTimeOffset? Published => _package.LastWriteTimeUtc;
 
         /// <remarks>
         /// There is no readme url for local packages. Later releases may display the readme file in a VS window.
         /// </remarks>
-        public Uri ReadmeUrl => null;
+        public Uri? ReadmeUrl => null;
 
         /// <remarks>
         /// There is no report abuse url for local packages.
         /// </remarks>
-        public Uri ReportAbuseUrl => null;
+        public Uri? ReportAbuseUrl => null;
 
-        public Uri PackageDetailsUrl => null;
+        public Uri? PackageDetailsUrl => null;
 
         public bool RequireLicenseAcceptance => _nuspec.GetRequireLicenseAcceptance();
 
-        public string Summary => !string.IsNullOrEmpty(_nuspec.GetSummary()) ? _nuspec.GetSummary() : Description;
+        public string? Summary => !string.IsNullOrEmpty(_nuspec.GetSummary()) ? _nuspec.GetSummary() : Description;
 
         public string Tags
         {
@@ -92,7 +90,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string Title => !string.IsNullOrEmpty(_nuspec.GetTitle()) ? _nuspec.GetTitle() : _nuspec.GetId();
+        public string Title => !string.IsNullOrEmpty(_nuspec.GetTitle()) ? _nuspec.GetTitle()! : _nuspec.GetId();
 
         /// <summary>
         /// Gets a function that provides <c>PackageReaderBase</c>-like objects, for reading package content
@@ -114,9 +112,9 @@ namespace NuGet.Protocol
         /// <summary>
         /// Convert a string to a URI safely. This will return null if there are errors.
         /// </summary>
-        private static Uri Convert(string uri)
+        private static Uri? Convert(string? uri)
         {
-            Uri fullUri = null;
+            Uri? fullUri = null;
 
             if (!string.IsNullOrEmpty(uri))
             {
@@ -133,13 +131,13 @@ namespace NuGet.Protocol
         /// </remarks>
         public bool PrefixReserved => false;
 
-        public LicenseMetadata LicenseMetadata => _nuspec.GetLicenseMetadata();
+        public LicenseMetadata? LicenseMetadata => _nuspec.GetLicenseMetadata();
 
         /// <inheritdoc cref="IPackageSearchMetadata.GetDeprecationMetadataAsync" />
-        public Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() => TaskResult.Null<PackageDeprecationMetadata>();
+        public Task<PackageDeprecationMetadata?> GetDeprecationMetadataAsync() => TaskResult.Null<PackageDeprecationMetadata>();
 
         /// <inheritdoc cref="IPackageSearchMetadata.Vulnerabilities" />
-        public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities => null;
+        public IEnumerable<PackageVulnerabilityMetadata>? Vulnerabilities => null;
 
         public string PackagePath => _package.Path;
 
@@ -147,7 +145,7 @@ namespace NuGet.Protocol
 
         public string LoadFileAsText(string path)
         {
-            string fileContent = null;
+            string? fileContent = null;
             try
             {
                 if (_package.GetReader() is PackageArchiveReader reader) // This will never be anything else in reality. The search resource always uses a PAR
@@ -191,16 +189,16 @@ namespace NuGet.Protocol
         /// <summary>
         /// Points to an Icon, either Embedded Icon or IconUrl
         /// </summary>
-        private Uri GetIconUri()
+        private Uri? GetIconUri()
         {
-            string embeddedIcon = _nuspec.GetIcon();
+            string? embeddedIcon = _nuspec.GetIcon();
 
             if (embeddedIcon == null)
             {
                 return Convert(_nuspec.GetIconUrl());
             }
 
-            var baseUri = Convert(_package.Path);
+            var baseUri = Convert(_package.Path)!;
 
             UriBuilder builder = new UriBuilder(baseUri)
             {
@@ -211,15 +209,15 @@ namespace NuGet.Protocol
             return builder.Uri;
         }
 
-        private string GetReadmeUri()
+        private string? GetReadmeUri()
         {
-            string embeddedReadme = _nuspec.GetReadme();
+            string? embeddedReadme = _nuspec.GetReadme();
             if (embeddedReadme == null)
             {
                 return null;
             }
 
-            var baseUri = Convert(_package.Path);
+            var baseUri = Convert(_package.Path)!;
             UriBuilder builder = new UriBuilder(baseUri)
             {
                 Fragment = embeddedReadme

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -417,22 +417,22 @@ NuGet.Protocol.FeedTypeResourceProvider.FeedTypeResourceProvider() -> void
 NuGet.Protocol.FeedTypeUtility
 NuGet.Protocol.FindLocalPackagesResource
 NuGet.Protocol.FindLocalPackagesResource.FindLocalPackagesResource() -> void
-~NuGet.Protocol.FindLocalPackagesResource.Root.get -> string
-~NuGet.Protocol.FindLocalPackagesResource.Root.set -> void
+NuGet.Protocol.FindLocalPackagesResource.Root.get -> string!
+NuGet.Protocol.FindLocalPackagesResource.Root.set -> void
 NuGet.Protocol.FindLocalPackagesResourcePackagesConfig
-~NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.FindLocalPackagesResourcePackagesConfig(string root) -> void
+NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.FindLocalPackagesResourcePackagesConfig(string! root) -> void
 NuGet.Protocol.FindLocalPackagesResourcePackagesConfigProvider
 NuGet.Protocol.FindLocalPackagesResourcePackagesConfigProvider.FindLocalPackagesResourcePackagesConfigProvider() -> void
 NuGet.Protocol.FindLocalPackagesResourceUnzipped
-~NuGet.Protocol.FindLocalPackagesResourceUnzipped.FindLocalPackagesResourceUnzipped(string root) -> void
+NuGet.Protocol.FindLocalPackagesResourceUnzipped.FindLocalPackagesResourceUnzipped(string! root) -> void
 NuGet.Protocol.FindLocalPackagesResourceUnzippedProvider
 NuGet.Protocol.FindLocalPackagesResourceUnzippedProvider.FindLocalPackagesResourceUnzippedProvider() -> void
 NuGet.Protocol.FindLocalPackagesResourceV2
-~NuGet.Protocol.FindLocalPackagesResourceV2.FindLocalPackagesResourceV2(string root) -> void
+NuGet.Protocol.FindLocalPackagesResourceV2.FindLocalPackagesResourceV2(string! root) -> void
 NuGet.Protocol.FindLocalPackagesResourceV2Provider
 NuGet.Protocol.FindLocalPackagesResourceV2Provider.FindLocalPackagesResourceV2Provider() -> void
 NuGet.Protocol.FindLocalPackagesResourceV3
-~NuGet.Protocol.FindLocalPackagesResourceV3.FindLocalPackagesResourceV3(string root) -> void
+NuGet.Protocol.FindLocalPackagesResourceV3.FindLocalPackagesResourceV3(string! root) -> void
 NuGet.Protocol.FindLocalPackagesResourceV3Provider
 NuGet.Protocol.FindLocalPackagesResourceV3Provider.FindLocalPackagesResourceV3Provider() -> void
 NuGet.Protocol.FindPackagesByIdNupkgDownloader
@@ -622,7 +622,7 @@ NuGet.Protocol.LocalPackageFileCache.LocalPackageFileCache() -> void
 NuGet.Protocol.LocalPackageFileCache.UpdateLastAccessTime(string! nupkgMetadataPath) -> void
 NuGet.Protocol.LocalPackageInfo
 NuGet.Protocol.LocalPackageInfo.LocalPackageInfo() -> void
-~NuGet.Protocol.LocalPackageInfo.LocalPackageInfo(NuGet.Packaging.Core.PackageIdentity identity, string path, System.DateTime lastWriteTimeUtc, System.Lazy<NuGet.Packaging.NuspecReader> nuspec, bool useFolder) -> void
+NuGet.Protocol.LocalPackageInfo.LocalPackageInfo(NuGet.Packaging.Core.PackageIdentity! identity, string! path, System.DateTime lastWriteTimeUtc, System.Lazy<NuGet.Packaging.NuspecReader!>! nuspec, bool useFolder) -> void
 NuGet.Protocol.LocalPackageListResource
 ~NuGet.Protocol.LocalPackageListResource.LocalPackageListResource(NuGet.Protocol.Core.Types.PackageSearchResource localPackageSearchResource, string baseAddress) -> void
 NuGet.Protocol.LocalPackageMetadataResource
@@ -630,35 +630,35 @@ NuGet.Protocol.LocalPackageMetadataResource
 NuGet.Protocol.LocalPackageMetadataResourceProvider
 NuGet.Protocol.LocalPackageMetadataResourceProvider.LocalPackageMetadataResourceProvider() -> void
 NuGet.Protocol.LocalPackageSearchMetadata
-~NuGet.Protocol.LocalPackageSearchMetadata.Authors.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.LocalPackageSearchMetadata.Description.get -> string
+NuGet.Protocol.LocalPackageSearchMetadata.Authors.get -> string?
+NuGet.Protocol.LocalPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.LocalPackageSearchMetadata.Description.get -> string?
 NuGet.Protocol.LocalPackageSearchMetadata.DownloadCount.get -> long?
-~NuGet.Protocol.LocalPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata>
-~NuGet.Protocol.LocalPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>
-~NuGet.Protocol.LocalPackageSearchMetadata.IconUrl.get -> System.Uri
-~NuGet.Protocol.LocalPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.LocalPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata?>!
+NuGet.Protocol.LocalPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!
+NuGet.Protocol.LocalPackageSearchMetadata.IconUrl.get -> System.Uri?
+NuGet.Protocol.LocalPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
 NuGet.Protocol.LocalPackageSearchMetadata.IsListed.get -> bool
-~NuGet.Protocol.LocalPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata
-~NuGet.Protocol.LocalPackageSearchMetadata.LicenseUrl.get -> System.Uri
-~NuGet.Protocol.LocalPackageSearchMetadata.LoadFileAsText(string path) -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.LocalPackageSearchMetadata(NuGet.Protocol.LocalPackageInfo package) -> void
-~NuGet.Protocol.LocalPackageSearchMetadata.Owners.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.LocalPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri
-~NuGet.Protocol.LocalPackageSearchMetadata.PackagePath.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.PackageReader.get -> System.Func<NuGet.Packaging.PackageReaderBase>
+NuGet.Protocol.LocalPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata?
+NuGet.Protocol.LocalPackageSearchMetadata.LicenseUrl.get -> System.Uri?
+NuGet.Protocol.LocalPackageSearchMetadata.LoadFileAsText(string! path) -> string!
+NuGet.Protocol.LocalPackageSearchMetadata.LocalPackageSearchMetadata(NuGet.Protocol.LocalPackageInfo! package) -> void
+NuGet.Protocol.LocalPackageSearchMetadata.Owners.get -> string?
+NuGet.Protocol.LocalPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.LocalPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri?
+NuGet.Protocol.LocalPackageSearchMetadata.PackagePath.get -> string!
+NuGet.Protocol.LocalPackageSearchMetadata.PackageReader.get -> System.Func<NuGet.Packaging.PackageReaderBase!>!
 NuGet.Protocol.LocalPackageSearchMetadata.PrefixReserved.get -> bool
-~NuGet.Protocol.LocalPackageSearchMetadata.ProjectUrl.get -> System.Uri
+NuGet.Protocol.LocalPackageSearchMetadata.ProjectUrl.get -> System.Uri?
 NuGet.Protocol.LocalPackageSearchMetadata.Published.get -> System.DateTimeOffset?
-~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeUrl.get -> System.Uri
-~NuGet.Protocol.LocalPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri
+NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> string?
+NuGet.Protocol.LocalPackageSearchMetadata.ReadmeUrl.get -> System.Uri?
+NuGet.Protocol.LocalPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri?
 NuGet.Protocol.LocalPackageSearchMetadata.RequireLicenseAcceptance.get -> bool
-~NuGet.Protocol.LocalPackageSearchMetadata.Summary.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.Tags.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.Title.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
+NuGet.Protocol.LocalPackageSearchMetadata.Summary.get -> string?
+NuGet.Protocol.LocalPackageSearchMetadata.Tags.get -> string!
+NuGet.Protocol.LocalPackageSearchMetadata.Title.get -> string!
+NuGet.Protocol.LocalPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
 NuGet.Protocol.LocalPackageSearchResource
 ~NuGet.Protocol.LocalPackageSearchResource.LocalPackageSearchResource(NuGet.Protocol.FindLocalPackagesResource localResource) -> void
 NuGet.Protocol.LocalPackageSearchResourceProvider
@@ -1561,10 +1561,10 @@ NuGet.Repositories.NuGetv3LocalRepositoryUtility
 ~abstract NuGet.Protocol.Core.Types.PackageMetadataResource.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
 ~abstract NuGet.Protocol.Core.Types.PackageSearchResource.SearchAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
 abstract NuGet.Protocol.Core.Types.ResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~abstract NuGet.Protocol.FindLocalPackagesResource.FindPackagesById(string id, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~abstract NuGet.Protocol.FindLocalPackagesResource.GetPackage(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~abstract NuGet.Protocol.FindLocalPackagesResource.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~abstract NuGet.Protocol.FindLocalPackagesResource.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
+abstract NuGet.Protocol.FindLocalPackagesResource.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+abstract NuGet.Protocol.FindLocalPackagesResource.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+abstract NuGet.Protocol.FindLocalPackagesResource.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+abstract NuGet.Protocol.FindLocalPackagesResource.GetPackages(NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
 abstract NuGet.Protocol.Plugins.OutboundRequestContext.Dispose(bool disposing) -> void
 abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleCancelResponse() -> void
 abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleFault(NuGet.Protocol.Plugins.Message! fault) -> void
@@ -1678,27 +1678,27 @@ override NuGet.Protocol.DownloadTimeoutStream.Seek(long offset, System.IO.SeekOr
 override NuGet.Protocol.DownloadTimeoutStream.SetLength(long value) -> void
 override NuGet.Protocol.DownloadTimeoutStream.Write(byte[]! buffer, int offset, int count) -> void
 ~override NuGet.Protocol.FeedTypeResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.FindPackagesById(string id, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourcePackagesConfigProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.FindLocalPackagesResourceUnzipped.Exists(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> bool
-~override NuGet.Protocol.FindLocalPackagesResourceUnzipped.FindPackagesById(string id, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackage(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceUnzippedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.FindLocalPackagesResourceV2.FindPackagesById(string id, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackage(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.FindLocalPackagesResourceV3.FindPackagesById(string id, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackage(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackages(NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourcePackagesConfigProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+override NuGet.Protocol.FindLocalPackagesResourceUnzipped.Exists(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> bool
+override NuGet.Protocol.FindLocalPackagesResourceUnzipped.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackages(NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceUnzippedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+override NuGet.Protocol.FindLocalPackagesResourceV2.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackages(NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+override NuGet.Protocol.FindLocalPackagesResourceV3.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackages(NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.FingerprintsConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.FingerprintsConverter.CanWrite.get -> bool
 override NuGet.Protocol.FingerprintsConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object!
@@ -2098,8 +2098,8 @@ virtual NuGet.Protocol.Core.Types.SourceRepository.GetResource<T>(System.Threadi
 virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>() -> System.Threading.Tasks.Task<T?>!
 virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T?>!
 virtual NuGet.Protocol.Core.Types.SourceRepository.PackageSource.get -> NuGet.Configuration.PackageSource!
-~virtual NuGet.Protocol.FindLocalPackagesResource.Exists(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> bool
-~virtual NuGet.Protocol.FindLocalPackagesResource.Exists(string packageId, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> bool
+virtual NuGet.Protocol.FindLocalPackagesResource.Exists(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> bool
+virtual NuGet.Protocol.FindLocalPackagesResource.Exists(string! packageId, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> bool
 virtual NuGet.Protocol.HttpSource.Dispose(bool disposing) -> void
 virtual NuGet.Protocol.HttpSource.GetAsync<T>(NuGet.Protocol.HttpSourceCachedRequest! request, System.Func<NuGet.Protocol.HttpSourceResult!, System.Threading.Tasks.Task<T>!>! processAsync, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
 virtual NuGet.Protocol.HttpSource.TryReadCacheFile(string! uri, System.TimeSpan maxAge, string! cacheFile) -> System.IO.Stream?
@@ -2109,12 +2109,12 @@ virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddNuspec(string! manifestPath
 virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddRuntimeGraph(string! expandedPath) -> System.Lazy<NuGet.RuntimeModel.RuntimeGraph?>!
 virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddSha512(string! sha512Path) -> System.Lazy<string!>!
 virtual NuGet.Protocol.LocalPackageFileCache.Sha512Exists(string! sha512Path) -> bool
-~virtual NuGet.Protocol.LocalPackageInfo.GetReader() -> NuGet.Packaging.PackageReaderBase
-~virtual NuGet.Protocol.LocalPackageInfo.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+virtual NuGet.Protocol.LocalPackageInfo.GetReader() -> NuGet.Packaging.PackageReaderBase!
+virtual NuGet.Protocol.LocalPackageInfo.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
 virtual NuGet.Protocol.LocalPackageInfo.IsNupkg.get -> bool
 virtual NuGet.Protocol.LocalPackageInfo.LastWriteTimeUtc.get -> System.DateTime
-~virtual NuGet.Protocol.LocalPackageInfo.Nuspec.get -> NuGet.Packaging.NuspecReader
-~virtual NuGet.Protocol.LocalPackageInfo.Path.get -> string
+virtual NuGet.Protocol.LocalPackageInfo.Nuspec.get -> NuGet.Packaging.NuspecReader!
+virtual NuGet.Protocol.LocalPackageInfo.Path.get -> string!
 virtual NuGet.Protocol.ODataServiceDocumentResourceV2.RequestTime.get -> System.DateTime
 virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
 virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile! pluginFile, System.Collections.Generic.IEnumerable<string!>! arguments, NuGet.Protocol.Plugins.IRequestHandlers! requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions! options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin!>!

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -417,22 +417,22 @@ NuGet.Protocol.FeedTypeResourceProvider.FeedTypeResourceProvider() -> void
 NuGet.Protocol.FeedTypeUtility
 NuGet.Protocol.FindLocalPackagesResource
 NuGet.Protocol.FindLocalPackagesResource.FindLocalPackagesResource() -> void
-~NuGet.Protocol.FindLocalPackagesResource.Root.get -> string
-~NuGet.Protocol.FindLocalPackagesResource.Root.set -> void
+NuGet.Protocol.FindLocalPackagesResource.Root.get -> string!
+NuGet.Protocol.FindLocalPackagesResource.Root.set -> void
 NuGet.Protocol.FindLocalPackagesResourcePackagesConfig
-~NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.FindLocalPackagesResourcePackagesConfig(string root) -> void
+NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.FindLocalPackagesResourcePackagesConfig(string! root) -> void
 NuGet.Protocol.FindLocalPackagesResourcePackagesConfigProvider
 NuGet.Protocol.FindLocalPackagesResourcePackagesConfigProvider.FindLocalPackagesResourcePackagesConfigProvider() -> void
 NuGet.Protocol.FindLocalPackagesResourceUnzipped
-~NuGet.Protocol.FindLocalPackagesResourceUnzipped.FindLocalPackagesResourceUnzipped(string root) -> void
+NuGet.Protocol.FindLocalPackagesResourceUnzipped.FindLocalPackagesResourceUnzipped(string! root) -> void
 NuGet.Protocol.FindLocalPackagesResourceUnzippedProvider
 NuGet.Protocol.FindLocalPackagesResourceUnzippedProvider.FindLocalPackagesResourceUnzippedProvider() -> void
 NuGet.Protocol.FindLocalPackagesResourceV2
-~NuGet.Protocol.FindLocalPackagesResourceV2.FindLocalPackagesResourceV2(string root) -> void
+NuGet.Protocol.FindLocalPackagesResourceV2.FindLocalPackagesResourceV2(string! root) -> void
 NuGet.Protocol.FindLocalPackagesResourceV2Provider
 NuGet.Protocol.FindLocalPackagesResourceV2Provider.FindLocalPackagesResourceV2Provider() -> void
 NuGet.Protocol.FindLocalPackagesResourceV3
-~NuGet.Protocol.FindLocalPackagesResourceV3.FindLocalPackagesResourceV3(string root) -> void
+NuGet.Protocol.FindLocalPackagesResourceV3.FindLocalPackagesResourceV3(string! root) -> void
 NuGet.Protocol.FindLocalPackagesResourceV3Provider
 NuGet.Protocol.FindLocalPackagesResourceV3Provider.FindLocalPackagesResourceV3Provider() -> void
 NuGet.Protocol.FindPackagesByIdNupkgDownloader
@@ -622,7 +622,7 @@ NuGet.Protocol.LocalPackageFileCache.LocalPackageFileCache() -> void
 NuGet.Protocol.LocalPackageFileCache.UpdateLastAccessTime(string! nupkgMetadataPath) -> void
 NuGet.Protocol.LocalPackageInfo
 NuGet.Protocol.LocalPackageInfo.LocalPackageInfo() -> void
-~NuGet.Protocol.LocalPackageInfo.LocalPackageInfo(NuGet.Packaging.Core.PackageIdentity identity, string path, System.DateTime lastWriteTimeUtc, System.Lazy<NuGet.Packaging.NuspecReader> nuspec, bool useFolder) -> void
+NuGet.Protocol.LocalPackageInfo.LocalPackageInfo(NuGet.Packaging.Core.PackageIdentity! identity, string! path, System.DateTime lastWriteTimeUtc, System.Lazy<NuGet.Packaging.NuspecReader!>! nuspec, bool useFolder) -> void
 NuGet.Protocol.LocalPackageListResource
 ~NuGet.Protocol.LocalPackageListResource.LocalPackageListResource(NuGet.Protocol.Core.Types.PackageSearchResource localPackageSearchResource, string baseAddress) -> void
 NuGet.Protocol.LocalPackageMetadataResource
@@ -630,35 +630,35 @@ NuGet.Protocol.LocalPackageMetadataResource
 NuGet.Protocol.LocalPackageMetadataResourceProvider
 NuGet.Protocol.LocalPackageMetadataResourceProvider.LocalPackageMetadataResourceProvider() -> void
 NuGet.Protocol.LocalPackageSearchMetadata
-~NuGet.Protocol.LocalPackageSearchMetadata.Authors.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.LocalPackageSearchMetadata.Description.get -> string
+NuGet.Protocol.LocalPackageSearchMetadata.Authors.get -> string?
+NuGet.Protocol.LocalPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.LocalPackageSearchMetadata.Description.get -> string?
 NuGet.Protocol.LocalPackageSearchMetadata.DownloadCount.get -> long?
-~NuGet.Protocol.LocalPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata>
-~NuGet.Protocol.LocalPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>
-~NuGet.Protocol.LocalPackageSearchMetadata.IconUrl.get -> System.Uri
-~NuGet.Protocol.LocalPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.LocalPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata?>!
+NuGet.Protocol.LocalPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!
+NuGet.Protocol.LocalPackageSearchMetadata.IconUrl.get -> System.Uri?
+NuGet.Protocol.LocalPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
 NuGet.Protocol.LocalPackageSearchMetadata.IsListed.get -> bool
-~NuGet.Protocol.LocalPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata
-~NuGet.Protocol.LocalPackageSearchMetadata.LicenseUrl.get -> System.Uri
-~NuGet.Protocol.LocalPackageSearchMetadata.LoadFileAsText(string path) -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.LocalPackageSearchMetadata(NuGet.Protocol.LocalPackageInfo package) -> void
-~NuGet.Protocol.LocalPackageSearchMetadata.Owners.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.LocalPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri
-~NuGet.Protocol.LocalPackageSearchMetadata.PackagePath.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.PackageReader.get -> System.Func<NuGet.Packaging.PackageReaderBase>
+NuGet.Protocol.LocalPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata?
+NuGet.Protocol.LocalPackageSearchMetadata.LicenseUrl.get -> System.Uri?
+NuGet.Protocol.LocalPackageSearchMetadata.LoadFileAsText(string! path) -> string!
+NuGet.Protocol.LocalPackageSearchMetadata.LocalPackageSearchMetadata(NuGet.Protocol.LocalPackageInfo! package) -> void
+NuGet.Protocol.LocalPackageSearchMetadata.Owners.get -> string?
+NuGet.Protocol.LocalPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.LocalPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri?
+NuGet.Protocol.LocalPackageSearchMetadata.PackagePath.get -> string!
+NuGet.Protocol.LocalPackageSearchMetadata.PackageReader.get -> System.Func<NuGet.Packaging.PackageReaderBase!>!
 NuGet.Protocol.LocalPackageSearchMetadata.PrefixReserved.get -> bool
-~NuGet.Protocol.LocalPackageSearchMetadata.ProjectUrl.get -> System.Uri
+NuGet.Protocol.LocalPackageSearchMetadata.ProjectUrl.get -> System.Uri?
 NuGet.Protocol.LocalPackageSearchMetadata.Published.get -> System.DateTimeOffset?
-~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.ReadmeUrl.get -> System.Uri
-~NuGet.Protocol.LocalPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri
+NuGet.Protocol.LocalPackageSearchMetadata.ReadmeFileUrl.get -> string?
+NuGet.Protocol.LocalPackageSearchMetadata.ReadmeUrl.get -> System.Uri?
+NuGet.Protocol.LocalPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri?
 NuGet.Protocol.LocalPackageSearchMetadata.RequireLicenseAcceptance.get -> bool
-~NuGet.Protocol.LocalPackageSearchMetadata.Summary.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.Tags.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.Title.get -> string
-~NuGet.Protocol.LocalPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
+NuGet.Protocol.LocalPackageSearchMetadata.Summary.get -> string?
+NuGet.Protocol.LocalPackageSearchMetadata.Tags.get -> string!
+NuGet.Protocol.LocalPackageSearchMetadata.Title.get -> string!
+NuGet.Protocol.LocalPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
 NuGet.Protocol.LocalPackageSearchResource
 ~NuGet.Protocol.LocalPackageSearchResource.LocalPackageSearchResource(NuGet.Protocol.FindLocalPackagesResource localResource) -> void
 NuGet.Protocol.LocalPackageSearchResourceProvider
@@ -1557,10 +1557,10 @@ NuGet.Repositories.NuGetv3LocalRepositoryUtility
 ~abstract NuGet.Protocol.Core.Types.PackageMetadataResource.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
 ~abstract NuGet.Protocol.Core.Types.PackageSearchResource.SearchAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
 abstract NuGet.Protocol.Core.Types.ResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~abstract NuGet.Protocol.FindLocalPackagesResource.FindPackagesById(string id, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~abstract NuGet.Protocol.FindLocalPackagesResource.GetPackage(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~abstract NuGet.Protocol.FindLocalPackagesResource.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~abstract NuGet.Protocol.FindLocalPackagesResource.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
+abstract NuGet.Protocol.FindLocalPackagesResource.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+abstract NuGet.Protocol.FindLocalPackagesResource.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+abstract NuGet.Protocol.FindLocalPackagesResource.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+abstract NuGet.Protocol.FindLocalPackagesResource.GetPackages(NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
 abstract NuGet.Protocol.Plugins.OutboundRequestContext.Dispose(bool disposing) -> void
 abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleCancelResponse() -> void
 abstract NuGet.Protocol.Plugins.OutboundRequestContext.HandleFault(NuGet.Protocol.Plugins.Message! fault) -> void
@@ -1669,27 +1669,27 @@ override NuGet.Protocol.DownloadTimeoutStream.Seek(long offset, System.IO.SeekOr
 override NuGet.Protocol.DownloadTimeoutStream.SetLength(long value) -> void
 override NuGet.Protocol.DownloadTimeoutStream.Write(byte[]! buffer, int offset, int count) -> void
 ~override NuGet.Protocol.FeedTypeResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.FindPackagesById(string id, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourcePackagesConfigProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.FindLocalPackagesResourceUnzipped.Exists(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> bool
-~override NuGet.Protocol.FindLocalPackagesResourceUnzipped.FindPackagesById(string id, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackage(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceUnzippedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.FindLocalPackagesResourceV2.FindPackagesById(string id, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackage(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.FindLocalPackagesResourceV3.FindPackagesById(string id, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackage(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackage(System.Uri path, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo
-~override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackages(NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo>
-~override NuGet.Protocol.FindLocalPackagesResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackages(NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourcePackagesConfigProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+override NuGet.Protocol.FindLocalPackagesResourceUnzipped.Exists(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> bool
+override NuGet.Protocol.FindLocalPackagesResourceUnzipped.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceUnzipped.GetPackages(NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceUnzippedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+override NuGet.Protocol.FindLocalPackagesResourceV2.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceV2.GetPackages(NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+override NuGet.Protocol.FindLocalPackagesResourceV3.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
+override NuGet.Protocol.FindLocalPackagesResourceV3.GetPackages(NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
+override NuGet.Protocol.FindLocalPackagesResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.FingerprintsConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.FingerprintsConverter.CanWrite.get -> bool
 override NuGet.Protocol.FingerprintsConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object!
@@ -2086,8 +2086,8 @@ virtual NuGet.Protocol.Core.Types.SourceRepository.GetResource<T>(System.Threadi
 virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>() -> System.Threading.Tasks.Task<T?>!
 virtual NuGet.Protocol.Core.Types.SourceRepository.GetResourceAsync<T>(System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T?>!
 virtual NuGet.Protocol.Core.Types.SourceRepository.PackageSource.get -> NuGet.Configuration.PackageSource!
-~virtual NuGet.Protocol.FindLocalPackagesResource.Exists(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> bool
-~virtual NuGet.Protocol.FindLocalPackagesResource.Exists(string packageId, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> bool
+virtual NuGet.Protocol.FindLocalPackagesResource.Exists(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> bool
+virtual NuGet.Protocol.FindLocalPackagesResource.Exists(string! packageId, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> bool
 virtual NuGet.Protocol.HttpSource.Dispose(bool disposing) -> void
 virtual NuGet.Protocol.HttpSource.GetAsync<T>(NuGet.Protocol.HttpSourceCachedRequest! request, System.Func<NuGet.Protocol.HttpSourceResult!, System.Threading.Tasks.Task<T>!>! processAsync, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
 virtual NuGet.Protocol.HttpSource.TryReadCacheFile(string! uri, System.TimeSpan maxAge, string! cacheFile) -> System.IO.Stream?
@@ -2097,12 +2097,12 @@ virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddNuspec(string! manifestPath
 virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddRuntimeGraph(string! expandedPath) -> System.Lazy<NuGet.RuntimeModel.RuntimeGraph?>!
 virtual NuGet.Protocol.LocalPackageFileCache.GetOrAddSha512(string! sha512Path) -> System.Lazy<string!>!
 virtual NuGet.Protocol.LocalPackageFileCache.Sha512Exists(string! sha512Path) -> bool
-~virtual NuGet.Protocol.LocalPackageInfo.GetReader() -> NuGet.Packaging.PackageReaderBase
-~virtual NuGet.Protocol.LocalPackageInfo.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+virtual NuGet.Protocol.LocalPackageInfo.GetReader() -> NuGet.Packaging.PackageReaderBase!
+virtual NuGet.Protocol.LocalPackageInfo.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
 virtual NuGet.Protocol.LocalPackageInfo.IsNupkg.get -> bool
 virtual NuGet.Protocol.LocalPackageInfo.LastWriteTimeUtc.get -> System.DateTime
-~virtual NuGet.Protocol.LocalPackageInfo.Nuspec.get -> NuGet.Packaging.NuspecReader
-~virtual NuGet.Protocol.LocalPackageInfo.Path.get -> string
+virtual NuGet.Protocol.LocalPackageInfo.Nuspec.get -> NuGet.Packaging.NuspecReader!
+virtual NuGet.Protocol.LocalPackageInfo.Path.get -> string!
 virtual NuGet.Protocol.ODataServiceDocumentResourceV2.RequestTime.get -> System.DateTime
 virtual NuGet.Protocol.Plugins.PluginFactory.Dispose() -> void
 virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plugins.PluginFile! pluginFile, System.Collections.Generic.IEnumerable<string!>! arguments, NuGet.Protocol.Plugins.IRequestHandlers! requestHandlers, NuGet.Protocol.Plugins.ConnectionOptions! options, System.Threading.CancellationToken sessionCancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Plugins.IPlugin!>!

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/FindLocalPackagesResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/FindLocalPackagesResourceTests.cs
@@ -210,11 +210,11 @@ namespace NuGet.Protocol.Tests
                 {
                     // Act
                     var result = resource.GetPackage(PackageA3, testLogger, CancellationToken.None);
-                    var result2 = resource.GetPackage(UriUtility.CreateSourceUri(result.Path), testLogger, CancellationToken.None);
+                    var result2 = resource.GetPackage(UriUtility.CreateSourceUri(result!.Path), testLogger, CancellationToken.None);
 
                     // Assert
                     Assert.Equal(PackageA3, result.Identity);
-                    Assert.Equal(PackageA3, result2.Identity);
+                    Assert.Equal(PackageA3, result2!.Identity);
                 }
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Progress: https://github.com/NuGet/Home/issues/14851

## Description

Enable nullable reference types on the local repository layer in NuGet.Protocol (Phase 19 of the nullable migration plan).

### Files changed (11 source + 2 PublicAPI + 1 test)

Removed `#nullable disable` from:
- `LocalPackageInfo` — core local package data class
- `FindLocalPackagesResource` — abstract base for local enumeration
- `FindLocalPackagesResourcePackagesConfig` / `Unzipped` / `V2` / `V3` — concrete implementations
- All four matching `*Provider` classes
- `LocalPackageSearchMetadata` — implements `IPackageSearchMetadata` for local packages

### Key decisions

- **`GetPackage()` now returns `LocalPackageInfo?`** — all implementations can return null (e.g., `TryGetValue` in Unzipped, nullable returns from `LocalFolderUtility`). This is the main API surface change.
- **`LocalPackageInfo` protected parameterless ctor** uses `null!` on fields/auto-properties. The only subclass (`TestLocalPackageInfo` in tests) overrides all virtual members, so these fields are never accessed through that path.
- **Added `ArgumentNullException` guards** to `PackagesConfig`, `Unzipped`, `V2`, `V3` constructors for the `root` parameter (previously had no null checks).
- **`LocalPackageSearchMetadata`**: nuspec-derived string/Uri properties are nullable (`Authors?`, `Description?`, `IconUrl?`, etc.); properties with guaranteed values are non-null (`Tags!`, `Title!`, `PackagePath!`, `LoadFileAsText!`).
- Updated **62 entries** in `PublicAPI.Shipped.txt` for both net472 and net8.0 TFMs.
- Fixed cascading `CS8602` in `FindLocalPackagesResourceTests.cs` (added `!` after `GetPackage()` calls in test assertions).

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
