### PR TITLE
Mark GetRestoreProjectStyleTask as MSBuild-multithreadable

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildMultiThreadableTaskAttribute.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildMultiThreadableTaskAttribute.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NETFRAMEWORK
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Compatibility shim for <c>Microsoft.Build.Framework.MSBuildMultiThreadableTaskAttribute</c>, which only exists
+    /// in MSBuild 18.6 and later. The .NET Framework build of NuGet's MSBuild tasks compiles against the in-box MSBuild
+    /// reference assemblies, which do not contain this type, so this polyfill lets the shared task source apply the
+    /// marker without conditional compilation at each task. MSBuild detects the attribute by namespace and name only
+    /// (ignoring the defining assembly), so a self-defined copy is recognized by 18.6+ hosts and ignored by older ones.
+    /// On .NET (non-NETFRAMEWORK) targets the real attribute from the Microsoft.Build.Framework package is used instead.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    internal sealed class MSBuildMultiThreadableTaskAttribute : Attribute
+    {
+    }
+}
+#endif

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
@@ -11,6 +11,7 @@ namespace NuGet.Build.Tasks
     /// <summary>
     /// Gets the project style.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class GetRestoreProjectStyleTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/14184

## What
Mark `GetRestoreProjectStyleTask` with `[MSBuildMultiThreadableTask]` so MSBuild can run it in-process during multithreaded builds (`dotnet build -mt`).

## Why attribute-only is safe
The task reads its item/property inputs and produces the project style outputs. Call-chain audit (`Execute` -> `BuildTasksUtility.GetProjectRestoreStyle` -> `ProjectHasPackagesConfigFile` -> `GetPackagesConfigFilePath`):
- The only file-system access is `File.Exists(Path.Combine(MSBuildProjectDirectory, "packages.config"))`. `MSBuildProjectDirectory` is the `[Required]`, always-absolute `$(MSBuildProjectDirectory)`, so the probe never resolves against the current directory.
- No environment variables, no `ProcessStartInfo`, no `Path.GetFullPath`, no mutable static state.

The `[MSBuildMultiThreadableTask]` attribute polyfill for the .NET Framework build is included as a separate commit.
