### PR TITLE
Add fast-path in wildcard search

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -129,8 +129,18 @@ namespace NuGet.Common
             basePath = NormalizeBasePath(basePath, ref searchPath);
             normalizedBasePath = GetPathToEnumerateFrom(basePath, searchPath);
 
+            string fullSearchPath = Path.Combine(basePath, searchPath);
+
+            // A search path with no wildcards refers to a single file. Probe it directly instead of
+            // enumerating the whole directory, which is the dominant cost and can fail intermittently
+            // on some virtual file systems (e.g. VirtioFS). Fall back to enumeration when not found.
+            if (!searchDirectory && !IsWildcardSearch(searchPath) && File.Exists(fullSearchPath))
+            {
+                return [new SearchPathResult(fullSearchPath, isFile: true)];
+            }
+
             // Append the basePath to searchPattern and get the search regex. We need to do this because the search regex is matched from line start.
-            Regex searchRegex = WildcardToRegex(Path.Combine(basePath, searchPath));
+            Regex searchRegex = WildcardToRegex(fullSearchPath);
 
             // This is a hack to prevent enumerating over the entire directory tree if the only wildcard characters are the ones in the file name. 
             // If the path portion of the search path does not contain any wildcard characters only iterate over the TopDirectory.

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -136,7 +136,7 @@ namespace NuGet.Common
             // on some virtual file systems (e.g. VirtioFS). Fall back to enumeration when not found.
             if (!searchDirectory && !IsWildcardSearch(searchPath) && File.Exists(fullSearchPath))
             {
-                return [new SearchPathResult(fullSearchPath, isFile: true)];
+                return [new SearchPathResult(fullSearchPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), isFile: true)];
             }
 
             // Append the basePath to searchPattern and get the search regex. We need to do this because the search regex is matched from line start.


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/13572

## Description

Before: when all paths are pre-resolved (no wildcards), each AddFiles still enumerated the file's entire containing directory of size M via Directory.GetFiles, so resolving N files cost O(N*M) inode lookups (the dominant file I/O, and the frame that intermittently fails on VirtioFS).

After: each pre-resolved path is confirmed with a single File.Exists stat, O(N) total with one inode touched per file, falling back to enumeration only when the exact path isn't found.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] <del>Added tests</del> (it's a performance improvement without changing the usage semantic)
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
