### PR TITLE
Make NuGet Apex tests self-suppress the Preview Changes dialog

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -182,6 +182,7 @@ namespace NuGet.Tests.Apex
         public async Task InstallAndUpdatePackageFromUI_NetCoreProject_Succeeds()
         {
             // Arrange
+            using var suppressNuGetUI = NuGetUISuppression.Suppress();
             using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger);
             var packageName = "NetCoreUpdateTestPackage";
             var packageVersion1 = "1.0.0";

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -377,6 +377,7 @@ namespace NuGet.Tests.Apex
         public async Task VerifyDeletedAssetsFileIsBackByReloadingProject()
         {
             // Arrange
+            using var suppressNuGetUI = NuGetUISuppression.Suppress();
             await CommonUtility.CreatePackageInSourceAsync(_pathContext.PackageSource, TestPackageName, TestPackageVersionV1);
 
             NuGetApexTestService nugetTestService = GetNuGetTestService();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/NuGetUISuppression.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Utility/NuGetUISuppression.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Win32;
+
+namespace NuGet.Tests.Apex
+{
+    /// <summary>
+    /// Suppresses the interactive NuGet Package Manager UI dialogs (the "Preview Changes" window) 
+    /// for the lifetime of the instance, then restores the previous registry state on
+    /// <see cref="Dispose"/>. Use it in a <c>using</c> around a test so the suppression is scoped to that
+    /// test instead of relying on persistent machine state set up elsewhere.
+    /// </summary>
+    internal sealed class NuGetUISuppression : IDisposable
+    {
+        private const string NuGetRegistryKey = @"Software\NuGet";
+        private const string DoNotShowPreviewWindowRegistryName = "DoNotShowPreviewWindow";
+        private const string SuppressUILegalDisclaimerRegistryName = "SuppressUILegalDisclaimer";
+
+        private readonly List<RegistryValueSnapshot> _originalValues = new();
+
+        private NuGetUISuppression()
+        {
+        }
+
+        public static NuGetUISuppression Suppress()
+        {
+            var suppression = new NuGetUISuppression();
+
+            using RegistryKey nugetRegistryKey = Registry.CurrentUser.CreateSubKey(NuGetRegistryKey);
+            suppression.SuppressValue(nugetRegistryKey, DoNotShowPreviewWindowRegistryName);
+            suppression.SuppressValue(nugetRegistryKey, SuppressUILegalDisclaimerRegistryName);
+
+            return suppression;
+        }
+
+        private void SuppressValue(RegistryKey nugetRegistryKey, string registryValueName)
+        {
+            object? originalValue = nugetRegistryKey.GetValue(registryValueName);
+            RegistryValueKind originalKind = originalValue is null
+                ? RegistryValueKind.None
+                : nugetRegistryKey.GetValueKind(registryValueName);
+
+            _originalValues.Add(new RegistryValueSnapshot(registryValueName, originalValue, originalKind));
+
+            nugetRegistryKey.SetValue(registryValueName, "1", RegistryValueKind.String);
+        }
+
+        public void Dispose()
+        {
+            using RegistryKey nugetRegistryKey = Registry.CurrentUser.CreateSubKey(NuGetRegistryKey);
+
+            foreach (RegistryValueSnapshot snapshot in _originalValues)
+            {
+                if (snapshot.OriginalValue is null)
+                {
+                    nugetRegistryKey.DeleteValue(snapshot.Name, throwOnMissingValue: false);
+                }
+                else
+                {
+                    nugetRegistryKey.SetValue(snapshot.Name, snapshot.OriginalValue, snapshot.Kind);
+                }
+            }
+        }
+
+        private sealed class RegistryValueSnapshot
+        {
+            public RegistryValueSnapshot(string name, object? originalValue, RegistryValueKind kind)
+            {
+                Name = name;
+                OriginalValue = originalValue;
+                Kind = kind;
+            }
+
+            public string Name { get; }
+
+            public object? OriginalValue { get; }
+
+            public RegistryValueKind Kind { get; }
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  https://github.com/NuGet/Client.Engineering/issues/3784

## Description

 The `NuGet.Tests.Apex` StagingGate were failing in the staging pipeline but succeed in nuget test pipeline. And it looks like the NuGet test pipeline has a predeployment operation `SetupFunctionalTests.ps1`.


 The setup suppresses two `HKCU:\Software\NuGet` registry values (`DoNotShowPreviewWindow`, `SuppressUILegalDisclaimer`). 

  Adds `NuGetUISuppression` , `IDisposable`  helper. On construction it captures the original   registry state of each value and then writes    the suppression values as. On `Dispose()`  it restores the captured state exactly: deletes values that were absent before, and rewrites pre-existing values with their original data and kind.

Tested: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14455613&view=results

I ran a test on this in staging by creating a branch that points to this PRs drop path. I hard coded it in the branch and ran the tests. 

The tests are failing with 

```
Method not found: 'System.Collections.Generic.IEnumerable`1<NuGet.VisualStudio.Internal.Contracts.IProjectContextInfo> NuGet.PackageManagement.UI.INuGetUIContext.get_Projects()'
```


I think that is probably because the `NuGet.PackageManagement` bit in the test VS is different from the `Nuget.PackageManagement` in the test dll I attached by hard coding the VS drop url. That means we probably have to wait until this is inserted to see the results in the staging pipeline.

My local tests show with this change one can run these tests without having to run the setup PS1 file.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
