### PR TITLE
Skip NU1703 for empty MonoAndroid assets

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -288,8 +288,11 @@ namespace NuGet.Commands
                         // Log NU1703 warning if the package uses the deprecated MonoAndroid framework
                         if (checkMonoAndroidDeprecation
                             && !librariesWithMonoAndroidWarnings.Contains(library)
-                            && (MonoAndroidDeprecation.IsMonoAndroidFramework(compileAssetFramework)
-                                || MonoAndroidDeprecation.IsMonoAndroidFramework(runtimeAssetFramework)))
+                            && MonoAndroidDeprecation.ShouldWarn(
+                                compileAssetFramework,
+                                targetLibrary.CompileTimeAssemblies,
+                                runtimeAssetFramework,
+                                targetLibrary.RuntimeAssemblies))
                         {
                             var message = string.Format(CultureInfo.CurrentCulture,
                                 Strings.Warning_MonoAndroidFrameworkDeprecated,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MonoAndroidDeprecation.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MonoAndroidDeprecation.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using NuGet.Frameworks;
+using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 
 namespace NuGet.Commands
@@ -53,6 +56,35 @@ namespace NuGet.Commands
                 && StringComparer.OrdinalIgnoreCase.Equals(
                     framework.Framework,
                     FrameworkConstants.FrameworkIdentifiers.MonoAndroid);
+        }
+
+        /// <summary>
+        /// Determines whether selected MonoAndroid assets should produce a deprecation warning.
+        /// </summary>
+        /// <param name="compileAssetFramework">The framework selected for compile assets.</param>
+        /// <param name="compileTimeAssemblies">The selected compile assets.</param>
+        /// <param name="runtimeAssetFramework">The framework selected for runtime assets.</param>
+        /// <param name="runtimeAssemblies">The selected runtime assets.</param>
+        /// <returns>True when a package contributes non-placeholder MonoAndroid compile or runtime assets.</returns>
+        internal static bool ShouldWarn(
+            NuGetFramework compileAssetFramework,
+            IEnumerable<LockFileItem> compileTimeAssemblies,
+            NuGetFramework runtimeAssetFramework,
+            IEnumerable<LockFileItem> runtimeAssemblies)
+        {
+            return HasNonEmptyMonoAndroidAssets(compileAssetFramework, compileTimeAssemblies)
+                || HasNonEmptyMonoAndroidAssets(runtimeAssetFramework, runtimeAssemblies);
+        }
+
+        private static bool HasNonEmptyMonoAndroidAssets(NuGetFramework framework, IEnumerable<LockFileItem> assets)
+        {
+            return IsMonoAndroidFramework(framework)
+                && assets?.Any(asset => !IsEmptyFolder(asset.Path)) == true;
+        }
+
+        private static bool IsEmptyFolder(string path)
+        {
+            return path.EndsWith(PackagingCoreConstants.ForwardSlashEmptyFolder, StringComparison.Ordinal);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MonoAndroidDeprecation.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MonoAndroidDeprecation.cs
@@ -79,7 +79,7 @@ namespace NuGet.Commands
         private static bool HasNonEmptyMonoAndroidAssets(NuGetFramework framework, IEnumerable<LockFileItem> assets)
         {
             return IsMonoAndroidFramework(framework)
-                && assets?.Any(asset => !IsEmptyFolder(asset.Path)) == true;
+                && assets.Any(asset => !IsEmptyFolder(asset.Path));
         }
 
         private static bool IsEmptyFolder(string path)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/MonoAndroidDeprecationTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/MonoAndroidDeprecationTests.cs
@@ -119,6 +119,30 @@ namespace NuGet.Commands.Test.RestoreCommandTests
 
         #endregion
 
+        #region ShouldWarn tests
+
+        [Fact]
+        public void ShouldWarn_MonoAndroidWithOnlyEmptyFolderPlaceholders_ReturnsFalse()
+        {
+            var monoAndroid = NuGetFramework.Parse("monoandroid10.0");
+            var compileItems = new[]
+            {
+                new LockFileItem("ref/MonoAndroid10/_._")
+            };
+            var runtimeItems = new[]
+            {
+                new LockFileItem("lib/MonoAndroid10/_._")
+            };
+
+            MonoAndroidDeprecation.ShouldWarn(
+                monoAndroid,
+                compileItems,
+                monoAndroid,
+                runtimeItems).Should().BeFalse();
+        }
+
+        #endregion
+
         #region Integration tests
 
         [Fact]


### PR DESCRIPTION
Avoid emitting the MonoAndroid deprecation warning (introduced in https://github.com/NuGet/NuGet.Client/pull/7229) when restore selects only `_._` placeholder assets from a package. Keep warning behavior for packages that contribute real MonoAndroid compile or runtime assets.

The warning was showing up on a transitive reference to System.Security.Cryptography.ProtectedData 4.5.0 in https://github.com/dotnet/runtime/pull/129836, but we don't want it to warn when no assets are used from the MonoAndroid TFM.

Assisted-by: GitHub Copilot CLI:gpt-5.5

@nkolev92 PTAL


<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:
NU1903 showing up on reference to old package with MonoAndroid TFM but no MonoAndroid assets, in https://github.com/dotnet/runtime/pull/129836.

## Description

The warning added in https://github.com/NuGet/NuGet.Client/pull/7229 fires for packages that declare a MonoAndroid TFM but only ship an empty `_._` placeholder for TFM compatibility. We shouldn't emit the warning if no MonoAndroid assets are consumed.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
