### PR TITLE
Bump MSBuild to 18.6.3 for NET compilation of Nuget.Build.Tasks.dll

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <!-- Read docs/updating-packages.md before updating MSBuild's version -->
-    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">18.0.2</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion Condition="'$(MicrosoftBuildVersion)' == ''">18.6.3</MicrosoftBuildVersion>
   </PropertyGroup>
 
     <!-- Overridden by source build to ensure the same version is used across products, do not remove these properties -->
@@ -27,7 +27,7 @@
     <SystemMemoryPackageVersion Condition="'$(SystemMemoryPackageVersion)' == ''">4.6.3</SystemMemoryPackageVersion>
     <SystemSecurityCryptographyPkcsVersion Condition="'$(SystemSecurityCryptographyPkcsVersion)' == ''">8.0.1</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyProtectedDataVersion Condition="'$(SystemSecurityCryptographyProtectedDataVersion)' == ''">8.0.0</SystemSecurityCryptographyProtectedDataVersion>
-    <SystemSecurityCryptographyXmlPackageVersion Condition="'$(SystemSecurityCryptographyXmlPackageVersion)' == ''">9.0.16</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion Condition="'$(SystemSecurityCryptographyXmlPackageVersion)' == ''">10.0.8</SystemSecurityCryptographyXmlPackageVersion>
     <MicrosoftDotNetXliffTasksVersion Condition="'$(MicrosoftDotNetXliffTasksVersion)' == ''">10.0.0-beta.25260.104</MicrosoftDotNetXliffTasksVersion>
   </PropertyGroup>
 


### PR DESCRIPTION


<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Part 2 of NuGet/Home#14958.

## Description

Updates MicrosoftBuildVersion 18.0.2 -> 18.6.3 so NuGet's .NET (SDK) MSBuild tasks compile against the MSBuild 18.6 API surface, enabling the in-process task-execution work tracked by the linked issue. The .NET Framework build of NuGet.Build.Tasks is unaffected because it compiles against the in-box MSBuild reference assemblies (not the package), so the legacy nuget.exe and desktop msbuild.exe paths stay on the frozen API surface. 
- this is due to discussion that new nuget.exe must keep working even used from vs17.14

It'd be desirable to decouple what ships in nuget.exe and what ships in Nuget.Build.Tasks.dll for VS so that `msbuild -m -mt -t:Restore` works in the new mode performantly, but that's out of scope for now and we'll proceed migrating tasks with conditional compilation.

MSBuild 18.6.3 introduces a transitive dependency on System.Security.Cryptography.Xml 10.0.3, which trips NU1903 (high severity; GHSA-37gx-xxp4-5rgx / GHSA-w3x6-4m5h-cxqf; vulnerable <= 10.0.5). Bump the existing SystemSecurityCryptographyXmlPackageVersion pin 9.0.16 -> 10.0.8 (patched) to clear the audit warning, continuing the existing pattern of pinning S.S.C.Xml because MSBuild drags in a vulnerable transitive version.



## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~~Added tests~~ n/a
- [x] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~ n/a
