### PR TITLE
Migrate GetRestoreProjectReferencesTask to the multithreadable model

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildMultiThreadableTaskAttribute.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildMultiThreadableTaskAttribute.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NETFRAMEWORK
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Compatibility shim for <c>Microsoft.Build.Framework.MSBuildMultiThreadableTaskAttribute</c>, which only exists
+    /// in MSBuild 18.6 and later. The .NET Framework build of NuGet's MSBuild tasks compiles against the in-box MSBuild
+    /// reference assemblies, which do not contain this type, so this polyfill lets the shared task source apply the
+    /// marker without conditional compilation at each task. MSBuild detects the attribute by namespace and name only
+    /// (ignoring the defining assembly), so a self-defined copy is recognized by 18.6+ hosts and ignored by older ones.
+    /// On .NET (non-NETFRAMEWORK) targets the real attribute from the Microsoft.Build.Framework package is used instead.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    internal sealed class MSBuildMultiThreadableTaskAttribute : Attribute
+    {
+    }
+}
+#endif

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
@@ -12,8 +12,17 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class GetRestoreProjectReferencesTask : Microsoft.Build.Utilities.Task
+#if !NETFRAMEWORK
+        , IMultiThreadableTask
+#endif
     {
+#if !NETFRAMEWORK
+        /// <inheritdoc />
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+#endif
+
         /// <summary>
         /// Full path to the msbuild project.
         /// </summary>
@@ -60,7 +69,12 @@ namespace NuGet.Build.Tasks
                     || Boolean.TrueString.Equals(refOutput, StringComparison.OrdinalIgnoreCase))
                 {
                     // Get the absolute path
-                    var referencePath = Path.GetFullPath(Path.Combine(parentDirectory, project.ItemSpec));
+                    var combinedPath = Path.Combine(parentDirectory, project.ItemSpec);
+#if !NETFRAMEWORK
+                    var referencePath = Path.GetFullPath(TaskEnvironment.GetAbsolutePath(combinedPath));
+#else
+                    var referencePath = Path.GetFullPath(combinedPath);
+#endif
 
                     if (!seen.Add(referencePath))
                     {

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectReferencesTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreProjectReferencesTaskTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if !NETFRAMEWORK
+using System.IO;
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using NuGet.Test.Utility;
+using Xunit;
+#endif
+
+namespace NuGet.Build.Tasks.Test
+{
+    public class GetRestoreProjectReferencesTaskTests
+    {
+#if !NETFRAMEWORK
+        [Fact]
+        public void Execute_RelativeProjectReference_ResolvesAgainstProjectDirectoryNotCurrentDirectory()
+        {
+            using TestDirectory projectDirectory = TestDirectory.Create();
+            var task = new GetRestoreProjectReferencesTask
+            {
+                BuildEngine = new TestBuildEngine(),
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDirectory.Path),
+                ProjectUniqueName = "MyProject",
+                ParentProjectPath = Path.Combine("solution", "MyProject.csproj"),                               // relative
+                ProjectReferences = new ITaskItem[] { new MockTaskItem(Path.Combine("ProjectA", "ProjectA.csproj")) }, // relative
+            };
+
+            task.Execute().Should().BeTrue();
+
+            string expectedRootedAtProjectDirectory = Path.GetFullPath(Path.Combine(projectDirectory.Path, "solution", "ProjectA", "ProjectA.csproj"));
+            string ifResolvedAgainstCurrentDirectory = Path.GetFullPath(Path.Combine("solution", "ProjectA", "ProjectA.csproj"));
+            string actual = task.RestoreGraphItems.Should().ContainSingle().Which.GetMetadata("ProjectPath");
+
+            actual.Should().Be(expectedRootedAtProjectDirectory);
+            actual.Should().StartWith(projectDirectory.Path);
+            actual.Should().NotBe(ifResolvedAgainstCurrentDirectory);
+        }
+#endif
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/14183

## What & why
MSBuild 18.6 can run tasks in-process during multithreaded builds (`dotnet build -mt`). `GetRestoreProjectReferencesTask` resolved each project reference with `Path.GetFullPath`, which depends on the process current directory — incorrect when the task shares a long-lived process. This migrates it to the multithreadable model.

## Changes
- Mark the task `[MSBuildMultiThreadableTask]`; implement `IMultiThreadableTask` on the .NET (SDK) build.
- Resolve the reference path via `TaskEnvironment.GetAbsolutePath` (project directory) instead of `Path.GetFullPath` (current directory). The .NET Framework build keeps the original behavior.
- Add the `[MSBuildMultiThreadableTask]` attribute polyfill for the .NET Framework build (separate commit) so the marker compiles against the in-box MSBuild facade.
- Add a net10.0 test asserting the reference path resolves against the project directory, not the current directory.
