### PR TITLE
Mark WarnForInvalidProjectsTask as MSBuild-multithreadable

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildMultiThreadableTaskAttribute.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildMultiThreadableTaskAttribute.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NETFRAMEWORK
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Compatibility shim for <c>Microsoft.Build.Framework.MSBuildMultiThreadableTaskAttribute</c>, which only exists
+    /// in MSBuild 18.6 and later. The .NET Framework build of NuGet's MSBuild tasks compiles against the in-box MSBuild
+    /// reference assemblies, which do not contain this type, so this polyfill lets the shared task source apply the
+    /// marker without conditional compilation at each task. MSBuild detects the attribute by namespace and name only
+    /// (ignoring the defining assembly), so a self-defined copy is recognized by 18.6+ hosts and ignored by older ones.
+    /// On .NET (non-NETFRAMEWORK) targets the real attribute from the Microsoft.Build.Framework package is used instead.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    internal sealed class MSBuildMultiThreadableTaskAttribute : Attribute
+    {
+    }
+}
+#endif

--- a/src/NuGet.Core/NuGet.Build.Tasks/WarnForInvalidProjectsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/WarnForInvalidProjectsTask.cs
@@ -11,6 +11,7 @@ using NuGet.Common;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class WarnForInvalidProjectsTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/14189

## What
Mark `WarnForInvalidProjectsTask` with `[MSBuildMultiThreadableTask]` so MSBuild can run it in-process during multithreaded builds (`dotnet build -mt`).

## Why attribute-only is safe
The task reads its item inputs (`AllProjects`/`ValidProjects`), computes the set difference, and logs a warning per invalid project through its own per-instance `Log`. It has:
- no current-working-directory use or relative-path resolution,
- no environment variables,
- no `ProcessStartInfo` / process spawning,
- no mutable static state — the only static it reaches, `PathUtility.IsFileSystemCaseInsensitive`, is a thread-safe `Lazy<bool>` derived from the OS (machine-invariant),
- no internally spawned threads.

So it is already thread-safe and needs only the marker — no `IMultiThreadableTask`/`TaskEnvironment`. Per the multithreadable-task guidance, an attribute-only migration with no file/env/process/static interaction has nothing meaningful to assert, so no new test is added.

The `[MSBuildMultiThreadableTask]` attribute polyfill for the .NET Framework build is included as a separate commit.
