### PR TITLE
Replace project adapter on PC to PR migration

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -840,7 +840,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 // Refresh the adapter in the cache after migration.
                 if (projectJsonNuGetProject.TryGetMetadata(NuGetProjectMetadataKeys.UniqueName, out projectJsonUniqueName))
                 {
-                    RemoveVsProjectAdapterFromCache(projectJsonUniqueName);
+                    // AddVsProjectAdapterToCacheAsync replaces the project when it already exists, so no need to remove.
                     IVsProjectAdapter vsProjectAdapterMigrated = await _vsProjectAdapterProvider.CreateAdapterForFullyLoadedProjectAsync(hierarchy);
                     await AddVsProjectAdapterToCacheAsync(vsProjectAdapterMigrated);
                 }
@@ -1127,12 +1127,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
             _projectSystemCache.TryGetProjectNames(projectName, out var projectNames);
 
-            RemoveVsProjectAdapterFromCache(projectName);
-
+            // AddProject replaces the project when it already exists, so no need to remove.
             var nuGetProject = await _projectSystemFactory.CreateNuGetProjectAsync<LegacyPackageReferenceProject>(
                 vsProjectAdapter, optionalContext: null);
 
-            var added = _projectSystemCache.AddProject(projectNames, vsProjectAdapter, nuGetProject);
+            _projectSystemCache.AddProject(projectNames, vsProjectAdapter, nuGetProject);
 
             if (DefaultNuGetProjectName == null)
             {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Moq;
+using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 using NuGet.VisualStudio;
 using Xunit;
@@ -175,6 +176,29 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.True(getProjectNameSuccess);
             Assert.Same(projectRestoreInfo, actual);
             Assert.Equal(@"folder\project", names.CustomUniqueName);
+        }
+
+        [Fact]
+        public void AddProject_WhenProjectAlreadyExists_SwapsNuGetProjectInPlaceWithoutRemoving()
+        {
+            // Arrange
+            var target = new ProjectSystemCache();
+            var projectNames = GetTestProjectNames();
+            NuGetProject originalProject = new Mock<NuGetProject>().Object;
+            NuGetProject migratedProject = new Mock<NuGetProject>().Object;
+
+            target.AddProject(projectNames, vsProjectAdapter: null, originalProject);
+
+            // Act
+            target.AddProject(projectNames, vsProjectAdapter: null, migratedProject);
+
+            // Assert
+            IReadOnlyList<NuGetProject> projects = target.GetNuGetProjects();
+            Assert.Equal(1, projects.Count);
+            Assert.Same(migratedProject, projects[0]);
+
+            Assert.True(target.TryGetNuGetProject(projectNames.FullName, out NuGetProject byFullName));
+            Assert.Same(migratedProject, byFullName);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/12397

## Description

I used to be able to reproduce the bug, when installing the first package in a legacy csproj, and choosing PackageReference as a reference format. Internally this did a packages.config project adapter migration to a PackageReference project adapter.

I'm no longer able to reproduce the bug, but the existing code removes NuGet's project adapter from the cache, then creates the new one and adds it to the cache, all in async code. If PM UI, while on another thread, tries to refresh in the time between removing the old adapter and adding the new, then PM UI will get an error.

But the project adapter cache's add method will replace an adapter if it already exists. So, we can do this to avoid timing issues.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
