### PR TITLE
Only mark GetRestoreProjectReferencesTask as multithreadable on .NET

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
@@ -12,7 +12,9 @@ using Newtonsoft.Json;
 
 namespace NuGet.Build.Tasks
 {
+#if !NETFRAMEWORK
     [MSBuildMultiThreadableTask]
+#endif
     public class GetRestoreProjectReferencesTask : Microsoft.Build.Utilities.Task
 #if !NETFRAMEWORK
         , IMultiThreadableTask


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
Fixes: N/A - engineering change

## Description

`GetRestoreProjectReferencesTask` carries the `[MSBuildMultiThreadableTask]` marker, but that guarantee only holds on .NET.

- On **.NET**, the task resolves each project path with `TaskEnvironment.GetAbsolutePath`, which anchors relative paths to the task's project directory. That is safe under multithreaded (in-process) execution.
- On **.NET Framework**, there is no `TaskEnvironment`, so the task falls back to `Path.GetFullPath(combinedPath)`. When `ParentProjectPath` (and therefore `combinedPath`) is relative, `Path.GetFullPath` resolves it against the process-wide current working directory. Two task instances running concurrently in one process can then observe each other's working-directory state and produce incorrect paths.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
