### PR TITLE
Enable nullable on NuGet.Protocol legacy feed types (phase 20)

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/IV2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/IV2FeedParser.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/ODataServiceDocumentResourceV2.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/ODataServiceDocumentResourceV2.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using NuGet.Protocol.Core.Types;
 
@@ -15,7 +13,7 @@ namespace NuGet.Protocol
 
         public ODataServiceDocumentResourceV2(string baseAddress, DateTime requestTime)
         {
-            _baseAddress = baseAddress.Trim('/');
+            _baseAddress = (baseAddress ?? throw new ArgumentNullException(nameof(baseAddress))).Trim('/');
             _requestTime = requestTime;
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -32,10 +30,10 @@ namespace NuGet.Protocol
             _cache = new ConcurrentDictionary<string, ODataServiceDocumentCacheInfo>(StringComparer.OrdinalIgnoreCase);
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            ODataServiceDocumentResourceV2 serviceDocument = null;
-            ODataServiceDocumentCacheInfo cacheInfo = null;
+            ODataServiceDocumentResourceV2? serviceDocument = null;
+            ODataServiceDocumentCacheInfo? cacheInfo = null;
             var url = source.PackageSource.Source;
 
             var utcNow = DateTime.UtcNow;
@@ -56,7 +54,7 @@ namespace NuGet.Protocol
                     // check the cache again, another thread may have finished this one waited for the lock
                     if (!_cache.TryGetValue(url, out cacheInfo) || entryValidCutoff > cacheInfo.CachedTime)
                     {
-                        var client = (await source.GetResourceAsync<HttpSourceResource>(token)).HttpSource;
+                        var client = (await source.GetResourceAsync<HttpSourceResource>(token))!.HttpSource;
                         serviceDocument = await ODataServiceDocumentUtils.CreateODataServiceDocumentResourceV2(url, client, utcNow, NullLogger.Instance, token);
 
                         // cache the value even if it is null to avoid checking it again later
@@ -84,12 +82,12 @@ namespace NuGet.Protocol
                 serviceDocument = cacheInfo.ServiceDocument;
             }
 
-            return new Tuple<bool, INuGetResource>(serviceDocument != null, serviceDocument);
+            return new Tuple<bool, INuGetResource?>(serviceDocument != null, serviceDocument);
         }
 
         protected class ODataServiceDocumentCacheInfo
         {
-            public ODataServiceDocumentResourceV2 ServiceDocument { get; set; }
+            public ODataServiceDocumentResourceV2? ServiceDocument { get; set; }
 
             public DateTime CachedTime { get; set; }
         }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/ODataServiceDocumentUtils.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/ODataServiceDocumentUtils.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using System.Net.Http;
@@ -35,7 +33,7 @@ static internal class ODataServiceDocumentUtils
                         return Task.FromResult(url);
                     }
 
-                    return Task.FromResult(response.RequestMessage.RequestUri.ToString());
+                    return Task.FromResult(response.RequestMessage.RequestUri!.ToString());
                 },
                 log,
                 token);

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedPackageInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedPackageInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -20,33 +18,33 @@ namespace NuGet.Protocol
     /// </summary>
     public class V2FeedPackageInfo : PackageIdentity
     {
-        private readonly string _title;
-        private readonly string _summary;
+        private readonly string? _title;
+        private readonly string? _summary;
         private readonly string[] _authors;
-        private readonly string _description;
+        private readonly string? _description;
         private readonly string[] _owners;
-        private readonly string _iconUrl;
-        private readonly string _licenseUrl;
-        private readonly string _projectUrl;
-        private readonly string _reportAbuseUrl;
-        private readonly string _galleryDetailsUrl;
-        private readonly string _tags;
-        private readonly string _downloadCount;
+        private readonly string? _iconUrl;
+        private readonly string? _licenseUrl;
+        private readonly string? _projectUrl;
+        private readonly string? _reportAbuseUrl;
+        private readonly string? _galleryDetailsUrl;
+        private readonly string? _tags;
+        private readonly string? _downloadCount;
         private readonly bool _requireLicenseAcceptance;
         private readonly DateTimeOffset? _created;
         private readonly DateTimeOffset? _lastEdited;
         private readonly DateTimeOffset? _published;
-        private readonly string _dependencies;
-        private readonly string _downloadUrl;
-        private readonly string _packageHash;
-        private readonly string _packageHashAlgorithm;
-        private readonly NuGetVersion _minClientVersion;
+        private readonly string? _dependencies;
+        private readonly string? _downloadUrl;
+        private readonly string? _packageHash;
+        private readonly string? _packageHashAlgorithm;
+        private readonly NuGetVersion? _minClientVersion;
         private const string NullString = "null";
 
-        public V2FeedPackageInfo(PackageIdentity identity, string title, string summary, string description, IEnumerable<string> authors, IEnumerable<string> owners,
-            string iconUrl, string licenseUrl, string projectUrl, string reportAbuseUrl, string galleryDetailsUrl,
-            string tags, DateTimeOffset? created, DateTimeOffset? lastEdited, DateTimeOffset? published, string dependencies, bool requireLicenseAccept, string downloadUrl, string downloadCount,
-            string packageHash, string packageHashAlgorithm, NuGetVersion minClientVersion)
+        public V2FeedPackageInfo(PackageIdentity identity, string? title, string? summary, string? description, IEnumerable<string>? authors, IEnumerable<string>? owners,
+            string? iconUrl, string? licenseUrl, string? projectUrl, string? reportAbuseUrl, string? galleryDetailsUrl,
+            string? tags, DateTimeOffset? created, DateTimeOffset? lastEdited, DateTimeOffset? published, string? dependencies, bool requireLicenseAccept, string? downloadUrl, string? downloadCount,
+            string? packageHash, string? packageHashAlgorithm, NuGetVersion? minClientVersion)
             : base(identity.Id, identity.Version)
         {
             _summary = summary;
@@ -74,7 +72,7 @@ namespace NuGet.Protocol
             _minClientVersion = minClientVersion;
         }
 
-        public string Title
+        public string? Title
         {
             get
             {
@@ -82,7 +80,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string Summary
+        public string? Summary
         {
             get
             {
@@ -90,7 +88,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string Description
+        public string? Description
         {
             get
             {
@@ -114,7 +112,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string IconUrl
+        public string? IconUrl
         {
             get
             {
@@ -122,7 +120,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string LicenseUrl
+        public string? LicenseUrl
         {
             get
             {
@@ -130,7 +128,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string ProjectUrl
+        public string? ProjectUrl
         {
             get
             {
@@ -138,7 +136,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string DownloadUrl
+        public string? DownloadUrl
         {
             get
             {
@@ -146,7 +144,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string ReportAbuseUrl
+        public string? ReportAbuseUrl
         {
             get
             {
@@ -154,7 +152,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string GalleryDetailsUrl
+        public string? GalleryDetailsUrl
         {
             get
             {
@@ -162,7 +160,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string Tags
+        public string? Tags
         {
             get
             {
@@ -170,7 +168,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string DownloadCount
+        public string? DownloadCount
         {
             get
             {
@@ -226,7 +224,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string Dependencies
+        public string? Dependencies
         {
             get
             {
@@ -251,7 +249,7 @@ namespace NuGet.Protocol
                 {
                     var results = new Dictionary<NuGetFramework, List<PackageDependency>>(NuGetFrameworkFullComparer.Instance);
 
-                    foreach (var set in Dependencies.Split('|'))
+                    foreach (var set in Dependencies!.Split('|'))
                     {
                         var parts = set.Trim().Split(new[] { ':' }, StringSplitOptions.None);
 
@@ -289,8 +287,7 @@ namespace NuGet.Protocol
                             }
 
                             // Group dependencies by target framework
-                            List<PackageDependency> deps = null;
-                            if (!results.TryGetValue(framework, out deps))
+                            if (!results.TryGetValue(framework, out List<PackageDependency>? deps))
                             {
                                 deps = new List<PackageDependency>();
                                 results.Add(framework, deps);
@@ -327,7 +324,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string PackageHash
+        public string? PackageHash
         {
             get
             {
@@ -335,7 +332,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public string PackageHashAlgorithm
+        public string? PackageHashAlgorithm
         {
             get
             {
@@ -343,7 +340,7 @@ namespace NuGet.Protocol
             }
         }
 
-        public NuGetVersion MinClientVersion
+        public NuGetVersion? MinClientVersion
         {
             get
             {

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedPage.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedPage.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 
@@ -13,7 +11,7 @@ namespace NuGet.Protocol
     /// </summary>
     public class V2FeedPage
     {
-        public V2FeedPage(List<V2FeedPackageInfo> items, string nextUri)
+        public V2FeedPage(List<V2FeedPackageInfo> items, string? nextUri)
         {
             if (items == null)
             {
@@ -25,6 +23,6 @@ namespace NuGet.Protocol
         }
 
         public IReadOnlyList<V2FeedPackageInfo> Items { get; }
-        public string NextUri { get; }
+        public string? NextUri { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -107,7 +105,7 @@ namespace NuGet.Protocol
         /// <summary>
         /// Get an exact package
         /// </summary>
-        public async Task<V2FeedPackageInfo> GetPackage(
+        public async Task<V2FeedPackageInfo?> GetPackage(
             PackageIdentity package,
             SourceCacheContext sourceCacheContext,
             ILogger log,
@@ -301,7 +299,7 @@ namespace NuGet.Protocol
             return await GetDownloadResultUtility.GetDownloadResultAsync(
                 _httpSource,
                 package,
-                new Uri(packageInfo.DownloadUrl),
+                new Uri(packageInfo.DownloadUrl!),
                 downloadContext,
                 globalPackagesFolder,
                 log,
@@ -311,9 +309,9 @@ namespace NuGet.Protocol
         /// <summary>
         /// Finds all entries on the page and parses them
         /// </summary>
-        private IEnumerable<V2FeedPackageInfo> ParsePage(XDocument doc, string id, MetadataReferenceCache metadataCache)
+        private IEnumerable<V2FeedPackageInfo> ParsePage(XDocument doc, string? id, MetadataReferenceCache metadataCache)
         {
-            if (doc.Root.Name == _xnameEntry)
+            if (doc.Root!.Name == _xnameEntry)
             {
                 return new List<V2FeedPackageInfo> { ParsePackage(id, doc.Root, metadataCache) };
             }
@@ -327,19 +325,19 @@ namespace NuGet.Protocol
         /// <summary>
         /// Parse an entry into a V2FeedPackageInfo
         /// </summary>
-        private V2FeedPackageInfo ParsePackage(string id, XElement element, MetadataReferenceCache metadataCache)
+        private V2FeedPackageInfo ParsePackage(string? id, XElement element, MetadataReferenceCache metadataCache)
         {
-            var properties = element.Element(_xnameProperties);
+            var properties = element.Element(_xnameProperties)!;
             var idElement = properties.Element(_xnameId);
             var titleElement = element.Element(_xnameTitle);
 
             // If 'Id' element exist, use its value as accurate package Id
             // Otherwise, use the value of 'title' if it exist
             // Use the given Id as final fallback if all elements above don't exist
-            var identityId = metadataCache.GetString(idElement?.Value ?? titleElement?.Value ?? id);
-            var versionString = properties.Element(_xnameVersion).Value;
-            var version = metadataCache.GetVersion(metadataCache.GetString(versionString));
-            var downloadUrl = metadataCache.GetString(element.Element(_xnameContent).Attribute("src").Value);
+            var identityId = metadataCache.GetString(idElement?.Value ?? titleElement?.Value ?? id)!;
+            var versionString = properties.Element(_xnameVersion)!.Value;
+            var version = metadataCache.GetVersion(metadataCache.GetString(versionString)!);
+            var downloadUrl = metadataCache.GetString(element.Element(_xnameContent)!.Attribute("src")!.Value);
 
             var title = metadataCache.GetString(titleElement?.Value);
             var summary = metadataCache.GetString(GetString(element, _xnameSummary));
@@ -358,14 +356,14 @@ namespace NuGet.Protocol
             var packageHash = metadataCache.GetString(GetString(properties, _xnamePackageHash));
             var packageHashAlgorithm = metadataCache.GetString(GetString(properties, _xnamePackageHashAlgorithm));
 
-            NuGetVersion minClientVersion = null;
+            NuGetVersion? minClientVersion = null;
 
             var minClientVersionString = GetString(properties, _xnameMinClientVersion);
             if (!string.IsNullOrEmpty(minClientVersionString))
             {
                 if (NuGetVersion.TryParse(minClientVersionString, out minClientVersion))
                 {
-                    minClientVersion = metadataCache.GetVersion(minClientVersionString);
+                    minClientVersion = metadataCache.GetVersion(minClientVersionString!);
                 }
             }
 
@@ -373,13 +371,13 @@ namespace NuGet.Protocol
             var lastEdited = GetDate(properties, _xnameLastEdited);
             var published = GetDate(properties, _xnamePublished);
 
-            IEnumerable<string> owners = null;
-            IEnumerable<string> authors = null;
+            IEnumerable<string>? owners = null;
+            IEnumerable<string>? authors = null;
 
             var authorNode = element.Element(_xnameAuthor);
             if (authorNode != null)
             {
-                authors = authorNode.Elements(_xnameName).Select(e => metadataCache.GetString(e.Value));
+                authors = authorNode.Elements(_xnameName).Select(e => metadataCache.GetString(e.Value)!);
             }
 
             return new V2FeedPackageInfo(new PackageIdentity(identityId, version), title, summary, description, authors,
@@ -391,9 +389,9 @@ namespace NuGet.Protocol
         /// <summary>
         /// Retrieve an XML <see cref="string"/> value safely
         /// </summary>
-        private static string GetString(XElement parent, XName childName)
+        private static string? GetString(XElement? parent, XName childName)
         {
-            string value = null;
+            string? value = null;
 
             if (parent != null)
             {
@@ -426,10 +424,10 @@ namespace NuGet.Protocol
 
         public async Task<V2FeedPage> QueryV2FeedAsync(
             string relativeUri,
-            string id,
+            string? id,
             int max,
             bool ignoreNotFounds,
-            SourceCacheContext sourceCacheContext,
+            SourceCacheContext? sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {
@@ -447,10 +445,10 @@ namespace NuGet.Protocol
             var cacheKey = GetCacheKey(relativeUri, page);
 
             // first request
-            Task<XDocument> docRequest = LoadXmlAsync(uri, cacheKey, ignoreNotFounds, sourceCacheContext, log, token);
+            Task<XDocument?>? docRequest = LoadXmlAsync(uri, cacheKey, ignoreNotFounds, sourceCacheContext, log, token);
 
             // TODO: re-implement caching at a higher level for both v2 and v3
-            string nextUri = null;
+            string? nextUri = null;
             while (!token.IsCancellationRequested && docRequest != null)
             {
                 // TODO: Pages for a package Id are cached separately.
@@ -479,7 +477,7 @@ namespace NuGet.Protocol
                         // keep track of all uri and error out for any duplicate uri which means
                         // potential bug at server side.
 
-                        if (!uris.Add(nextUri))
+                        if (!uris.Add(nextUri!))
                         {
                             throw new FatalProtocolException(string.Format(
                                 CultureInfo.CurrentCulture,
@@ -488,7 +486,7 @@ namespace NuGet.Protocol
                         }
                         page++;
                         cacheKey = GetCacheKey(relativeUri, page);
-                        docRequest = LoadXmlAsync(nextUri, cacheKey, ignoreNotFounds, sourceCacheContext, log, token);
+                        docRequest = LoadXmlAsync(nextUri!, cacheKey, ignoreNotFounds, sourceCacheContext, log, token);
                     }
                 }
             }
@@ -517,11 +515,11 @@ namespace NuGet.Protocol
             return $"list_{relativeUri}_page{page}";
         }
 
-        internal async Task<XDocument> LoadXmlAsync(
+        internal async Task<XDocument?> LoadXmlAsync(
             string uri,
             string cacheKey,
             bool ignoreNotFounds,
-            SourceCacheContext sourceCacheContext,
+            SourceCacheContext? sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {
@@ -560,7 +558,7 @@ namespace NuGet.Protocol
                             }
                             else
                             {
-                                return await LoadXmlAsync(response.Stream, token);
+                                return await LoadXmlAsync(response.Stream!, token);
                             }
                         },
                         log,
@@ -625,11 +623,11 @@ namespace NuGet.Protocol
             }
         }
 
-        internal static string GetNextUrl(XDocument doc)
+        internal static string? GetNextUrl(XDocument doc)
         {
             // Example of what this looks like in the odata feed:
             // <link rel="next" href="{nextLink}" />
-            return (from e in doc.Root.Elements(_xnameLink)
+            return (from e in doc.Root!.Elements(_xnameLink)
                     let attr = e.Attribute("rel")
                     where attr != null && string.Equals(attr.Value, "next", StringComparison.OrdinalIgnoreCase)
                     select e.Attribute("href") into nextLink
@@ -639,7 +637,7 @@ namespace NuGet.Protocol
 
         internal static async Task<XDocument> LoadXmlAsync(Stream stream, CancellationToken token)
         {
-            using var memStream = await stream.AsSeekableStreamAsync(token);
+            using var memStream = (await stream.AsSeekableStreamAsync(token))!;
             using var xmlReader = XmlReader.Create(memStream, new XmlReaderSettings()
             {
                 CloseInput = true,

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedQueryBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedQueryBuilder.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -131,7 +129,7 @@ namespace NuGet.Protocol
         }
 
         public string BuildGetPackagesUri(
-            string searchTerm,
+            string? searchTerm,
             SearchFilter filters,
             int? skip,
             int? take)
@@ -198,7 +196,7 @@ namespace NuGet.Protocol
             return builder.ToString();
         }
 
-        private string BuildTop(int? top)
+        private string? BuildTop(int? top)
         {
             if (!top.HasValue)
             {
@@ -208,7 +206,7 @@ namespace NuGet.Protocol
             return string.Format(CultureInfo.InvariantCulture, TopFormat, top);
         }
 
-        private string BuildSkip(int? skip)
+        private string? BuildSkip(int? skip)
         {
             if (!skip.HasValue)
             {
@@ -218,9 +216,9 @@ namespace NuGet.Protocol
             return string.Format(CultureInfo.InvariantCulture, SkipFormat, skip);
         }
 
-        private string BuildFilter(string searchTerm, SearchFilterType? searchFilterType)
+        private string? BuildFilter(string? searchTerm, SearchFilterType? searchFilterType)
         {
-            var pieces = new List<string>
+            var pieces = new List<string?>
             {
                 BuildFieldSearchFilter(searchTerm),
                 BuildPropertyFilter(searchFilterType)
@@ -239,9 +237,9 @@ namespace NuGet.Protocol
             return string.Format(CultureInfo.InvariantCulture, FilterFormat, filter);
         }
 
-        private string BuildOrderBy(SearchOrderBy? searchOrderBy)
+        private string? BuildOrderBy(SearchOrderBy? searchOrderBy)
         {
-            string orderBy;
+            string? orderBy;
             switch (searchOrderBy)
             {
                 case SearchOrderBy.Id:
@@ -264,9 +262,9 @@ namespace NuGet.Protocol
             return orderBy;
         }
 
-        private string BuildPropertyFilter(SearchFilterType? searchFilterType)
+        private string? BuildPropertyFilter(SearchFilterType? searchFilterType)
         {
-            string filter;
+            string? filter;
             switch (searchFilterType)
             {
                 case SearchFilterType.IsLatestVersion:
@@ -287,7 +285,7 @@ namespace NuGet.Protocol
             return filter;
         }
 
-        private string BuildFieldSearchFilter(string searchTerm)
+        private string? BuildFieldSearchFilter(string? searchTerm)
         {
             if (searchTerm == null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedUtilities.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataV2Feed.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -31,9 +29,9 @@ namespace NuGet.Protocol
             ReportAbuseUrl = GetUriSafe(package.ReportAbuseUrl);
             PackageDetailsUrl = GetUriSafe(package.GalleryDetailsUrl);
             RequireLicenseAcceptance = package.RequireLicenseAcceptance;
-            Summary = package.Summary;
+            _summaryValue = package.Summary;
             Tags = package.Tags;
-            Title = package.Title;
+            _titleValue = package.Title;
             Version = package.Version;
             IsListed = package.IsListed;
 
@@ -45,13 +43,13 @@ namespace NuGet.Protocol
         }
         public PackageSearchMetadataV2Feed(V2FeedPackageInfo package, MetadataReferenceCache metadataCache)
         {
-            Authors = metadataCache.GetString(string.Join(", ", package.Authors));
+            Authors = metadataCache.GetString(string.Join(", ", package.Authors))!;
             DependencySets = package.DependencySets;
             Description = package.Description;
             IconUrl = GetUriSafe(package.IconUrl);
             LicenseUrl = GetUriSafe(package.LicenseUrl);
             _ownersList = (IReadOnlyList<string>)package.Owners;
-            Owners = metadataCache.GetString(string.Join(", ", package.Owners));
+            Owners = metadataCache.GetString(string.Join(", ", package.Owners))!;
             PackageId = package.Id;
             ProjectUrl = GetUriSafe(package.ProjectUrl);
             Created = package.Created;
@@ -60,9 +58,9 @@ namespace NuGet.Protocol
             ReportAbuseUrl = GetUriSafe(package.ReportAbuseUrl);
             PackageDetailsUrl = GetUriSafe(package.GalleryDetailsUrl);
             RequireLicenseAcceptance = package.RequireLicenseAcceptance;
-            Summary = package.Summary;
+            _summaryValue = package.Summary;
             Tags = package.Tags;
-            Title = package.Title;
+            _titleValue = package.Title;
             Version = package.Version;
             IsListed = package.IsListed;
 
@@ -77,24 +75,24 @@ namespace NuGet.Protocol
 
         public IEnumerable<PackageDependencyGroup> DependencySets { get; private set; }
 
-        public string Description { get; private set; }
+        public string? Description { get; private set; }
 
         public long? DownloadCount { get; private set; }
 
-        public Uri IconUrl { get; private set; }
+        public Uri? IconUrl { get; private set; }
 
         public PackageIdentity Identity => new PackageIdentity(PackageId, Version);
 
-        public Uri LicenseUrl { get; private set; }
+        public Uri? LicenseUrl { get; private set; }
 
-        private IReadOnlyList<string> _ownersList;
-        public IReadOnlyList<string> OwnersList => _ownersList;
+        private IReadOnlyList<string>? _ownersList;
+        public IReadOnlyList<string>? OwnersList => _ownersList;
 
         public string Owners { get; private set; }
 
         public string PackageId { get; private set; }
 
-        public Uri ProjectUrl { get; private set; }
+        public Uri? ProjectUrl { get; private set; }
 
         // Prefix Reservation should never be shown on a V2 Feed
         public bool PrefixReserved => false;
@@ -105,54 +103,53 @@ namespace NuGet.Protocol
 
         public DateTimeOffset? Published { get; private set; }
 
-        public Uri ReadmeUrl { get; } = null; // The ReadmeUrl has not been added to the V2 feed.
+        public Uri? ReadmeUrl { get; } = null; // The ReadmeUrl has not been added to the V2 feed.
 
-        public string ReadmeFileUrl { get; } = null; // The ReadmeFileUrl has not been added to the V2 feed.
+        public string? ReadmeFileUrl { get; } = null; // The ReadmeFileUrl has not been added to the V2 feed.
 
-        public Uri ReportAbuseUrl { get; private set; }
+        public Uri? ReportAbuseUrl { get; private set; }
 
-        public Uri PackageDetailsUrl { get; private set; }
+        public Uri? PackageDetailsUrl { get; private set; }
 
         public bool RequireLicenseAcceptance { get; private set; }
 
-        private string _summaryValue;
-        public string Summary
+        private string? _summaryValue;
+        public string? Summary
         {
             get { return !string.IsNullOrEmpty(_summaryValue) ? _summaryValue : Description; }
             private set { _summaryValue = value; }
         }
 
-        public string Tags { get; private set; }
+        public string? Tags { get; private set; }
 
-        private string _titleValue;
+        private string? _titleValue;
 
         public string Title
         {
-            get { return !string.IsNullOrEmpty(_titleValue) ? _titleValue : PackageId; }
+            get { return !string.IsNullOrEmpty(_titleValue) ? _titleValue! : PackageId; }
             private set { _titleValue = value; }
         }
 
-        public LicenseMetadata LicenseMetadata { get; } = null; // The LicenseExpression is not added to the V2 feed.
+        public LicenseMetadata? LicenseMetadata { get; } = null; // The LicenseExpression is not added to the V2 feed.
 
-        public PackageDeprecationMetadata DeprecationMetadata { get; } = null; // Deprecation metadata is not added to the v2 feed.
+        public PackageDeprecationMetadata? DeprecationMetadata { get; } = null; // Deprecation metadata is not added to the v2 feed.
 
         public NuGetVersion Version { get; private set; }
 
         /// <inheritdoc cref="IPackageSearchMetadata.GetVersionsAsync" />
         public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => TaskResult.EmptyEnumerable<VersionInfo>();
 
-        private static Uri GetUriSafe(string url)
+        private static Uri? GetUriSafe(string? url)
         {
-            Uri uri = null;
-            Uri.TryCreate(url, UriKind.Absolute, out uri);
+            Uri.TryCreate(url, UriKind.Absolute, out Uri? uri);
             return uri;
         }
 
         /// <inheritdoc cref="IPackageSearchMetadata.GetDeprecationMetadataAsync" />
-        public Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() => TaskResult.Null<PackageDeprecationMetadata>();
+        public Task<PackageDeprecationMetadata?> GetDeprecationMetadataAsync() => TaskResult.Null<PackageDeprecationMetadata>();
 
         /// <inheritdoc cref="IPackageSearchMetadata.Vulnerabilities" />
-        public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; } = null; // Vulnerability metadata is not added to nuget.org's v2 feed.
+        public IEnumerable<PackageVulnerabilityMetadata>? Vulnerabilities { get; } = null; // Vulnerability metadata is not added to nuget.org's v2 feed.
 
         public bool IsListed { get; }
     }

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -576,8 +576,8 @@ NuGet.Protocol.IThrottle
 NuGet.Protocol.IThrottle.Release() -> void
 NuGet.Protocol.IThrottle.WaitAsync() -> System.Threading.Tasks.Task!
 NuGet.Protocol.IV2FeedParser
-~NuGet.Protocol.IV2FeedParser.GetPackagesPageAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage>
-~NuGet.Protocol.IV2FeedParser.GetSearchPageAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage>
+NuGet.Protocol.IV2FeedParser.GetPackagesPageAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage!>!
+NuGet.Protocol.IV2FeedParser.GetSearchPageAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage!>!
 NuGet.Protocol.IVulnerabilityInfoResource
 NuGet.Protocol.IVulnerabilityInfoResource.GetVulnerabilityInfoAsync(NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Model.GetVulnerabilityInfoResult!>!
 NuGet.Protocol.InvalidCacheProtocolException
@@ -715,8 +715,8 @@ NuGet.Protocol.NullThrottle.NullThrottle() -> void
 NuGet.Protocol.NullThrottle.Release() -> void
 NuGet.Protocol.NullThrottle.WaitAsync() -> System.Threading.Tasks.Task!
 NuGet.Protocol.ODataServiceDocumentResourceV2
-~NuGet.Protocol.ODataServiceDocumentResourceV2.BaseAddress.get -> string
-~NuGet.Protocol.ODataServiceDocumentResourceV2.ODataServiceDocumentResourceV2(string baseAddress, System.DateTime requestTime) -> void
+NuGet.Protocol.ODataServiceDocumentResourceV2.BaseAddress.get -> string!
+NuGet.Protocol.ODataServiceDocumentResourceV2.ODataServiceDocumentResourceV2(string! baseAddress, System.DateTime requestTime) -> void
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.MaxCacheDuration.get -> System.TimeSpan
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.MaxCacheDuration.set -> void
@@ -724,8 +724,8 @@ NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheI
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.CachedTime.get -> System.DateTime
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.CachedTime.set -> void
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ODataServiceDocumentCacheInfo() -> void
-~NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ServiceDocument.get -> NuGet.Protocol.ODataServiceDocumentResourceV2
-~NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ServiceDocument.set -> void
+NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ServiceDocument.get -> NuGet.Protocol.ODataServiceDocumentResourceV2?
+NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ServiceDocument.set -> void
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentResourceV2Provider() -> void
 NuGet.Protocol.PackageDeprecationMetadata
 NuGet.Protocol.PackageDeprecationMetadata.AlternatePackage.get -> NuGet.Protocol.AlternatePackageMetadata?
@@ -788,38 +788,38 @@ NuGet.Protocol.PackageSearchMetadataRegistration
 ~NuGet.Protocol.PackageSearchMetadataRegistration.CatalogUri.get -> System.Uri
 NuGet.Protocol.PackageSearchMetadataRegistration.PackageSearchMetadataRegistration() -> void
 NuGet.Protocol.PackageSearchMetadataV2Feed
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Authors.get -> string
+NuGet.Protocol.PackageSearchMetadataV2Feed.Authors.get -> string!
 NuGet.Protocol.PackageSearchMetadataV2Feed.Created.get -> System.DateTimeOffset?
-~NuGet.Protocol.PackageSearchMetadataV2Feed.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.PackageSearchMetadataV2Feed.DeprecationMetadata.get -> NuGet.Protocol.PackageDeprecationMetadata
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Description.get -> string
+NuGet.Protocol.PackageSearchMetadataV2Feed.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.PackageSearchMetadataV2Feed.DeprecationMetadata.get -> NuGet.Protocol.PackageDeprecationMetadata?
+NuGet.Protocol.PackageSearchMetadataV2Feed.Description.get -> string?
 NuGet.Protocol.PackageSearchMetadataV2Feed.DownloadCount.get -> long?
-~NuGet.Protocol.PackageSearchMetadataV2Feed.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata>
-~NuGet.Protocol.PackageSearchMetadataV2Feed.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>
-~NuGet.Protocol.PackageSearchMetadataV2Feed.IconUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.PackageSearchMetadataV2Feed.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata?>!
+NuGet.Protocol.PackageSearchMetadataV2Feed.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!
+NuGet.Protocol.PackageSearchMetadataV2Feed.IconUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadataV2Feed.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
 NuGet.Protocol.PackageSearchMetadataV2Feed.IsListed.get -> bool
 NuGet.Protocol.PackageSearchMetadataV2Feed.LastEdited.get -> System.DateTimeOffset?
-~NuGet.Protocol.PackageSearchMetadataV2Feed.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata
-~NuGet.Protocol.PackageSearchMetadataV2Feed.LicenseUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Owners.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.PackageSearchMetadataV2Feed.PackageDetailsUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadataV2Feed.PackageId.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.PackageSearchMetadataV2Feed(NuGet.Protocol.V2FeedPackageInfo package) -> void
-~NuGet.Protocol.PackageSearchMetadataV2Feed.PackageSearchMetadataV2Feed(NuGet.Protocol.V2FeedPackageInfo package, NuGet.Protocol.MetadataReferenceCache metadataCache) -> void
+NuGet.Protocol.PackageSearchMetadataV2Feed.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata?
+NuGet.Protocol.PackageSearchMetadataV2Feed.LicenseUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadataV2Feed.Owners.get -> string!
+NuGet.Protocol.PackageSearchMetadataV2Feed.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.PackageSearchMetadataV2Feed.PackageDetailsUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadataV2Feed.PackageId.get -> string!
+NuGet.Protocol.PackageSearchMetadataV2Feed.PackageSearchMetadataV2Feed(NuGet.Protocol.V2FeedPackageInfo! package) -> void
+NuGet.Protocol.PackageSearchMetadataV2Feed.PackageSearchMetadataV2Feed(NuGet.Protocol.V2FeedPackageInfo! package, NuGet.Protocol.MetadataReferenceCache! metadataCache) -> void
 NuGet.Protocol.PackageSearchMetadataV2Feed.PrefixReserved.get -> bool
-~NuGet.Protocol.PackageSearchMetadataV2Feed.ProjectUrl.get -> System.Uri
+NuGet.Protocol.PackageSearchMetadataV2Feed.ProjectUrl.get -> System.Uri?
 NuGet.Protocol.PackageSearchMetadataV2Feed.Published.get -> System.DateTimeOffset?
-~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadataV2Feed.ReportAbuseUrl.get -> System.Uri
+NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> string?
+NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadataV2Feed.ReportAbuseUrl.get -> System.Uri?
 NuGet.Protocol.PackageSearchMetadataV2Feed.RequireLicenseAcceptance.get -> bool
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Summary.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Tags.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Title.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Version.get -> NuGet.Versioning.NuGetVersion
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
+NuGet.Protocol.PackageSearchMetadataV2Feed.Summary.get -> string?
+NuGet.Protocol.PackageSearchMetadataV2Feed.Tags.get -> string?
+NuGet.Protocol.PackageSearchMetadataV2Feed.Title.get -> string!
+NuGet.Protocol.PackageSearchMetadataV2Feed.Version.get -> NuGet.Versioning.NuGetVersion!
+NuGet.Protocol.PackageSearchMetadataV2Feed.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
 NuGet.Protocol.PackageSearchResourceV2Feed
 ~NuGet.Protocol.PackageSearchResourceV2Feed.PackageSearchResourceV2Feed(NuGet.Protocol.HttpSourceResource httpSourceResource, string baseAddress, NuGet.Configuration.PackageSource packageSource) -> void
 NuGet.Protocol.PackageSearchResourceV2FeedProvider
@@ -1453,53 +1453,53 @@ NuGet.Protocol.V2FeedListResource
 NuGet.Protocol.V2FeedListResourceProvider
 NuGet.Protocol.V2FeedListResourceProvider.V2FeedListResourceProvider() -> void
 NuGet.Protocol.V2FeedPackageInfo
-~NuGet.Protocol.V2FeedPackageInfo.Authors.get -> System.Collections.Generic.IEnumerable<string>
+NuGet.Protocol.V2FeedPackageInfo.Authors.get -> System.Collections.Generic.IEnumerable<string!>!
 NuGet.Protocol.V2FeedPackageInfo.Created.get -> System.DateTimeOffset?
-~NuGet.Protocol.V2FeedPackageInfo.Dependencies.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.DependencySets.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.V2FeedPackageInfo.Description.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.DownloadCount.get -> string
+NuGet.Protocol.V2FeedPackageInfo.Dependencies.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.DependencySets.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.V2FeedPackageInfo.Description.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.DownloadCount.get -> string?
 NuGet.Protocol.V2FeedPackageInfo.DownloadCountAsInt.get -> int
-~NuGet.Protocol.V2FeedPackageInfo.DownloadUrl.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.GalleryDetailsUrl.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.IconUrl.get -> string
+NuGet.Protocol.V2FeedPackageInfo.DownloadUrl.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.GalleryDetailsUrl.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.IconUrl.get -> string?
 NuGet.Protocol.V2FeedPackageInfo.IsListed.get -> bool
 NuGet.Protocol.V2FeedPackageInfo.LastEdited.get -> System.DateTimeOffset?
-~NuGet.Protocol.V2FeedPackageInfo.LicenseUrl.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.MinClientVersion.get -> NuGet.Versioning.NuGetVersion
-~NuGet.Protocol.V2FeedPackageInfo.Owners.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.V2FeedPackageInfo.PackageHash.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.PackageHashAlgorithm.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.ProjectUrl.get -> string
+NuGet.Protocol.V2FeedPackageInfo.LicenseUrl.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.MinClientVersion.get -> NuGet.Versioning.NuGetVersion?
+NuGet.Protocol.V2FeedPackageInfo.Owners.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Protocol.V2FeedPackageInfo.PackageHash.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.PackageHashAlgorithm.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.ProjectUrl.get -> string?
 NuGet.Protocol.V2FeedPackageInfo.Published.get -> System.DateTimeOffset?
-~NuGet.Protocol.V2FeedPackageInfo.ReportAbuseUrl.get -> string
+NuGet.Protocol.V2FeedPackageInfo.ReportAbuseUrl.get -> string?
 NuGet.Protocol.V2FeedPackageInfo.RequireLicenseAcceptance.get -> bool
-~NuGet.Protocol.V2FeedPackageInfo.Summary.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.Tags.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.Title.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.V2FeedPackageInfo(NuGet.Packaging.Core.PackageIdentity identity, string title, string summary, string description, System.Collections.Generic.IEnumerable<string> authors, System.Collections.Generic.IEnumerable<string> owners, string iconUrl, string licenseUrl, string projectUrl, string reportAbuseUrl, string galleryDetailsUrl, string tags, System.DateTimeOffset? created, System.DateTimeOffset? lastEdited, System.DateTimeOffset? published, string dependencies, bool requireLicenseAccept, string downloadUrl, string downloadCount, string packageHash, string packageHashAlgorithm, NuGet.Versioning.NuGetVersion minClientVersion) -> void
+NuGet.Protocol.V2FeedPackageInfo.Summary.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.Tags.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.Title.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.V2FeedPackageInfo(NuGet.Packaging.Core.PackageIdentity! identity, string? title, string? summary, string? description, System.Collections.Generic.IEnumerable<string!>? authors, System.Collections.Generic.IEnumerable<string!>? owners, string? iconUrl, string? licenseUrl, string? projectUrl, string? reportAbuseUrl, string? galleryDetailsUrl, string? tags, System.DateTimeOffset? created, System.DateTimeOffset? lastEdited, System.DateTimeOffset? published, string? dependencies, bool requireLicenseAccept, string? downloadUrl, string? downloadCount, string? packageHash, string? packageHashAlgorithm, NuGet.Versioning.NuGetVersion? minClientVersion) -> void
 NuGet.Protocol.V2FeedPage
-~NuGet.Protocol.V2FeedPage.Items.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>
-~NuGet.Protocol.V2FeedPage.NextUri.get -> string
-~NuGet.Protocol.V2FeedPage.V2FeedPage(System.Collections.Generic.List<NuGet.Protocol.V2FeedPackageInfo> items, string nextUri) -> void
+NuGet.Protocol.V2FeedPage.Items.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo!>!
+NuGet.Protocol.V2FeedPage.NextUri.get -> string?
+NuGet.Protocol.V2FeedPage.V2FeedPage(System.Collections.Generic.List<NuGet.Protocol.V2FeedPackageInfo!>! items, string? nextUri) -> void
 NuGet.Protocol.V2FeedParser
-~NuGet.Protocol.V2FeedParser.DownloadFromIdentity(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult>
-~NuGet.Protocol.V2FeedParser.DownloadFromUrl(NuGet.Packaging.Core.PackageIdentity package, System.Uri downloadUri, NuGet.Protocol.Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult>
-~NuGet.Protocol.V2FeedParser.FindPackagesByIdAsync(string id, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
-~NuGet.Protocol.V2FeedParser.FindPackagesByIdAsync(string id, bool includeUnlisted, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
-~NuGet.Protocol.V2FeedParser.GetPackage(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPackageInfo>
-~NuGet.Protocol.V2FeedParser.GetPackagesPageAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage>
-~NuGet.Protocol.V2FeedParser.GetSearchPageAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage>
-~NuGet.Protocol.V2FeedParser.QueryV2FeedAsync(string relativeUri, string id, int max, bool ignoreNotFounds, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage>
-~NuGet.Protocol.V2FeedParser.Search(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
-~NuGet.Protocol.V2FeedParser.Source.get -> string
-~NuGet.Protocol.V2FeedParser.V2FeedParser(NuGet.Protocol.HttpSource httpSource, string baseAddress) -> void
-~NuGet.Protocol.V2FeedParser.V2FeedParser(NuGet.Protocol.HttpSource httpSource, string baseAddress, string source) -> void
+NuGet.Protocol.V2FeedParser.DownloadFromIdentity(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
+NuGet.Protocol.V2FeedParser.DownloadFromUrl(NuGet.Packaging.Core.PackageIdentity! package, System.Uri! downloadUri, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
+NuGet.Protocol.V2FeedParser.FindPackagesByIdAsync(string! id, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo!>!>!
+NuGet.Protocol.V2FeedParser.FindPackagesByIdAsync(string! id, bool includeUnlisted, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo!>!>!
+NuGet.Protocol.V2FeedParser.GetPackage(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPackageInfo?>!
+NuGet.Protocol.V2FeedParser.GetPackagesPageAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage!>!
+NuGet.Protocol.V2FeedParser.GetSearchPageAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage!>!
+NuGet.Protocol.V2FeedParser.QueryV2FeedAsync(string! relativeUri, string? id, int max, bool ignoreNotFounds, NuGet.Protocol.Core.Types.SourceCacheContext? sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage!>!
+NuGet.Protocol.V2FeedParser.Search(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo!>!>!
+NuGet.Protocol.V2FeedParser.Source.get -> string!
+NuGet.Protocol.V2FeedParser.V2FeedParser(NuGet.Protocol.HttpSource! httpSource, string! baseAddress) -> void
+NuGet.Protocol.V2FeedParser.V2FeedParser(NuGet.Protocol.HttpSource! httpSource, string! baseAddress, string! source) -> void
 NuGet.Protocol.V2FeedQueryBuilder
-~NuGet.Protocol.V2FeedQueryBuilder.BuildFindPackagesByIdUri(string id) -> string
-~NuGet.Protocol.V2FeedQueryBuilder.BuildGetPackageUri(NuGet.Packaging.Core.PackageIdentity package) -> string
-~NuGet.Protocol.V2FeedQueryBuilder.BuildGetPackagesUri(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int? skip, int? take) -> string
-~NuGet.Protocol.V2FeedQueryBuilder.BuildSearchUri(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take) -> string
+NuGet.Protocol.V2FeedQueryBuilder.BuildFindPackagesByIdUri(string! id) -> string!
+NuGet.Protocol.V2FeedQueryBuilder.BuildGetPackageUri(NuGet.Packaging.Core.PackageIdentity! package) -> string!
+NuGet.Protocol.V2FeedQueryBuilder.BuildGetPackagesUri(string? searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int? skip, int? take) -> string!
+NuGet.Protocol.V2FeedQueryBuilder.BuildSearchUri(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take) -> string!
 NuGet.Protocol.V2FeedQueryBuilder.V2FeedQueryBuilder() -> void
 NuGet.Protocol.V2FeedUtilities
 NuGet.Protocol.V3FeedListResourceProvider
@@ -1769,7 +1769,7 @@ override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
 override NuGet.Protocol.NuGetVersionConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.NuGetVersionConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
-~override NuGet.Protocol.ODataServiceDocumentResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.ODataServiceDocumentResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 ~override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
 ~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
@@ -2032,7 +2032,7 @@ static NuGet.Protocol.StreamExtensions.CopyToAsync(this System.IO.Stream! stream
 static NuGet.Protocol.TimeoutUtility.StartWithTimeout(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! getTask, System.TimeSpan timeout, string? timeoutMessage, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
 static NuGet.Protocol.TimeoutUtility.StartWithTimeout<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>!>! getTask, System.TimeSpan timeout, string? timeoutMessage, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
 static NuGet.Protocol.TokenStore.Instance.get -> NuGet.Protocol.TokenStore!
-~static NuGet.Protocol.V2FeedUtilities.CreatePackageSearchResult(NuGet.Protocol.V2FeedPackageInfo package, NuGet.Protocol.MetadataReferenceCache metadataCache, NuGet.Protocol.Core.Types.SearchFilter filter, NuGet.Protocol.V2FeedParser feedParser, NuGet.Common.ILogger log, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
+static NuGet.Protocol.V2FeedUtilities.CreatePackageSearchResult(NuGet.Protocol.V2FeedPackageInfo! package, NuGet.Protocol.MetadataReferenceCache! metadataCache, NuGet.Protocol.Core.Types.SearchFilter! filter, NuGet.Protocol.V2FeedParser! feedParser, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
 ~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.ProviderFactory factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>
 ~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
 ~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, string source) -> NuGet.Protocol.Core.Types.SourceRepository

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -576,8 +576,8 @@ NuGet.Protocol.IThrottle
 NuGet.Protocol.IThrottle.Release() -> void
 NuGet.Protocol.IThrottle.WaitAsync() -> System.Threading.Tasks.Task!
 NuGet.Protocol.IV2FeedParser
-~NuGet.Protocol.IV2FeedParser.GetPackagesPageAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage>
-~NuGet.Protocol.IV2FeedParser.GetSearchPageAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage>
+NuGet.Protocol.IV2FeedParser.GetPackagesPageAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage!>!
+NuGet.Protocol.IV2FeedParser.GetSearchPageAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage!>!
 NuGet.Protocol.IVulnerabilityInfoResource
 NuGet.Protocol.IVulnerabilityInfoResource.GetVulnerabilityInfoAsync(NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Model.GetVulnerabilityInfoResult!>!
 NuGet.Protocol.InvalidCacheProtocolException
@@ -715,8 +715,8 @@ NuGet.Protocol.NullThrottle.NullThrottle() -> void
 NuGet.Protocol.NullThrottle.Release() -> void
 NuGet.Protocol.NullThrottle.WaitAsync() -> System.Threading.Tasks.Task!
 NuGet.Protocol.ODataServiceDocumentResourceV2
-~NuGet.Protocol.ODataServiceDocumentResourceV2.BaseAddress.get -> string
-~NuGet.Protocol.ODataServiceDocumentResourceV2.ODataServiceDocumentResourceV2(string baseAddress, System.DateTime requestTime) -> void
+NuGet.Protocol.ODataServiceDocumentResourceV2.BaseAddress.get -> string!
+NuGet.Protocol.ODataServiceDocumentResourceV2.ODataServiceDocumentResourceV2(string! baseAddress, System.DateTime requestTime) -> void
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.MaxCacheDuration.get -> System.TimeSpan
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.MaxCacheDuration.set -> void
@@ -724,8 +724,8 @@ NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheI
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.CachedTime.get -> System.DateTime
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.CachedTime.set -> void
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ODataServiceDocumentCacheInfo() -> void
-~NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ServiceDocument.get -> NuGet.Protocol.ODataServiceDocumentResourceV2
-~NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ServiceDocument.set -> void
+NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ServiceDocument.get -> NuGet.Protocol.ODataServiceDocumentResourceV2?
+NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentCacheInfo.ServiceDocument.set -> void
 NuGet.Protocol.ODataServiceDocumentResourceV2Provider.ODataServiceDocumentResourceV2Provider() -> void
 NuGet.Protocol.PackageDeprecationMetadata
 NuGet.Protocol.PackageDeprecationMetadata.AlternatePackage.get -> NuGet.Protocol.AlternatePackageMetadata?
@@ -788,38 +788,38 @@ NuGet.Protocol.PackageSearchMetadataRegistration
 ~NuGet.Protocol.PackageSearchMetadataRegistration.CatalogUri.get -> System.Uri
 NuGet.Protocol.PackageSearchMetadataRegistration.PackageSearchMetadataRegistration() -> void
 NuGet.Protocol.PackageSearchMetadataV2Feed
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Authors.get -> string
+NuGet.Protocol.PackageSearchMetadataV2Feed.Authors.get -> string!
 NuGet.Protocol.PackageSearchMetadataV2Feed.Created.get -> System.DateTimeOffset?
-~NuGet.Protocol.PackageSearchMetadataV2Feed.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.PackageSearchMetadataV2Feed.DeprecationMetadata.get -> NuGet.Protocol.PackageDeprecationMetadata
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Description.get -> string
+NuGet.Protocol.PackageSearchMetadataV2Feed.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.PackageSearchMetadataV2Feed.DeprecationMetadata.get -> NuGet.Protocol.PackageDeprecationMetadata?
+NuGet.Protocol.PackageSearchMetadataV2Feed.Description.get -> string?
 NuGet.Protocol.PackageSearchMetadataV2Feed.DownloadCount.get -> long?
-~NuGet.Protocol.PackageSearchMetadataV2Feed.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata>
-~NuGet.Protocol.PackageSearchMetadataV2Feed.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>
-~NuGet.Protocol.PackageSearchMetadataV2Feed.IconUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.PackageSearchMetadataV2Feed.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata?>!
+NuGet.Protocol.PackageSearchMetadataV2Feed.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!
+NuGet.Protocol.PackageSearchMetadataV2Feed.IconUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadataV2Feed.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
 NuGet.Protocol.PackageSearchMetadataV2Feed.IsListed.get -> bool
 NuGet.Protocol.PackageSearchMetadataV2Feed.LastEdited.get -> System.DateTimeOffset?
-~NuGet.Protocol.PackageSearchMetadataV2Feed.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata
-~NuGet.Protocol.PackageSearchMetadataV2Feed.LicenseUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Owners.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.PackageSearchMetadataV2Feed.PackageDetailsUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadataV2Feed.PackageId.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.PackageSearchMetadataV2Feed(NuGet.Protocol.V2FeedPackageInfo package) -> void
-~NuGet.Protocol.PackageSearchMetadataV2Feed.PackageSearchMetadataV2Feed(NuGet.Protocol.V2FeedPackageInfo package, NuGet.Protocol.MetadataReferenceCache metadataCache) -> void
+NuGet.Protocol.PackageSearchMetadataV2Feed.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata?
+NuGet.Protocol.PackageSearchMetadataV2Feed.LicenseUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadataV2Feed.Owners.get -> string!
+NuGet.Protocol.PackageSearchMetadataV2Feed.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.PackageSearchMetadataV2Feed.PackageDetailsUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadataV2Feed.PackageId.get -> string!
+NuGet.Protocol.PackageSearchMetadataV2Feed.PackageSearchMetadataV2Feed(NuGet.Protocol.V2FeedPackageInfo! package) -> void
+NuGet.Protocol.PackageSearchMetadataV2Feed.PackageSearchMetadataV2Feed(NuGet.Protocol.V2FeedPackageInfo! package, NuGet.Protocol.MetadataReferenceCache! metadataCache) -> void
 NuGet.Protocol.PackageSearchMetadataV2Feed.PrefixReserved.get -> bool
-~NuGet.Protocol.PackageSearchMetadataV2Feed.ProjectUrl.get -> System.Uri
+NuGet.Protocol.PackageSearchMetadataV2Feed.ProjectUrl.get -> System.Uri?
 NuGet.Protocol.PackageSearchMetadataV2Feed.Published.get -> System.DateTimeOffset?
-~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadataV2Feed.ReportAbuseUrl.get -> System.Uri
+NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeFileUrl.get -> string?
+NuGet.Protocol.PackageSearchMetadataV2Feed.ReadmeUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadataV2Feed.ReportAbuseUrl.get -> System.Uri?
 NuGet.Protocol.PackageSearchMetadataV2Feed.RequireLicenseAcceptance.get -> bool
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Summary.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Tags.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Title.get -> string
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Version.get -> NuGet.Versioning.NuGetVersion
-~NuGet.Protocol.PackageSearchMetadataV2Feed.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
+NuGet.Protocol.PackageSearchMetadataV2Feed.Summary.get -> string?
+NuGet.Protocol.PackageSearchMetadataV2Feed.Tags.get -> string?
+NuGet.Protocol.PackageSearchMetadataV2Feed.Title.get -> string!
+NuGet.Protocol.PackageSearchMetadataV2Feed.Version.get -> NuGet.Versioning.NuGetVersion!
+NuGet.Protocol.PackageSearchMetadataV2Feed.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
 NuGet.Protocol.PackageSearchResourceV2Feed
 ~NuGet.Protocol.PackageSearchResourceV2Feed.PackageSearchResourceV2Feed(NuGet.Protocol.HttpSourceResource httpSourceResource, string baseAddress, NuGet.Configuration.PackageSource packageSource) -> void
 NuGet.Protocol.PackageSearchResourceV2FeedProvider
@@ -1449,53 +1449,53 @@ NuGet.Protocol.V2FeedListResource
 NuGet.Protocol.V2FeedListResourceProvider
 NuGet.Protocol.V2FeedListResourceProvider.V2FeedListResourceProvider() -> void
 NuGet.Protocol.V2FeedPackageInfo
-~NuGet.Protocol.V2FeedPackageInfo.Authors.get -> System.Collections.Generic.IEnumerable<string>
+NuGet.Protocol.V2FeedPackageInfo.Authors.get -> System.Collections.Generic.IEnumerable<string!>!
 NuGet.Protocol.V2FeedPackageInfo.Created.get -> System.DateTimeOffset?
-~NuGet.Protocol.V2FeedPackageInfo.Dependencies.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.DependencySets.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.V2FeedPackageInfo.Description.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.DownloadCount.get -> string
+NuGet.Protocol.V2FeedPackageInfo.Dependencies.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.DependencySets.get -> System.Collections.Generic.IReadOnlyList<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.V2FeedPackageInfo.Description.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.DownloadCount.get -> string?
 NuGet.Protocol.V2FeedPackageInfo.DownloadCountAsInt.get -> int
-~NuGet.Protocol.V2FeedPackageInfo.DownloadUrl.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.GalleryDetailsUrl.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.IconUrl.get -> string
+NuGet.Protocol.V2FeedPackageInfo.DownloadUrl.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.GalleryDetailsUrl.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.IconUrl.get -> string?
 NuGet.Protocol.V2FeedPackageInfo.IsListed.get -> bool
 NuGet.Protocol.V2FeedPackageInfo.LastEdited.get -> System.DateTimeOffset?
-~NuGet.Protocol.V2FeedPackageInfo.LicenseUrl.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.MinClientVersion.get -> NuGet.Versioning.NuGetVersion
-~NuGet.Protocol.V2FeedPackageInfo.Owners.get -> System.Collections.Generic.IEnumerable<string>
-~NuGet.Protocol.V2FeedPackageInfo.PackageHash.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.PackageHashAlgorithm.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.ProjectUrl.get -> string
+NuGet.Protocol.V2FeedPackageInfo.LicenseUrl.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.MinClientVersion.get -> NuGet.Versioning.NuGetVersion?
+NuGet.Protocol.V2FeedPackageInfo.Owners.get -> System.Collections.Generic.IEnumerable<string!>!
+NuGet.Protocol.V2FeedPackageInfo.PackageHash.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.PackageHashAlgorithm.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.ProjectUrl.get -> string?
 NuGet.Protocol.V2FeedPackageInfo.Published.get -> System.DateTimeOffset?
-~NuGet.Protocol.V2FeedPackageInfo.ReportAbuseUrl.get -> string
+NuGet.Protocol.V2FeedPackageInfo.ReportAbuseUrl.get -> string?
 NuGet.Protocol.V2FeedPackageInfo.RequireLicenseAcceptance.get -> bool
-~NuGet.Protocol.V2FeedPackageInfo.Summary.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.Tags.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.Title.get -> string
-~NuGet.Protocol.V2FeedPackageInfo.V2FeedPackageInfo(NuGet.Packaging.Core.PackageIdentity identity, string title, string summary, string description, System.Collections.Generic.IEnumerable<string> authors, System.Collections.Generic.IEnumerable<string> owners, string iconUrl, string licenseUrl, string projectUrl, string reportAbuseUrl, string galleryDetailsUrl, string tags, System.DateTimeOffset? created, System.DateTimeOffset? lastEdited, System.DateTimeOffset? published, string dependencies, bool requireLicenseAccept, string downloadUrl, string downloadCount, string packageHash, string packageHashAlgorithm, NuGet.Versioning.NuGetVersion minClientVersion) -> void
+NuGet.Protocol.V2FeedPackageInfo.Summary.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.Tags.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.Title.get -> string?
+NuGet.Protocol.V2FeedPackageInfo.V2FeedPackageInfo(NuGet.Packaging.Core.PackageIdentity! identity, string? title, string? summary, string? description, System.Collections.Generic.IEnumerable<string!>? authors, System.Collections.Generic.IEnumerable<string!>? owners, string? iconUrl, string? licenseUrl, string? projectUrl, string? reportAbuseUrl, string? galleryDetailsUrl, string? tags, System.DateTimeOffset? created, System.DateTimeOffset? lastEdited, System.DateTimeOffset? published, string? dependencies, bool requireLicenseAccept, string? downloadUrl, string? downloadCount, string? packageHash, string? packageHashAlgorithm, NuGet.Versioning.NuGetVersion? minClientVersion) -> void
 NuGet.Protocol.V2FeedPage
-~NuGet.Protocol.V2FeedPage.Items.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>
-~NuGet.Protocol.V2FeedPage.NextUri.get -> string
-~NuGet.Protocol.V2FeedPage.V2FeedPage(System.Collections.Generic.List<NuGet.Protocol.V2FeedPackageInfo> items, string nextUri) -> void
+NuGet.Protocol.V2FeedPage.Items.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo!>!
+NuGet.Protocol.V2FeedPage.NextUri.get -> string?
+NuGet.Protocol.V2FeedPage.V2FeedPage(System.Collections.Generic.List<NuGet.Protocol.V2FeedPackageInfo!>! items, string? nextUri) -> void
 NuGet.Protocol.V2FeedParser
-~NuGet.Protocol.V2FeedParser.DownloadFromIdentity(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult>
-~NuGet.Protocol.V2FeedParser.DownloadFromUrl(NuGet.Packaging.Core.PackageIdentity package, System.Uri downloadUri, NuGet.Protocol.Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult>
-~NuGet.Protocol.V2FeedParser.FindPackagesByIdAsync(string id, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
-~NuGet.Protocol.V2FeedParser.FindPackagesByIdAsync(string id, bool includeUnlisted, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
-~NuGet.Protocol.V2FeedParser.GetPackage(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPackageInfo>
-~NuGet.Protocol.V2FeedParser.GetPackagesPageAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage>
-~NuGet.Protocol.V2FeedParser.GetSearchPageAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage>
-~NuGet.Protocol.V2FeedParser.QueryV2FeedAsync(string relativeUri, string id, int max, bool ignoreNotFounds, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage>
-~NuGet.Protocol.V2FeedParser.Search(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo>>
-~NuGet.Protocol.V2FeedParser.Source.get -> string
-~NuGet.Protocol.V2FeedParser.V2FeedParser(NuGet.Protocol.HttpSource httpSource, string baseAddress) -> void
-~NuGet.Protocol.V2FeedParser.V2FeedParser(NuGet.Protocol.HttpSource httpSource, string baseAddress, string source) -> void
+NuGet.Protocol.V2FeedParser.DownloadFromIdentity(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
+NuGet.Protocol.V2FeedParser.DownloadFromUrl(NuGet.Packaging.Core.PackageIdentity! package, System.Uri! downloadUri, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
+NuGet.Protocol.V2FeedParser.FindPackagesByIdAsync(string! id, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo!>!>!
+NuGet.Protocol.V2FeedParser.FindPackagesByIdAsync(string! id, bool includeUnlisted, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo!>!>!
+NuGet.Protocol.V2FeedParser.GetPackage(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPackageInfo?>!
+NuGet.Protocol.V2FeedParser.GetPackagesPageAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage!>!
+NuGet.Protocol.V2FeedParser.GetSearchPageAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage!>!
+NuGet.Protocol.V2FeedParser.QueryV2FeedAsync(string! relativeUri, string? id, int max, bool ignoreNotFounds, NuGet.Protocol.Core.Types.SourceCacheContext? sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.V2FeedPage!>!
+NuGet.Protocol.V2FeedParser.Search(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<NuGet.Protocol.V2FeedPackageInfo!>!>!
+NuGet.Protocol.V2FeedParser.Source.get -> string!
+NuGet.Protocol.V2FeedParser.V2FeedParser(NuGet.Protocol.HttpSource! httpSource, string! baseAddress) -> void
+NuGet.Protocol.V2FeedParser.V2FeedParser(NuGet.Protocol.HttpSource! httpSource, string! baseAddress, string! source) -> void
 NuGet.Protocol.V2FeedQueryBuilder
-~NuGet.Protocol.V2FeedQueryBuilder.BuildFindPackagesByIdUri(string id) -> string
-~NuGet.Protocol.V2FeedQueryBuilder.BuildGetPackageUri(NuGet.Packaging.Core.PackageIdentity package) -> string
-~NuGet.Protocol.V2FeedQueryBuilder.BuildGetPackagesUri(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int? skip, int? take) -> string
-~NuGet.Protocol.V2FeedQueryBuilder.BuildSearchUri(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take) -> string
+NuGet.Protocol.V2FeedQueryBuilder.BuildFindPackagesByIdUri(string! id) -> string!
+NuGet.Protocol.V2FeedQueryBuilder.BuildGetPackageUri(NuGet.Packaging.Core.PackageIdentity! package) -> string!
+NuGet.Protocol.V2FeedQueryBuilder.BuildGetPackagesUri(string? searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int? skip, int? take) -> string!
+NuGet.Protocol.V2FeedQueryBuilder.BuildSearchUri(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take) -> string!
 NuGet.Protocol.V2FeedQueryBuilder.V2FeedQueryBuilder() -> void
 NuGet.Protocol.V2FeedUtilities
 NuGet.Protocol.V3FeedListResourceProvider
@@ -1760,7 +1760,7 @@ override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
 override NuGet.Protocol.NuGetVersionConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.NuGetVersionConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
-~override NuGet.Protocol.ODataServiceDocumentResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.ODataServiceDocumentResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 ~override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
 ~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
 ~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
@@ -2020,7 +2020,7 @@ static NuGet.Protocol.StreamExtensions.CopyToAsync(this System.IO.Stream! stream
 static NuGet.Protocol.TimeoutUtility.StartWithTimeout(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! getTask, System.TimeSpan timeout, string? timeoutMessage, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
 static NuGet.Protocol.TimeoutUtility.StartWithTimeout<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>!>! getTask, System.TimeSpan timeout, string? timeoutMessage, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
 static NuGet.Protocol.TokenStore.Instance.get -> NuGet.Protocol.TokenStore!
-~static NuGet.Protocol.V2FeedUtilities.CreatePackageSearchResult(NuGet.Protocol.V2FeedPackageInfo package, NuGet.Protocol.MetadataReferenceCache metadataCache, NuGet.Protocol.Core.Types.SearchFilter filter, NuGet.Protocol.V2FeedParser feedParser, NuGet.Common.ILogger log, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
+static NuGet.Protocol.V2FeedUtilities.CreatePackageSearchResult(NuGet.Protocol.V2FeedPackageInfo! package, NuGet.Protocol.MetadataReferenceCache! metadataCache, NuGet.Protocol.Core.Types.SearchFilter! filter, NuGet.Protocol.V2FeedParser! feedParser, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
 ~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.ProviderFactory factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>
 ~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
 ~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, string source) -> NuGet.Protocol.Core.Types.SourceRepository

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LegacyFeed/V2FeedQueryBuilderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LegacyFeed/V2FeedQueryBuilderTests.cs
@@ -236,7 +236,7 @@ namespace NuGet.Protocol.Tests
             var target = new V2FeedQueryBuilder();
 
             // Act & Assert
-            var actual = Assert.Throws<ArgumentNullException>(() => target.BuildGetPackageUri(package: null));
+            var actual = Assert.Throws<ArgumentNullException>(() => target.BuildGetPackageUri(package: null!));
             Assert.Equal("package", actual.ParamName);
         }
 


### PR DESCRIPTION
# Bug

Progress: https://github.com/nuget/home/issues/14851

## Description

Phase 20 of the NuGet.Protocol nullable migration: enable nullable reference types on legacy V2 feed types.

### Changes

- **V2FeedPackageInfo**: most string properties → `string?` (XML source), Authors/Owners stay non-null (`Array.Empty` fallback), `MinClientVersion` → `NuGetVersion?`
- **V2FeedParser**: `GetPackage` returns `V2FeedPackageInfo?`, nullable params for `id` and `SourceCacheContext`
- **V2FeedQueryBuilder**: private helpers return `string?`, `searchTerm` nullable
- **V2FeedPage**: `NextUri` → `string?`
- **PackageSearchMetadataV2Feed**: nullable URIs, Description, Summary, Tags; Title stays non-null (PackageId fallback)
- **ODataServiceDocumentResourceV2**: add `ArgumentNullException` guard for `baseAddress`
- **ODataServiceDocumentResourceV2Provider**: `TryCreate` returns `INuGetResource?`
- Update `PublicAPI.Shipped.txt` for both net472 and net8.0 (~70 entries each)
- Fix test: `null` → `null!` in `V2FeedQueryBuilderTests` for `ArgumentNullException` test

Note that IPackageSearchMetadata is not yet annotated. The idea is we annotate the implementation first and then we basically OR all of those values to annotate IPackageSearchMetadata correctly.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.