### PR TITLE
Add MSBuild CLI tests to Apex tests

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGet.Tests.Apex.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.VisualStudio\NuGet.VisualStudio.csproj" />
     <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.VisualStudio.Contracts\NuGet.VisualStudio.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\src\NuGet.Core\NuGet.ProjectModel\NuGet.ProjectModel.csproj" />
     <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
     <ProjectReference Include="..\NuGet.Console.TestContract\NuGet.Console.TestContract.csproj" />
     <ProjectReference Include="..\NuGet.PackageManagement.UI.TestContract\NuGet.PackageManagement.UI.TestContract.csproj" />

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/CliRestoreTests.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/CliRestoreTests.cs
@@ -18,21 +18,19 @@ using Xunit.Abstractions;
 namespace NuGet.Tests.Apex
 {
     /// <summary>
-    /// Verifies that NuGet restore works on the machine under test by running
-    /// <c>msbuild -t:restore</c> using the MSBuild that ships with the Visual Studio
-    /// installation under test, restoring a <c>PackageReference</c> from an HTTP package feed
-    /// (a <see cref="FileSystemBackedV3MockServer" />). The test package contains a file under
-    /// <c>contentFiles/</c> matched by a wildcard in its nuspec, and the test asserts (via
-    /// <see cref="LockFileFormat" />) that restore selected that content file. This means if you
-    /// modify restore and run this test locally, it will not test your changes. Use
-    /// MSBuild.Integration.Tests or unit tests to test other changes. This test is intended to catch
-    /// issues that may be specific to the environment on the machine, such as upgrading packages to a
-    /// version incompatible with MSBuild.
+    /// These tests are intended to validate that restore works with the MSBuild when NuGet is installed in VS normally.
+    /// MSBuild.Integration.Tests should be used for more exhaustive testing of restore with MSBuild.
     /// </summary>
+    /// <remarks>
+    /// These tests locate MSBuild.exe using vswhere.exe, so when running these tests locally, they will not take into
+    /// account any changes you have made to any product code. It will only test the NuGet that is installed in the VS
+    /// installation directory.
+    /// </remarks>
     [TestClass]
-    public class MSBuildRestoreTestCase
+    public class CliRestoreTests
     {
         private const int DefaultTimeout = 5 * 60 * 1000; // 5 minutes
+        private const string LoadMSBuildAssembliesMarkerFileName = "LoadMSBuildAssemblies.ran";
 
         /// <summary>
         /// Set by the MSTest framework. Used to write the MSBuild output into the test results
@@ -40,9 +38,21 @@ namespace NuGet.Tests.Apex
         /// </summary>
         public TestContext TestContext { get; set; } = null!;
 
+        /// <summary>
+        /// This test simulates a task running as part of the CollectPackageReferences target, which loads assemblies
+        /// out of MSBuild's bin directory, so the assemblies are loaded before NuGet's Restore task starts. It is intended
+        /// to validate whether MSBuild ships any assemblies that cause assembly loading conflicts with NuGet's Restore task.
+        /// </summary>
+        /// <remarks>
+        /// Key assemblies tested:
+        /// <list type="bullet">
+        /// <item>Newtonsoft.Json: NuGet.Protocol's HTTP deserialization</item>
+        /// <item>Microsoft.Extensions.FileSystemGlobbing: contentFiles with a wildcard include</item>
+        /// </list>
+        /// </remarks>
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        public async Task RestoreWithPackageReference_UsingVsUnderTestMSBuild_Succeeds()
+        public async Task RestoreRunsWhenMSBuildDepdendenciesAreLoaded()
         {
             // Arrange
             string? msbuildPath = LocateVisualStudioUnderTestMSBuild();
@@ -61,8 +71,8 @@ namespace NuGet.Tests.Apex
             string contentFileName = "sample.txt";
             string contentFilePackagePath = "contentFiles/any/any/" + contentFileName;
 
-            // Build a package with a file under contentFiles/ and a nuspec that uses a wildcard
-            // include to match it, so restore exercises the contentFiles glob-matching code path.
+            // Ensure Microsoft.Extensions.FileSystemGlobbing.dll can be loaded by using
+            // contentFiles with a wildcard include.
             var package = new SimpleTestPackageContext(packageName, packageVersion);
             package.Files.Clear();
             package.AddFile("lib/net472/_._");
@@ -82,8 +92,7 @@ namespace NuGet.Tests.Apex
 </package>");
             await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, package);
 
-            // Serve the package over HTTP via a mock V3 feed and remove the default local folder source,
-            // so the test exercises an HTTP restore rather than a file-system restore.
+            // Test Newtonsoft.Json can be loaded by using a V3 HTTP feed, so json has to be deserialized.
             using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
             mockServer.Start();
             pathContext.Settings.RemoveSource(SimpleTestSettingsContext.DefaultPackageSourceName);
@@ -99,6 +108,7 @@ namespace NuGet.Tests.Apex
                 filename: msbuildPath!,
                 workingDirectory: pathContext.SolutionRoot,
                 arguments: $"-t:restore \"{projectPath}\"",
+                timeOutInMilliseconds: DefaultTimeout,
                 testOutputHelper: outputCapture);
 
             CaptureMSBuildOutput(result, outputCapture);
@@ -109,15 +119,33 @@ namespace NuGet.Tests.Apex
                 result.ExitCode,
                 $"msbuild -t:restore failed (exit code {result.ExitCode}).{Environment.NewLine}{result.AllOutput}");
 
+            string markerFilePath = Path.Combine(pathContext.SolutionRoot, "obj", LoadMSBuildAssembliesMarkerFileName);
+            Assert.IsTrue(
+                File.Exists(markerFilePath),
+                $"Expected LoadMSBuildAssemblies to create '{markerFilePath}'.{Environment.NewLine}{result.AllOutput}");
+
+            string markerFileContents = File.ReadAllText(markerFilePath);
+            Assert.IsTrue(
+                int.TryParse(markerFileContents, NumberStyles.Integer, CultureInfo.InvariantCulture, out int loadedAssemblyCount),
+                $"Expected LoadMSBuildAssemblies marker file '{markerFilePath}' to contain an integer, but found '{markerFileContents}'." +
+                Environment.NewLine +
+                result.AllOutput);
+
+            Assert.IsTrue(
+                loadedAssemblyCount > 0,
+                $"Expected LoadMSBuildAssemblies to load at least one assembly, but it loaded {loadedAssemblyCount}." +
+                Environment.NewLine +
+                result.AllOutput);
+
             string assetsFilePath = Path.Combine(pathContext.SolutionRoot, "obj", "project.assets.json");
             Assert.IsTrue(
                 File.Exists(assetsFilePath),
                 $"Expected restore to generate '{assetsFilePath}'.{Environment.NewLine}{result.AllOutput}");
 
-            // Parse the assets file and verify the package was restored and its content file was
-            // selected for the project's target (i.e. the wildcard contentFiles include matched).
             LockFile lockFile = new LockFileFormat().Read(assetsFilePath);
 
+            // If restore successfully included the test package, this means it succesfully downloaded and parsed the flat
+            // container's index.json version list, which validates that Newtonsoft.Json could be loaded.
             LockFileTargetLibrary? library = lockFile.Targets
                 .SelectMany(target => target.Libraries)
                 .FirstOrDefault(lib => StringComparer.OrdinalIgnoreCase.Equals(lib.Name, packageName));
@@ -126,13 +154,18 @@ namespace NuGet.Tests.Apex
                 library,
                 $"Expected the assets file to contain a target library for '{packageName}'.{Environment.NewLine}{result.AllOutput}");
 
-            bool selectedContentFile = library!.ContentFiles
-                .Any(contentFile => StringComparer.OrdinalIgnoreCase.Equals(contentFile.Path, contentFilePackagePath));
+            // If the package's sample.txt is included as a content file with the correct action and copyToOutput value,
+            // this means Microsoft.Extensions.FileSystemGlobbing could be loaded
+            LockFileContentFile? selectedContentFile = library!.ContentFiles
+                .FirstOrDefault(contentFile => StringComparer.OrdinalIgnoreCase.Equals(contentFile.Path, contentFilePackagePath));
 
-            Assert.IsTrue(
+            Assert.IsNotNull(
                 selectedContentFile,
                 $"Expected the assets file to select content file '{contentFilePackagePath}' for '{packageName}', " +
                 $"but found: {string.Join(", ", library!.ContentFiles.Select(c => c.Path))}.{Environment.NewLine}{result.AllOutput}");
+
+            Assert.AreEqual("Content", selectedContentFile.BuildAction.Value, ignoreCase: true);
+            Assert.AreEqual(true, selectedContentFile.CopyToOutput);
         }
 
         private void CaptureMSBuildOutput(CommandRunnerResult result, CapturingTestOutputHelper outputCapture)
@@ -172,40 +205,52 @@ namespace NuGet.Tests.Apex
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
                     <TargetFramework>net472</TargetFramework>
+                    <LoadMSBuildAssembliesMarkerFile>$(MSBuildProjectDirectory)\obj\{{LoadMSBuildAssembliesMarkerFileName}}</LoadMSBuildAssembliesMarkerFile>
                   </PropertyGroup>
                   <ItemGroup>
                     <PackageReference Include="{{packageName}}" Version="{{packageVersion}}" />
                   </ItemGroup>
 
                   <!--
-                    Verifies that every assembly shipped next to MSBuild.exe can be loaded in the environment under
-                    test. Runs before CollectPackageReference (i.e. as part of restore) so the test catches machines
-                    where an assembly in the MSBuild directory fails to load. Each load is wrapped in a try-catch so
-                    an individual assembly that cannot be loaded is skipped rather than failing the build.
+                    Simulate a task that loads all the assemblies in the MSBuild bin directory.
                   -->
                   <UsingTask TaskName="LoadMSBuildAssemblies" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
                     <ParameterGroup>
                       <Directory ParameterType="System.String" Required="true" />
+                      <MarkerFile ParameterType="System.String" Required="true" />
                     </ParameterGroup>
                     <Task>
                       <Code Type="Fragment" Language="cs"><![CDATA[
+                        int loadedAssemblyCount = 0;
+
                         foreach (string file in System.IO.Directory.GetFiles(Directory, "*.dll"))
                         {
                             try
                             {
                                 System.Reflection.Assembly.LoadFrom(file);
+                                loadedAssemblyCount++;
                             }
                             catch
                             {
                                 // Skip assemblies that fail to load.
                             }
                         }
+
+                        string markerDirectory = System.IO.Path.GetDirectoryName(MarkerFile);
+                        if (!string.IsNullOrEmpty(markerDirectory))
+                        {
+                            System.IO.Directory.CreateDirectory(markerDirectory);
+                        }
+
+                        System.IO.File.WriteAllText(
+                            MarkerFile,
+                            loadedAssemblyCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
                       ]]></Code>
                     </Task>
                   </UsingTask>
 
-                  <Target Name="LoadMSBuildAssembliesBeforeRestore" BeforeTargets="CollectPackageReference">
-                    <LoadMSBuildAssemblies Directory="$(MSBuildBinPath)" />
+                  <Target Name="LoadMSBuildAssembliesBeforeRestore" BeforeTargets="CollectPackageReferences">
+                    <LoadMSBuildAssemblies Directory="$(MSBuildBinPath)" MarkerFile="$(LoadMSBuildAssembliesMarkerFile)" />
                   </Target>
                 </Project>
                 """;
@@ -331,8 +376,9 @@ namespace NuGet.Tests.Apex
         }
 
         /// <summary>
-        /// Captures the lines forwarded by <see cref="CommandRunner" /> into a single buffer,
-        /// preserving the chronological order in which stdout and stderr were written.
+        /// CommandRunnerResult doesn't maintain the correct order of stderr and stdout messages, and this test project
+        /// uses MSTest, whereas CommandRunner takes in xUnit's ITestOutputHelper. So, this helper is a simple buffer
+        /// that captures both stdout and stderr in the order they were received.
         /// </summary>
         private sealed class CapturingTestOutputHelper : ITestOutputHelper
         {

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/CliRestoreTests.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/CliRestoreTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
@@ -13,18 +11,17 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using Test.Utility;
-using Xunit.Abstractions;
 
 namespace NuGet.Tests.Apex
 {
     /// <summary>
-    /// These tests are intended to validate that restore works with the MSBuild when NuGet is installed in VS normally.
+    /// These tests are intended to validate that restore works with MSBuild when NuGet is installed in VS normally.
     /// MSBuild.Integration.Tests should be used for more exhaustive testing of restore with MSBuild.
     /// </summary>
     /// <remarks>
     /// These tests locate MSBuild.exe using vswhere.exe, so when running these tests locally, they will not take into
     /// account any changes you have made to any product code. It will only test the NuGet that is installed in the VS
-    /// installation directory.
+    /// installation directory. The VS "experimental instance" is a devenv.exe only concept, not MSBuild.
     /// </remarks>
     [TestClass]
     public class CliRestoreTests
@@ -32,47 +29,63 @@ namespace NuGet.Tests.Apex
         private const int DefaultTimeout = 5 * 60 * 1000; // 5 minutes
         private const string LoadMSBuildAssembliesMarkerFileName = "LoadMSBuildAssemblies.ran";
 
-        /// <summary>
-        /// Set by the MSTest framework. Used to write the MSBuild output into the test results
-        /// and to attach the captured stdout/stderr as result files.
-        /// </summary>
         public TestContext TestContext { get; set; } = null!;
 
         /// <summary>
-        /// This test simulates a task running as part of the CollectPackageReferences target, which loads assemblies
-        /// out of MSBuild's bin directory, so the assemblies are loaded before NuGet's Restore task starts. It is intended
-        /// to validate whether MSBuild ships any assemblies that cause assembly loading conflicts with NuGet's Restore task.
+        /// Validates restore still runs when assemblies from MSBuild's bin directory are loaded first.
         /// </summary>
         /// <remarks>
-        /// Key assemblies tested:
-        /// <list type="bullet">
-        /// <item>Newtonsoft.Json: NuGet.Protocol's HTTP deserialization</item>
-        /// <item>Microsoft.Extensions.FileSystemGlobbing: contentFiles with a wildcard include</item>
-        /// </list>
+        /// Uses a V3 HTTP feed to exercise Newtonsoft.Json and contentFiles wildcard matching to exercise
+        /// Microsoft.Extensions.FileSystemGlobbing.
         /// </remarks>
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        public async Task RestoreRunsWhenMSBuildDepdendenciesAreLoaded()
+        public async Task RestoreRunsWhenMSBuildDependenciesAreLoaded()
         {
             // Arrange
-            string? msbuildPath = LocateVisualStudioUnderTestMSBuild();
+            string? msbuildPath = VisualStudioMSBuildLocator.GetMSBuildPath();
             if (msbuildPath is null)
             {
                 Assert.Inconclusive(
-                    "Could not locate MSBuild from the Visual Studio installation under test. " +
-                    "Checked the 'MSBUILD_EXE_PATH' and 'VisualStudio.InstallationUnderTest.Path' environment variables, " +
-                    "'VSAPPIDDIR'/'DevEnvDir', and vswhere. Ensure a Visual Studio instance with MSBuild is installed.");
+                    "Could not locate MSBuild from the Visual Studio installation under test using vswhere. " +
+                    "Ensure a Visual Studio instance with MSBuild is installed.");
+                return;
             }
 
             using var pathContext = new SimpleTestPathContext();
 
-            string packageName = "TestPackage";
-            string packageVersion = "1.0.0";
-            string contentFileName = "sample.txt";
-            string contentFilePackagePath = "contentFiles/any/any/" + contentFileName;
+            const string PackageName = "TestPackage";
+            const string PackageVersion = "1.0.0";
+            const string ContentFilePackagePath = "contentFiles/any/any/sample.txt";
 
-            // Ensure Microsoft.Extensions.FileSystemGlobbing.dll can be loaded by using
-            // contentFiles with a wildcard include.
+            await CreatePackageWithContentFileAsync(pathContext.PackageSource, PackageName, PackageVersion, ContentFilePackagePath);
+
+            using var mockServer = CreateMockServer(pathContext);
+
+            string projectPath = Path.Combine(pathContext.SolutionRoot, "test.csproj");
+            File.WriteAllText(projectPath, GetProjectXml(PackageName, PackageVersion));
+
+            // Act
+            CommandRunnerResult result = RunMSBuildRestore(msbuildPath, pathContext.SolutionRoot, projectPath);
+            TestContext.WriteLine($"msbuild -t:restore exit code: {result.ExitCode}");
+            TestContext.WriteLine(result.AllOutput);
+
+            // Assert
+            Assert.AreEqual(
+                0,
+                result.ExitCode,
+                result.AllOutput);
+
+            AssertLoadMSBuildAssembliesRan(pathContext.SolutionRoot, result.AllOutput);
+            AssertContentFileSelected(pathContext.SolutionRoot, PackageName, PackageVersion, ContentFilePackagePath, result.AllOutput);
+        }
+
+        private static async Task CreatePackageWithContentFileAsync(
+            string packageSource,
+            string packageName,
+            string packageVersion,
+            string contentFilePackagePath)
+        {
             var package = new SimpleTestPackageContext(packageName, packageVersion);
             package.Files.Clear();
             package.AddFile("lib/net472/_._");
@@ -90,117 +103,79 @@ namespace NuGet.Tests.Apex
     </contentFiles>
   </metadata>
 </package>");
-            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, package);
 
-            // Test Newtonsoft.Json can be loaded by using a V3 HTTP feed, so json has to be deserialized.
-            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
+            await SimpleTestPackageUtility.CreatePackagesAsync(packageSource, package);
+        }
+
+        private static FileSystemBackedV3MockServer CreateMockServer(SimpleTestPathContext pathContext)
+        {
+            var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
             mockServer.Start();
+
             pathContext.Settings.RemoveSource(SimpleTestSettingsContext.DefaultPackageSourceName);
             pathContext.Settings.AddSource("mockSource", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "true");
 
-            string projectName = "test";
-            string projectPath = Path.Combine(pathContext.SolutionRoot, projectName + ".csproj");
-            File.WriteAllText(projectPath, GetProjectXml(packageName, packageVersion));
+            return mockServer;
+        }
 
-            // Act
-            var outputCapture = new CapturingTestOutputHelper();
-            CommandRunnerResult result = CommandRunner.Run(
-                filename: msbuildPath!,
-                workingDirectory: pathContext.SolutionRoot,
+        private static CommandRunnerResult RunMSBuildRestore(string msbuildPath, string solutionRoot, string projectPath)
+        {
+            return CommandRunner.Run(
+                filename: msbuildPath,
+                workingDirectory: solutionRoot,
                 arguments: $"-t:restore \"{projectPath}\"",
-                timeOutInMilliseconds: DefaultTimeout,
-                testOutputHelper: outputCapture);
+                timeOutInMilliseconds: DefaultTimeout);
+        }
 
-            CaptureMSBuildOutput(result, outputCapture);
-
-            // Assert
-            Assert.AreEqual(
-                0,
-                result.ExitCode,
-                $"msbuild -t:restore failed (exit code {result.ExitCode}).{Environment.NewLine}{result.AllOutput}");
-
-            string markerFilePath = Path.Combine(pathContext.SolutionRoot, "obj", LoadMSBuildAssembliesMarkerFileName);
+        private static void AssertLoadMSBuildAssembliesRan(string solutionRoot, string output)
+        {
+            string markerFilePath = Path.Combine(solutionRoot, "obj", LoadMSBuildAssembliesMarkerFileName);
             Assert.IsTrue(
                 File.Exists(markerFilePath),
-                $"Expected LoadMSBuildAssemblies to create '{markerFilePath}'.{Environment.NewLine}{result.AllOutput}");
+                $"Expected LoadMSBuildAssemblies to create '{markerFilePath}'.{Environment.NewLine}{output}");
+        }
 
-            string markerFileContents = File.ReadAllText(markerFilePath);
-            Assert.IsTrue(
-                int.TryParse(markerFileContents, NumberStyles.Integer, CultureInfo.InvariantCulture, out int loadedAssemblyCount),
-                $"Expected LoadMSBuildAssemblies marker file '{markerFilePath}' to contain an integer, but found '{markerFileContents}'." +
-                Environment.NewLine +
-                result.AllOutput);
-
-            Assert.IsTrue(
-                loadedAssemblyCount > 0,
-                $"Expected LoadMSBuildAssemblies to load at least one assembly, but it loaded {loadedAssemblyCount}." +
-                Environment.NewLine +
-                result.AllOutput);
-
-            string assetsFilePath = Path.Combine(pathContext.SolutionRoot, "obj", "project.assets.json");
+        private static void AssertContentFileSelected(
+            string solutionRoot,
+            string packageName,
+            string packageVersion,
+            string contentFilePackagePath,
+            string output)
+        {
+            string assetsFilePath = Path.Combine(solutionRoot, "obj", "project.assets.json");
             Assert.IsTrue(
                 File.Exists(assetsFilePath),
-                $"Expected restore to generate '{assetsFilePath}'.{Environment.NewLine}{result.AllOutput}");
+                $"Expected restore to generate '{assetsFilePath}'.{Environment.NewLine}{output}");
 
-            LockFile lockFile = new LockFileFormat().Read(assetsFilePath);
+            TestLogger logger = new();
+            LockFile? assetsFile = new LockFileFormat().Read(assetsFilePath, logger);
+            Assert.AreEqual(0, logger.Messages.Count, string.Join("\n", logger.Messages));
 
-            // If restore successfully included the test package, this means it succesfully downloaded and parsed the flat
-            // container's index.json version list, which validates that Newtonsoft.Json could be loaded.
-            LockFileTargetLibrary? library = lockFile.Targets
-                .SelectMany(target => target.Libraries)
-                .FirstOrDefault(lib => StringComparer.OrdinalIgnoreCase.Equals(lib.Name, packageName));
+            if (assetsFile is null)
+            {
+                Assert.Fail($"Expected restore to generate a valid assets file at '{assetsFilePath}'.{Environment.NewLine}{output}");
+                return;
+            }
 
-            Assert.IsNotNull(
-                library,
-                $"Expected the assets file to contain a target library for '{packageName}'.{Environment.NewLine}{result.AllOutput}");
+            LockFileTarget target = assetsFile.Targets.Single();
+            LockFileTargetLibrary library = target.Libraries.Single(l => l.Name == packageName);
+            LockFileContentFile? selectedContentFile = library.ContentFiles
+                .SingleOrDefault(contentFile => StringComparer.OrdinalIgnoreCase.Equals(contentFile.Path, contentFilePackagePath));
 
-            // If the package's sample.txt is included as a content file with the correct action and copyToOutput value,
-            // this means Microsoft.Extensions.FileSystemGlobbing could be loaded
-            LockFileContentFile? selectedContentFile = library!.ContentFiles
-                .FirstOrDefault(contentFile => StringComparer.OrdinalIgnoreCase.Equals(contentFile.Path, contentFilePackagePath));
-
-            Assert.IsNotNull(
-                selectedContentFile,
-                $"Expected the assets file to select content file '{contentFilePackagePath}' for '{packageName}', " +
-                $"but found: {string.Join(", ", library!.ContentFiles.Select(c => c.Path))}.{Environment.NewLine}{result.AllOutput}");
+            if (selectedContentFile is null)
+            {
+                Assert.Fail(
+                    $"Expected the assets file to select content file '{contentFilePackagePath}' for '{packageName}', " +
+                    $"but found: {string.Join(", ", library.ContentFiles.Select(c => c.Path))}.{Environment.NewLine}{output}");
+                return;
+            }
 
             Assert.AreEqual("Content", selectedContentFile.BuildAction.Value, ignoreCase: true);
             Assert.AreEqual(true, selectedContentFile.CopyToOutput);
         }
 
-        private void CaptureMSBuildOutput(CommandRunnerResult result, CapturingTestOutputHelper outputCapture)
-        {
-            // outputCapture preserves the chronological order in which MSBuild wrote to stdout and
-            // stderr, because CommandRunner forwards both streams to the ITestOutputHelper as lines
-            // arrive. result.AllOutput, by contrast, concatenates stdout then stderr and loses ordering.
-            string combinedOutput = outputCapture.ToString();
-
-            TestContext.WriteLine($"msbuild -t:restore exit code: {result.ExitCode}");
-            TestContext.WriteLine(combinedOutput);
-
-            string? resultsDirectory = TestContext.ResultsDirectory;
-            if (string.IsNullOrEmpty(resultsDirectory))
-            {
-                // Without a results directory we can't attach a file, but the output above is still
-                // captured inline in the test results.
-                return;
-            }
-
-            // Write the captured output outside the SimpleTestPathContext working directory so the
-            // file survives its disposal and can be copied into the test results.
-            string outputDirectory = Path.Combine(resultsDirectory!, "MSBuildRestoreTestCase", Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(outputDirectory);
-
-            string logPath = Path.Combine(outputDirectory, "msbuild.restore.log");
-            File.WriteAllText(logPath, combinedOutput);
-
-            TestContext.AddResultFile(logPath);
-        }
-
         private static string GetProjectXml(string packageName, string packageVersion)
         {
-            // Raw string literal with a doubled interpolation prefix ($$), so {{ }} delimit the
-            // interpolation holes and the inline task's single braces are treated as literal text.
             return $$"""
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
@@ -211,9 +186,6 @@ namespace NuGet.Tests.Apex
                     <PackageReference Include="{{packageName}}" Version="{{packageVersion}}" />
                   </ItemGroup>
 
-                  <!--
-                    Simulate a task that loads all the assemblies in the MSBuild bin directory.
-                  -->
                   <UsingTask TaskName="LoadMSBuildAssemblies" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
                     <ParameterGroup>
                       <Directory ParameterType="System.String" Required="true" />
@@ -221,14 +193,11 @@ namespace NuGet.Tests.Apex
                     </ParameterGroup>
                     <Task>
                       <Code Type="Fragment" Language="cs"><![CDATA[
-                        int loadedAssemblyCount = 0;
-
                         foreach (string file in System.IO.Directory.GetFiles(Directory, "*.dll"))
                         {
                             try
                             {
                                 System.Reflection.Assembly.LoadFrom(file);
-                                loadedAssemblyCount++;
                             }
                             catch
                             {
@@ -242,9 +211,7 @@ namespace NuGet.Tests.Apex
                             System.IO.Directory.CreateDirectory(markerDirectory);
                         }
 
-                        System.IO.File.WriteAllText(
-                            MarkerFile,
-                            loadedAssemblyCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                        System.IO.File.WriteAllText(MarkerFile, string.Empty);
                       ]]></Code>
                     </Task>
                   </UsingTask>
@@ -254,156 +221,6 @@ namespace NuGet.Tests.Apex
                   </Target>
                 </Project>
                 """;
-        }
-
-        /// <summary>
-        /// Resolves the path to <c>MSBuild.exe</c> from the Visual Studio installation under test,
-        /// without launching Visual Studio. Apex's own installation discovery (the internal
-        /// <c>Microsoft.Test.Apex.VisualStudio.Skus</c> types) is not exposed as a public helper that
-        /// can be queried without starting the host, so this mirrors the discovery Apex itself relies
-        /// on and that the rest of this repository already uses (see
-        /// <c>MsbuildIntegrationTestFixture</c> and <c>build/common.ps1</c>):
-        /// <list type="number">
-        /// <item><description><c>MSBUILD_EXE_PATH</c> (set by build.proj when running Apex tests standalone).</description></item>
-        /// <item><description>The Apex install environment variables <c>VisualStudio.InstallationUnderTest.Path</c>,
-        /// <c>VSAPPIDDIR</c>, and <c>DevEnvDir</c>.</description></item>
-        /// <item><description><c>vswhere</c>, which uses the VS Setup Configuration API to locate an installed instance
-        /// (this is what works on the CI/DartLab machines, where the install is configured via the .runsettings).</description></item>
-        /// </list>
-        /// </summary>
-        /// <returns>The full path to MSBuild.exe, or <see langword="null" /> if it cannot be resolved.</returns>
-        private static string? LocateVisualStudioUnderTestMSBuild()
-        {
-            // 1. MSBUILD_EXE_PATH points directly at MSBuild.exe when set (e.g. by build.proj).
-            string? msbuildExePath = Environment.GetEnvironmentVariable("MSBUILD_EXE_PATH");
-            if (!string.IsNullOrEmpty(msbuildExePath) && File.Exists(msbuildExePath))
-            {
-                return msbuildExePath;
-            }
-
-            // 2. Apex install environment variables. The value may be the install root (build.proj sets
-            // it to VSINSTALLDIR) or a path to devenv.exe (VisualStudioOperationsFixture sets it that way),
-            // and VSAPPIDDIR/DevEnvDir point at <root>\Common7\IDE, so each value is normalized to a root.
-            foreach (string variableName in new[] { "VisualStudio.InstallationUnderTest.Path", "VSAPPIDDIR", "DevEnvDir" })
-            {
-                string? installRoot = GetInstallRoot(Environment.GetEnvironmentVariable(variableName));
-                string? msbuild = TryGetMSBuildFromInstallRoot(installRoot);
-                if (msbuild != null)
-                {
-                    return msbuild;
-                }
-            }
-
-            // 3. Fall back to vswhere, which is what locates the instance on CI machines.
-            return FindMSBuildWithVsWhere();
-        }
-
-        /// <summary>
-        /// Normalizes a Visual Studio path environment variable value to the installation root.
-        /// Handles values that point at devenv.exe, at the <c>Common7\IDE</c> directory, or already at the root.
-        /// </summary>
-        private static string? GetInstallRoot(string? value)
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                return null;
-            }
-
-            string path = value!;
-
-            // A path to an executable (e.g. devenv.exe) -> its containing directory.
-            if (path.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-            {
-                path = Path.GetDirectoryName(path) ?? path;
-            }
-
-            path = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-            // <root>\Common7\IDE -> <root>
-            string common7Ide = Path.Combine("Common7", "IDE");
-            if (path.EndsWith(common7Ide, StringComparison.OrdinalIgnoreCase))
-            {
-                string? common7Directory = Path.GetDirectoryName(path);
-                return common7Directory is null ? null : Path.GetDirectoryName(common7Directory);
-            }
-
-            return path;
-        }
-
-        /// <summary>
-        /// Returns the path to <c>MSBuild.exe</c> under the given install root if it exists, otherwise <see langword="null" />.
-        /// </summary>
-        private static string? TryGetMSBuildFromInstallRoot(string? installRoot)
-        {
-            if (string.IsNullOrEmpty(installRoot))
-            {
-                return null;
-            }
-
-            string msbuildPath = Path.Combine(installRoot!, "MSBuild", "Current", "Bin", "MSBuild.exe");
-            return File.Exists(msbuildPath) ? msbuildPath : null;
-        }
-
-        /// <summary>
-        /// Locates MSBuild.exe using vswhere, which queries the Visual Studio Setup Configuration API.
-        /// </summary>
-        private static string? FindMSBuildWithVsWhere()
-        {
-            string vswherePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
-                "Microsoft Visual Studio",
-                "Installer",
-                "vswhere.exe");
-
-            if (!File.Exists(vswherePath))
-            {
-                return null;
-            }
-
-            CommandRunnerResult result = CommandRunner.Run(
-                filename: vswherePath,
-                arguments: "-latest -prerelease -requires Microsoft.Component.MSBuild -find MSBuild\\**\\Bin\\MSBuild.exe");
-
-            if (!result.Success)
-            {
-                return null;
-            }
-
-            using var reader = new StringReader(result.Output);
-            string? line = reader.ReadLine();
-
-            return !string.IsNullOrEmpty(line) && File.Exists(line) ? line : null;
-        }
-
-        /// <summary>
-        /// CommandRunnerResult doesn't maintain the correct order of stderr and stdout messages, and this test project
-        /// uses MSTest, whereas CommandRunner takes in xUnit's ITestOutputHelper. So, this helper is a simple buffer
-        /// that captures both stdout and stderr in the order they were received.
-        /// </summary>
-        private sealed class CapturingTestOutputHelper : ITestOutputHelper
-        {
-            private readonly StringBuilder _builder = new();
-
-            public void WriteLine(string message)
-            {
-                lock (_builder)
-                {
-                    _builder.AppendLine(message);
-                }
-            }
-
-            public void WriteLine(string format, params object[] args)
-            {
-                WriteLine(string.Format(CultureInfo.CurrentCulture, format, args));
-            }
-
-            public override string ToString()
-            {
-                lock (_builder)
-                {
-                    return _builder.ToString();
-                }
-            }
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/MSBuildRestoreTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/MSBuildRestoreTestCase.cs
@@ -4,11 +4,15 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NuGet.ProjectModel;
 using NuGet.Test.Utility;
+using Test.Utility;
 using Xunit.Abstractions;
 
 namespace NuGet.Tests.Apex
@@ -16,10 +20,14 @@ namespace NuGet.Tests.Apex
     /// <summary>
     /// Verifies that NuGet restore works on the machine under test by running
     /// <c>msbuild -t:restore</c> using the MSBuild that ships with the Visual Studio
-    /// installation under test. This means if you modify restore and run this test locally,
-    /// it will not test your changes. Use MSBuild.Integration.Tests or unit tests to test
-    /// other changes. This test is intended to catch issues that may be specific to the environment
-    /// on the machine, such as upgrading packages to a version incompatible with MSBuild.
+    /// installation under test, restoring a <c>PackageReference</c> from an HTTP package feed
+    /// (a <see cref="FileSystemBackedV3MockServer" />). The test package contains a file under
+    /// <c>contentFiles/</c> matched by a wildcard in its nuspec, and the test asserts (via
+    /// <see cref="LockFileFormat" />) that restore selected that content file. This means if you
+    /// modify restore and run this test locally, it will not test your changes. Use
+    /// MSBuild.Integration.Tests or unit tests to test other changes. This test is intended to catch
+    /// issues that may be specific to the environment on the machine, such as upgrading packages to a
+    /// version incompatible with MSBuild.
     /// </summary>
     [TestClass]
     public class MSBuildRestoreTestCase
@@ -50,7 +58,36 @@ namespace NuGet.Tests.Apex
 
             string packageName = "TestPackage";
             string packageVersion = "1.0.0";
-            await CommonUtility.CreatePackageInSourceAsync(pathContext.PackageSource, packageName, packageVersion);
+            string contentFileName = "sample.txt";
+            string contentFilePackagePath = "contentFiles/any/any/" + contentFileName;
+
+            // Build a package with a file under contentFiles/ and a nuspec that uses a wildcard
+            // include to match it, so restore exercises the contentFiles glob-matching code path.
+            var package = new SimpleTestPackageContext(packageName, packageVersion);
+            package.Files.Clear();
+            package.AddFile("lib/net472/_._");
+            package.AddFile(contentFilePackagePath, "// content file served by the test package");
+            package.Nuspec = XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+  <metadata>
+    <id>{packageName}</id>
+    <version>{packageVersion}</version>
+    <title>{packageName}</title>
+    <authors>NuGet</authors>
+    <description>{packageName}</description>
+    <contentFiles>
+      <files include=""any/any/*.txt"" buildAction=""Content"" copyToOutput=""true"" flatten=""false"" />
+    </contentFiles>
+  </metadata>
+</package>");
+            await SimpleTestPackageUtility.CreatePackagesAsync(pathContext.PackageSource, package);
+
+            // Serve the package over HTTP via a mock V3 feed and remove the default local folder source,
+            // so the test exercises an HTTP restore rather than a file-system restore.
+            using var mockServer = new FileSystemBackedV3MockServer(pathContext.PackageSource);
+            mockServer.Start();
+            pathContext.Settings.RemoveSource(SimpleTestSettingsContext.DefaultPackageSourceName);
+            pathContext.Settings.AddSource("mockSource", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "true");
 
             string projectName = "test";
             string projectPath = Path.Combine(pathContext.SolutionRoot, projectName + ".csproj");
@@ -77,11 +114,25 @@ namespace NuGet.Tests.Apex
                 File.Exists(assetsFilePath),
                 $"Expected restore to generate '{assetsFilePath}'.{Environment.NewLine}{result.AllOutput}");
 
-            string assetsFileContent = File.ReadAllText(assetsFilePath);
-            StringAssert.Contains(
-                assetsFileContent,
-                packageName,
-                $"Expected the assets file to reference '{packageName}'.{Environment.NewLine}{result.AllOutput}");
+            // Parse the assets file and verify the package was restored and its content file was
+            // selected for the project's target (i.e. the wildcard contentFiles include matched).
+            LockFile lockFile = new LockFileFormat().Read(assetsFilePath);
+
+            LockFileTargetLibrary? library = lockFile.Targets
+                .SelectMany(target => target.Libraries)
+                .FirstOrDefault(lib => StringComparer.OrdinalIgnoreCase.Equals(lib.Name, packageName));
+
+            Assert.IsNotNull(
+                library,
+                $"Expected the assets file to contain a target library for '{packageName}'.{Environment.NewLine}{result.AllOutput}");
+
+            bool selectedContentFile = library!.ContentFiles
+                .Any(contentFile => StringComparer.OrdinalIgnoreCase.Equals(contentFile.Path, contentFilePackagePath));
+
+            Assert.IsTrue(
+                selectedContentFile,
+                $"Expected the assets file to select content file '{contentFilePackagePath}' for '{packageName}', " +
+                $"but found: {string.Join(", ", library!.ContentFiles.Select(c => c.Path))}.{Environment.NewLine}{result.AllOutput}");
         }
 
         private void CaptureMSBuildOutput(CommandRunnerResult result, CapturingTestOutputHelper outputCapture)

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/MSBuildRestoreTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/MSBuildRestoreTestCase.cs
@@ -2,11 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NuGet.Test.Utility;
+using Xunit.Abstractions;
 
 namespace NuGet.Tests.Apex
 {
@@ -23,6 +26,12 @@ namespace NuGet.Tests.Apex
     {
         private const int DefaultTimeout = 5 * 60 * 1000; // 5 minutes
 
+        /// <summary>
+        /// Set by the MSTest framework. Used to write the MSBuild output into the test results
+        /// and to attach the captured stdout/stderr as result files.
+        /// </summary>
+        public TestContext TestContext { get; set; } = null!;
+
         [TestMethod]
         [Timeout(DefaultTimeout)]
         public async Task RestoreWithPackageReference_UsingVsUnderTestMSBuild_Succeeds()
@@ -32,9 +41,9 @@ namespace NuGet.Tests.Apex
             if (msbuildPath is null)
             {
                 Assert.Inconclusive(
-                    "Could not locate the Visual Studio installation under test. " +
-                    "Set the 'VisualStudio.InstallationUnderTest.Path' environment variable, " +
-                    "or run from a Developer Command Prompt/PowerShell so that VSAPPIDDIR or DevEnvDir is set.");
+                    "Could not locate MSBuild from the Visual Studio installation under test. " +
+                    "Checked the 'MSBUILD_EXE_PATH' and 'VisualStudio.InstallationUnderTest.Path' environment variables, " +
+                    "'VSAPPIDDIR'/'DevEnvDir', and vswhere. Ensure a Visual Studio instance with MSBuild is installed.");
             }
 
             using var pathContext = new SimpleTestPathContext();
@@ -48,10 +57,14 @@ namespace NuGet.Tests.Apex
             File.WriteAllText(projectPath, GetProjectXml(packageName, packageVersion));
 
             // Act
+            var outputCapture = new CapturingTestOutputHelper();
             CommandRunnerResult result = CommandRunner.Run(
                 filename: msbuildPath!,
                 workingDirectory: pathContext.SolutionRoot,
-                arguments: $"-t:restore \"{projectPath}\"");
+                arguments: $"-t:restore \"{projectPath}\"",
+                testOutputHelper: outputCapture);
+
+            CaptureMSBuildOutput(result, outputCapture);
 
             // Assert
             Assert.AreEqual(
@@ -71,6 +84,35 @@ namespace NuGet.Tests.Apex
                 $"Expected the assets file to reference '{packageName}'.{Environment.NewLine}{result.AllOutput}");
         }
 
+        private void CaptureMSBuildOutput(CommandRunnerResult result, CapturingTestOutputHelper outputCapture)
+        {
+            // outputCapture preserves the chronological order in which MSBuild wrote to stdout and
+            // stderr, because CommandRunner forwards both streams to the ITestOutputHelper as lines
+            // arrive. result.AllOutput, by contrast, concatenates stdout then stderr and loses ordering.
+            string combinedOutput = outputCapture.ToString();
+
+            TestContext.WriteLine($"msbuild -t:restore exit code: {result.ExitCode}");
+            TestContext.WriteLine(combinedOutput);
+
+            string? resultsDirectory = TestContext.ResultsDirectory;
+            if (string.IsNullOrEmpty(resultsDirectory))
+            {
+                // Without a results directory we can't attach a file, but the output above is still
+                // captured inline in the test results.
+                return;
+            }
+
+            // Write the captured output outside the SimpleTestPathContext working directory so the
+            // file survives its disposal and can be copied into the test results.
+            string outputDirectory = Path.Combine(resultsDirectory!, "MSBuildRestoreTestCase", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(outputDirectory);
+
+            string logPath = Path.Combine(outputDirectory, "msbuild.restore.log");
+            File.WriteAllText(logPath, combinedOutput);
+
+            TestContext.AddResultFile(logPath);
+        }
+
         private static string GetProjectXml(string packageName, string packageVersion)
         {
             return $@"<Project Sdk=""Microsoft.NET.Sdk"">
@@ -84,46 +126,152 @@ namespace NuGet.Tests.Apex
         }
 
         /// <summary>
-        /// Resolves the path to <c>MSBuild.exe</c> from the Visual Studio installation under test.
-        /// Uses the same environment variables that the Apex host uses to locate Visual Studio:
-        /// <c>VisualStudio.InstallationUnderTest.Path</c> (path to devenv.exe), falling back to
-        /// <c>VSAPPIDDIR</c> / <c>DevEnvDir</c> (the Common7\IDE directory).
+        /// Resolves the path to <c>MSBuild.exe</c> from the Visual Studio installation under test,
+        /// without launching Visual Studio. Apex's own installation discovery (the internal
+        /// <c>Microsoft.Test.Apex.VisualStudio.Skus</c> types) is not exposed as a public helper that
+        /// can be queried without starting the host, so this mirrors the discovery Apex itself relies
+        /// on and that the rest of this repository already uses (see
+        /// <c>MsbuildIntegrationTestFixture</c> and <c>build/common.ps1</c>):
+        /// <list type="number">
+        /// <item><description><c>MSBUILD_EXE_PATH</c> (set by build.proj when running Apex tests standalone).</description></item>
+        /// <item><description>The Apex install environment variables <c>VisualStudio.InstallationUnderTest.Path</c>,
+        /// <c>VSAPPIDDIR</c>, and <c>DevEnvDir</c>.</description></item>
+        /// <item><description><c>vswhere</c>, which uses the VS Setup Configuration API to locate an installed instance
+        /// (this is what works on the CI/DartLab machines, where the install is configured via the .runsettings).</description></item>
+        /// </list>
         /// </summary>
         /// <returns>The full path to MSBuild.exe, or <see langword="null" /> if it cannot be resolved.</returns>
         private static string? LocateVisualStudioUnderTestMSBuild()
         {
-            string? ideDirectory = null;
-
-            string? devenvPath = Environment.GetEnvironmentVariable("VisualStudio.InstallationUnderTest.Path");
-            if (!string.IsNullOrEmpty(devenvPath))
+            // 1. MSBUILD_EXE_PATH points directly at MSBuild.exe when set (e.g. by build.proj).
+            string? msbuildExePath = Environment.GetEnvironmentVariable("MSBUILD_EXE_PATH");
+            if (!string.IsNullOrEmpty(msbuildExePath) && File.Exists(msbuildExePath))
             {
-                // The value points to devenv.exe, which lives in <root>\Common7\IDE.
-                ideDirectory = Path.GetDirectoryName(devenvPath);
+                return msbuildExePath;
             }
 
-            if (string.IsNullOrEmpty(ideDirectory))
+            // 2. Apex install environment variables. The value may be the install root (build.proj sets
+            // it to VSINSTALLDIR) or a path to devenv.exe (VisualStudioOperationsFixture sets it that way),
+            // and VSAPPIDDIR/DevEnvDir point at <root>\Common7\IDE, so each value is normalized to a root.
+            foreach (string variableName in new[] { "VisualStudio.InstallationUnderTest.Path", "VSAPPIDDIR", "DevEnvDir" })
             {
-                ideDirectory = Environment.GetEnvironmentVariable("VSAPPIDDIR")
-                    ?? Environment.GetEnvironmentVariable("DevEnvDir");
+                string? installRoot = GetInstallRoot(Environment.GetEnvironmentVariable(variableName));
+                string? msbuild = TryGetMSBuildFromInstallRoot(installRoot);
+                if (msbuild != null)
+                {
+                    return msbuild;
+                }
             }
 
-            if (string.IsNullOrEmpty(ideDirectory))
+            // 3. Fall back to vswhere, which is what locates the instance on CI machines.
+            return FindMSBuildWithVsWhere();
+        }
+
+        /// <summary>
+        /// Normalizes a Visual Studio path environment variable value to the installation root.
+        /// Handles values that point at devenv.exe, at the <c>Common7\IDE</c> directory, or already at the root.
+        /// </summary>
+        private static string? GetInstallRoot(string? value)
+        {
+            if (string.IsNullOrEmpty(value))
             {
                 return null;
             }
 
-            // <root>\Common7\IDE -> <root>
-            string? common7Directory = Path.GetDirectoryName(ideDirectory!.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-            string? installRoot = common7Directory is null ? null : Path.GetDirectoryName(common7Directory);
+            string path = value!;
 
+            // A path to an executable (e.g. devenv.exe) -> its containing directory.
+            if (path.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                path = Path.GetDirectoryName(path) ?? path;
+            }
+
+            path = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            // <root>\Common7\IDE -> <root>
+            string common7Ide = Path.Combine("Common7", "IDE");
+            if (path.EndsWith(common7Ide, StringComparison.OrdinalIgnoreCase))
+            {
+                string? common7Directory = Path.GetDirectoryName(path);
+                return common7Directory is null ? null : Path.GetDirectoryName(common7Directory);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Returns the path to <c>MSBuild.exe</c> under the given install root if it exists, otherwise <see langword="null" />.
+        /// </summary>
+        private static string? TryGetMSBuildFromInstallRoot(string? installRoot)
+        {
             if (string.IsNullOrEmpty(installRoot))
             {
                 return null;
             }
 
             string msbuildPath = Path.Combine(installRoot!, "MSBuild", "Current", "Bin", "MSBuild.exe");
-
             return File.Exists(msbuildPath) ? msbuildPath : null;
+        }
+
+        /// <summary>
+        /// Locates MSBuild.exe using vswhere, which queries the Visual Studio Setup Configuration API.
+        /// </summary>
+        private static string? FindMSBuildWithVsWhere()
+        {
+            string vswherePath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                "Microsoft Visual Studio",
+                "Installer",
+                "vswhere.exe");
+
+            if (!File.Exists(vswherePath))
+            {
+                return null;
+            }
+
+            CommandRunnerResult result = CommandRunner.Run(
+                filename: vswherePath,
+                arguments: "-latest -prerelease -requires Microsoft.Component.MSBuild -find MSBuild\\**\\Bin\\MSBuild.exe");
+
+            if (!result.Success)
+            {
+                return null;
+            }
+
+            using var reader = new StringReader(result.Output);
+            string? line = reader.ReadLine();
+
+            return !string.IsNullOrEmpty(line) && File.Exists(line) ? line : null;
+        }
+
+        /// <summary>
+        /// Captures the lines forwarded by <see cref="CommandRunner" /> into a single buffer,
+        /// preserving the chronological order in which stdout and stderr were written.
+        /// </summary>
+        private sealed class CapturingTestOutputHelper : ITestOutputHelper
+        {
+            private readonly StringBuilder _builder = new();
+
+            public void WriteLine(string message)
+            {
+                lock (_builder)
+                {
+                    _builder.AppendLine(message);
+                }
+            }
+
+            public void WriteLine(string format, params object[] args)
+            {
+                WriteLine(string.Format(CultureInfo.CurrentCulture, format, args));
+            }
+
+            public override string ToString()
+            {
+                lock (_builder)
+                {
+                    return _builder.ToString();
+                }
+            }
         }
     }
 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/MSBuildRestoreTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/MSBuildRestoreTestCase.cs
@@ -166,14 +166,49 @@ namespace NuGet.Tests.Apex
 
         private static string GetProjectXml(string packageName, string packageVersion)
         {
-            return $@"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include=""{packageName}"" Version=""{packageVersion}"" />
-  </ItemGroup>
-</Project>";
+            // Raw string literal with a doubled interpolation prefix ($$), so {{ }} delimit the
+            // interpolation holes and the inline task's single braces are treated as literal text.
+            return $$"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net472</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="{{packageName}}" Version="{{packageVersion}}" />
+                  </ItemGroup>
+
+                  <!--
+                    Verifies that every assembly shipped next to MSBuild.exe can be loaded in the environment under
+                    test. Runs before CollectPackageReference (i.e. as part of restore) so the test catches machines
+                    where an assembly in the MSBuild directory fails to load. Each load is wrapped in a try-catch so
+                    an individual assembly that cannot be loaded is skipped rather than failing the build.
+                  -->
+                  <UsingTask TaskName="LoadMSBuildAssemblies" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+                    <ParameterGroup>
+                      <Directory ParameterType="System.String" Required="true" />
+                    </ParameterGroup>
+                    <Task>
+                      <Code Type="Fragment" Language="cs"><![CDATA[
+                        foreach (string file in System.IO.Directory.GetFiles(Directory, "*.dll"))
+                        {
+                            try
+                            {
+                                System.Reflection.Assembly.LoadFrom(file);
+                            }
+                            catch
+                            {
+                                // Skip assemblies that fail to load.
+                            }
+                        }
+                      ]]></Code>
+                    </Task>
+                  </UsingTask>
+
+                  <Target Name="LoadMSBuildAssembliesBeforeRestore" BeforeTargets="CollectPackageReference">
+                    <LoadMSBuildAssemblies Directory="$(MSBuildBinPath)" />
+                  </Target>
+                </Project>
+                """;
         }
 
         /// <summary>

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/MSBuildRestoreTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/MSBuildRestoreTestCase.cs
@@ -1,0 +1,129 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NuGet.Test.Utility;
+
+namespace NuGet.Tests.Apex
+{
+    /// <summary>
+    /// Verifies that NuGet restore works on the machine under test by running
+    /// <c>msbuild -t:restore</c> using the MSBuild that ships with the Visual Studio
+    /// installation under test. This means if you modify restore and run this test locally,
+    /// it will not test your changes. Use MSBuild.Integration.Tests or unit tests to test
+    /// other changes. This test is intended to catch issues that may be specific to the environment
+    /// on the machine, such as upgrading packages to a version incompatible with MSBuild.
+    /// </summary>
+    [TestClass]
+    public class MSBuildRestoreTestCase
+    {
+        private const int DefaultTimeout = 5 * 60 * 1000; // 5 minutes
+
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        public async Task RestoreWithPackageReference_UsingVsUnderTestMSBuild_Succeeds()
+        {
+            // Arrange
+            string? msbuildPath = LocateVisualStudioUnderTestMSBuild();
+            if (msbuildPath is null)
+            {
+                Assert.Inconclusive(
+                    "Could not locate the Visual Studio installation under test. " +
+                    "Set the 'VisualStudio.InstallationUnderTest.Path' environment variable, " +
+                    "or run from a Developer Command Prompt/PowerShell so that VSAPPIDDIR or DevEnvDir is set.");
+            }
+
+            using var pathContext = new SimpleTestPathContext();
+
+            string packageName = "TestPackage";
+            string packageVersion = "1.0.0";
+            await CommonUtility.CreatePackageInSourceAsync(pathContext.PackageSource, packageName, packageVersion);
+
+            string projectName = "test";
+            string projectPath = Path.Combine(pathContext.SolutionRoot, projectName + ".csproj");
+            File.WriteAllText(projectPath, GetProjectXml(packageName, packageVersion));
+
+            // Act
+            CommandRunnerResult result = CommandRunner.Run(
+                filename: msbuildPath!,
+                workingDirectory: pathContext.SolutionRoot,
+                arguments: $"-t:restore \"{projectPath}\"");
+
+            // Assert
+            Assert.AreEqual(
+                0,
+                result.ExitCode,
+                $"msbuild -t:restore failed (exit code {result.ExitCode}).{Environment.NewLine}{result.AllOutput}");
+
+            string assetsFilePath = Path.Combine(pathContext.SolutionRoot, "obj", "project.assets.json");
+            Assert.IsTrue(
+                File.Exists(assetsFilePath),
+                $"Expected restore to generate '{assetsFilePath}'.{Environment.NewLine}{result.AllOutput}");
+
+            string assetsFileContent = File.ReadAllText(assetsFilePath);
+            StringAssert.Contains(
+                assetsFileContent,
+                packageName,
+                $"Expected the assets file to reference '{packageName}'.{Environment.NewLine}{result.AllOutput}");
+        }
+
+        private static string GetProjectXml(string packageName, string packageVersion)
+        {
+            return $@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""{packageName}"" Version=""{packageVersion}"" />
+  </ItemGroup>
+</Project>";
+        }
+
+        /// <summary>
+        /// Resolves the path to <c>MSBuild.exe</c> from the Visual Studio installation under test.
+        /// Uses the same environment variables that the Apex host uses to locate Visual Studio:
+        /// <c>VisualStudio.InstallationUnderTest.Path</c> (path to devenv.exe), falling back to
+        /// <c>VSAPPIDDIR</c> / <c>DevEnvDir</c> (the Common7\IDE directory).
+        /// </summary>
+        /// <returns>The full path to MSBuild.exe, or <see langword="null" /> if it cannot be resolved.</returns>
+        private static string? LocateVisualStudioUnderTestMSBuild()
+        {
+            string? ideDirectory = null;
+
+            string? devenvPath = Environment.GetEnvironmentVariable("VisualStudio.InstallationUnderTest.Path");
+            if (!string.IsNullOrEmpty(devenvPath))
+            {
+                // The value points to devenv.exe, which lives in <root>\Common7\IDE.
+                ideDirectory = Path.GetDirectoryName(devenvPath);
+            }
+
+            if (string.IsNullOrEmpty(ideDirectory))
+            {
+                ideDirectory = Environment.GetEnvironmentVariable("VSAPPIDDIR")
+                    ?? Environment.GetEnvironmentVariable("DevEnvDir");
+            }
+
+            if (string.IsNullOrEmpty(ideDirectory))
+            {
+                return null;
+            }
+
+            // <root>\Common7\IDE -> <root>
+            string? common7Directory = Path.GetDirectoryName(ideDirectory!.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            string? installRoot = common7Directory is null ? null : Path.GetDirectoryName(common7Directory);
+
+            if (string.IsNullOrEmpty(installRoot))
+            {
+                return null;
+            }
+
+            string msbuildPath = Path.Combine(installRoot!, "MSBuild", "Current", "Bin", "MSBuild.exe");
+
+            return File.Exists(msbuildPath) ? msbuildPath : null;
+        }
+    }
+}

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/VisualStudioMSBuildLocator.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/VisualStudioMSBuildLocator.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess;
+
+namespace NuGet.Tests.Apex
+{
+    internal static class VisualStudioMSBuildLocator
+    {
+        private static readonly Lazy<string?> MSBuildPath = new(FindMSBuildWithVsWhere);
+
+        internal static string? GetMSBuildPath()
+        {
+            return MSBuildPath.Value;
+        }
+
+        private static string? FindMSBuildWithVsWhere()
+        {
+            string vswherePath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                "Microsoft Visual Studio",
+                "Installer",
+                "vswhere.exe");
+
+            if (!File.Exists(vswherePath))
+            {
+                return null;
+            }
+
+            CommandRunnerResult result = CommandRunner.Run(
+                filename: vswherePath,
+                arguments: "-latest -prerelease -requires Microsoft.Component.MSBuild -find MSBuild\\**\\Bin\\MSBuild.exe");
+
+            if (!result.Success)
+            {
+                return null;
+            }
+
+            using var reader = new StringReader(result.Output);
+            string? line = reader.ReadLine();
+
+            return !string.IsNullOrEmpty(line) && File.Exists(line) ? line : null;
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: potential gap in test coverage

## Description

When NuGet's restore runs on the command line, MSBuild will load our assemblies in its process space. If it has already loaded some of our dependencies, then those dependencies will not be loaded from NuGet's install directory, and will have been loaded from elsewhere.

Therefore, this test tries to validate that NuGet is compatible with all the assemblies (and their versions) that MSBuild ship in its own bin directory. Primarily Newtonsoft.Json and Microsoft.Extensions.FileSystemGlobbing.

It does this by emulating a C# MSBuild Task that loads assemblies from the MSBuild bin directory, during NuGet's CollectPackageReferences target, and then runs a restore, making sure to exercise code paths that uses Newtonsoft.Json (via NuGet.Protocol and an HTTP feed) and FileSystemGlobbing (via a package that has `contentFiles/` with a wildcard in the nuspec metadata). If MSBuild fails to load NuGet's dependencies because it's already loaded a lower version of the same assemblies, then restore will fail.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
