### PR TITLE
Reference MSBuild via packages on net472 to enable multithreaded task APIs

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/ConsoleLoggingQueue.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/ConsoleLoggingQueue.cs
@@ -2,19 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 #nullable disable
 
-#if IS_DESKTOP
-extern alias MicrosoftBuildUtilitiesv4;
-#endif
-
 using System;
 using System.Collections;
 using Microsoft.Build.Framework;
-#if IS_CORECLR
 using Microsoft.Build.Utilities;
-#endif
-#if IS_DESKTOP
-using TaskLoggingHelper = MicrosoftBuildUtilitiesv4::Microsoft.Build.Utilities.TaskLoggingHelper;
-#endif
 
 namespace NuGet.Build.Tasks.Console
 {

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/NuGet.Build.Tasks.Console.csproj
@@ -30,10 +30,6 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
-    <Reference Include="Microsoft.Build.Utilities.v4.0" Aliases="MicrosoftBuildUtilitiesv4" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="App.config" Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' " />
     <None Include="app.manifest" />

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -28,15 +28,13 @@
     <ProjectReference Include="..\NuGet.Commands\NuGet.Commands.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
-    <Reference Include="Microsoft.Build.Utilities.v4.0" Pack="false" />
-    <Reference Include="Microsoft.Build.Framework" Pack="false" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != '$(NETFXTargetFramework)' ">
-    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" GeneratePathProperty="true" />
     <!-- MSBuild has a dependency on a vulnerable version of System.Security.Cryptography.Xml. Once MSBuild no longer has a transitive dependency on a vulnerable version, this can be removed -->
     <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -42,14 +42,16 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
     <ProjectReference Include="..\NuGet.PackageManagement\NuGet.PackageManagement.csproj" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="Microsoft.Build.Framework" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != '$(NETFXTargetFramework)' ">
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/NuGet.Build.Tasks.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/NuGet.Build.Tasks.Test.csproj
@@ -22,10 +22,6 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NETFXTargetFramework)' ">
-    <Reference Include="Microsoft.Build.Utilities.v4.0" Aliases="MicrosoftBuildUtilitiesv4" />
-  </ItemGroup>
-
   <ItemGroup>
     <Compile Update="TestStrings.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TaskLoggingQueueTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TaskLoggingQueueTests.cs
@@ -1,18 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if IS_DESKTOP
-extern alias MicrosoftBuildUtilitiesv4;
-#endif
-
 using System;
 using FluentAssertions;
 using Microsoft.Build.Framework;
-#if IS_DESKTOP
-using MicrosoftBuildUtilitiesv4::Microsoft.Build.Utilities;
-#else
 using Microsoft.Build.Utilities;
-#endif
 using NuGet.Common;
 using Xunit;
 


### PR DESCRIPTION
# Bug

Fixes: 

## Description

On `net472`, `NuGet.Build.Tasks` and `NuGet.Build.Tasks.Pack` referenced the in-box `Microsoft.Build.*` assemblies, which predate MSBuild 18.6 and therefore lack `IMultiThreadableTask`, `TaskEnvironment`, and `MSBuildMultiThreadableTaskAttribute`.

This switches `net472` to the `Microsoft.Build.Framework` / `Microsoft.Build.Utilities.Core` **packages** (`ExcludeAssets=runtime`) for all TFMs — matching the .NET SDK task projects — so those multithreaded-task APIs are available on `net472` too.

Consumers of the shared `MSBuildLogger` (`NuGet.Build.Tasks.Console` and the unit tests) now use the package `TaskLoggingHelper` instead of the in-box `Microsoft.Build.Utilities.v4.0` one. No behavior change.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
