### PR TITLE
Fix Installed tab freeze from sync-over-async in GetPackageVersionsAsync

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetPackageSearchService.cs
@@ -216,16 +216,23 @@ namespace NuGet.PackageManagement.VisualStudio
             // Transitive packages will have only one version the first time they are loaded, when the package is selected we update the cache with all the versions
             if (backgroundDataCache != null)
             {
+                // Await the cached versions once. This is a background task that may still be in flight.
+                IReadOnlyCollection<VersionInfoContextInfo> cachedVersions = await backgroundDataCache.AllVersionsContextInfo;
+
                 // If the item was cached with search API, PackageSearchMetadata could be null. If so, update it with registration api information
                 if (isTransitive
-                    && !(backgroundDataCache.AllVersionsContextInfo.Result?.Count > 1)
-                    || backgroundDataCache.AllVersionsContextInfo.Result?.FirstOrDefault()?.PackageSearchMetadata == null)
+                    && !(cachedVersions?.Count > 1)
+                    || cachedVersions?.FirstOrDefault()?.PackageSearchMetadata == null)
                 {
                     IPackageMetadataProvider newPackageMetadataProvider = await GetPackageMetadataProviderAsync(packageSources, projects?.ToList().AsReadOnly(), cancellationToken);
                     IPackageSearchMetadata newPackageMetadata = await newPackageMetadataProvider.GetPackageMetadataAsync(identity, includePrerelease, cancellationToken);
                     backgroundDataCache.UpdateSearchMetadata(newPackageMetadata);
+
+                    // UpdateSearchMetadata replaces AllVersionsContextInfo with a fresh task. Return the refreshed versions.
+                    return await backgroundDataCache.AllVersionsContextInfo;
                 }
-                return await backgroundDataCache.AllVersionsContextInfo;
+
+                return cachedVersions;
             }
 
             IPackageMetadataProvider packageMetadataProvider = await GetPackageMetadataProviderAsync(packageSources, projects?.ToList().AsReadOnly(), cancellationToken);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14964

## Description
The PM UI's Installed tab froze for tens of seconds before showing any packages on slow feeds. The root cause is a sync-over-async call in NuGetPackageSearchService.GetPackageVersionsAsync: it read the still-running AllVersionsContextInfo background task via .Result before the method's first await, so the whole call ran synchronously and blocked the caller by roughly one registration round-trip per package. Because the package list view models are built on that thread, the list couldn't render until every package's version load completed.

This change awaits AllVersionsContextInfo once into a local and uses that for the null/count check and the return value, so the method is genuinely asynchronous and yields instead of blocking. The list now renders immediately while version/update info streams in. (It also removes a latent bug where the same ValueTask was consumed two or three times.)

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~~Added tests~~
- [ ] ~~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~~
