### PR TITLE
Apply insecure HTTP source checks to audit sources during restore

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/IVulnerabilityInformationProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/IVulnerabilityInformationProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Configuration;
 using NuGet.Protocol.Model;
 
 namespace NuGet.Commands
@@ -20,5 +21,8 @@ namespace NuGet.Commands
 
         /// <summary>The name (key) of the source.</summary>
         string SourceName { get; }
+
+        /// <summary>The <see cref="Configuration.PackageSource"/> the vulnerability data is read from.</summary>
+        PackageSource PackageSource { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -240,7 +240,7 @@ namespace NuGet.Commands
                 telemetry.TelemetryEvent[NoOpResult] = false; // Getting here means we did not no-op.
 
                 bool success = !_request.AdditionalMessages?.Any(m => m.Level == LogLevel.Error) ?? true;
-                success &= BeforeGraphResolutionValidations(httpSourcesCount);
+                success &= BeforeGraphResolutionValidations(httpSourcesCount, auditEnabled);
 
                 var packagesLockFilePath = PackagesLockFileUtilities.GetNuGetLockFilePath(_request.Project);
                 PackagesLockFile packagesLockFile = null;
@@ -360,13 +360,13 @@ namespace NuGet.Commands
             }
         }
 
-        private bool BeforeGraphResolutionValidations(int httpSourcesCount)
+        private bool BeforeGraphResolutionValidations(int httpSourcesCount, bool auditEnabled)
         {
             var success = true;
 
             success &= EnsureNotDeprecatedProjectJsonProjectType();
             success &= AreCentralVersionRequirementsSatisfied(_request, httpSourcesCount);
-            success &= EvaluateHttpSourceUsage();
+            success &= EvaluateHttpSourceUsage(auditEnabled);
             success &= HasValidPlatformVersions();
             success &= PackageReferencesHaveVersions();
             success &= EnsureNoAliasesWithDisallowedCharacters();
@@ -515,7 +515,7 @@ namespace NuGet.Commands
             return (null, noOpCacheFileEvaluation, cacheFile);
         }
 
-        private bool EvaluateHttpSourceUsage()
+        private bool EvaluateHttpSourceUsage(bool auditEnabled)
         {
             bool error = false;
 
@@ -523,17 +523,18 @@ namespace NuGet.Commands
             {
                 foreach (var remoteProvider in _request.DependencyProviders.RemoteProviders)
                 {
-                    error |= CheckDisallowedInsecureHttpSource(remoteProvider.Source);
+                    error |= CheckDisallowedInsecureHttpSource(remoteProvider.Source, SdkAnalysisLevelMinimums.V9_0_100);
                 }
             }
 
-            if (_request.DependencyProviders.VulnerabilityInfoProviders != null)
+            // Audit sources are only contacted when auditing is enabled, so only warn/error about insecure audit sources in that case.
+            if (auditEnabled && _request.DependencyProviders.VulnerabilityInfoProviders != null)
             {
                 foreach (var vulnerabilityInfoProvider in _request.DependencyProviders.VulnerabilityInfoProviders)
                 {
                     if (vulnerabilityInfoProvider.IsAuditSource)
                     {
-                        error |= CheckDisallowedInsecureHttpSource(vulnerabilityInfoProvider.PackageSource);
+                        error |= CheckDisallowedInsecureHttpSource(vulnerabilityInfoProvider.PackageSource, SdkAnalysisLevelMinimums.V10_0_400);
                     }
                 }
             }
@@ -541,7 +542,7 @@ namespace NuGet.Commands
             return !error;
         }
 
-        private bool CheckDisallowedInsecureHttpSource(PackageSource source)
+        private bool CheckDisallowedInsecureHttpSource(PackageSource source, NuGetVersion errorMinSdkAnalysisLevel)
         {
             if (!source.IsHttp || source.IsHttps || source.AllowInsecureConnections)
             {
@@ -551,7 +552,7 @@ namespace NuGet.Commands
             var isErrorEnabled = SdkAnalysisLevelMinimums.IsEnabled(
                 _request.Project.RestoreMetadata.SdkAnalysisLevel,
                 _request.Project.RestoreMetadata.UsingMicrosoftNETSdk,
-                SdkAnalysisLevelMinimums.V9_0_100);
+                errorMinSdkAnalysisLevel);
 
             if (isErrorEnabled)
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -567,11 +567,11 @@ namespace NuGet.Commands
             else if (warnWhenNotError)
             {
                 var message = RestoreLogMessage.CreateWarning(
-                        NuGetLogCode.NU1803,
-                        string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source));
+                    NuGetLogCode.NU1803,
+                    string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source));
                 _logger.Log(message);
 
-                // If the project treats this warning as an error, we should not continue
+                // If the project treats this warning as an error, we should not restore
                 return message.Level == LogLevel.Error;
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -527,14 +527,15 @@ namespace NuGet.Commands
                 }
             }
 
-            // Audit sources are only contacted when auditing is enabled, so only warn/error about insecure audit sources in that case.
+            // Audit sources are only contacted when auditing is enabled, so only error about insecure audit sources in that case.
+            // Unlike package sources, audit sources error when the SDK analysis level is high enough and are silent otherwise (no warning).
             if (auditEnabled && _request.DependencyProviders.VulnerabilityInfoProviders != null)
             {
                 foreach (var vulnerabilityInfoProvider in _request.DependencyProviders.VulnerabilityInfoProviders)
                 {
                     if (vulnerabilityInfoProvider.IsAuditSource)
                     {
-                        error |= CheckDisallowedInsecureHttpSource(vulnerabilityInfoProvider.PackageSource, SdkAnalysisLevelMinimums.V10_0_400);
+                        error |= CheckDisallowedInsecureHttpSource(vulnerabilityInfoProvider.PackageSource, SdkAnalysisLevelMinimums.V10_0_400, warnWhenNotError: false);
                     }
                 }
             }
@@ -542,7 +543,7 @@ namespace NuGet.Commands
             return !error;
         }
 
-        private bool CheckDisallowedInsecureHttpSource(PackageSource source, NuGetVersion errorMinSdkAnalysisLevel)
+        private bool CheckDisallowedInsecureHttpSource(PackageSource source, NuGetVersion errorMinSdkAnalysisLevel, bool warnWhenNotError = true)
         {
             if (!source.IsHttp || source.IsHttps || source.AllowInsecureConnections)
             {
@@ -563,7 +564,7 @@ namespace NuGet.Commands
 
                 return true;
             }
-            else
+            else if (warnWhenNotError)
             {
                 var message = RestoreLogMessage.CreateWarning(
                         NuGetLogCode.NU1803,
@@ -573,6 +574,8 @@ namespace NuGet.Commands
                 // If the project treats this warning as an error, we should not continue
                 return message.Level == LogLevel.Error;
             }
+
+            return false;
         }
 
         private record struct EvaluateLockFileResult(bool Success, bool IsLockFileValid, bool RegenerateLockFile, string PackagesLockFilePath, PackagesLockFile PackagesLockFile);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Commands.Restore.Utility;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.DependencyResolver;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -522,41 +523,55 @@ namespace NuGet.Commands
             {
                 foreach (var remoteProvider in _request.DependencyProviders.RemoteProviders)
                 {
-                    var source = remoteProvider.Source;
-                    if (source.IsHttp && !source.IsHttps && !source.AllowInsecureConnections)
+                    error |= CheckDisallowedInsecureHttpSource(remoteProvider.Source);
+                }
+            }
+
+            if (_request.DependencyProviders.VulnerabilityInfoProviders != null)
+            {
+                foreach (var vulnerabilityInfoProvider in _request.DependencyProviders.VulnerabilityInfoProviders)
+                {
+                    if (vulnerabilityInfoProvider.IsAuditSource)
                     {
-                        var isErrorEnabled = SdkAnalysisLevelMinimums.IsEnabled(
-                            _request.Project.RestoreMetadata.SdkAnalysisLevel,
-                            _request.Project.RestoreMetadata.UsingMicrosoftNETSdk,
-                            SdkAnalysisLevelMinimums.V9_0_100);
-
-                        if (isErrorEnabled)
-                        {
-                            _logger.Log(
-                                RestoreLogMessage.CreateError(
-                                    NuGetLogCode.NU1302,
-                                    string.Format(CultureInfo.CurrentCulture, Strings.Error_HttpSource_Single, "restore", source.Source)));
-
-                            error = true;
-                        }
-                        else
-                        {
-                            var message = RestoreLogMessage.CreateWarning(
-                                    NuGetLogCode.NU1803,
-                                    string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source));
-                            _logger.Log(message);
-
-                            // If the project treats this warning as an error, we should not continue
-                            if (message.Level == LogLevel.Error)
-                            {
-                                error = true;
-                            }
-                        }
+                        error |= CheckDisallowedInsecureHttpSource(vulnerabilityInfoProvider.PackageSource);
                     }
                 }
             }
 
             return !error;
+        }
+
+        private bool CheckDisallowedInsecureHttpSource(PackageSource source)
+        {
+            if (!source.IsHttp || source.IsHttps || source.AllowInsecureConnections)
+            {
+                return false;
+            }
+
+            var isErrorEnabled = SdkAnalysisLevelMinimums.IsEnabled(
+                _request.Project.RestoreMetadata.SdkAnalysisLevel,
+                _request.Project.RestoreMetadata.UsingMicrosoftNETSdk,
+                SdkAnalysisLevelMinimums.V9_0_100);
+
+            if (isErrorEnabled)
+            {
+                _logger.Log(
+                    RestoreLogMessage.CreateError(
+                        NuGetLogCode.NU1302,
+                        string.Format(CultureInfo.CurrentCulture, Strings.Error_HttpSource_Single, "restore", source.Source)));
+
+                return true;
+            }
+            else
+            {
+                var message = RestoreLogMessage.CreateWarning(
+                        NuGetLogCode.NU1803,
+                        string.Format(CultureInfo.CurrentCulture, Strings.Warning_HttpServerUsage, "restore", source.Source));
+                _logger.Log(message);
+
+                // If the project treats this warning as an error, we should not continue
+                return message.Level == LogLevel.Error;
+            }
         }
 
         private record struct EvaluateLockFileResult(bool Success, bool IsLockFileValid, bool RegenerateLockFile, string PackagesLockFilePath, PackagesLockFile PackagesLockFile);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -519,11 +519,15 @@ namespace NuGet.Commands
         {
             bool error = false;
 
+            // Track source URLs that have already been warned/errored about so the same URL,
+            // even when configured as both a package source and an audit source, is only reported once.
+            var reportedSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
             if (_request.DependencyProviders.RemoteProviders != null)
             {
                 foreach (var remoteProvider in _request.DependencyProviders.RemoteProviders)
                 {
-                    error |= CheckDisallowedInsecureHttpSource(remoteProvider.Source, SdkAnalysisLevelMinimums.V9_0_100);
+                    error |= CheckDisallowedInsecureHttpSource(remoteProvider.Source, SdkAnalysisLevelMinimums.V9_0_100, reportedSources);
                 }
             }
 
@@ -535,7 +539,7 @@ namespace NuGet.Commands
                 {
                     if (vulnerabilityInfoProvider.IsAuditSource)
                     {
-                        error |= CheckDisallowedInsecureHttpSource(vulnerabilityInfoProvider.PackageSource, SdkAnalysisLevelMinimums.V10_0_400, warnWhenNotError: false);
+                        error |= CheckDisallowedInsecureHttpSource(vulnerabilityInfoProvider.PackageSource, SdkAnalysisLevelMinimums.V10_0_400, reportedSources, warnWhenNotError: false);
                     }
                 }
             }
@@ -543,9 +547,15 @@ namespace NuGet.Commands
             return !error;
         }
 
-        private bool CheckDisallowedInsecureHttpSource(PackageSource source, NuGetVersion errorMinSdkAnalysisLevel, bool warnWhenNotError = true)
+        private bool CheckDisallowedInsecureHttpSource(PackageSource source, NuGetVersion errorMinSdkAnalysisLevel, HashSet<string> reportedSources, bool warnWhenNotError = true)
         {
             if (!source.IsHttp || source.IsHttps || source.AllowInsecureConnections)
+            {
+                return false;
+            }
+
+            // Only warn/error once per unique source URL.
+            if (!reportedSources.Add(source.Source))
             {
                 return false;
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/VulnerabilityInformationProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
@@ -56,6 +57,8 @@ namespace NuGet.Commands
         public bool IsAuditSource { get; }
 
         public string SourceName => _source.PackageSource.Name;
+
+        public PackageSource PackageSource => _source.PackageSource;
 
         private async Task<GetVulnerabilityInfoResult?> GetVulnerabilityInfoAsync(CancellationToken cancellationToken)
         {

--- a/src/NuGet.Core/NuGet.Commands/Utility/SdkAnalysisLevelMinimums.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/SdkAnalysisLevelMinimums.cs
@@ -37,6 +37,14 @@ namespace NuGet.Commands
         /// <summary>
         /// Minimum SDK Analysis Level required for:
         /// <list type="bullet">
+        /// <item>error/warning when an audit source uses an insecure HTTP connection</item>
+        /// </list>
+        /// </summary>
+        internal static readonly NuGetVersion V10_0_400 = new("10.0.400");
+
+        /// <summary>
+        /// Minimum SDK Analysis Level required for:
+        /// <list type="bullet">
         /// <item>warning when packages use the deprecated MonoAndroid framework</item>
         /// <item>error when TargetFramework alias contains non-ASCII characters</item>
         /// <item>warning when package ID does not adhere to the restricted character set (NU5052)</item>

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4276,7 +4276,7 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
-        public async Task Restore_WithHttpAuditSourceSdkAnalysisLevelLowerThan100400_Warns()
+        public async Task Restore_WithHttpAuditSourceSdkAnalysisLevelLowerThan100400_NoHttpDiagnostics()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
@@ -4294,7 +4294,7 @@ namespace NuGet.Commands.FuncTest
             ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
             var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
             project1Spec.RestoreMetadata.RestoreAuditProperties = new RestoreAuditProperties() { EnableAudit = bool.TrueString };
-            // Audit sources are gated at 10.0.400. A level below that (but at or above the 9.0.100 package-source gate) warns rather than errors.
+            // Audit sources error at SDK analysis level 10.0.400 or higher and are silent (no warning) below that.
             project1Spec.RestoreMetadata.SdkAnalysisLevel = new NuGetVersion("10.0.100");
             project1Spec.RestoreMetadata.UsingMicrosoftNETSdk = true;
             var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
@@ -4309,8 +4309,33 @@ namespace NuGet.Commands.FuncTest
 
             // Assert
             result.Success.Should().BeTrue(because: logger.ShowMessages());
-            result.LockFile.LogMessages.Should().Contain(m => m.Code == NuGetLogCode.NU1803 && m.Level == LogLevel.Warning && m.Message.Contains(mockServer.ServiceIndexUri));
-            result.LockFile.LogMessages.Should().NotContain(m => m.Code == NuGetLogCode.NU1302);
+            result.LockFile.LogMessages.Should().NotContain(m => m.Code == NuGetLogCode.NU1302 || m.Code == NuGetLogCode.NU1803);
+        }
+
+        [Fact]
+        public async Task Restore_WithHttpAuditSourceSdkAnalysisLevel100400_ThrowsError()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            string httpAuditSourceUrl = "http://unit.test/vulnerabilities/index.json";
+            pathContext.Settings.AddAuditSource("http-audit", httpAuditSourceUrl, allowInsecureConnectionsValue: "False");
+
+            var logger = new TestLogger();
+            ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
+            var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
+            project1Spec.RestoreMetadata.RestoreAuditProperties = new RestoreAuditProperties() { EnableAudit = bool.TrueString };
+            // Audit sources error at SDK analysis level 10.0.400 or higher.
+            project1Spec.RestoreMetadata.SdkAnalysisLevel = new NuGetVersion("10.0.400");
+            project1Spec.RestoreMetadata.UsingMicrosoftNETSdk = true;
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
+            var command = new RestoreCommand(request);
+
+            // Act
+            var result = await command.ExecuteAsync();
+
+            // Assert
+            result.Success.Should().BeFalse(because: logger.ShowMessages());
+            result.LockFile.LogMessages.Should().ContainSingle(m => m.Code == NuGetLogCode.NU1302 && m.Message.Contains(httpAuditSourceUrl));
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4316,6 +4316,31 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
+        public async Task Restore_WithSameInsecureHttpUrlAsPackageAndAuditSource_ReportsOnce()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            string httpSourceUrl = "http://unit.test/v3/index.json";
+            pathContext.Settings.AddAuditSource("http-audit", httpSourceUrl, allowInsecureConnectionsValue: "False");
+
+            var logger = new TestLogger();
+            ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
+            var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
+            project1Spec.RestoreMetadata.RestoreAuditProperties = new RestoreAuditProperties() { EnableAudit = bool.TrueString };
+            // Configure the same insecure HTTP URL as both a package source and an audit source.
+            project1Spec.RestoreMetadata.Sources.Add(new PackageSource(httpSourceUrl, "http-package"));
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
+            var command = new RestoreCommand(request);
+
+            // Act
+            var result = await command.ExecuteAsync();
+
+            // Assert
+            result.Success.Should().BeFalse(because: logger.ShowMessages());
+            result.LockFile.LogMessages.Should().ContainSingle(m => m.Code == NuGetLogCode.NU1302 && m.Message.Contains(httpSourceUrl));
+        }
+
+        [Fact]
         public async Task Restore_WithHttpAuditSourceAndAuditDisabled_NoHttpDiagnostics()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4253,6 +4253,96 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
+        public async Task Restore_WithHttpAuditSourceAndAllowInsecureConnectionsFalse_ThrowsError()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            string httpAuditSourceUrl = "http://unit.test/vulnerabilities/index.json";
+            pathContext.Settings.AddAuditSource("http-audit", httpAuditSourceUrl, allowInsecureConnectionsValue: "False");
+
+            var logger = new TestLogger();
+            ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
+            var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
+            var command = new RestoreCommand(request);
+
+            // Act
+            var result = await command.ExecuteAsync();
+
+            // Assert
+            result.Success.Should().BeFalse(because: logger.ShowMessages());
+            result.LockFile.LogMessages.Should().ContainSingle(m => m.Code == NuGetLogCode.NU1302 && m.Message.Contains(httpAuditSourceUrl));
+        }
+
+        [Fact]
+        public async Task Restore_WithHttpAuditSourceSdkAnalysisLevelLowerThan90100_Warns()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            using var mockServer = new FileSystemBackedV3MockServer(Directory.CreateDirectory(Path.Combine(pathContext.WorkingDirectory, "audit-feed")).FullName, sourceReportsVulnerabilities: true);
+            // Add an unrelated vulnerability so the audit source returns a vulnerability database.
+            mockServer.Vulnerabilities.Add(
+                "not.a.referenced.package",
+                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)>
+                {
+                    (new Uri("https://contoso.com/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)"))
+                });
+            pathContext.Settings.AddAuditSource("http-audit", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "False");
+
+            var logger = new TestLogger();
+            ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
+            var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
+            project1Spec.RestoreMetadata.SdkAnalysisLevel = new NuGetVersion("7.8.100");
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
+            var command = new RestoreCommand(request);
+
+            mockServer.Start();
+
+            // Act
+            var result = await command.ExecuteAsync();
+
+            mockServer.Stop();
+
+            // Assert
+            result.Success.Should().BeTrue(because: logger.ShowMessages());
+            result.LockFile.LogMessages.Should().Contain(m => m.Code == NuGetLogCode.NU1803 && m.Level == LogLevel.Warning && m.Message.Contains(mockServer.ServiceIndexUri));
+            result.LockFile.LogMessages.Should().NotContain(m => m.Code == NuGetLogCode.NU1302);
+        }
+
+        [Fact]
+        public async Task Restore_WithHttpAuditSourceAndAllowInsecureConnectionsTrue_Succeeds()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            using var mockServer = new FileSystemBackedV3MockServer(Directory.CreateDirectory(Path.Combine(pathContext.WorkingDirectory, "audit-feed")).FullName, sourceReportsVulnerabilities: true);
+            // Add an unrelated vulnerability so the audit source returns a vulnerability database (avoids NU1905).
+            mockServer.Vulnerabilities.Add(
+                "not.a.referenced.package",
+                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)>
+                {
+                    (new Uri("https://contoso.com/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)"))
+                });
+            pathContext.Settings.AddAuditSource("http-audit", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "True");
+
+            var logger = new TestLogger();
+            ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
+            var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
+            var command = new RestoreCommand(request);
+
+            mockServer.Start();
+
+            // Act
+            var result = await command.ExecuteAsync();
+
+            mockServer.Stop();
+
+            // Assert
+            result.Success.Should().BeTrue(because: logger.ShowMessages());
+            result.LockFile.LogMessages.Should().NotContain(m => m.Code == NuGetLogCode.NU1302 || m.Code == NuGetLogCode.NU1803);
+        }
+
+        [Fact]
         public async Task Restore_WithPackageWithoutAsset_Succeeds()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4263,6 +4263,7 @@ namespace NuGet.Commands.FuncTest
             var logger = new TestLogger();
             ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
             var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
+            project1Spec.RestoreMetadata.RestoreAuditProperties = new RestoreAuditProperties() { EnableAudit = bool.TrueString };
             var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
             var command = new RestoreCommand(request);
 
@@ -4275,7 +4276,7 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
-        public async Task Restore_WithHttpAuditSourceSdkAnalysisLevelLowerThan90100_Warns()
+        public async Task Restore_WithHttpAuditSourceSdkAnalysisLevelLowerThan100400_Warns()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
@@ -4292,7 +4293,10 @@ namespace NuGet.Commands.FuncTest
             var logger = new TestLogger();
             ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
             var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
-            project1Spec.RestoreMetadata.SdkAnalysisLevel = new NuGetVersion("7.8.100");
+            project1Spec.RestoreMetadata.RestoreAuditProperties = new RestoreAuditProperties() { EnableAudit = bool.TrueString };
+            // Audit sources are gated at 10.0.400. A level below that (but at or above the 9.0.100 package-source gate) warns rather than errors.
+            project1Spec.RestoreMetadata.SdkAnalysisLevel = new NuGetVersion("10.0.100");
+            project1Spec.RestoreMetadata.UsingMicrosoftNETSdk = true;
             var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
             var command = new RestoreCommand(request);
 
@@ -4307,6 +4311,29 @@ namespace NuGet.Commands.FuncTest
             result.Success.Should().BeTrue(because: logger.ShowMessages());
             result.LockFile.LogMessages.Should().Contain(m => m.Code == NuGetLogCode.NU1803 && m.Level == LogLevel.Warning && m.Message.Contains(mockServer.ServiceIndexUri));
             result.LockFile.LogMessages.Should().NotContain(m => m.Code == NuGetLogCode.NU1302);
+        }
+
+        [Fact]
+        public async Task Restore_WithHttpAuditSourceAndAuditDisabled_NoHttpDiagnostics()
+        {
+            // Arrange
+            using var pathContext = new SimpleTestPathContext();
+            string httpAuditSourceUrl = "http://unit.test/vulnerabilities/index.json";
+            pathContext.Settings.AddAuditSource("http-audit", httpAuditSourceUrl, allowInsecureConnectionsValue: "False");
+
+            var logger = new TestLogger();
+            ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
+            var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
+            project1Spec.RestoreMetadata.RestoreAuditProperties = new RestoreAuditProperties() { EnableAudit = bool.FalseString };
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
+            var command = new RestoreCommand(request);
+
+            // Act
+            var result = await command.ExecuteAsync();
+
+            // Assert
+            result.Success.Should().BeTrue(because: logger.ShowMessages());
+            result.LockFile.LogMessages.Should().NotContain(m => m.Code == NuGetLogCode.NU1302 || m.Code == NuGetLogCode.NU1803);
         }
 
         [Fact]
@@ -4327,6 +4354,7 @@ namespace NuGet.Commands.FuncTest
             var logger = new TestLogger();
             ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
             var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
+            project1Spec.RestoreMetadata.RestoreAuditProperties = new RestoreAuditProperties() { EnableAudit = bool.TrueString };
             var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
             var command = new RestoreCommand(request);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4257,15 +4257,8 @@ namespace NuGet.Commands.FuncTest
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
-            using var mockServer = new FileSystemBackedV3MockServer(Directory.CreateDirectory(Path.Combine(pathContext.WorkingDirectory, "audit-feed")).FullName, sourceReportsVulnerabilities: true);
-            // Add an unrelated vulnerability so the audit source returns a vulnerability database.
-            mockServer.Vulnerabilities.Add(
-                "not.a.referenced.package",
-                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)>
-                {
-                    (new Uri("https://contoso.com/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)"))
-                });
-            pathContext.Settings.AddAuditSource("http-audit", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "False");
+            string httpAuditSourceUrl = "http://source.test/v3/index.json";
+            SourceRepository auditSource = CreateStaticHttpAuditSource(httpAuditSourceUrl, allowInsecureConnections: false);
 
             var logger = new TestLogger();
             ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
@@ -4274,15 +4267,11 @@ namespace NuGet.Commands.FuncTest
             // Audit sources error at SDK analysis level 10.0.400 or higher and are silent (no warning) below that.
             project1Spec.RestoreMetadata.SdkAnalysisLevel = new NuGetVersion("10.0.100");
             project1Spec.RestoreMetadata.UsingMicrosoftNETSdk = true;
-            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, new[] { auditSource }, project1Spec);
             var command = new RestoreCommand(request);
-
-            mockServer.Start();
 
             // Act
             var result = await command.ExecuteAsync();
-
-            mockServer.Stop();
 
             // Assert
             result.Success.Should().BeTrue(because: logger.ShowMessages());
@@ -4294,7 +4283,7 @@ namespace NuGet.Commands.FuncTest
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
-            string httpAuditSourceUrl = "http://unit.test/vulnerabilities/index.json";
+            string httpAuditSourceUrl = "http://source.test/v3/index.json";
             pathContext.Settings.AddAuditSource("http-audit", httpAuditSourceUrl, allowInsecureConnectionsValue: "False");
 
             var logger = new TestLogger();
@@ -4320,7 +4309,7 @@ namespace NuGet.Commands.FuncTest
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
-            string httpSourceUrl = "http://unit.test/v3/index.json";
+            string httpSourceUrl = "http://source.test/v3/index.json";
             pathContext.Settings.AddSource("http-package", httpSourceUrl, allowInsecureConnectionsValue: "False");
             pathContext.Settings.AddAuditSource("http-audit", httpSourceUrl, allowInsecureConnectionsValue: "False");
 
@@ -4344,7 +4333,7 @@ namespace NuGet.Commands.FuncTest
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
-            string httpAuditSourceUrl = "http://unit.test/vulnerabilities/index.json";
+            string httpAuditSourceUrl = "http://source.test/v3/index.json";
             pathContext.Settings.AddAuditSource("http-audit", httpAuditSourceUrl, allowInsecureConnectionsValue: "False");
 
             var logger = new TestLogger();
@@ -4367,33 +4356,62 @@ namespace NuGet.Commands.FuncTest
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
-            using var mockServer = new FileSystemBackedV3MockServer(Directory.CreateDirectory(Path.Combine(pathContext.WorkingDirectory, "audit-feed")).FullName, sourceReportsVulnerabilities: true);
-            // Add an unrelated vulnerability so the audit source returns a vulnerability database (avoids NU1905).
-            mockServer.Vulnerabilities.Add(
-                "not.a.referenced.package",
-                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)>
-                {
-                    (new Uri("https://contoso.com/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)"))
-                });
-            pathContext.Settings.AddAuditSource("http-audit", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "True");
+            string httpAuditSourceUrl = "http://source.test/v3/index.json";
+            SourceRepository auditSource = CreateStaticHttpAuditSource(httpAuditSourceUrl, allowInsecureConnections: true);
 
             var logger = new TestLogger();
             ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
             var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
             project1Spec.RestoreMetadata.RestoreAuditProperties = new RestoreAuditProperties() { EnableAudit = bool.TrueString };
-            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
+            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, new[] { auditSource }, project1Spec);
             var command = new RestoreCommand(request);
-
-            mockServer.Start();
 
             // Act
             var result = await command.ExecuteAsync();
 
-            mockServer.Stop();
-
             // Assert
             result.Success.Should().BeTrue(because: logger.ShowMessages());
             result.LockFile.LogMessages.Should().NotContain(m => m.Code == NuGetLogCode.NU1302 || m.Code == NuGetLogCode.NU1803);
+        }
+
+        /// <summary>
+        /// Creates an audit <see cref="SourceRepository"/> whose HTTP requests are served from static, in-memory
+        /// responses (via <see cref="StaticHttpSource"/>) instead of a real <see cref="System.Net.HttpListener"/>.
+        /// The source advertises a VulnerabilityInfo resource and returns a vulnerability database containing an
+        /// unrelated package, which avoids NU1905 while never making a real network connection.
+        /// </summary>
+        private static SourceRepository CreateStaticHttpAuditSource(string serviceIndexUrl, bool allowInsecureConnections)
+        {
+            // serviceIndexUrl is expected to end with "index.json"; the base URL is used to build the vulnerability resource URLs.
+            string baseUrl = serviceIndexUrl.Substring(0, serviceIndexUrl.Length - "index.json".Length);
+            string vulnerabilityIndexUrl = baseUrl + "vulnerability/index.json";
+            string vulnerabilityDataUrl = baseUrl + "vulnerability/vulnerability.json";
+
+            JObject serviceIndex = FeedUtilities.CreateIndexJson();
+            FeedUtilities.AddVulnerabilitiesResource(serviceIndex, baseUrl);
+
+            JArray vulnerabilityIndex = FeedUtilities.CreateVulnerabilitiesJson(vulnerabilityDataUrl);
+
+            JObject vulnerabilityData = FeedUtilities.CreateVulnerabilityForPackages(
+                new Dictionary<string, List<(Uri, PackageVulnerabilitySeverity, VersionRange)>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["not.a.referenced.package"] = new()
+                    {
+                        (new Uri("https://contoso.test/advisories/12345"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0, 2.0.0)"))
+                    }
+                });
+
+            var responses = new Dictionary<string, string>()
+            {
+                [serviceIndexUrl] = serviceIndex.ToString(),
+                [vulnerabilityIndexUrl] = vulnerabilityIndex.ToString(),
+                [vulnerabilityDataUrl] = vulnerabilityData.ToString(),
+            };
+
+            var packageSource = new PackageSource(serviceIndexUrl, "http-audit") { AllowInsecureConnections = allowInsecureConnections };
+            var providers = Repository.Provider.GetCoreV3().ToList();
+            providers.Add(new Lazy<INuGetResourceProvider>(() => StaticHttpSource.CreateHttpSource(responses)));
+            return new SourceRepository(packageSource, providers);
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4290,7 +4290,7 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
-        public async Task Restore_WithHttpAuditSourceSdkAnalysisLevel100400_ThrowsError()
+        public async Task Restore_WithHttpAuditSourceSdkAnalysisLevel100400_LogsNU1302Error()
         {
             // Arrange
             using var pathContext = new SimpleTestPathContext();
@@ -4321,14 +4321,13 @@ namespace NuGet.Commands.FuncTest
             // Arrange
             using var pathContext = new SimpleTestPathContext();
             string httpSourceUrl = "http://unit.test/v3/index.json";
+            pathContext.Settings.AddSource("http-package", httpSourceUrl, allowInsecureConnectionsValue: "False");
             pathContext.Settings.AddAuditSource("http-audit", httpSourceUrl, allowInsecureConnectionsValue: "False");
 
             var logger = new TestLogger();
             ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
             var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
             project1Spec.RestoreMetadata.RestoreAuditProperties = new RestoreAuditProperties() { EnableAudit = bool.TrueString };
-            // Configure the same insecure HTTP URL as both a package source and an audit source.
-            project1Spec.RestoreMetadata.Sources.Add(new PackageSource(httpSourceUrl, "http-package"));
             var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
             var command = new RestoreCommand(request);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -4253,29 +4253,6 @@ namespace NuGet.Commands.FuncTest
         }
 
         [Fact]
-        public async Task Restore_WithHttpAuditSourceAndAllowInsecureConnectionsFalse_ThrowsError()
-        {
-            // Arrange
-            using var pathContext = new SimpleTestPathContext();
-            string httpAuditSourceUrl = "http://unit.test/vulnerabilities/index.json";
-            pathContext.Settings.AddAuditSource("http-audit", httpAuditSourceUrl, allowInsecureConnectionsValue: "False");
-
-            var logger = new TestLogger();
-            ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
-            var project1Spec = ProjectTestHelpers.GetPackageSpec(settings, "Project1", pathContext.SolutionRoot, framework: "net5.0");
-            project1Spec.RestoreMetadata.RestoreAuditProperties = new RestoreAuditProperties() { EnableAudit = bool.TrueString };
-            var request = ProjectTestHelpers.CreateRestoreRequest(pathContext, logger, project1Spec);
-            var command = new RestoreCommand(request);
-
-            // Act
-            var result = await command.ExecuteAsync();
-
-            // Assert
-            result.Success.Should().BeFalse(because: logger.ShowMessages());
-            result.LockFile.LogMessages.Should().ContainSingle(m => m.Code == NuGetLogCode.NU1302 && m.Message.Contains(httpAuditSourceUrl));
-        }
-
-        [Fact]
         public async Task Restore_WithHttpAuditSourceSdkAnalysisLevelLowerThan100400_NoHttpDiagnostics()
         {
             // Arrange

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -197,6 +197,15 @@ namespace NuGet.Commands.Test
         /// </summary>
         public static TestRestoreRequest CreateRestoreRequest(SimpleTestPathContext pathContext, ILogger logger, params PackageSpec[] projects)
         {
+            return CreateRestoreRequest(pathContext, logger, auditSources: null, projects);
+        }
+
+        /// <summary>
+        /// Creates a restore request for the first project in the <paramref name="projects"/> list. If <see cref="ProjectRestoreMetadata.Sources"/> has any values, it is used for creating the providers, otherwise <see cref="SimpleTestPathContext.PackageSource"/> from <paramref name="pathContext"/> will be used.
+        /// When <paramref name="auditSources"/> is not null, it is used as the audit sources; otherwise the audit sources are loaded from the settings in <paramref name="pathContext"/>.
+        /// </summary>
+        public static TestRestoreRequest CreateRestoreRequest(SimpleTestPathContext pathContext, ILogger logger, IReadOnlyList<SourceRepository> auditSources, params PackageSpec[] projects)
+        {
             DependencyGraphSpec dgSpec = GetDGSpecForFirstProject(projects);
             var projectToRestore = projects[0];
             var sources = projectToRestore.RestoreMetadata.Sources.Any() ?
@@ -207,10 +216,13 @@ namespace NuGet.Commands.Test
             ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
             var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
 
-            IReadOnlyList<PackageSource> auditPackageSources = new PackageSourceProvider(settings).LoadAuditSources();
-            IReadOnlyList<SourceRepository> auditSources = auditPackageSources.Count == 0
-                ? Array.Empty<SourceRepository>()
-                : auditPackageSources.Select(Repository.Factory.GetCoreV3).ToList();
+            if (auditSources == null)
+            {
+                IReadOnlyList<PackageSource> auditPackageSources = new PackageSourceProvider(settings).LoadAuditSources();
+                auditSources = auditPackageSources.Count == 0
+                    ? Array.Empty<SourceRepository>()
+                    : auditPackageSources.Select(Repository.Factory.GetCoreV3).ToList();
+            }
 
             return new TestRestoreRequest(projectToRestore, sources, pathContext.UserPackagesFolder, new TestSourceCacheContext(), packageSourceMapping, logger, auditSources)
             {

--- a/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectTestHelpers.cs
@@ -13,6 +13,8 @@ using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Test;
 using NuGet.RuntimeModel;
 using NuGet.Test.Utility;
@@ -202,9 +204,15 @@ namespace NuGet.Commands.Test
                        [new PackageSource(pathContext.PackageSource)];
 
             var externalClosure = DependencyGraphSpecRequestProvider.GetExternalClosure(dgSpec, projectToRestore.RestoreMetadata.ProjectUniqueName).ToList();
-            var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(Settings.LoadDefaultSettings(pathContext.SolutionRoot));
+            ISettings settings = Settings.LoadDefaultSettings(pathContext.SolutionRoot);
+            var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
 
-            return new TestRestoreRequest(projectToRestore, sources, pathContext.UserPackagesFolder, new TestSourceCacheContext(), packageSourceMapping, logger)
+            IReadOnlyList<PackageSource> auditPackageSources = new PackageSourceProvider(settings).LoadAuditSources();
+            IReadOnlyList<SourceRepository> auditSources = auditPackageSources.Count == 0
+                ? Array.Empty<SourceRepository>()
+                : auditPackageSources.Select(Repository.Factory.GetCoreV3).ToList();
+
+            return new TestRestoreRequest(projectToRestore, sources, pathContext.UserPackagesFolder, new TestSourceCacheContext(), packageSourceMapping, logger, auditSources)
             {
                 LockFilePath = Path.Combine(projectToRestore.RestoreMetadata.OutputPath, LockFileFormat.AssetsFileName),
                 DependencyGraphSpec = dgSpec,

--- a/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
+++ b/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
@@ -108,13 +108,14 @@ namespace NuGet.Commands.Test
             string packagesDirectory,
             SourceCacheContext cacheContext,
             PackageSourceMapping packageSourceMappingConfiguration,
-            ILogger log) : base(
+            ILogger log,
+            IReadOnlyList<SourceRepository>? auditSources = null) : base(
                 project,
                 new RestoreCommandProvidersCache().GetOrCreate(
                     packagesDirectory,
                     Array.Empty<string>(),
                     packageSources: sources.Select(Repository.Factory.GetCoreV3).ToList(),
-                    auditSources: Array.Empty<SourceRepository>(),
+                    auditSources: auditSources ?? Array.Empty<SourceRepository>(),
                     cacheContext: cacheContext,
                     log: log,
                     updateLastAccess: false,

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -261,13 +261,6 @@ namespace NuGet.Test.Utility
             Save();
         }
 
-        public void AddAuditSource(string sourceName, string sourceUri)
-        {
-            var section = GetOrAddSection(XML, "auditSources");
-            AddEntry(section, sourceName, sourceUri);
-            Save();
-        }
-
         public void AddAuditSource(string sourceName, string sourceUri, string allowInsecureConnectionsValue)
         {
             var section = GetOrAddSection(XML, "auditSources");

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestSettingsContext.cs
@@ -261,6 +261,13 @@ namespace NuGet.Test.Utility
             Save();
         }
 
+        public void AddAuditSource(string sourceName, string sourceUri)
+        {
+            var section = GetOrAddSection(XML, "auditSources");
+            AddEntry(section, sourceName, sourceUri);
+            Save();
+        }
+
         public void AddAuditSource(string sourceName, string sourceUri, string allowInsecureConnectionsValue)
         {
             var section = GetOrAddSection(XML, "auditSources");


### PR DESCRIPTION
# Bug

Fixes: https://github.com/NuGet/Home/issues/14962

## Description

Restore only validated regular package sources for insecure HTTP usage, so an HTTP audit source configured without `allowInsecureConnections` was contacted silently, unlike package sources which produce NU1302/NU1803. This makes audit sources respect `allowInsecureConnections` too, matching what `dotnet list package --vulnerable` already does.

Key behavior, with two intentional differences from package sources:

- **Only when auditing is enabled.** Audit sources are only contacted while auditing, so the insecure-HTTP check is skipped entirely when `NuGetAudit` is disabled.
- **Error-or-silent gating, not warn-then-error.** Package sources warn (NU1803) below their SdkAnalysisLevel gate and error (NU1302) at/above it. Audit sources instead error at SdkAnalysisLevel `10.0.400` or higher and emit no diagnostic below that. The package-source gate stays at `9.0.100`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A