### PR TITLE
Test against .NET 11.0.1xx only and disable SDK Next integration tests by default since we're only targeting 11.0.1xx now.

### DIFF
--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -1,6 +1,4 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
 # To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
--Channel 8.0 -Runtime dotnet
--Channel 9.0 -Runtime dotnet
--Version 10.0.400-preview.0.26360.120
+-Channel 10.0 -Runtime dotnet
 -Channel 11.0.1xx -Quality preview

--- a/configure.sh
+++ b/configure.sh
@@ -83,7 +83,7 @@ if [ "$DOTNET_SDK_TEST_VERSIONS" != "" ]; then
     done
 else
     # Get CLI Branches for testing
-    cat build/DotNetSdkTestVersions.txt | while IFS=$'\r' read -r CliArgs || [[ -n $line ]];
+    cat build/DotNetSdkTestVersions.txt | while IFS=$'\r' read -r CliArgs || [[ -n $CliArgs ]];
     do
         if [ "${CliArgs:0:1}" != "#" ] || [ "$CliArgs" == "" ]; then
             echo "'cli/dotnet-install.sh -InstallDir $NETSDK_FOR_TESTING_DIR -NoPath $CliArgs'"

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -23,6 +23,10 @@ parameters:
   displayName: Run functional tests on MacOS
   type: boolean
   default: true
+- name: RunSdkNextTests
+  displayName: Run SDK Next integration tests
+  type: boolean
+  default: false
 - name: RunSourceBuild
   displayName: Run a SourceBuild build
   type: boolean
@@ -177,7 +181,7 @@ stages:
         testProjectName: Dotnet.Integration.Test
         timeoutInMinutes: 60
 
-- ${{ if eq(parameters.RunFunctionalTestsOnWindows, true) }}:
+- ${{ if and(eq(parameters.RunFunctionalTestsOnWindows, true), eq(parameters.RunSdkNextTests, true)) }}:
   - stage:
     displayName: Dotnet.Integration.Test on Windows (SDK Next)
     dependsOn: []
@@ -242,7 +246,7 @@ stages:
         testTargetFramework: net10.0
         timeoutInMinutes: 30
 
-- ${{ if eq(parameters.RunFunctionalTestsOnLinux, true) }}:
+- ${{ if and(eq(parameters.RunFunctionalTestsOnLinux, true), eq(parameters.RunSdkNextTests, true)) }}:
   - stage:
     displayName: Dotnet.Integration.Test on Linux (SDK Next)
     dependsOn: []
@@ -284,7 +288,7 @@ stages:
         testTargetFramework: net10.0
         timeoutInMinutes: 30
 
-- ${{ if eq(parameters.RunFunctionalTestsOnMacOS, true) }}:
+- ${{ if and(eq(parameters.RunFunctionalTestsOnMacOS, true), eq(parameters.RunSdkNextTests, true)) }}:
   - stage:
     displayName: Dotnet.Integration.Test on MacOS (SDK Next)
     dependsOn: []

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(DotNetBuildSourceOnly)' == 'true' Or '$(DotNetBuildFromVMR)' == 'true'">$(LatestNETCoreTargetFramework)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildSourceOnly)' != 'true' And '$(DotNetBuildFromVMR)' != 'true'">$(LatestNETCoreTargetFramework);sdkNext</TargetFrameworks>
+    <TestSDKNext>false</TestSDKNext>
+    <TargetFrameworks Condition="'$(DotNetBuildSourceOnly)' == 'true' Or '$(DotNetBuildFromVMR)' == 'true' or '$(IsEscrowMode)' == 'true' or '$(TestSDKNext)' != 'true'">$(LatestNETCoreTargetFramework)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildSourceOnly)' != 'true' And '$(DotNetBuildFromVMR)' != 'true' And '$(IsEscrowMode)' != 'true' And '$(TestSDKNext)' == 'true'">$(LatestNETCoreTargetFramework);sdkNext</TargetFrameworks>
     <Description>Integration tests for NuGet-powered dotnet CLI commands such as pack/restore/list package and dotnet nuget.</Description>
-    <LatestNETCoreTargetFrameworkMajorVersion>$([System.Version]::Parse('$([MSBuild]::GetTargetFrameworkVersion('$(LatestNETCoreTargetFramework)', 2))').Major)</LatestNETCoreTargetFrameworkMajorVersion>
+    <LatestNETCoreTargetFrameworkMajorVersion>$([MSBuild]::Add($([System.Version]::Parse('$([MSBuild]::GetTargetFrameworkVersion('$(LatestNETCoreTargetFramework)', 2))').Major), 1))</LatestNETCoreTargetFrameworkMajorVersion>
     <NextNETCoreTargetFrameworkMajorVersion>$([MSBuild]::Add($(LatestNETCoreTargetFrameworkMajorVersion), 1))</NextNETCoreTargetFrameworkMajorVersion>
   </PropertyGroup>
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs
@@ -93,13 +93,8 @@ namespace Dotnet.Integration.Test
 
             // Run "why" command.
             var result = _testFixture.RunDotnetExpectSuccess(fbaDir, "nuget why app.cs PackageB", testOutputHelper: _testOutputHelper);
-#if SDK_CURRENT
-            Assert.Contains("packageA (v1.0.0)", result.AllOutput);
-            Assert.Contains("packageB (v1.0.1)", result.AllOutput);
-#else
             result.AllOutput.Should().Contain("packageA@1.0.0 (>= 1.0.0)");
             result.AllOutput.Should().Contain("packageB@1.0.1 (>= 1.0.1)");
-#endif
         }
 
         [Fact]
@@ -209,11 +204,7 @@ namespace Dotnet.Integration.Test
 
             // Assert
             Assert.Equal(ExitCodes.InvalidArguments, result.ExitCode);
-#if SDK_CURRENT
-            Assert.Contains($"Required argument missing for command: 'why'.", result.Errors);
-#else
             Assert.Contains("Required argument 'PACKAGE' missing for command: 'why'", result.Errors);
-#endif
         }
 
         [Fact]
@@ -230,11 +221,7 @@ namespace Dotnet.Integration.Test
 
             // Assert
             Assert.Equal(ExitCodes.InvalidArguments, result.ExitCode);
-#if SDK_CURRENT
-            Assert.Contains($"Required argument missing for command: 'why'.", result.Errors);
-#else
             Assert.Contains($"Required argument 'PACKAGE' missing for command: 'why'.", result.Errors);
-#endif
         }
 
         [Fact]
@@ -351,20 +338,6 @@ namespace Dotnet.Integration.Test
 
             // Assert
             // project references should not have version numbers
-#if SDK_CURRENT
-            string[] expected =
-                [
-                "Project 'ProjectC' has the following dependency graph(s) for 'PackageX':",
-                "",
-                $"  [{TestConstants.ProjectTargetFramework}]                                                                     ",
-                "  └── ProjectB                                                                  ",
-                "      └── ProjectA                                                              ",
-                "          └── PackageX (v1.0.0)                                                 ",
-                "",
-                "",
-                ""
-                ];
-#else
             string[] expected =
                 [
                 "Project 'ProjectC' has the following dependency graph(s) for 'PackageX':",
@@ -377,7 +350,6 @@ namespace Dotnet.Integration.Test
                 "",
                 ""
                 ];
-#endif
             StripAnsiCodes(result.AllOutput).Should().Be(string.Join(Environment.NewLine, expected));
         }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -6734,11 +6734,7 @@ namespace ClassLibrary
             _dotnetFixture.RestoreProjectExpectSuccess(workingDirectory, projectName, testOutputHelper: _testOutputHelper);
             var result = _dotnetFixture.PackProjectExpectSuccess(workingDirectory, projectName, $"-o {workingDirectory}", testOutputHelper: _testOutputHelper);
 
-#if SDK_NEXT
             result.AllOutput.Should().Contain("NU5052");
-#else
-            result.AllOutput.Should().NotContain("NU5052");
-#endif
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/TestConstants.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/TestConstants.cs
@@ -9,11 +9,11 @@ public static class TestConstants
 {
 #if SDK_NEXT
     // Specifies a target framework for projects used during testing.  This should match the framework that the SDK being tested has.
-    public const string ProjectTargetFramework = "net11.0";
+    public const string ProjectTargetFramework = "net12.0";
     public static readonly NuGetFramework DefaultTargetFramework = NuGetFramework.Parse(ProjectTargetFramework);
 #elif NET10_0
     // Specifies a target framework for projects used during testing.  This should match the framework that the SDK being tested has.
-    public const string ProjectTargetFramework = "net10.0";
+    public const string ProjectTargetFramework = "net11.0";
     public static readonly NuGetFramework DefaultTargetFramework = NuGetFramework.Parse(ProjectTargetFramework);
 #else
 #error Update the logic for which target framework to use for tests projects!!!

--- a/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/CrossVerifyTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/CrossVerifyTestFixture.cs
@@ -18,7 +18,7 @@ namespace NuGet.Signing.CrossFramework.Test
         private const string DotnetExe = "dotnet.exe";
         //In net472 code path, the SDK version and TFM could not be detected automatically, so we manually specified according to the sdk version we're testing against.
         //https://github.com/NuGet/Home/issues/12187
-        private const string SdkVersion = "10";
+        private const string SdkVersion = "11";
         private const string SdkTfm = "net10.0";
         internal string _dotnetExePath;
 #else


### PR DESCRIPTION
# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
Fixes: 

Progress: https://github.com/NuGet/Client.Engineering/issues/3874

## Description

Test/CI configuration change only (no product code) in preparation for the 7.9 branch. Moves `Dotnet.Integration.Test` onto the .NET 11.0.1xx SDK and turns the SDK Next test legs **off by default** so they don't gate PRs while SDK Next does not exist. Nothing is deleted — SDK Next remains easy to re-enable.

**Pipeline**
- **`eng/pipelines/pr.yml`** — Added a new `RunSdkNextTests` pipeline parameter (default `false`) and gated the three `Dotnet.Integration.Test ... (SDK Next)` stages (Windows / Linux / MacOS) on it, combined with the existing per-OS switches. The stages stay in the file and can be re-enabled by flipping the parameter.

**SDK install / configure**
- **`build/DotNetSdkTestVersions.txt`** — Slimmed the test SDK/runtime matrix: removed the standalone 8.0 and 9.0 runtime installs and the `10.0.4xx` SDK daily; now installs the 10.0 shared runtime (`-Channel 10.0 -Runtime dotnet`) and the 11.0.1xx SDK daily (`-Channel 11.0.1xx -Quality daily`).
- **`configure.sh`** — Fixed the read loop that parses `DotNetSdkTestVersions.txt`: the continuation guard referenced an undefined `$line`, so the last line was dropped when the file had no trailing newline. It now guards on `$CliArgs`.

**Test project targeting**
- **`test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj`** — Added a `TestSDKNext` property (default `false`) that controls whether the `sdkNext` target framework is built, added an `IsEscrowMode` guard to the TFM conditions, and adjusted `LatestNETCoreTargetFrameworkMajorVersion` (now latest major + 1) so the "next framework" math lines up with 11.x being latest.
- **`test/NuGet.Core.FuncTests/Dotnet.Integration.Test/TestConstants.cs`** — Bumped `ProjectTargetFramework`: `net10.0` → `net11.0` (current SDK) and `net11.0` → `net12.0` (SDK Next).

**Test assertion cleanup (only 11.0.1xx is exercised now)**
- **`test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetWhyTests.cs`** — Removed the now-dead `#if SDK_CURRENT` branches across the `why` tests, keeping the current `dotnet nuget why` expected output.
- **`test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs`** — `PackCommand_PackageIdWithNonAsciiCharacters_NU5052` now always asserts the `NU5052` warning is present (dropped the `#if SDK_NEXT` split).
- **`test/NuGet.Core.FuncTests/NuGet.Signing.CrossFramework.Test/CrossVerifyTestFixture.cs`** — Bumped the manually-specified net472 `SdkVersion` from `10` to `11`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
