### PR TITLE
Retarget to 7.10

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -13,7 +13,7 @@
     <!-- **  Change for each new version -->
     <!-- when changing any of the NuGetVersion props below, run tools-local\ship-public-apis -->
     <MajorNuGetVersion Condition="'$(MajorNuGetVersion)' == ''">7</MajorNuGetVersion>
-    <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">9</MinorNuGetVersion>
+    <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">10</MinorNuGetVersion>
     <PatchNuGetVersion Condition="'$(PatchNuGetVersion)' == ''">0</PatchNuGetVersion>
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
 

--- a/tools-local/ship-public-apis/Program.cs
+++ b/tools-local/ship-public-apis/Program.cs
@@ -106,10 +106,17 @@ namespace NuGet.Internal.Tools.ShipPublicApis
             return 0;
         }
 
+        // The public API analyzer records an intentionally removed public API by adding a line to
+        // PublicAPI.Unshipped.txt with this prefix followed by the exact signature that currently
+        // exists in PublicAPI.Shipped.txt. Shipping such an entry means deleting the matching line
+        // from PublicAPI.Shipped.txt; the marker itself must not be written into either file.
+        private const string RemovedApiPrefix = "*REMOVED*";
+
         private static async Task<int> MoveUnshippedApisToShippedAsync(string shippedTxtPath, string unshippedTxtPath)
         {
             var shippedLines = new List<string>();
             var unshippedLines = new List<string>();
+            var removedApis = new List<string>();
             int unshippedApiCount = 0;
 
             using (var stream = File.OpenText(unshippedTxtPath))
@@ -122,6 +129,11 @@ namespace NuGet.Internal.Tools.ShipPublicApis
                         if (line.StartsWith("#"))
                         {
                             unshippedLines.Add(line);
+                        }
+                        else if (line.StartsWith(RemovedApiPrefix, StringComparison.Ordinal))
+                        {
+                            removedApis.Add(line.Substring(RemovedApiPrefix.Length));
+                            unshippedApiCount++;
                         }
                         else
                         {
@@ -141,6 +153,19 @@ namespace NuGet.Internal.Tools.ShipPublicApis
                     {
                         shippedLines.Add(line);
                     }
+                }
+            }
+
+            foreach (var removedApi in removedApis)
+            {
+                int index = shippedLines.FindIndex(shippedLine => PublicAPIAnalyzerLineComparer.Instance.Compare(shippedLine, removedApi) == 0);
+                if (index < 0)
+                {
+                    Console.Error.WriteLine($"warning: {shippedTxtPath}: '{RemovedApiPrefix}{removedApi}' has no matching entry in PublicAPI.Shipped.txt; nothing to remove.");
+                }
+                else
+                {
+                    shippedLines.RemoveAt(index);
                 }
             }
 


### PR DESCRIPTION
# Bug

Progress: https://github.com/NuGet/Client.Engineering/issues/3874

## Description

- Bump `MinorNuGetVersion` from `9` to `10` in `build/config.props` (NuGet product version -> 7.10.0).
- Fix the `ship-public-apis` tool (`tools-local/ship-public-apis/Program.cs`) to honor `*REMOVED*` directives: a `*REMOVED*<sig>` line in `PublicAPI.Unshipped.txt` now deletes the matching `<sig>` from `PublicAPI.Shipped.txt`, and the marker is written to neither file (previously it was copied verbatim into `Shipped.txt` and the stale entry was left behind). Warns if a `*REMOVED*` entry has no matching shipped API.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
