### PR TITLE
[release/7.6.x] Pin 10.0.3xx sdk version for tests (#7371)

### DIFF
--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -2,4 +2,4 @@
 # To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
 -Channel 8.0 -Runtime dotnet
 -Channel 9.0 -Runtime dotnet
--Channel 10.0.3xx -Quality daily
+-Version 10.0.301-servicing.26227.122


### PR DESCRIPTION
# Bug

<!-- This is an engineering/CI change only, so no NuGet/Home issue is required per the PR template. -->
Fixes: N/A (CI engineering change)

## Description

Backport of #7371 ("Pin 10.0.3xx sdk version for tests") to `release/7.6.x`.

The Functional Tests (Linux/macOS) and Dotnet.Integration.Test (Windows) legs are failing on `release/7.6.x` PRs. The failing `DotnetPackageUpdateTests`/`DotnetListPackageTests` cases error during restore with:

```
NU1102: Unable to find package Microsoft.NETCore.App.Ref     with version (= 9.0.18 / = 8.0.29)
NU1102: Unable to find package Microsoft.AspNetCore.App.Ref  with version (= 9.0.18 / = 8.0.29)
NU1102: Unable to find package Microsoft.WindowsDesktop.App.Ref with version (= 9.0.18)
  - Found 0 version(s) in source
```

### Root cause

`release/7.6.x` installs the test SDK from a moving `-Channel 10.0.3xx -Quality daily` channel. That daily SDK references brand-new servicing reference packs (9.0.18 / 8.0.29) that are newer than the latest publicly published servicing (9.0.17 / 8.0.28) and are therefore not present on the network-isolated restore feed used under the CFSClean isolation policy (#7328, present on `release/7.6.x` but not on `dev`). Restore then fails with `NU1102`.

`dev` does not hit this because it already pinned the test SDK in #7371 (and later reworked it in #7423). This PR brings the #7371 pin to `release/7.6.x` so the test SDK is deterministic and references already-published, mirrored reference packs.

### Change

`build/DotNetSdkTestVersions.txt`:

```diff
--Channel 10.0.3xx -Quality daily
+-Version 10.0.301-servicing.26227.122
```

This is a clean cherry-pick of d01cd6854 (`-x` trailer preserved). #7423 was intentionally **not** backported because it moves to `10.0.4xx`/`11.0` daily SDKs and adds an "SDK Next" CI matrix, which would re-introduce the moving-daily drift on this servicing branch.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
