### PR TITLE
Use hardcoded psmdcp name to fix deterministic pack file-handle leak

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -377,8 +377,11 @@ namespace NuGet.Packaging
                 {
                     foreach (var file in Files.OrderBy(f => f, new NormalizedPathComparer()))
                     {
-                        var data = ReadAllBytes(file.GetStream());
-                        hashFunc.Update(data, 0, data.Length);
+                        using (var stream = file.GetStream())
+                        {
+                            var data = ReadAllBytes(stream);
+                            hashFunc.Update(data, 0, data.Length);
+                        }
                     }
                     return EncodeHexString(hashFunc.GetHashBytes())!.Substring(0, 32);
                 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -343,7 +343,7 @@ namespace NuGet.Packaging
 
             using (var package = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
             {
-                string psmdcpPath = $"package/services/metadata/core-properties/{CalcPsmdcpName()}.psmdcp";
+                string psmdcpPath = "package/services/metadata/core-properties/nuget.psmdcp";
 
                 // Validate and write the manifest
                 WriteManifest(package, DetermineMinimumSchemaVersion(Files, DependencyGroups), psmdcpPath);
@@ -357,38 +357,6 @@ namespace NuGet.Packaging
                 WriteOpcContentTypes(package, extensions, filesWithoutExtensions);
 
                 WriteOpcPackageProperties(package, psmdcpPath);
-            }
-        }
-
-        private static byte[] ReadAllBytes(Stream stream)
-        {
-            using (var ms = new MemoryStream())
-            {
-                stream.CopyTo(ms);
-                return ms.ToArray();
-            }
-        }
-
-        internal string CalcPsmdcpName()
-        {
-            if (_deterministic)
-            {
-                using (var hashFunc = new Sha512HashFunction())
-                {
-                    foreach (var file in Files.OrderBy(f => f, new NormalizedPathComparer()))
-                    {
-                        using (var stream = file.GetStream())
-                        {
-                            var data = ReadAllBytes(stream);
-                            hashFunc.Update(data, 0, data.Length);
-                        }
-                    }
-                    return EncodeHexString(hashFunc.GetHashBytes())!.Substring(0, 32);
-                }
-            }
-            else
-            {
-                return Guid.NewGuid().ToString("N", provider: null);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -87,6 +87,55 @@ namespace Dotnet.Integration.Test
         }
 
         [PlatformFact(Platform.Windows)]
+        public void Pack_Deterministic_DoesNotLeakSourceFileHandle()
+        {
+            // Arrange
+            using (var testDirectory = _dotnetFixture.CreateTestDirectory())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                _dotnetFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "classlib", testOutputHelper: _testOutputHelper);
+
+                // A physical file included in the package. PhysicalPackageFile.GetStream() returns
+                // File.OpenRead(SourcePath), so the leaked handle locks this very file on disk.
+                File.WriteAllText(Path.Combine(workingDirectory, "signme.txt"), "original content to be signed");
+                File.WriteAllText(Path.Combine(workingDirectory, "signed.txt"), "signed content");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", TestConstants.ProjectTargetFramework);
+                    ProjectFileUtils.AddProperty(xml, "Deterministic", "true");
+
+                    var itemGroupXml = @"<ItemGroup>
+    <None Include=""signme.txt"" Pack=""True"" PackagePath=""contentFiles/any/any/"" />
+  </ItemGroup>";
+                    // Simulate the signing step that copies signed files over the originals after pack.
+                    var signingTargetXml = @"<Target Name=""SimulateSigningOverwrite"" AfterTargets=""Pack"">
+    <Copy SourceFiles=""$(MSBuildProjectDirectory)/signed.txt""
+          DestinationFiles=""$(MSBuildProjectDirectory)/signme.txt""
+          OverwriteReadOnlyFiles=""true"" />
+  </Target>";
+                    ProjectFileUtils.AddCustomXmlToProjectRoot(xml, itemGroupXml);
+                    ProjectFileUtils.AddCustomXmlToProjectRoot(xml, signingTargetXml);
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                _dotnetFixture.RestoreProjectExpectSuccess(workingDirectory, projectName, testOutputHelper: _testOutputHelper);
+
+                // Act & Assert
+                // With the handle leak, the post-pack Copy fails with a file-in-use/sharing-violation
+                // because PackTask still holds an open read handle on signme.txt, so pack exits non-zero.
+                var result = _dotnetFixture.PackProjectExpectSuccess(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}", testOutputHelper: _testOutputHelper);
+
+                Assert.Equal("signed content", File.ReadAllText(Path.Combine(workingDirectory, "signme.txt")));
+            }
+        }
+
+        [PlatformFact(Platform.Windows)]
         public void PackCommand_NewProject_OutputsInDefaultPaths()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -86,8 +86,9 @@ namespace Dotnet.Integration.Test
             }
         }
 
+        // Other platforms may not have the same file locking behavior as Windows, so this test is only run on Windows.
         [PlatformFact(Platform.Windows)]
-        public void Pack_Deterministic_DoesNotLeakSourceFileHandle()
+        public void Pack_DoesNotLeakSourceFileHandle()
         {
             // Arrange
             using (var testDirectory = _dotnetFixture.CreateTestDirectory())

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -223,48 +223,6 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
-        public void CreatePackageWithChangingOrderOfFilesIsDeterministic()
-        {
-            var sep = Path.DirectorySeparatorChar;
-            string[] hashes = new string[2];
-
-            for (var i = 0; i < 2; i++)
-            {
-                // Arrange
-                PackageBuilder builder = new PackageBuilder(deterministic: true)
-                {
-                    Id = "A",
-                    Version = NuGetVersion.Parse("1.0"),
-                    Description = "Descriptions",
-                    DeterministicTimestamp = "2009-02-13T23:31:30+00:00",
-                };
-
-                // With globs like <file src="**" >, the order of files can be
-                // random. Simulate that by using different order different
-                // times.
-                List<IPackageFile> files = new List<IPackageFile>
-                {
-                    CreatePackageFile(@"content" + sep + "file1.txt", new byte[] { 0x01 }),
-                    CreatePackageFile(@"content" + sep + "file2.txt", new byte[] { 0x02 }),
-                    CreatePackageFile(@"data" + sep + "file1.txt", new byte[] { 0x03 }),
-                    CreatePackageFile(@"data" + sep + "file2.txt", new byte[] { 0x04 }),
-                    CreatePackageFile(@"content" + sep + "file3.txt", new byte[] { 0x05 }),
-                };
-
-                if (i % 2 != 0)
-                {
-                    files.Reverse();
-                }
-
-                builder.Files.AddRange(files);
-
-                hashes[i] = builder.CalcPsmdcpName();
-            }
-
-            Assert.Equal(hashes[0], hashes[1]);
-        }
-
-        [Fact]
         public void CreatePackage_IncludesAStableOrderOfContentTypesXml()
         {
             // Arrange


### PR DESCRIPTION
# Bug

Fixes: https://github.com/NuGet/Home/issues/14959

## Description

Deterministic pack leaks a file handle: `PackageBuilder.CalcPsmdcpName()` calls `file.GetStream()` for every file in the package and passes it to `ReadAllBytes()`, which only disposes the intermediate `MemoryStream` — the source stream returned by `GetStream()` (a `File.OpenRead(...)` for physical files) is never disposed.

Per OPC standards, the actual name just needs to be deterministic and it does not have to be per package unique, so using a hardcoded name is just fine.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
