### PR TITLE
Add restore telemetry to count package refs with floating versions

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -105,6 +105,7 @@ namespace NuGet.Commands
         private const string IsCentralPackageTransitivePinningEnabled = nameof(IsCentralPackageTransitivePinningEnabled);
         private const string UseLegacyDependencyResolver = nameof(UseLegacyDependencyResolver);
         private const string UsedLegacyDependencyResolver = nameof(UsedLegacyDependencyResolver);
+        private const string PackagesWithFloatingVersionCount = nameof(PackagesWithFloatingVersionCount);
 
         // PackageSourceMapping names
         private const string PackageSourceMappingIsMappingEnabled = "PackageSourceMapping.IsMappingEnabled";
@@ -254,6 +255,8 @@ namespace NuGet.Commands
                 success &= successfulResult;
 
                 AnalyzePruningResults(_request.Project, telemetry.TelemetryEvent, _logger);
+
+                telemetry.TelemetryEvent[PackagesWithFloatingVersionCount] = CountPackagesWithFloatingVersion(_request.Project);
 
                 // if success == false, it generates an empty restore graph suitable to create an assets file with errors.
                 // Since the graph is empty, any code that analyzes the graph (like audit) will have nothing to do.
@@ -961,6 +964,26 @@ namespace NuGet.Commands
             }
 
             return true;
+        }
+
+        internal static int CountPackagesWithFloatingVersion(PackageSpec project)
+        {
+            HashSet<string> packagesWithFloatingVersion = null;
+
+            foreach (TargetFrameworkInformation framework in project.TargetFrameworks)
+            {
+                foreach (LibraryDependency dependency in framework.Dependencies)
+                {
+                    if (dependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)
+                        && dependency.LibraryRange.VersionRange?.IsFloating == true)
+                    {
+                        packagesWithFloatingVersion ??= new(StringComparer.OrdinalIgnoreCase);
+                        packagesWithFloatingVersion.Add(dependency.Name);
+                    }
+                }
+            }
+
+            return packagesWithFloatingVersion?.Count ?? 0;
         }
 
         internal static void AnalyzePruningResults(PackageSpec project, TelemetryEvent telemetryEvent, ILogger logger)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -209,6 +209,7 @@ namespace NuGet.Commands
                     _request.Project.FilePath,
                     _logger);
                 InitializeTelemetry(telemetry, httpSourcesCount, auditEnabled);
+                telemetry.TelemetryEvent[PackagesWithFloatingVersionCount] = CountPackagesWithFloatingVersion(_request.Project);
 
                 var restoreTime = Stopwatch.StartNew();
 
@@ -255,8 +256,6 @@ namespace NuGet.Commands
                 success &= successfulResult;
 
                 AnalyzePruningResults(_request.Project, telemetry.TelemetryEvent, _logger);
-
-                telemetry.TelemetryEvent[PackagesWithFloatingVersionCount] = CountPackagesWithFloatingVersion(_request.Project);
 
                 // if success == false, it generates an empty restore graph suitable to create an assets file with errors.
                 // Since the graph is empty, any code that analyzes the graph (like audit) will have nothing to do.
@@ -968,6 +967,22 @@ namespace NuGet.Commands
 
         internal static int CountPackagesWithFloatingVersion(PackageSpec project)
         {
+            // With a single target framework there can be no duplicate package names, so avoid the HashSet allocation.
+            if (project.TargetFrameworks.Count == 1)
+            {
+                int count = 0;
+                foreach (LibraryDependency dependency in project.TargetFrameworks[0].Dependencies)
+                {
+                    if (dependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)
+                        && dependency.LibraryRange.VersionRange?.IsFloating == true)
+                    {
+                        count++;
+                    }
+                }
+
+                return count;
+            }
+
             HashSet<string> packagesWithFloatingVersion = null;
 
             foreach (TargetFrameworkInformation framework in project.TargetFrameworks)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -3057,6 +3057,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["Audit.Level"] = value => value.Should().Be(0),
                 ["Audit.Mode"] = value => value.Should().Be("Unknown"),
                 ["Audit.SuppressedAdvisories.Defined.Count"] = value => value.Should().Be(1),
+                ["PackagesWithFloatingVersionCount"] = value => value.Should().Be(0),
                 ["Audit.SuppressedAdvisories.TotalWarningsSuppressed.Count"] = value => value.Should().Be(0),
                 ["Audit.SuppressedAdvisories.DistinctAdvisoriesSuppressed.Count"] = value => value.Should().Be(0),
                 ["Audit.Vulnerability.Direct.Count"] = value => value.Should().Be(0),
@@ -3118,6 +3119,54 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 object value = projectInformationEvent[kvp.Key];
                 kvp.Value(value);
             }
+        }
+
+        [Theory]
+        [InlineData("1.0.0", 0)]
+        [InlineData("[1.0.0]", 0)]
+        [InlineData("*", 1)]
+        [InlineData("1.*", 1)]
+        [InlineData("1.0.*", 1)]
+        [InlineData("1.0.0-*", 1)]
+        public void CountPackagesWithFloatingVersion_WithSingleDependency_ReturnsExpectedCount(string version, int expectedCount)
+        {
+            // Arrange
+            PackageSpec packageSpec = ProjectTestHelpers.GetPackageSpec("TestProject", @"C:\", "net8.0", "packageA", version);
+
+            // Act
+            int actualCount = RestoreCommand.CountPackagesWithFloatingVersion(packageSpec);
+
+            // Assert
+            actualCount.Should().Be(expectedCount);
+        }
+
+        [Fact]
+        public void CountPackagesWithFloatingVersion_WithSamePackageFloatingInMultipleFrameworks_CountsPackageOnce()
+        {
+            // Arrange
+            const string spec = @"
+                {
+                    ""frameworks"": {
+                        ""net8.0"": {
+                            ""dependencies"": {
+                                ""packageA"" : ""1.0.*"",
+                                ""packageB"" : ""2.0.0""
+                            }
+                        },
+                        ""net9.0"": {
+                            ""dependencies"": {
+                                ""packageA"" : ""1.0.*""
+                            }
+                        }
+                    }
+                }";
+            PackageSpec packageSpec = ProjectTestHelpers.GetPackageSpecWithProjectNameAndSpec("TestProject", @"C:\", spec);
+
+            // Act
+            int actualCount = RestoreCommand.CountPackagesWithFloatingVersion(packageSpec);
+
+            // Assert
+            actualCount.Should().Be(1);
         }
 
         [Fact]
@@ -3386,6 +3435,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
                 ["LockFileEvaluationResult"] = value => value.Should().Be(true),
                 ["NoOpDuration"] = value => value.Should().NotBeNull(),
                 ["TotalUniquePackagesCount"] = value => value.Should().Be(2),
+                ["PackagesWithFloatingVersionCount"] = value => value.Should().Be(0),
                 ["NewPackagesInstalledCount"] = value => value.Should().Be(1),
                 ["AnyPackageIdContainsNonAlphanumericDotDashOrUnderscoreCharacters"] = value => value.Should().Be(false),
                 ["EvaluateLockFileDuration"] = value => value.Should().NotBeNull(),

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests/RestoreCommandTests.cs
@@ -3311,6 +3311,7 @@ namespace NuGet.Commands.Test.RestoreCommandTests
             {
                 ["RestoreSuccess"] = value => value.Should().Be(true),
                 ["NoOpResult"] = value => value.Should().Be(true),
+                ["PackagesWithFloatingVersionCount"] = value => value.Should().Be(0),
                 ["IsCentralVersionManagementEnabled"] = value => value.Should().Be(false),
                 ["NoOpCacheFileEvaluationResult"] = value => value.Should().Be(true),
                 ["NoOpRestoreOutputEvaluationResult"] = value => value.Should().Be(true),


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Informs: https://github.com/NuGet/Home/issues/14657

## Description

A package cooldown feature will probably have customer expectation that it not only makes PM UI and `dotnet package update` cool down, but customers using floating versions probably will expect the cooldown to work there as well. It'd be useful for the NuGet team to know how common it is for floating versions to be used.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
