### PR TITLE
Prepare tests for canary promotion

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -179,6 +179,7 @@ namespace NuGet.Tests.Apex
         [TestMethod]
         [Timeout(DefaultTimeout)]
         [TestCategory("StagingGate")]
+        [TestCatagory("CanaryGate")]
         public async Task InstallAndUpdatePackageFromUI_NetCoreProject_Succeeds()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NetCoreProjectTestCase.cs
@@ -179,7 +179,7 @@ namespace NuGet.Tests.Apex
         [TestMethod]
         [Timeout(DefaultTimeout)]
         [TestCategory("StagingGate")]
-        [TestCatagory("CanaryGate")]
+        [TestCategory("CanaryGate")]
         public async Task InstallAndUpdatePackageFromUI_NetCoreProject_Succeeds()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -374,6 +374,7 @@ namespace NuGet.Tests.Apex
         [TestMethod]
         [Timeout(DefaultTimeout)]
         [TestCategory("StagingGate")]
+        [TestCatagory("CanaryGate")]
         public async Task VerifyDeletedAssetsFileIsBackByReloadingProject()
         {
             // Arrange

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetUITestCase.cs
@@ -374,7 +374,7 @@ namespace NuGet.Tests.Apex
         [TestMethod]
         [Timeout(DefaultTimeout)]
         [TestCategory("StagingGate")]
-        [TestCatagory("CanaryGate")]
+        [TestCategory("CanaryGate")]
         public async Task VerifyDeletedAssetsFileIsBackByReloadingProject()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3853

## Description

This PR adds the `CanaryGate` test category to existing staging-gated tests to prepare for canary promotion.

The goal is to enable a smooth transition from `StagingGate` to `CanaryGate` **without deleting one category and waiting for insertions to complete** before adding the new one. That approach could create a temporary gap where no tests are selected in between updates.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/14973
