### PR TITLE
Annotate trivial Nuget.Build.Tasks for multithreadable MSBuild execution  

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <Compile Include="..\NuGet.Build.Tasks\Common\MSBuildLogger.cs" />
+    <Compile Include="..\NuGet.Build.Tasks\Common\MSBuildMultiThreadableTaskAttribute.cs" />
     <Compile Include="..\NuGet.Build.Tasks\GetProjectTargetFrameworksTask.cs" />
   </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/CheckForDuplicateNuGetItemsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/CheckForDuplicateNuGetItemsTask.cs
@@ -17,6 +17,7 @@ using Task = Microsoft.Build.Utilities.Task;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class CheckForDuplicateNuGetItemsTask : Task
     {
         [Required]

--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildMultiThreadableTaskAttribute.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildMultiThreadableTaskAttribute.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NETFRAMEWORK
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Compatibility shim for <c>Microsoft.Build.Framework.MSBuildMultiThreadableTaskAttribute</c>, which only exists
+    /// in MSBuild 18.6 and later. The .NET Framework build of NuGet's MSBuild tasks compiles against the in-box MSBuild
+    /// reference assemblies, which do not contain this type, so this polyfill lets the shared task source apply the
+    /// marker without conditional compilation at each task. MSBuild detects the attribute by namespace and name only
+    /// (ignoring the defining assembly), so a self-defined copy is recognized by 18.6+ hosts and ignored by older ones.
+    /// On .NET (non-NETFRAMEWORK) targets the real attribute from the Microsoft.Build.Framework package is used instead.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    internal sealed class MSBuildMultiThreadableTaskAttribute : Attribute
+    {
+    }
+}
+#endif

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetCentralPackageVersionsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetCentralPackageVersionsTask.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class GetCentralPackageVersionsTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetGlobalPropertyValueTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetGlobalPropertyValueTask.cs
@@ -16,6 +16,7 @@ using Task = Microsoft.Build.Utilities.Task;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class GetGlobalPropertyValueTask : Task
     {
         [Required]

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetProjectTargetFrameworksTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetProjectTargetFrameworksTask.cs
@@ -13,6 +13,7 @@ namespace NuGet.Build.Tasks
     /// Determine the project's targetframework(s) based
     /// on the available properties.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class GetProjectTargetFrameworksTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetReferenceNearestTargetFrameworkTask.cs
@@ -17,6 +17,7 @@ using NuGet.ProjectModel;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class GetReferenceNearestTargetFrameworkTask : Task
     {
         private const string NEAREST_TARGET_FRAMEWORK = "NearestTargetFramework";

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
@@ -15,6 +15,7 @@ using NuGet.Versioning;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class GetRestoreDotnetCliToolsTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreFrameworkReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreFrameworkReferencesTask.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class GetRestoreFrameworkReferencesTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreNuGetAuditSuppressionsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreNuGetAuditSuppressionsTask.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class GetRestoreNuGetAuditSuppressionsTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageDownloadsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageDownloadsTask.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class GetRestorePackageDownloadsTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageReferencesTask.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class GetRestorePackageReferencesTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePrunedPackageReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePrunedPackageReferencesTask.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class GetRestorePrunePackageReferencesTask : Task
     {
         /// <summary>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGetMessageTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGetMessageTask.cs
@@ -12,6 +12,7 @@ namespace NuGet.Build.Tasks
     /// <summary>
     /// A task that logs a message from the localized <see cref="Strings"/> resource.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class NuGetMessageTask : Task
     {
         [Required]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: addresses the trivial case of part 3 https://github.com/NuGet/Home/issues/14958

## Description
These tasks are stateless so they can be used in multithreaded msbuild execution without changes.

polyfill the attribute to net472 where we're not consuming the new MSBuild API 
- this is publicly documented compat option https://learn.microsoft.com/en-us/visualstudio/msbuild/update-task-multithreaded?view=visualstudio

on top of https://github.com/NuGet/NuGet.Client/pull/7508

## PR Checklist

- [x ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
