### PR TITLE
NuGet.Protocol should not use Newtonsoft.Json when AoT trimmed

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
@@ -3,13 +3,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
+using NuGet.Protocol.Converters;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Extensions;
+using NuGet.Protocol.Model;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol
@@ -101,6 +105,93 @@ namespace NuGet.Protocol
             await Task.WhenAll(rangeTasks.ToArray());
 
             return rangeTasks.Select((t) => t.Result);
+        }
+
+        /// <summary>
+        /// Strongly typed, System.Text.Json based equivalent of <see cref="LoadRanges"/>. Returns the registration
+        /// pages (with their leaf items populated) that intersect the requested <paramref name="range"/>. Used by the
+        /// callers when the <c>NuGet.UseSystemTextJsonDeserialization</c> feature switch is enabled so that the
+        /// Newtonsoft.Json based <see cref="LoadRanges"/> path can be trimmed by the linker.
+        /// </summary>
+        internal async static Task<IReadOnlyList<RegistrationPage?>> LoadRangesAsItemsAsync(
+            HttpSource httpSource,
+            Uri registrationUri,
+            string packageId,
+            VersionRange range,
+            SourceCacheContext cacheContext,
+            ILogger log,
+            CancellationToken token)
+        {
+            var packageIdLowerCase = packageId.ToLowerInvariant();
+
+            var httpSourceCacheContext = HttpSourceCacheContext.Create(cacheContext, 0);
+
+            var index = await httpSource.GetAsync(
+                new HttpSourceCachedRequest(
+                    registrationUri.OriginalString,
+                    $"list_{packageIdLowerCase}_index",
+                    httpSourceCacheContext)
+                {
+                    IgnoreNotFounds = true,
+                },
+                httpSourceResult => DeserializeStreamAsync<RegistrationIndex>(httpSourceResult.Stream, token),
+                log,
+                token);
+
+            if (index?.Items == null)
+            {
+                // The server returned a 404, the package does not exist
+                return Array.Empty<RegistrationPage?>();
+            }
+
+            IList<Task<RegistrationPage?>> rangeTasks = new List<Task<RegistrationPage?>>();
+
+            foreach (RegistrationPage page in index.Items)
+            {
+                var lower = NuGetVersion.Parse(page.Lower);
+                var upper = NuGetVersion.Parse(page.Upper);
+
+                if (range.DoesRangeSatisfy(lower, upper))
+                {
+                    if (page.Items == null)
+                    {
+                        var rangeUri = page.Url;
+
+                        rangeTasks.Add(httpSource.GetAsync(
+                            new HttpSourceCachedRequest(
+                                rangeUri,
+                                $"list_{packageIdLowerCase}_range_{lower.ToNormalizedString()}-{upper.ToNormalizedString()}",
+                                httpSourceCacheContext)
+                            {
+                                IgnoreNotFounds = true,
+                            },
+                            httpSourceResult => DeserializeStreamAsync<RegistrationPage>(httpSourceResult.Stream, token),
+                            log,
+                            token));
+                    }
+                    else
+                    {
+                        rangeTasks.Add(Task.FromResult<RegistrationPage?>(page));
+                    }
+                }
+            }
+
+            await Task.WhenAll(rangeTasks.ToArray());
+
+            return rangeTasks.Select((t) => t.Result).ToList();
+        }
+
+        private static async Task<T?> DeserializeStreamAsync<T>(Stream? stream, CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+
+            if (stream == null)
+            {
+                return default;
+            }
+
+            var typeInfo = (JsonTypeInfo<T>)PackageSearchJsonContext.Default.GetTypeInfo(typeof(T))!;
+            return await System.Text.Json.JsonSerializer.DeserializeAsync(stream, typeInfo, token);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
@@ -122,11 +122,11 @@ namespace NuGet.Protocol
             ILogger log,
             CancellationToken token)
         {
-            var packageIdLowerCase = packageId.ToLowerInvariant();
+            string packageIdLowerCase = packageId.ToLowerInvariant();
 
-            var httpSourceCacheContext = HttpSourceCacheContext.Create(cacheContext, 0);
+            HttpSourceCacheContext httpSourceCacheContext = HttpSourceCacheContext.Create(cacheContext, 0);
 
-            var index = await httpSource.GetAsync(
+            RegistrationIndex? index = await httpSource.GetAsync(
                 new HttpSourceCachedRequest(
                     registrationUri.OriginalString,
                     $"list_{packageIdLowerCase}_index",
@@ -148,14 +148,14 @@ namespace NuGet.Protocol
 
             foreach (RegistrationPage page in index.Items)
             {
-                var lower = NuGetVersion.Parse(page.Lower);
-                var upper = NuGetVersion.Parse(page.Upper);
+                NuGetVersion lower = NuGetVersion.Parse(page.Lower);
+                NuGetVersion upper = NuGetVersion.Parse(page.Upper);
 
                 if (range.DoesRangeSatisfy(lower, upper))
                 {
                     if (page.Items == null)
                     {
-                        var rangeUri = page.Url;
+                        string rangeUri = page.Url;
 
                         rangeTasks.Add(httpSource.GetAsync(
                             new HttpSourceCachedRequest(

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
@@ -13,6 +13,8 @@ using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol
@@ -24,6 +26,31 @@ namespace NuGet.Protocol
         /// </summary>
         /// <returns>Returns an empty sequence if the package does not exist.</returns>
         public static async Task<IEnumerable<RemoteSourceDependencyInfo>> GetDependencies(
+            HttpSource httpClient,
+            Uri registrationUri,
+            string packageId,
+            VersionRange range,
+            SourceCacheContext cacheContext,
+            ILogger log,
+            CancellationToken token)
+        {
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+            {
+                return await GetDependenciesFromItemsAsync(httpClient, registrationUri, packageId, range, cacheContext, log, token);
+            }
+
+            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+            {
+                return await GetDependenciesFromItemsAsync(httpClient, registrationUri, packageId, range, cacheContext, log, token);
+            }
+
+            return await GetDependenciesFromJObjectsAsync(httpClient, registrationUri, packageId, range, cacheContext, log, token);
+        }
+
+        /// <summary>
+        /// Newtonsoft.Json (JObject) based registration walk.
+        /// </summary>
+        private static async Task<HashSet<RemoteSourceDependencyInfo>> GetDependenciesFromJObjectsAsync(
             HttpSource httpClient,
             Uri registrationUri,
             string packageId,
@@ -55,6 +82,62 @@ namespace NuGet.Protocol
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// System.Text.Json based registration walk.
+        /// </summary>
+        private static async Task<HashSet<RemoteSourceDependencyInfo>> GetDependenciesFromItemsAsync(
+            HttpSource httpClient,
+            Uri registrationUri,
+            string packageId,
+            VersionRange range,
+            SourceCacheContext cacheContext,
+            ILogger log,
+            CancellationToken token)
+        {
+            var results = new HashSet<RemoteSourceDependencyInfo>();
+
+            var pages = await RegistrationUtility.LoadRangesAsItemsAsync(httpClient, registrationUri, packageId, range, cacheContext, log, token);
+
+            foreach (var page in pages)
+            {
+                if (page == null)
+                {
+                    throw new InvalidDataException(registrationUri.AbsoluteUri);
+                }
+
+                foreach (RegistrationLeafItem leaf in page.Items!)
+                {
+                    var catalogEntry = leaf.CatalogEntry!;
+                    var version = catalogEntry.Version;
+
+                    if (range.Satisfies(version))
+                    {
+                        results.Add(ProcessPackageVersion(leaf, version));
+                    }
+                }
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Process an individual package version entry from a strongly typed registration leaf.
+        /// </summary>
+        /// <returns>Returns the RemoteSourceDependencyInfo object corresponding to this package version</returns>
+        private static RemoteSourceDependencyInfo ProcessPackageVersion(RegistrationLeafItem leaf, NuGetVersion version)
+        {
+            var catalogEntry = leaf.CatalogEntry!;
+
+            var listed = catalogEntry.IsListed;
+            var id = catalogEntry.PackageId!;
+
+            var identity = new PackageIdentity(id, version);
+
+            var contentUri = leaf.PackageContent!.OriginalString;
+
+            return new RemoteSourceDependencyInfo(identity, listed, catalogEntry.DependencySets, contentUri);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
@@ -32,14 +32,15 @@ namespace NuGet.Protocol
             VersionRange range,
             SourceCacheContext cacheContext,
             ILogger log,
-            CancellationToken token)
+            CancellationToken token,
+            IEnvironmentVariableReader? env)
         {
             if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
             {
                 return await GetDependenciesFromItemsAsync(httpClient, registrationUri, packageId, range, cacheContext, log, token);
             }
 
-            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(env))
             {
                 return await GetDependenciesFromItemsAsync(httpClient, registrationUri, packageId, range, cacheContext, log, token);
             }
@@ -98,10 +99,13 @@ namespace NuGet.Protocol
         {
             var results = new HashSet<RemoteSourceDependencyInfo>();
 
-            var pages = await RegistrationUtility.LoadRangesAsItemsAsync(httpClient, registrationUri, packageId, range, cacheContext, log, token);
+            IReadOnlyList<RegistrationPage?> pages = await RegistrationUtility.LoadRangesAsItemsAsync(httpClient, registrationUri, packageId, range, cacheContext, log, token);
 
-            foreach (var page in pages)
+            // NoAllocEnumerate can't be used on nullable types, so avoid allocating an enumerator by using a for loop.
+            for (int i = 0; i < pages.Count; i++)
             {
+                RegistrationPage? page = pages[i];
+
                 if (page == null)
                 {
                     throw new InvalidDataException(registrationUri.AbsoluteUri);
@@ -109,8 +113,8 @@ namespace NuGet.Protocol
 
                 foreach (RegistrationLeafItem leaf in page.Items!)
                 {
-                    var catalogEntry = leaf.CatalogEntry!;
-                    var version = catalogEntry.Version;
+                    PackageSearchMetadataRegistration catalogEntry = leaf.CatalogEntry!;
+                    NuGetVersion version = catalogEntry.Version;
 
                     if (range.Satisfies(version))
                     {
@@ -128,14 +132,14 @@ namespace NuGet.Protocol
         /// <returns>Returns the RemoteSourceDependencyInfo object corresponding to this package version</returns>
         private static RemoteSourceDependencyInfo ProcessPackageVersion(RegistrationLeafItem leaf, NuGetVersion version)
         {
-            var catalogEntry = leaf.CatalogEntry!;
+            PackageSearchMetadataRegistration catalogEntry = leaf.CatalogEntry!;
 
-            var listed = catalogEntry.IsListed;
-            var id = catalogEntry.PackageId!;
+            bool listed = catalogEntry.IsListed;
+            string id = catalogEntry.PackageId!;
 
             var identity = new PackageIdentity(id, version);
 
-            var contentUri = leaf.PackageContent!.OriginalString;
+            string contentUri = leaf.PackageContent!.OriginalString;
 
             return new RemoteSourceDependencyInfo(identity, listed, catalogEntry.DependencySets, contentUri);
         }
@@ -205,11 +209,12 @@ namespace NuGet.Protocol
             SourceCacheContext cacheContext,
             NuGetFramework projectTargetFramework,
             ILogger log,
-            CancellationToken token)
+            CancellationToken token,
+            IEnvironmentVariableReader? env)
         {
             var frameworkComparer = NuGetFrameworkFullComparer.Instance;
             var frameworkReducer = new FrameworkReducer();
-            var dependencies = await GetDependencies(httpClient, registrationUri, packageId, range, cacheContext, log, token);
+            IEnumerable<RemoteSourceDependencyInfo> dependencies = await GetDependencies(httpClient, registrationUri, packageId, range, cacheContext, log, token, env);
 
             if (!dependencies.Any())
             {

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
@@ -111,14 +111,24 @@ namespace NuGet.Protocol
                     throw new InvalidDataException(registrationUri.AbsoluteUri);
                 }
 
-                foreach (RegistrationLeafItem leaf in page.Items!)
+                if (page.Items is null)
                 {
-                    PackageSearchMetadataRegistration catalogEntry = leaf.CatalogEntry!;
+                    throw new InvalidDataException(registrationUri.AbsoluteUri);
+                }
+
+                foreach (RegistrationLeafItem leaf in page.Items)
+                {
+                    if (leaf is null || leaf.CatalogEntry is null)
+                    {
+                        throw new InvalidDataException(registrationUri.AbsoluteUri);
+                    }
+
+                    PackageSearchMetadataRegistration catalogEntry = leaf.CatalogEntry;
                     NuGetVersion version = catalogEntry.Version;
 
                     if (range.Satisfies(version))
                     {
-                        results.Add(ProcessPackageVersion(leaf, version));
+                        results.Add(ProcessPackageVersion(leaf, version, registrationUri));
                     }
                 }
             }
@@ -130,7 +140,7 @@ namespace NuGet.Protocol
         /// Process an individual package version entry from a strongly typed registration leaf.
         /// </summary>
         /// <returns>Returns the RemoteSourceDependencyInfo object corresponding to this package version</returns>
-        private static RemoteSourceDependencyInfo ProcessPackageVersion(RegistrationLeafItem leaf, NuGetVersion version)
+        private static RemoteSourceDependencyInfo ProcessPackageVersion(RegistrationLeafItem leaf, NuGetVersion version, Uri registrationUri)
         {
             PackageSearchMetadataRegistration catalogEntry = leaf.CatalogEntry!;
 
@@ -139,7 +149,12 @@ namespace NuGet.Protocol
 
             var identity = new PackageIdentity(id, version);
 
-            string contentUri = leaf.PackageContent!.OriginalString;
+            if (leaf.PackageContent is null)
+            {
+                throw new InvalidDataException(registrationUri.AbsoluteUri);
+            }
+
+            string contentUri = leaf.PackageContent.OriginalString;
 
             return new RemoteSourceDependencyInfo(identity, listed, catalogEntry.DependencySets, contentUri);
         }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpStreamValidation.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpStreamValidation.cs
@@ -5,11 +5,13 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Text.Json;
 using System.Xml;
 using Newtonsoft.Json;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
 
 namespace NuGet.Protocol
 {
@@ -27,6 +29,46 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(stream));
             }
 
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+            {
+                ValidateJsonObjectWithStj(uri, stream);
+                return;
+            }
+
+            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+            {
+                ValidateJsonObjectWithStj(uri, stream);
+                return;
+            }
+
+            ValidateJObjectWithNewtonsoftJson(uri, stream);
+        }
+
+        private static void ValidateJsonObjectWithStj(string uri, Stream stream)
+        {
+            try
+            {
+                using (JsonDocument document = JsonDocument.Parse(stream))
+                {
+                    if (document.RootElement.ValueKind != JsonValueKind.Object)
+                    {
+                        throw new InvalidOperationException("The JSON document is not an object.");
+                    }
+                }
+            }
+            catch (Exception e) when (!(e is InvalidDataException))
+            {
+                string message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.Protocol_InvalidJsonObject,
+                    uri);
+
+                throw new InvalidDataException(message, e);
+            }
+        }
+
+        private static void ValidateJObjectWithNewtonsoftJson(string uri, Stream stream)
+        {
             try
             {
                 using (var reader = new StreamReader(
@@ -173,7 +215,7 @@ namespace NuGet.Protocol
 
                     if (xmlReader.Depth != 0)
                     {
-                        throw new JsonReaderException("The XML document is not complete.");
+                        throw new InvalidOperationException("The XML document is not complete.");
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpStreamValidation.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpStreamValidation.cs
@@ -19,6 +19,11 @@ namespace NuGet.Protocol
     {
         public static void ValidateJObject(string uri, Stream stream)
         {
+            ValidateJObject(uri, stream, environmentVariableReader: null);
+        }
+
+        internal static void ValidateJObject(string uri, Stream stream, Common.IEnvironmentVariableReader? environmentVariableReader)
+        {
             if (uri == null)
             {
                 throw new ArgumentNullException(nameof(uri));
@@ -35,7 +40,7 @@ namespace NuGet.Protocol
                 return;
             }
 
-            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(environmentVariableReader))
             {
                 ValidateJsonObjectWithStj(uri, stream);
                 return;

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/AssemblyLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/AssemblyLogMessage.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Reflection;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -38,18 +38,20 @@ namespace NuGet.Protocol.Plugins
 
         public override string ToString()
         {
-            var message = new JObject(
-                new JProperty("assembly full name", _fullName),
-                new JProperty("entry assembly full name", _entryAssemblyFullName));
+            var message = new JsonObject
+            {
+                ["assembly full name"] = _fullName,
+                ["entry assembly full name"] = _entryAssemblyFullName,
+            };
 
             if (!string.IsNullOrEmpty(_fileVersion))
             {
-                message.Add("file version", _fileVersion);
+                message["file version"] = _fileVersion;
             }
 
             if (!string.IsNullOrEmpty(_informationalVersion))
             {
-                message.Add("informational version", _informationalVersion);
+                message["informational version"] = _informationalVersion;
             }
 
             return ToString("assembly", message);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/CommunicationLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/CommunicationLogMessage.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -24,11 +24,13 @@ namespace NuGet.Protocol.Plugins
 
         public override string ToString()
         {
-            var message = new JObject(
-                new JProperty("request ID", _requestId),
-                new JProperty("method", _method),
-                new JProperty("type", _type),
-                new JProperty("state", _state));
+            var message = new JsonObject
+            {
+                ["request ID"] = _requestId,
+                ["method"] = _method.ToString(),
+                ["type"] = _type.ToString(),
+                ["state"] = _state.ToString(),
+            };
 
             return ToString("communication", message);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/EnvironmentVariablesLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/EnvironmentVariablesLogMessage.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 using NuGet.Common;
 
 namespace NuGet.Protocol.Plugins
@@ -31,21 +31,21 @@ namespace NuGet.Protocol.Plugins
 
         public override string ToString()
         {
-            var message = new JObject();
+            var message = new JsonObject();
 
             if (_handshakeTimeout.HasValue)
             {
-                message.Add("handshake timeout in seconds", _handshakeTimeout.Value);
+                message["handshake timeout in seconds"] = _handshakeTimeout.Value;
             }
 
             if (_idleTimeout.HasValue)
             {
-                message.Add("idle timeout in seconds", _idleTimeout.Value);
+                message["idle timeout in seconds"] = _idleTimeout.Value;
             }
 
             if (_requestTimeout.HasValue)
             {
-                message.Add("request timeout in seconds", _requestTimeout.Value);
+                message["request timeout in seconds"] = _requestTimeout.Value;
             }
 
             return ToString("environment variables", message);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/MachineLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/MachineLogMessage.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -18,7 +18,10 @@ namespace NuGet.Protocol.Plugins
 
         public override string ToString()
         {
-            var message = new JObject(new JProperty("logical processor count", _logicalProcessorCount));
+            var message = new JsonObject
+            {
+                ["logical processor count"] = _logicalProcessorCount,
+            };
 
             return ToString("machine", message);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginInstanceLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginInstanceLogMessage.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -27,13 +27,15 @@ namespace NuGet.Protocol.Plugins
 
         public override string ToString()
         {
-            var message = new JObject(
-                new JProperty("plugin ID", _pluginId),
-                new JProperty("state", _state));
+            var message = new JsonObject
+            {
+                ["plugin ID"] = _pluginId,
+                ["state"] = _state.ToString(),
+            };
 
             if (_processId.HasValue)
             {
-                message.Add("process ID", _processId.Value);
+                message["process ID"] = _processId.Value;
             }
 
             return ToString("plugin instance", message);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/PluginLogMessage.cs
@@ -2,24 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-#if NET5_0_OR_GREATER
-using System.Diagnostics.CodeAnalysis;
-#endif
 using System.Globalization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace NuGet.Protocol.Plugins
 {
-#if NET5_0_OR_GREATER
-    [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Legacy Newtonsoft.Json infrastructure; plugin logging is not used in AOT code paths.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Legacy Newtonsoft.Json infrastructure; plugin logging is not used in AOT code paths.")]
-#endif
     internal abstract class PluginLogMessage : IPluginLogMessage
     {
-        private static readonly StringEnumConverter _enumConverter = new StringEnumConverter();
-
         private readonly DateTime _now;
 
         protected PluginLogMessage(DateTimeOffset now)
@@ -27,7 +16,7 @@ namespace NuGet.Protocol.Plugins
             _now = now.UtcDateTime;
         }
 
-        protected string ToString(string type, JObject message)
+        protected string ToString(string type, JsonObject message)
         {
             if (string.IsNullOrEmpty(type))
             {
@@ -39,12 +28,14 @@ namespace NuGet.Protocol.Plugins
                 throw new ArgumentNullException(nameof(message));
             }
 
-            var outerMessage = new JObject(
-                new JProperty("now", _now.ToString("O", CultureInfo.InvariantCulture)), // round-trip format
-                new JProperty("type", type),
-                new JProperty("message", message));
+            var outerMessage = new JsonObject
+            {
+                ["now"] = _now.ToString("O", CultureInfo.InvariantCulture), // round-trip format
+                ["type"] = type,
+                ["message"] = message,
+            };
 
-            return outerMessage.ToString(Formatting.None, _enumConverter);
+            return outerMessage.ToJsonString();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/ProcessLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/ProcessLogMessage.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -27,10 +27,12 @@ namespace NuGet.Protocol.Plugins
 
         public override string ToString()
         {
-            var message = new JObject(
-                new JProperty("process ID", _processId),
-                new JProperty("process name", _processName),
-                new JProperty("process start time", _processStartTime.ToString("O", CultureInfo.CurrentCulture)));
+            var message = new JsonObject
+            {
+                ["process ID"] = _processId,
+                ["process name"] = _processName,
+                ["process start time"] = _processStartTime.ToString("O", CultureInfo.CurrentCulture),
+            };
 
             return ToString("process", message);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/StopwatchLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/StopwatchLogMessage.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -18,7 +18,10 @@ namespace NuGet.Protocol.Plugins
 
         public override string ToString()
         {
-            var message = new JObject(new JProperty("frequency", _frequency));
+            var message = new JsonObject
+            {
+                ["frequency"] = _frequency,
+            };
 
             return ToString("stopwatch", message);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/TaskLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/TaskLogMessage.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -27,15 +27,17 @@ namespace NuGet.Protocol.Plugins
 
         public override string ToString()
         {
-            var message = new JObject(
-                new JProperty("request ID", _requestId),
-                new JProperty("method", _method),
-                new JProperty("type", _type),
-                new JProperty("state", _state));
+            var message = new JsonObject
+            {
+                ["request ID"] = _requestId,
+                ["method"] = _method.ToString(),
+                ["type"] = _type.ToString(),
+                ["state"] = _state.ToString(),
+            };
 
             if (_currentTaskId.HasValue)
             {
-                message.Add(new JProperty("current task ID", _currentTaskId.Value));
+                message["current task ID"] = _currentTaskId.Value;
             }
 
             return ToString("task", message);

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/ThreadPoolLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Logging/ThreadPoolLogMessage.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text.Json.Nodes;
 using System.Threading;
-using Newtonsoft.Json.Linq;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -23,11 +23,13 @@ namespace NuGet.Protocol.Plugins
 
         public override string ToString()
         {
-            var message = new JObject(
-                new JProperty("worker thread minimum count", _minWorkerThreads),
-                new JProperty("worker thread maximum count", _maxWorkerThreads),
-                new JProperty("completion port thread minimum count", _minCompletionPortThreads),
-                new JProperty("completion port thread maximum count", _maxCompletionPortThreads));
+            var message = new JsonObject
+            {
+                ["worker thread minimum count"] = _minWorkerThreads,
+                ["worker thread maximum count"] = _maxWorkerThreads,
+                ["completion port thread minimum count"] = _minCompletionPortThreads,
+                ["completion port thread maximum count"] = _maxCompletionPortThreads,
+            };
 
             return ToString("thread pool", message);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/MessageUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/MessageUtilities.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 #endif
 using Newtonsoft.Json.Linq;
+using NuGet.Shared;
 
 namespace NuGet.Protocol.Plugins
 {
@@ -126,6 +127,11 @@ namespace NuGet.Protocol.Plugins
             if (message.PayloadObject == null)
             {
                 return default;
+            }
+
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+            {
+                return (TPayload)message.PayloadObject;
             }
 
             if (message.PayloadObject is Newtonsoft.Json.Linq.JObject jobj)

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RepositorySignatureResourceProvider.cs
@@ -82,7 +82,7 @@ namespace NuGet.Protocol
                                     cacheKey,
                                     cacheContext)
                                 {
-                                    EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(repositorySignaturesResourceUri.AbsoluteUri, stream),
+                                    EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(repositorySignaturesResourceUri.AbsoluteUri, stream, _environmentVariableReader),
                                     MaxTries = 1,
                                     IsRetry = retry > 1,
                                     IsLastAttempt = retry == maxRetries
@@ -107,7 +107,7 @@ namespace NuGet.Protocol
                                     cacheKey,
                                     cacheContext)
                                 {
-                                    EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(repositorySignaturesResourceUri.AbsoluteUri, stream),
+                                    EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(repositorySignaturesResourceUri.AbsoluteUri, stream, _environmentVariableReader),
                                     MaxTries = 1,
                                     IsRetry = retry > 1,
                                     IsLastAttempt = retry == maxRetries

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
@@ -141,7 +141,7 @@ namespace NuGet.Protocol
                                 "service_index",
                                 cacheContext)
                             {
-                                EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(url, stream),
+                                EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(url, stream, _environmentVariableReader),
                                 MaxTries = 1,
                                 IsRetry = retry > 1,
                                 IsLastAttempt = retry == maxRetries

--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
@@ -158,8 +158,51 @@ namespace NuGet.Protocol
             Common.ILogger logger = log ?? Common.NullLogger.Instance;
 
             //*TODOs : Take prerelease as parameter. Also it should return both listed and unlisted for powershell ?
-            var packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, sourceCacheContext, logger, token);
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+            {
+                return await VersionStartsWithFromItemsAsync(packageId, versionPrefix, includePrerelease, sourceCacheContext, logger, token);
+            }
+
+            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+            {
+                return await VersionStartsWithFromItemsAsync(packageId, versionPrefix, includePrerelease, sourceCacheContext, logger, token);
+            }
+
+            return await VersionStartsWithFromJObjectsAsync(packageId, versionPrefix, includePrerelease, sourceCacheContext, logger, token);
+        }
+
+        private async Task<IEnumerable<NuGetVersion>> VersionStartsWithFromItemsAsync(
+            string packageId,
+            string versionPrefix,
+            bool includePrerelease,
+            SourceCacheContext sourceCacheContext,
+            Common.ILogger logger,
+            CancellationToken token)
+        {
             var versions = new List<NuGetVersion>();
+            var items = await _regResource.GetPackageMetadataItemsAsync(packageId, VersionRange.All, includePrerelease, includeUnlisted: false, sourceCacheContext, logger, token);
+            foreach (var item in items)
+            {
+                var version = item.CatalogEntry.Version;
+                if (version != null
+                    && version.ToString().StartsWith(versionPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    versions.Add(version);
+                }
+            }
+            return versions;
+        }
+
+        private async Task<IEnumerable<NuGetVersion>> VersionStartsWithFromJObjectsAsync(
+            string packageId,
+            string versionPrefix,
+            bool includePrerelease,
+            SourceCacheContext sourceCacheContext,
+            Common.ILogger logger,
+            CancellationToken token)
+        {
+            var versions = new List<NuGetVersion>();
+            var packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, sourceCacheContext, logger, token);
             foreach (var package in packages)
             {
                 var version = (string)package["version"];

--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
@@ -163,7 +163,7 @@ namespace NuGet.Protocol
                 return await VersionStartsWithFromItemsAsync(packageId, versionPrefix, includePrerelease, sourceCacheContext, logger, token);
             }
 
-            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
             {
                 return await VersionStartsWithFromItemsAsync(packageId, versionPrefix, includePrerelease, sourceCacheContext, logger, token);
             }
@@ -180,10 +180,10 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             var versions = new List<NuGetVersion>();
-            var items = await _regResource.GetPackageMetadataItemsAsync(packageId, VersionRange.All, includePrerelease, includeUnlisted: false, sourceCacheContext, logger, token);
-            foreach (var item in items)
+            IReadOnlyList<RegistrationLeafItem> items = await _regResource.GetPackageMetadataItemsAsync(packageId, VersionRange.All, includePrerelease, includeUnlisted: false, sourceCacheContext, logger, token);
+            foreach (RegistrationLeafItem item in items.NoAllocEnumerate())
             {
-                var version = item.CatalogEntry.Version;
+                NuGetVersion version = item.CatalogEntry.Version;
                 if (version != null
                     && version.ToString().StartsWith(versionPrefix, StringComparison.OrdinalIgnoreCase))
                 {
@@ -202,8 +202,8 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             var versions = new List<NuGetVersion>();
-            var packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, sourceCacheContext, logger, token);
-            foreach (var package in packages)
+            IEnumerable<JObject> packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, sourceCacheContext, logger, token);
+            foreach (JObject package in packages.NoAllocEnumerate())
             {
                 var version = (string)package["version"];
                 if (version.StartsWith(versionPrefix, StringComparison.OrdinalIgnoreCase))

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DependencyInfoResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DependencyInfoResourceV3.cs
@@ -24,6 +24,7 @@ namespace NuGet.Protocol
         private readonly HttpSource _client;
         private readonly RegistrationResourceV3 _regResource;
         private readonly SourceRepository _source;
+        private readonly Common.IEnvironmentVariableReader _environmentVariableReader;
 
         /// <summary>
         /// Dependency info resource
@@ -31,6 +32,11 @@ namespace NuGet.Protocol
         /// <param name="client">Http client</param>
         /// <param name="regResource">Registration blob resource</param>
         public DependencyInfoResourceV3(HttpSource client, RegistrationResourceV3 regResource, SourceRepository source)
+            : this(client, regResource, source, environmentVariableReader: null)
+        {
+        }
+
+        internal DependencyInfoResourceV3(HttpSource client, RegistrationResourceV3 regResource, SourceRepository source, Common.IEnvironmentVariableReader environmentVariableReader)
         {
             if (client == null)
             {
@@ -50,6 +56,7 @@ namespace NuGet.Protocol
             _client = client;
             _regResource = regResource;
             _source = source;
+            _environmentVariableReader = environmentVariableReader;
         }
 
         /// <summary>
@@ -73,7 +80,7 @@ namespace NuGet.Protocol
 
                 // Retrieve the registration blob
                 var singleVersion = new VersionRange(minVersion: package.Version, includeMinVersion: true, maxVersion: package.Version, includeMaxVersion: true);
-                var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, package.Id, singleVersion, cacheContext, projectFramework, log, token);
+                RegistrationInfo regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, package.Id, singleVersion, cacheContext, projectFramework, log, token, _environmentVariableReader);
 
                 // regInfo is null if the package does not exist
                 if (regInfo != null)
@@ -110,7 +117,7 @@ namespace NuGet.Protocol
                 var uri = _regResource.GetUri(packageId);
 
                 // Retrieve the registration blob
-                var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, packageId, VersionRange.All, cacheContext, projectFramework, log, token);
+                RegistrationInfo regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, packageId, VersionRange.All, cacheContext, projectFramework, log, token, _environmentVariableReader);
 
                 // regInfo is null if the package does not exist
                 if (regInfo != null)
@@ -145,7 +152,7 @@ namespace NuGet.Protocol
                 var uri = _regResource.GetUri(packageId);
 
                 // Retrieve the registration blob
-                return ResolverMetadataClient.GetDependencies(_client, uri, packageId, VersionRange.All, cacheContext, log, token);
+                return ResolverMetadataClient.GetDependencies(_client, uri, packageId, VersionRange.All, cacheContext, log, token, _environmentVariableReader);
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
@@ -7,10 +7,12 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Events;
+using NuGet.Protocol.Model;
 using NuGet.Shared;
 
 namespace NuGet.Protocol
@@ -24,11 +26,17 @@ namespace NuGet.Protocol
         private readonly RegistrationResourceV3 _regResource;
         private readonly HttpSource _client;
         private readonly string _packageBaseAddressUrl;
+        private readonly IEnvironmentVariableReader _environmentVariableReader;
 
         /// <summary>
         /// Download packages using the download url found in the registration resource.
         /// </summary>
         public DownloadResourceV3(string source, HttpSource client, RegistrationResourceV3 regResource)
+            : this(source, client, regResource, environmentVariableReader: null)
+        {
+        }
+
+        internal DownloadResourceV3(string source, HttpSource client, RegistrationResourceV3 regResource, IEnvironmentVariableReader environmentVariableReader)
             : this(client)
         {
             if (regResource == null)
@@ -38,6 +46,7 @@ namespace NuGet.Protocol
 
             _source = source;
             _regResource = regResource;
+            _environmentVariableReader = environmentVariableReader;
         }
 
         /// <summary>
@@ -100,7 +109,7 @@ namespace NuGet.Protocol
                     {
                         downloadUri = await GetDownloadUrlFromItemAsync(identity, sourceCacheContext, log, token);
                     }
-                    else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+                    else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
                     {
                         downloadUri = await GetDownloadUrlFromItemAsync(identity, sourceCacheContext, log, token);
                     }
@@ -117,7 +126,7 @@ namespace NuGet.Protocol
         private async Task<Uri> GetDownloadUrlFromItemAsync(PackageIdentity identity, SourceCacheContext sourceCacheContext, ILogger log, CancellationToken token)
         {
             // Read the url from the registration information
-            var leaf = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
+            RegistrationLeafItem leaf = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
 
             return leaf?.PackageContent;
         }
@@ -125,7 +134,7 @@ namespace NuGet.Protocol
         private async Task<Uri> GetDownloadUrlFromJObjectAsync(PackageIdentity identity, SourceCacheContext sourceCacheContext, ILogger log, CancellationToken token)
         {
             // Read the url from the registration information
-            var blob = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
+            JObject blob = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
 
             if (blob != null
                 && blob["packageContent"] != null)

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
@@ -11,6 +11,7 @@ using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Events;
+using NuGet.Shared;
 
 namespace NuGet.Protocol
 {
@@ -95,18 +96,44 @@ namespace NuGet.Protocol
             {
                 using (var sourceCacheContext = new SourceCacheContext())
                 {
-                    // Read the url from the registration information
-                    var blob = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
-
-                    if (blob != null
-                        && blob["packageContent"] != null)
+                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
                     {
-                        downloadUri = new Uri(blob["packageContent"].ToString());
+                        downloadUri = await GetDownloadUrlFromItemAsync(identity, sourceCacheContext, log, token);
+                    }
+                    else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+                    {
+                        downloadUri = await GetDownloadUrlFromItemAsync(identity, sourceCacheContext, log, token);
+                    }
+                    else
+                    {
+                        downloadUri = await GetDownloadUrlFromJObjectAsync(identity, sourceCacheContext, log, token);
                     }
                 }
             }
 
             return downloadUri;
+        }
+
+        private async Task<Uri> GetDownloadUrlFromItemAsync(PackageIdentity identity, SourceCacheContext sourceCacheContext, ILogger log, CancellationToken token)
+        {
+            // Read the url from the registration information
+            var leaf = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
+
+            return leaf?.PackageContent;
+        }
+
+        private async Task<Uri> GetDownloadUrlFromJObjectAsync(PackageIdentity identity, SourceCacheContext sourceCacheContext, ILogger log, CancellationToken token)
+        {
+            // Read the url from the registration information
+            var blob = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
+
+            if (blob != null
+                && blob["packageContent"] != null)
+            {
+                return new Uri(blob["packageContent"].ToString());
+            }
+
+            return null;
         }
 
         public override async Task<DownloadResourceResult> GetDownloadResourceResultAsync(

--- a/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResourceV3.cs
@@ -9,8 +9,10 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
 using NuGet.Shared;
 using NuGet.Versioning;
 
@@ -22,11 +24,18 @@ namespace NuGet.Protocol
     public class MetadataResourceV3 : MetadataResource
     {
         private RegistrationResourceV3 _regResource;
+        private readonly Common.IEnvironmentVariableReader _environmentVariableReader;
 
         public MetadataResourceV3(RegistrationResourceV3 regResource)
+            : this(regResource, environmentVariableReader: null)
+        {
+        }
+
+        internal MetadataResourceV3(RegistrationResourceV3 regResource, Common.IEnvironmentVariableReader environmentVariableReader)
             : base()
         {
             _regResource = regResource ?? throw new ArgumentNullException(nameof(regResource));
+            _environmentVariableReader = environmentVariableReader;
         }
 
         /// <summary>
@@ -53,7 +62,7 @@ namespace NuGet.Protocol
                     {
                         allVersions = await GetVersionsFromItemsAsync(id, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
                     }
-                    else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+                    else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
                     {
                         allVersions = await GetVersionsFromItemsAsync(id, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
                     }
@@ -86,14 +95,14 @@ namespace NuGet.Protocol
             // TODO: get the url and just check the headers?
             if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
             {
-                var item = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
+                RegistrationLeafItem item = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
 
                 // TODO: listed check
                 return item != null;
             }
-            else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+            else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
             {
-                var item = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
+                RegistrationLeafItem item = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
 
                 // TODO: listed check
                 return item != null;
@@ -132,7 +141,7 @@ namespace NuGet.Protocol
                 return await GetVersionsFromItemsAsync(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
             }
 
-            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
             {
                 return await GetVersionsFromItemsAsync(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
             }
@@ -148,11 +157,11 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            var items = await _regResource.GetPackageMetadataItemsAsync(packageId, VersionRange.All, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+            IReadOnlyList<RegistrationLeafItem> items = await _regResource.GetPackageMetadataItemsAsync(packageId, VersionRange.All, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
 
             var versions = new List<NuGetVersion>();
 
-            foreach (var item in items.NoAllocEnumerate())
+            foreach (RegistrationLeafItem item in items.NoAllocEnumerate())
             {
                 NuGetVersion version = item.CatalogEntry.Version;
 
@@ -173,7 +182,7 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            var entries = await _regResource.GetPackageMetadata(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+            IEnumerable<JObject> entries = await _regResource.GetPackageMetadata(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
 
             var versions = new List<NuGetVersion>();
 
@@ -200,7 +209,7 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            var metadata = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
+            JObject metadata = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
 
             // TODO: listed check
             return metadata != null;

--- a/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResourceV3.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol
@@ -48,8 +49,18 @@ namespace NuGet.Protocol
                 IEnumerable<NuGetVersion> allVersions;
                 try
                 {
-                    var catalogEntries = await _regResource.GetPackageMetadata(id, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
-                    allVersions = catalogEntries.Select(p => NuGetVersion.Parse(p["version"].ToString()));
+                    if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+                    {
+                        allVersions = await GetVersionsFromItemsAsync(id, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+                    }
+                    else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+                    {
+                        allVersions = await GetVersionsFromItemsAsync(id, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+                    }
+                    else
+                    {
+                        allVersions = await GetVersionsFromJObjectsAsync(id, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -73,10 +84,26 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             // TODO: get the url and just check the headers?
-            var metadata = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+            {
+                var item = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
 
-            // TODO: listed check
-            return metadata != null;
+                // TODO: listed check
+                return item != null;
+            }
+            else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+            {
+                var item = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
+
+                // TODO: listed check
+                return item != null;
+            }
+            else
+            {
+                // To make the AoT linker reliably trim the Newtonsoft.Json code in async state machines, the entire method needs to be
+                // in a separate method that is only called when the feature switch is disabled.
+                return await ExistsFromJObjectAsync(identity, sourceCacheContext, log, token);
+            }
         }
 
         public override async Task<bool> Exists(
@@ -100,9 +127,55 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            var results = new List<NuGetVersion>();
+            if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
+            {
+                return await GetVersionsFromItemsAsync(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+            }
 
-            var entries = await _regResource.GetPackageEntries(packageId, includeUnlisted, sourceCacheContext, log, token);
+            if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment())
+            {
+                return await GetVersionsFromItemsAsync(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+            }
+
+            return await GetVersionsFromJObjectsAsync(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+        }
+
+        private async Task<List<NuGetVersion>> GetVersionsFromItemsAsync(
+            string packageId,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            Common.ILogger log,
+            CancellationToken token)
+        {
+            var items = await _regResource.GetPackageMetadataItemsAsync(packageId, VersionRange.All, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+
+            var versions = new List<NuGetVersion>();
+
+            foreach (var item in items.NoAllocEnumerate())
+            {
+                NuGetVersion version = item.CatalogEntry.Version;
+
+                if (version != null)
+                {
+                    versions.Add(version);
+                }
+            }
+
+            return versions;
+        }
+
+        private async Task<List<NuGetVersion>> GetVersionsFromJObjectsAsync(
+            string packageId,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            Common.ILogger log,
+            CancellationToken token)
+        {
+            var entries = await _regResource.GetPackageMetadata(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
+
+            var versions = new List<NuGetVersion>();
 
             foreach (var catalogEntry in entries)
             {
@@ -113,12 +186,24 @@ namespace NuGet.Protocol
                 {
                     if (includePrerelease || !version.IsPrerelease)
                     {
-                        results.Add(version);
+                        versions.Add(version);
                     }
                 }
             }
 
-            return results;
+            return versions;
+        }
+
+        private async Task<bool> ExistsFromJObjectAsync(
+            PackageIdentity identity,
+            SourceCacheContext sourceCacheContext,
+            Common.ILogger log,
+            CancellationToken token)
+        {
+            var metadata = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
+
+            // TODO: listed check
+            return metadata != null;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Model;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol
@@ -171,6 +172,57 @@ namespace NuGet.Protocol
         public virtual Task<IEnumerable<JObject>> GetPackageEntries(string packageId, bool includeUnlisted, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
         {
             return GetPackageMetadata(packageId, VersionRange.All, true, includeUnlisted, cacheContext, log, token);
+        }
+
+        /// <summary>
+        /// Strongly typed, System.Text.Json based equivalent of <see cref="GetPackageMetadata(string, VersionRange, bool, bool, SourceCacheContext, Common.ILogger, CancellationToken)"/>.
+        /// Returns the registration leaf items (catalog entry plus package content url) matching the filters. Used when
+        /// the <c>NuGet.UseSystemTextJsonDeserialization</c> feature switch is enabled so that the Newtonsoft.Json based
+        /// JObject path can be trimmed by the linker.
+        /// </summary>
+        internal virtual async Task<IReadOnlyList<RegistrationLeafItem>> GetPackageMetadataItemsAsync(
+            string packageId,
+            VersionRange range,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext cacheContext,
+            Common.ILogger log,
+            CancellationToken token)
+        {
+            var results = new List<RegistrationLeafItem>();
+
+            var registrationUri = GetUri(packageId);
+
+            var ranges = await RegistrationUtility.LoadRangesAsItemsAsync(_client, registrationUri, packageId, range, cacheContext, log, token);
+
+            foreach (var page in ranges)
+            {
+                if (page == null)
+                {
+                    throw new InvalidDataException(registrationUri.AbsoluteUri);
+                }
+
+                foreach (RegistrationLeafItem leaf in page.Items)
+                {
+                    var catalogEntry = leaf.CatalogEntry;
+                    var version = catalogEntry.Version;
+                    var listed = catalogEntry.IsListed;
+
+                    if (range.Satisfies(version)
+                        && (includePrerelease || !version.IsPrerelease)
+                        && (includeUnlisted || listed))
+                    {
+                        results.Add(leaf);
+                    }
+                }
+            }
+
+            return results;
+        }
+
+        internal virtual async Task<RegistrationLeafItem> GetPackageMetadataItemAsync(PackageIdentity identity, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
+        {
+            return (await GetPackageMetadataItemsAsync(identity.Id, new VersionRange(identity.Version, true, identity.Version, true), true, true, cacheContext, log, token)).SingleOrDefault();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
@@ -191,11 +191,11 @@ namespace NuGet.Protocol
         {
             var results = new List<RegistrationLeafItem>();
 
-            var registrationUri = GetUri(packageId);
+            Uri registrationUri = GetUri(packageId);
 
-            var ranges = await RegistrationUtility.LoadRangesAsItemsAsync(_client, registrationUri, packageId, range, cacheContext, log, token);
+            IReadOnlyList<RegistrationPage> ranges = await RegistrationUtility.LoadRangesAsItemsAsync(_client, registrationUri, packageId, range, cacheContext, log, token);
 
-            foreach (var page in ranges)
+            foreach (RegistrationPage page in ranges.NoAllocEnumerate())
             {
                 if (page == null)
                 {
@@ -204,9 +204,9 @@ namespace NuGet.Protocol
 
                 foreach (RegistrationLeafItem leaf in page.Items)
                 {
-                    var catalogEntry = leaf.CatalogEntry;
-                    var version = catalogEntry.Version;
-                    var listed = catalogEntry.IsListed;
+                    PackageSearchMetadataRegistration catalogEntry = leaf.CatalogEntry;
+                    NuGetVersion version = catalogEntry.Version;
+                    bool listed = catalogEntry.IsListed;
 
                     if (range.Satisfies(version)
                         && (includePrerelease || !version.IsPrerelease)

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
@@ -197,13 +197,18 @@ namespace NuGet.Protocol
 
             foreach (RegistrationPage page in ranges.NoAllocEnumerate())
             {
-                if (page == null)
+                if (page is null || page.Items is null)
                 {
                     throw new InvalidDataException(registrationUri.AbsoluteUri);
                 }
 
                 foreach (RegistrationLeafItem leaf in page.Items)
                 {
+                    if (leaf is null || leaf.CatalogEntry is null)
+                    {
+                        throw new InvalidDataException(registrationUri.AbsoluteUri);
+                    }
+
                     PackageSearchMetadataRegistration catalogEntry = leaf.CatalogEntry;
                     NuGetVersion version = catalogEntry.Version;
                     bool listed = catalogEntry.IsListed;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV3Tests.cs
@@ -44,5 +44,33 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(10, result.Count());
             Assert.NotEmpty(logger.Messages);
         }
+
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task VersionStartsWith_BothPaths_ReturnsResultsAsync(string useStj)
+        {
+            // Arrange
+            var responses = new Dictionary<string, string>();
+            responses.Add("http://testsource.test/v3/index.json", JsonData.IndexWithoutFlatContainer);
+            responses.Add("https://api.nuget.org/v3/registration0/deepequal/index.json", JsonData.DeepEqualRegistationIndex);
+
+            var repo = StaticHttpHandler.CreateSource("http://testsource.test/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+            var resource = (AutoCompleteResourceV3)(await repo.GetResourceAsync<AutoCompleteResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected AutoCompleteResource."));
+
+            var envReader = new Mock<IEnvironmentVariableReader>();
+            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar)).Returns(useStj);
+            var testResource = new AutoCompleteResourceV3(resource._client, resource._serviceIndex, resource._regResource, envReader.Object);
+            var logger = new TestLogger();
+
+            using var sourceCacheContext = new SourceCacheContext();
+
+            // Act
+            var result = await testResource.VersionStartsWith("deepequal", "0.9", includePrerelease: true, sourceCacheContext, logger, CancellationToken.None);
+
+            // Assert
+            Assert.Equal("0.9.0", Assert.Single(result).ToNormalizedString());
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfoResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfoResourceV3Tests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Common;
+using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class DependencyInfoResourceV3Tests
+    {
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task ResolvePackages_BothPaths_ReturnsDependencyInfoAsync(string useStj)
+        {
+            // Arrange
+            var responses = new Dictionary<string, string>
+            {
+                { "http://testsource.test/v3/index.json", JsonData.IndexWithoutFlatContainer },
+                { "https://api.nuget.org/v3/registration0/deepequal/index.json", JsonData.DeepEqualRegistationIndex },
+            };
+
+            var repo = StaticHttpHandler.CreateSource("http://testsource.test/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+            HttpSource httpSource = (await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected HttpSourceResource.")).HttpSource;
+            var regResource = await repo.GetResourceAsync<RegistrationResourceV3>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected RegistrationResourceV3.");
+
+            var envReader = new Mock<IEnvironmentVariableReader>();
+            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar)).Returns(useStj);
+
+            var resource = new DependencyInfoResourceV3(httpSource, regResource, repo, envReader.Object);
+
+            // Act
+            using var sourceCacheContext = new SourceCacheContext();
+            IEnumerable<RemoteSourceDependencyInfo> results = await resource.ResolvePackages("deepequal", sourceCacheContext, NullLogger.Instance, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(19, results.Count());
+            RemoteSourceDependencyInfo target = results.Single(p => p.Identity.Version == NuGetVersion.Parse("0.9.0"));
+            Assert.Equal("deepequal", target.Identity.Id, ignoreCase: true);
+            Assert.Equal("https://api.nuget.org/packages/deepequal.0.9.0.nupkg", target.ContentUri);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV3Tests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Common;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class DownloadResourceV3Tests
+    {
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task GetDownloadResourceResultAsync_FromRegistration_BothPathsAsync(string useStj)
+        {
+            // Arrange
+            using var cacheContext = new SourceCacheContext();
+            using var workingDir = TestDirectory.Create();
+
+            var source = "http://testsource.test/v3/index.json";
+            var package = await SimpleTestPackageUtility.CreateFullPackageAsync(workingDir, "DeepEqual", "0.9.0");
+            var packageBytes = File.ReadAllBytes(package.FullName);
+
+            var responses = new Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>>
+            {
+                {
+                    source,
+                    _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new TestContent(JsonData.IndexWithoutFlatContainer) })
+                },
+                {
+                    "https://api.nuget.org/v3/registration0/deepequal/index.json",
+                    _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new TestContent(JsonData.DeepEqualRegistationIndex) })
+                },
+                {
+                    "https://api.nuget.org/packages/deepequal.0.9.0.nupkg",
+                    _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(packageBytes) })
+                },
+            };
+
+            var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+            HttpSource httpSource = (await repo.GetResourceAsync<HttpSourceResource>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected HttpSourceResource.")).HttpSource;
+            var regResource = await repo.GetResourceAsync<RegistrationResourceV3>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected RegistrationResourceV3.");
+
+            var envReader = new Mock<IEnvironmentVariableReader>();
+            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar)).Returns(useStj);
+
+            var resource = new DownloadResourceV3(source, httpSource, regResource, envReader.Object);
+
+            // Act
+            using var packagesFolder = TestDirectory.Create();
+            var downloadContext = new PackageDownloadContext(cacheContext);
+            using DownloadResourceResult result = await resource.GetDownloadResourceResultAsync(
+                new PackageIdentity("deepequal", NuGetVersion.Parse("0.9.0")),
+                downloadContext,
+                packagesFolder,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            // Assert
+            Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
+            Assert.NotNull(result.PackageReader);
+            Assert.Equal("DeepEqual", result.PackageReader!.GetIdentity().Id);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV3Tests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Common;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Shared;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class MetadataResourceV3Tests
+    {
+        private static async Task<MetadataResourceV3> CreateResourceAsync(string useStj, Dictionary<string, string> responses)
+        {
+            var repo = StaticHttpHandler.CreateSource("http://testsource.test/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+            var regResource = await repo.GetResourceAsync<RegistrationResourceV3>(CancellationToken.None)
+                ?? throw new Xunit.Sdk.XunitException("Expected RegistrationResourceV3.");
+
+            var envReader = new Mock<IEnvironmentVariableReader>();
+            envReader.Setup(e => e.GetEnvironmentVariable(NuGetFeatureFlags.UseSystemTextJsonDeserializationEnvVar)).Returns(useStj);
+
+            return new MetadataResourceV3(regResource, envReader.Object);
+        }
+
+        private static Dictionary<string, string> DeepEqualResponses()
+        {
+            return new Dictionary<string, string>
+            {
+                { "http://testsource.test/v3/index.json", JsonData.IndexWithoutFlatContainer },
+                { "https://api.nuget.org/v3/registration0/deepequal/index.json", JsonData.DeepEqualRegistationIndex },
+            };
+        }
+
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task GetVersions_BothPaths_ReturnsAllVersionsAsync(string useStj)
+        {
+            // Arrange
+            MetadataResourceV3 resource = await CreateResourceAsync(useStj, DeepEqualResponses());
+
+            // Act
+            using var sourceCacheContext = new SourceCacheContext();
+            IEnumerable<NuGetVersion> versions = await resource.GetVersions("deepequal", includePrerelease: true, includeUnlisted: true, sourceCacheContext, NullLogger.Instance, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(19, versions.Count());
+            Assert.Equal(1, versions.Count(v => v.IsPrerelease));
+            Assert.Contains(versions, v => v.ToNormalizedString() == "0.9.0");
+        }
+
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task GetLatestVersions_BothPaths_ReturnsLatestStableAsync(string useStj)
+        {
+            // Arrange
+            MetadataResourceV3 resource = await CreateResourceAsync(useStj, DeepEqualResponses());
+
+            // Act
+            using var sourceCacheContext = new SourceCacheContext();
+            IEnumerable<KeyValuePair<string, NuGetVersion>> latest = await resource.GetLatestVersions(new[] { "deepequal" }, includePrerelease: false, includeUnlisted: true, sourceCacheContext, NullLogger.Instance, CancellationToken.None);
+
+            // Assert
+            KeyValuePair<string, NuGetVersion> result = Assert.Single(latest);
+            Assert.Equal("deepequal", result.Key);
+            Assert.Equal("1.4.0", result.Value.ToNormalizedString());
+        }
+
+        [Theory]
+        [InlineData("true")]  // STJ path
+        [InlineData("false")] // NSJ path
+        public async Task Exists_BothPaths_ReturnsExpectedAsync(string useStj)
+        {
+            // Arrange
+            MetadataResourceV3 resource = await CreateResourceAsync(useStj, DeepEqualResponses());
+
+            // Act
+            using var sourceCacheContext = new SourceCacheContext();
+            bool exists = await resource.Exists(new PackageIdentity("deepequal", NuGetVersion.Parse("0.9.0")), includeUnlisted: true, sourceCacheContext, NullLogger.Instance, CancellationToken.None);
+            bool missing = await resource.Exists(new PackageIdentity("deepequal", NuGetVersion.Parse("99.0.0")), includeUnlisted: true, sourceCacheContext, NullLogger.Instance, CancellationToken.None);
+
+            // Assert
+            Assert.True(exists);
+            Assert.False(missing);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/PluginLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Logging/PluginLoggerTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text.Json.Nodes;
 using System.Threading;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -189,7 +190,7 @@ namespace NuGet.Protocol.Plugins.Tests
 
             public override string ToString()
             {
-                var message = new JObject(new JProperty("message", Message));
+                var message = new JsonObject { ["message"] = Message };
 
                 return ToString("random", message);
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ServiceIndexResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ServiceIndexResourceV3ProviderTests.cs
@@ -108,7 +108,14 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
             });
 
             Assert.IsType<InvalidDataException>(exception.InnerException);
-            Assert.IsType<JsonReaderException>(exception.InnerException.InnerException);
+            if (useStj)
+            {
+                Assert.IsAssignableFrom<System.Text.Json.JsonException>(exception.InnerException.InnerException);
+            }
+            else
+            {
+                Assert.IsType<JsonReaderException>(exception.InnerException.InnerException);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: follow up on other NuGet.Protocol AoT work

## Description

When running `dotnet publish` on an AoT app, you can use `/p:IlcGenerateMapFile=true /p:IlcGenerateDgmlFile=true` to generate extra diagnostic output which can be used to analyze what's contributing to the size of the executable, and the dependency graph of all the methods. This was used to determine that several megabytes of Newtonsoft.Json code was being included, and what parts of NuGet.Protocol were calling it (bringing it in).

Fixing the code reduces the AoT trimmed app by about 6 MB. There's no longer any Newtonsoft.Json code in the symbol map, but there is about 4.5 KB of metadata because some of NuGet.Protocol's public APIs return types like JObject, even if those APIs are never called.

There are basically two groups of changes:
* Data types related to plugins (credential providers) used JObject to create a json string in their `ToString()` implementations. These were switched over to System.Text.Json equivalents, even when the feature flag is not enabled. It's low risk because it's not parsing json provided by 3rd parties.
* Several of the remaining methods changed had return types of Newtonsoft.Json types, like `JObject`. Therefore, it's not possible to create Stj and Nj methods and have the existing public API call it. Instead, a new method with a strongly typed return type needs to be created, leading to what looks like a lot of duplicated code.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A, more of a refactoring. Existing tests that test the feature flag should already follow the new code paths.
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
