### PR TITLE
Port eng/common --add-source -> --source from #7437 to fix Publish Using Darc

### DIFF
--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -32,9 +32,6 @@ steps:
       '$(MaestroAccessToken)'
       '$(dn-bot-all-orgs-artifact-feeds-rw)'
       '$(akams-client-id)'
-      '$(microsoft-symbol-server-pat)'
-      '$(symweb-symbol-server-pat)'
-      '$(dnceng-symbol-server-pat)'
       '$(dn-bot-all-orgs-build-rw-code-rw)'
       '$(System.AccessToken)'
       ${{parameters.CustomSensitiveDataList}}

--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -14,8 +14,8 @@ steps:
     workingDirectory: $(Agent.TempDirectory)
 
 - script: |
-    $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version ${{parameters.sourceIndexProcessBinlogPackageVersion}} --add-source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
-    $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version ${{parameters.sourceIndexUploadPackageVersion}} --add-source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+    $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version ${{parameters.sourceIndexProcessBinlogPackageVersion}} --source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+    $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version ${{parameters.sourceIndexUploadPackageVersion}} --source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
   displayName: "Source Index: Download netsourceindex Tools"
   # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
   workingDirectory: $(Agent.TempDirectory)

--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -29,11 +29,11 @@ function InstallDarcCli ($darcVersion, $toolpath) {
   Write-Host "Installing Darc CLI version $darcVersion..."
   Write-Host 'You may need to restart your command window if this is the first dotnet tool you have installed.'
   if (-not $toolpath) {
-    Write-Host "'$dotnet' tool install $darcCliPackageName --version $darcVersion --add-source '$arcadeServicesSource' -v $verbosity -g"
-    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity -g
+    Write-Host "'$dotnet' tool install $darcCliPackageName --version $darcVersion --source '$arcadeServicesSource' -v $verbosity -g"
+    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --source "$arcadeServicesSource" -v $verbosity -g
   }else {
-    Write-Host "'$dotnet' tool install $darcCliPackageName --version $darcVersion --add-source '$arcadeServicesSource' -v $verbosity --tool-path '$toolpath'"
-    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity --tool-path "$toolpath"
+    Write-Host "'$dotnet' tool install $darcCliPackageName --version $darcVersion --source '$arcadeServicesSource' -v $verbosity --tool-path '$toolpath'"
+    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --source "$arcadeServicesSource" -v $verbosity --tool-path "$toolpath"
   }
 }
 

--- a/eng/common/darc-init.sh
+++ b/eng/common/darc-init.sh
@@ -73,9 +73,9 @@ function InstallDarcCli {
   echo "Installing Darc CLI version $darcVersion..."
   echo "You may need to restart your command shell if this is the first dotnet tool you have installed."
   if [ -z "$toolpath" ]; then
-    echo $($dotnet_root/dotnet tool install $darc_cli_package_name --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity -g)
+    echo $($dotnet_root/dotnet tool install $darc_cli_package_name --version $darcVersion --source "$arcadeServicesSource" -v $verbosity -g)
   else
-    echo $($dotnet_root/dotnet tool install $darc_cli_package_name --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity --tool-path "$toolpath")
+    echo $($dotnet_root/dotnet tool install $darc_cli_package_name --version $darcVersion --source "$arcadeServicesSource" -v $verbosity --tool-path "$toolpath")
   fi
 }
 

--- a/eng/common/post-build/redact-logs.ps1
+++ b/eng/common/post-build/redact-logs.ps1
@@ -47,8 +47,8 @@ try {
     Write-Host "Installing Binlog redactor CLI..."
     Write-Host "'$dotnet' new tool-manifest"
     & "$dotnet" new tool-manifest
-    Write-Host "'$dotnet' tool install $packageName --local --add-source '$PackageFeed' -v $verbosity --version $BinlogToolVersion"
-    & "$dotnet" tool install $packageName --local --add-source "$PackageFeed" -v $verbosity --version $BinlogToolVersion
+    Write-Host "'$dotnet' tool install $packageName --local --source '$PackageFeed' -v $verbosity --version $BinlogToolVersion"
+    & "$dotnet" tool install $packageName --local --source "$PackageFeed" -v $verbosity --version $BinlogToolVersion
 
     if (Test-Path $TokensFilePath) {
         Write-Host "Adding additional sensitive data for redaction from file: " $TokensFilePath


### PR DESCRIPTION
# Bug

<!-- Engineering/CI change — no NuGet/Home issue required per template. -->
Fixes: N/A (engineering change)

## Description

### Symptom
The `NuGet.Client-Official` build's **Publish Using Darc** stage has been failing since 2026-06-18:

> The --add-source option cannot be combined with package source mapping.
> The term '...\darc.exe' is not recognized as the name of a cmdlet, function, script file, or operable program.

The "darc.exe is not recognized" error is a symptom — the real failure is the `dotnet tool install ... --add-source` line just above it failing, so darc never installs.

### Root cause
- Our `NuGet.Config` has long used `<packageSourceMapping>`.
- `eng/common` tool-install scripts use `dotnet tool install --add-source`.
- PR #7453 bumped `global.json` `tools.dotnet` from `10.0.100` → `10.0.300`. SDK **10.0.300 now rejects `--add-source` when package source mapping is configured** (dotnet/sdk#52863); 10.0.100 allowed it. The last green build used 10.0.100; the first red build used 10.0.300 with the identical command.

### Fix
`eng/common` is VMR-managed. The fix already exists upstream (dotnet/arcade#16642, `--add-source` → `--source`) and flowed to `release/7.6.x` via backflow PR #7437, but `dev`'s VMR backflow is behind. This PR manually ports #7437's `eng/common` changes to `dev`:

- `eng/common/darc-init.ps1` / `darc-init.sh` — `--add-source` → `--source`
- `eng/common/post-build/redact-logs.ps1` — `--add-source` → `--source`
- `eng/common/core-templates/steps/source-index-stage1-publish.yml` — `--add-source` → `--source`
- `eng/common/core-templates/steps/publish-logs.yml` — drop deprecated symbol-server PATs

`--source` overrides the source list (compatible with package source mapping) instead of appending an unmapped feed. The next VMR backflow will carry the identical change, so this won't conflict.

`vmr-sync.yml` (also changed by #7437) was intentionally **excluded** — dev's version has diverged from release/7.6.x (it contains additional VMR-sha-checkout steps) and it's unrelated to this fix.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue <!-- engineering change; no issue required -->
- [x] ~Added tests~ <!-- covered by the official build's Publish Using Darc stage -->
- [x] ~Link to an issue or pull request to update docs~ <!-- no settings/docs impact -->
