### PR TITLE
PMC test improvements; remove regions, use a dedicated fixtures folder, improve apex migration skill

### DIFF
--- a/.copilot/skills/apex-migration/SKILL.md
+++ b/.copilot/skills/apex-migration/SKILL.md
@@ -263,13 +263,17 @@ using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCor
 
 ## Style rules
 
+Follow the repo-wide coding guidelines first — they apply to all code, not just migrations:
+[`docs/coding-guidelines.md`](../../../docs/coding-guidelines.md) (e.g. no `#region` blocks, no
+reflection, `var` usage, nullable enabled). Don't restate or duplicate those rules here; this section
+only lists conventions **specific to test migration** that supplement the common guidelines:
+
 - Use `using var` (inline using declaration), not `using (var ...) { }`.
 - Place migrated tests before the static helper methods (`GetNetCoreTemplates`, etc.) in the file.
 - Method names: `{Action}FromPMC{Scenario}[_Fails|Async]`. Suffix with `_Fails` for error tests,
   `Async` for async tests.
 - Always include `[Timeout(DefaultTimeout)]`.
 - Always include `nugetConsole.GetText()` in assertion failure messages for diagnostics.
-- Use `var` for local variables except value tuples (use decomposed names).
 - The test class inherits `SharedVisualStudioHostTestClass` which provides `VisualStudio` and `Logger`.
 - Get PMC console via `GetConsole(testContext.Project)` helper method in the test class.
 - Don't use the method-delegates-to-async-helper pattern unless the helper is actually called from

--- a/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/Cmdlets/FindPackageCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/Cmdlets/FindPackageCommandTests.cs
@@ -3,12 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Management.Automation;
-using System.Management.Automation.Host;
-using System.Management.Automation.Runspaces;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.ComponentModelHost;
@@ -26,7 +21,6 @@ using NuGet.Test.Utility;
 using NuGet.VisualStudio;
 using Test.Utility;
 using Xunit;
-using PSCommand = System.Management.Automation.Runspaces.Command;
 
 namespace NuGetConsole.Host.PowerShell.Test
 {
@@ -239,8 +233,6 @@ namespace NuGetConsole.Host.PowerShell.Test
             package.Version.ToString().Should().Be("1.0.0-beta");
         }
 
-        #region Helpers
-
         private void SetupSourceRepositoryProvider(string localSourcePath)
         {
             var localSource = new PackageSource(localSourcePath);
@@ -257,78 +249,5 @@ namespace NuGetConsole.Host.PowerShell.Test
 
             return Task.FromResult<object?>(null);
         }
-
-        #endregion
-
-        #region Test Infrastructure
-
-        /// <summary>
-        /// Encapsulates runspace and host setup for invoking the Find-Package cmdlet in tests.
-        /// </summary>
-        private sealed class CmdletRunspaceFixture : IDisposable
-        {
-            private readonly Runspace _runspace;
-
-            public CmdletRunspaceFixture(string activeSource = "https://contoso.com/v3/index.json")
-            {
-                var host = new TestPSHost(activeSource);
-                var initialSessionState = InitialSessionState.CreateDefault();
-                initialSessionState.Commands.Add(
-                    new SessionStateCmdletEntry("Find-Package", typeof(FindPackageCommand), null));
-
-                _runspace = RunspaceFactory.CreateRunspace(host, initialSessionState);
-                _runspace.Open();
-            }
-
-            public IList<PSObject> Invoke(string cmdletName, Dictionary<string, object> parameters)
-            {
-                using var pipeline = _runspace.CreatePipeline();
-                var cmd = new PSCommand(cmdletName);
-                foreach (var kvp in parameters)
-                {
-                    cmd.Parameters.Add(kvp.Key, kvp.Value);
-                }
-                pipeline.Commands.Add(cmd);
-                return pipeline.Invoke().ToList();
-            }
-
-            public void Dispose()
-            {
-                _runspace.Close();
-                _runspace.Dispose();
-            }
-        }
-
-        /// <summary>
-        /// Minimal PSHost that provides PrivateData with properties expected by NuGet cmdlets.
-        /// </summary>
-        private sealed class TestPSHost : PSHost
-        {
-            private readonly Guid _instanceId = Guid.NewGuid();
-            private readonly PSObject _privateData;
-
-            public TestPSHost(string activeSource)
-            {
-                _privateData = new PSObject();
-                _privateData.Properties.Add(new PSNoteProperty("activePackageSource", activeSource));
-                _privateData.Properties.Add(new PSNoteProperty("CancellationTokenKey", CancellationToken.None));
-            }
-
-            public override CultureInfo CurrentCulture => CultureInfo.InvariantCulture;
-            public override CultureInfo CurrentUICulture => CultureInfo.InvariantCulture;
-            public override Guid InstanceId => _instanceId;
-            public override string Name => "TestNuGetHost";
-            public override PSObject PrivateData => _privateData;
-            public override PSHostUserInterface? UI => null;
-            public override Version Version => new Version(1, 0);
-
-            public override void EnterNestedPrompt() { }
-            public override void ExitNestedPrompt() { }
-            public override void NotifyBeginApplication() { }
-            public override void NotifyEndApplication() { }
-            public override void SetShouldExit(int exitCode) { }
-        }
-
-        #endregion
     }
 }

--- a/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/Cmdlets/GetPackageCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/Cmdlets/GetPackageCommandTests.cs
@@ -3,11 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
-using System.Management.Automation.Host;
-using System.Management.Automation.Runspaces;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -30,7 +27,6 @@ using NuGet.Versioning;
 using NuGet.VisualStudio;
 using Test.Utility;
 using Xunit;
-using PSCommand = System.Management.Automation.Runspaces.Command;
 
 namespace NuGetConsole.Host.PowerShell.Test
 {
@@ -629,8 +625,6 @@ namespace NuGetConsole.Host.PowerShell.Test
                 .Contain("Solution is not saved.");
         }
 
-        #region Helpers
-
         private void SetupSourceRepositoryProvider(string localSourcePath)
         {
             var localSource = new PackageSource(localSourcePath);
@@ -688,78 +682,5 @@ namespace NuGetConsole.Host.PowerShell.Test
 
             return Task.FromResult<object?>(null);
         }
-
-        #endregion
-
-        #region Test Infrastructure
-
-        /// <summary>
-        /// Encapsulates runspace and host setup for invoking NuGet PowerShell cmdlets in tests.
-        /// </summary>
-        private sealed class CmdletRunspaceFixture : IDisposable
-        {
-            private readonly Runspace _runspace;
-
-            public CmdletRunspaceFixture(string activeSource = "https://contoso.com/v3/index.json")
-            {
-                var host = new TestPSHost(activeSource);
-                var initialSessionState = InitialSessionState.CreateDefault();
-                initialSessionState.Commands.Add(
-                    new SessionStateCmdletEntry("Get-Package", typeof(GetPackageCommand), null));
-
-                _runspace = RunspaceFactory.CreateRunspace(host, initialSessionState);
-                _runspace.Open();
-            }
-
-            public IList<PSObject> Invoke(string cmdletName, Dictionary<string, object> parameters)
-            {
-                using var pipeline = _runspace.CreatePipeline();
-                var cmd = new PSCommand(cmdletName);
-                foreach (var kvp in parameters)
-                {
-                    cmd.Parameters.Add(kvp.Key, kvp.Value);
-                }
-                pipeline.Commands.Add(cmd);
-                return pipeline.Invoke().ToList();
-            }
-
-            public void Dispose()
-            {
-                _runspace.Close();
-                _runspace.Dispose();
-            }
-        }
-
-        /// <summary>
-        /// Minimal PSHost that provides PrivateData with properties expected by NuGet cmdlets.
-        /// </summary>
-        private sealed class TestPSHost : PSHost
-        {
-            private readonly Guid _instanceId = Guid.NewGuid();
-            private readonly PSObject _privateData;
-
-            public TestPSHost(string activeSource)
-            {
-                _privateData = new PSObject();
-                _privateData.Properties.Add(new PSNoteProperty("activePackageSource", activeSource));
-                _privateData.Properties.Add(new PSNoteProperty("CancellationTokenKey", CancellationToken.None));
-            }
-
-            public override CultureInfo CurrentCulture => CultureInfo.InvariantCulture;
-            public override CultureInfo CurrentUICulture => CultureInfo.InvariantCulture;
-            public override Guid InstanceId => _instanceId;
-            public override string Name => "TestNuGetHost";
-            public override PSObject PrivateData => _privateData;
-            public override PSHostUserInterface? UI => null;
-            public override Version Version => new Version(1, 0);
-
-            public override void EnterNestedPrompt() { }
-            public override void ExitNestedPrompt() { }
-            public override void NotifyBeginApplication() { }
-            public override void NotifyEndApplication() { }
-            public override void SetShouldExit(int exitCode) { }
-        }
-
-        #endregion
     }
 }

--- a/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/Fixtures/CmdletRunspaceFixture.cs
+++ b/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/Fixtures/CmdletRunspaceFixture.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Management.Automation.Runspaces;
+using System.Threading;
+using NuGet.PackageManagement.PowerShellCmdlets;
+using PSCommand = System.Management.Automation.Runspaces.Command;
+
+namespace NuGetConsole.Host.PowerShell.Test
+{
+    /// <summary>
+    /// Encapsulates runspace and host setup for invoking NuGet PowerShell cmdlets in tests.
+    /// </summary>
+    internal sealed class CmdletRunspaceFixture : IDisposable
+    {
+        private readonly Runspace _runspace;
+
+        public CmdletRunspaceFixture(string activeSource = "https://contoso.com/v3/index.json")
+        {
+            var host = new TestPSHost(activeSource);
+            var initialSessionState = InitialSessionState.CreateDefault();
+            initialSessionState.Commands.Add(
+                new SessionStateCmdletEntry("Find-Package", typeof(FindPackageCommand), null));
+            initialSessionState.Commands.Add(
+                new SessionStateCmdletEntry("Get-Package", typeof(GetPackageCommand), null));
+
+            _runspace = RunspaceFactory.CreateRunspace(host, initialSessionState);
+            _runspace.Open();
+        }
+
+        public IList<PSObject> Invoke(string cmdletName, Dictionary<string, object> parameters)
+        {
+            using var pipeline = _runspace.CreatePipeline();
+            var cmd = new PSCommand(cmdletName);
+            foreach (var kvp in parameters)
+            {
+                cmd.Parameters.Add(kvp.Key, kvp.Value);
+            }
+            pipeline.Commands.Add(cmd);
+            return pipeline.Invoke().ToList();
+        }
+
+        public void Dispose()
+        {
+            _runspace.Close();
+            _runspace.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Minimal PSHost that provides PrivateData with properties expected by NuGet cmdlets.
+    /// </summary>
+    internal sealed class TestPSHost : PSHost
+    {
+        private readonly Guid _instanceId = Guid.NewGuid();
+        private readonly PSObject _privateData;
+
+        public TestPSHost(string activeSource)
+        {
+            _privateData = new PSObject();
+            _privateData.Properties.Add(new PSNoteProperty("activePackageSource", activeSource));
+            _privateData.Properties.Add(new PSNoteProperty("CancellationTokenKey", CancellationToken.None));
+        }
+
+        public override CultureInfo CurrentCulture => CultureInfo.InvariantCulture;
+        public override CultureInfo CurrentUICulture => CultureInfo.InvariantCulture;
+        public override Guid InstanceId => _instanceId;
+        public override string Name => "TestNuGetHost";
+        public override PSObject PrivateData => _privateData;
+        public override PSHostUserInterface? UI => null;
+        public override Version Version => new Version(1, 0);
+
+        public override void EnterNestedPrompt() { }
+        public override void ExitNestedPrompt() { }
+        public override void NotifyBeginApplication() { }
+        public override void NotifyEndApplication() { }
+        public override void SetShouldExit(int exitCode) { }
+    }
+}

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/GetPackageTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/GetPackageTestCase.cs
@@ -104,7 +104,7 @@ namespace NuGet.Tests.Apex
 
         /// <summary>
         /// Verifies that Get-Package -ListAvailable returns a package whose IsUpdate property
-        /// is not set (falsy). The original E2E test (Test-GetPackagesWithNoUpdatesReturnPackagesWithIsUpdateNotSet)
+        /// is not set (false). The original E2E test (Test-GetPackagesWithNoUpdatesReturnPackagesWithIsUpdateNotSet)
         /// called Assert-False on $package.IsUpdate — which succeeds because PowerShellRemotePackage
         /// does not have an IsUpdate property, so PowerShell returns $null (falsy).
         /// </summary>


### PR DESCRIPTION
# Bug

This is a test-only follow-up change; no issue required.

## Description

Addresses post-merge review feedback from #7467 (PMC `Find-Package` / `Get-Package` test migration):

- **Removed `#region` blocks** from `FindPackageCommandTests.cs` and `GetPackageCommandTests.cs` (Coding Guideline 17).
- **Extracted shared test infrastructure into a Fixtures folder** — moved the duplicated `CmdletRunspaceFixture` and `TestPSHost` into `Fixtures/CmdletRunspaceFixture.cs` as shared internal classes (registers both `Find-Package` and `Get-Package`), eliminating duplication across the two test files. Cleaned up now-unused usings.
- **Fixed a comment typo** in `GetPackageTestCase.cs` (`falsy` -> `false`).
- **Updated the `apex-migration` skill** to reference the repo-wide `docs/coding-guidelines.md` instead of restating common rules; the Style rules section now only lists migration-specific conventions that supplement the common guidelines.

Verified: `NuGetConsole.Host.PowerShell.Test` builds with 0 warnings/0 errors and all 23 Find/Get cmdlet unit tests pass.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
