### PR TITLE
Skip nonexistent fallback folders when resolving installed package paths

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/NuGetProjectService.cs
@@ -155,7 +155,13 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
 
             var packageSpec = packageSpecs.Single(s => s.RestoreMetadata.ProjectStyle == ProjectModel.ProjectStyle.PackageReference || s.RestoreMetadata.ProjectStyle == ProjectModel.ProjectStyle.ProjectJson);
             var packagesPath = VSRestoreSettingsUtilities.GetPackagesPath(_settings, packageSpec);
-            FallbackPackagePathResolver pathResolver = new FallbackPackagePathResolver(packagesPath, VSRestoreSettingsUtilities.GetFallbackFolders(_settings, packageSpec));
+
+            // Resolving installed package paths tolerates a missing fallback folder, unlike restore.
+            // Filter out folders that don't exist on disk; the resolver would otherwise throw.
+            var fallbackFolders = VSRestoreSettingsUtilities.GetFallbackFolders(_settings, packageSpec)
+                .Where(Directory.Exists)
+                .ToList();
+            FallbackPackagePathResolver pathResolver = new FallbackPackagePathResolver(packagesPath, fallbackFolders);
 
             IReadOnlyCollection<PackageReference> directPackages;
             IReadOnlyCollection<PackageReference> transitivePackages;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
@@ -152,7 +152,12 @@ namespace NuGet.VisualStudio.Implementation.Extensibility
 
             var packagesPath = VSRestoreSettingsUtilities.GetPackagesPath(_settings, packageSpec);
 
-            return new FallbackPackagePathResolver(packagesPath, VSRestoreSettingsUtilities.GetFallbackFolders(_settings, packageSpec));
+            // Resolving installed package paths tolerates a missing fallback folder, unlike restore.
+            // Filter out folders that don't exist on disk; the resolver would otherwise throw.
+            var fallbackFolders = VSRestoreSettingsUtilities.GetFallbackFolders(_settings, packageSpec)
+                .Where(Directory.Exists)
+                .ToList();
+            return new FallbackPackagePathResolver(packagesPath, fallbackFolders);
         }
 
         private async Task<IEnumerable<PackageReference>> GetInstalledPackageReferencesAsync(

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/NuGetProjectServiceTests.cs
@@ -129,18 +129,63 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             Assert.False(package.DirectDependency);
         }
 
+        [Fact]
+        public async Task GetInstalledPackagesAsync_MissingFallbackFolder_DoesNotFaultAndReturnsPackagesAsync()
+        {
+            // Arrange
+            var projectGuid = Guid.NewGuid();
+
+            var settings = new Mock<ISettings>();
+            // Strict so that any unexpected PostFaultAsync (i.e. the fault we're trying to eliminate) fails the test.
+            var telemetryProvider = new Mock<INuGetTelemetryProvider>(MockBehavior.Strict);
+
+            var installedPackages = new List<PackageReference>()
+            {
+                new PackageReference(new PackageIdentity("a", new NuGetVersion(1, 0, 0)), FrameworkConstants.CommonFrameworks.Net50)
+            };
+            var transitivePackages = new List<PackageReference>();
+
+            // A user-configured fallback folder that doesn't exist on disk previously caused the
+            // FallbackPackagePathResolver constructor to throw, which surfaced as a NuGet fault.
+            var missingFallbackFolder = Path.Combine(Path.GetTempPath(), "NuGet.Tests", Guid.NewGuid().ToString("N"));
+            var project = new TestPackageReferenceProject("ProjectA", @"src\ProjectA\Project.csproj", @"c:\path\to\src\ProjectA\ProjectA.csproj",
+                installedPackages, transitivePackages, fallbackFolders: new List<string>() { missingFallbackFolder });
+
+            var solutionManager = new Mock<IVsSolutionManager>();
+            solutionManager.Setup(sm => sm.GetNuGetProjectAsync(projectGuid.ToString()))
+                .Returns(() => Task.FromResult<NuGetProject>(project));
+
+            // Act
+            var target = new NuGetProjectService(solutionManager.Object, settings.Object, telemetryProvider.Object);
+            InstalledPackagesResult actual = await target.GetInstalledPackagesAsync(projectGuid, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.Equal(InstalledPackageResultStatus.Successful, actual.Status);
+
+            NuGetInstalledPackage package = actual.Packages.FirstOrDefault(p => p.Id == "a");
+            Assert.NotNull(package);
+            // The package can't be located on disk, so it has no install path, but no fault is raised.
+            Assert.Null(package.InstallPath);
+            telemetryProvider.Verify(t => t.PostFaultAsync(It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IDictionary<string, object>>()), Times.Never);
+        }
+
         class TestPackageReferenceProject : PackageReferenceProject<List<PackageReference>, PackageReference>
         {
+            private readonly List<string> _fallbackFolders;
+
             public TestPackageReferenceProject(
                 string projectName,
                 string projectUniqueName,
                 string projectFullPath,
                 List<PackageReference> installedPackages,
-                List<PackageReference> transitivePackages)
+                List<PackageReference> transitivePackages,
+                List<string> fallbackFolders = null)
                 : base(projectName, projectUniqueName, projectFullPath)
             {
                 InstalledPackages = installedPackages;
                 TransitivePackages = transitivePackages;
+                _fallbackFolders = fallbackFolders ?? new List<string>();
             }
 
             public override string MSBuildProjectPath => ProjectFullPath;
@@ -173,7 +218,9 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 DependencyGraphSpec dgSpec = DependencyGraphSpecTestUtilities.CreateMinimalDependencyGraphSpec(ProjectFullPath, MSBuildProjectPath);
 
                 List<PackageSpec> packageSpecs = new List<PackageSpec>();
-                packageSpecs.Add(dgSpec.GetProjectSpec(ProjectFullPath));
+                PackageSpec packageSpec = dgSpec.GetProjectSpec(ProjectFullPath);
+                packageSpec.RestoreMetadata.FallbackFolders = _fallbackFolders;
+                packageSpecs.Add(packageSpec);
 
                 (IReadOnlyList<PackageSpec>, IReadOnlyList<IAssetsLogMessage>) result = (packageSpecs, null);
                 return Task.FromResult(result);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3665

## Description
The `INuGetProjectService.GetInstalledPackagesAsync` and `IVsPackageInstallerServices.GetInstalledPackages` extensibility APIs build a `FallbackPackagePathResolver` to resolve installed package paths. The resolver's constructor throws a `PackagingException` ("Unable to find fallback package folder '{0}'.") when any configured fallback folder does not exist on disk. On these read-only paths the exception was caught and reported as a fault (`vs.nuget.fault_..._FallbackPackagePathResolver..ctor__`), and it aborted the entire installed-packages query.

A configured fallback folder that is missing from disk is a user misconfiguration, not a product failure, and it should not fault or block reading the installed packages. This is distinct from restore, which intentionally fails when a configured fallback folder is missing.

This change filters out fallback folders that don't exist on disk before constructing the resolver, at both extensibility read paths. Packages that can't be located simply get a null install path instead of throwing. Restore behavior is unchanged.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
