### PR TITLE
Annotate MSBuild in proc calls

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -8,6 +8,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -98,6 +99,7 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="globalProperties">The global properties to use when evaluation MSBuild projects.</param>
         /// <param name="options">The set of options to use when restoring.  These options come from the main MSBuild process and control how restore functions.</param>
         /// <returns><code>true</code> if the restore succeeded, otherwise <code>false</code>.</returns>
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public async Task<bool> RestoreAsync(string entryProjectFilePath, IDictionary<string, string> globalProperties, IReadOnlyDictionary<string, string> options)
         {
@@ -186,6 +188,7 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="globalProperties">The global properties to use when evaluation MSBuild projects.</param>
         /// <param name="options">The set of options to use to generate the graph, including the restore graph output path.</param>
         /// <returns><code>true</code> if the dependency graph spec was generated and written, otherwise <code>false</code>.</returns>
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         public bool WriteDependencyGraphSpec(string entryProjectFilePath, IDictionary<string, string> globalProperties, IReadOnlyDictionary<string, string> options)
         {
             bool interactive = IsOptionTrue(nameof(RestoreTaskEx.Interactive), options);
@@ -806,6 +809,7 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="globalProperties">An <see cref="IDictionary{String,String}" /> containing the global properties to use when evaluation MSBuild projects.</param>
         /// <param name="interactive"><see langword="true" /> if the build is allowed to interact with the user, otherwise <see langword="false" />.</param>
         /// <returns>A <see cref="DependencyGraphSpec" /> for the specified project if they could be loaded, otherwise <code>null</code>.</returns>
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         private (DependencyGraphSpec DependencyGraphSpec, IReadOnlyList<IAssetsLogMessage> AdditionalMessages) GetDependencyGraphSpec(string entryProjectPath, IDictionary<string, string> globalProperties, bool interactive, string binaryLoggerParameters, IEnvironmentVariableReader environmentVariableReader)
         {
             var additionalMessages = new ConcurrentBag<IAssetsLogMessage>();
@@ -937,6 +941,7 @@ namespace NuGet.Build.Tasks.Console
             };
         }
 
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         private DependencyGraphSpec GetDependencyGraphSpec<TProject>(
             string entryProjectPath,
             IDictionary<string, string> globalProperties,
@@ -1224,9 +1229,7 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="updateProjectFactory">A factory method that updates a project adapter with a target framework and MSBuild ProjectInstance.</param>
         /// <param name="projectFinalizeDelegate">An option delegate to finalize a project adapter once all projects have been evaluated.</param>
         /// <returns>An <see cref="ICollection{ProjectWithInnerNodes}" /> object containing projects and their inner nodes if they are targeting multiple frameworks.</returns>
-#if NET5_0_OR_GREATER
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Temporary VMR unblock: static graph restore intentionally runs full MSBuild in-process. Replace with proper annotations in NuGet/Home#14987.")]
-#endif
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         private ConcurrentDictionary<string, TProject> LoadProjects<TProject>(
             IEnumerable<ProjectGraphEntryPoint> entryProjects,
             bool interactive,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/MSBuildStaticGraphRestore.cs
@@ -99,7 +99,9 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="globalProperties">The global properties to use when evaluation MSBuild projects.</param>
         /// <param name="options">The set of options to use when restoring.  These options come from the main MSBuild process and control how restore functions.</param>
         /// <returns><code>true</code> if the restore succeeded, otherwise <code>false</code>.</returns>
+#if NET
         [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
+#endif
         [MethodImpl(MethodImplOptions.NoInlining)]
         public async Task<bool> RestoreAsync(string entryProjectFilePath, IDictionary<string, string> globalProperties, IReadOnlyDictionary<string, string> options)
         {
@@ -188,7 +190,9 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="globalProperties">The global properties to use when evaluation MSBuild projects.</param>
         /// <param name="options">The set of options to use to generate the graph, including the restore graph output path.</param>
         /// <returns><code>true</code> if the dependency graph spec was generated and written, otherwise <code>false</code>.</returns>
+#if NET
         [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
+#endif
         public bool WriteDependencyGraphSpec(string entryProjectFilePath, IDictionary<string, string> globalProperties, IReadOnlyDictionary<string, string> options)
         {
             bool interactive = IsOptionTrue(nameof(RestoreTaskEx.Interactive), options);
@@ -809,7 +813,9 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="globalProperties">An <see cref="IDictionary{String,String}" /> containing the global properties to use when evaluation MSBuild projects.</param>
         /// <param name="interactive"><see langword="true" /> if the build is allowed to interact with the user, otherwise <see langword="false" />.</param>
         /// <returns>A <see cref="DependencyGraphSpec" /> for the specified project if they could be loaded, otherwise <code>null</code>.</returns>
+#if NET
         [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
+#endif
         private (DependencyGraphSpec DependencyGraphSpec, IReadOnlyList<IAssetsLogMessage> AdditionalMessages) GetDependencyGraphSpec(string entryProjectPath, IDictionary<string, string> globalProperties, bool interactive, string binaryLoggerParameters, IEnvironmentVariableReader environmentVariableReader)
         {
             var additionalMessages = new ConcurrentBag<IAssetsLogMessage>();
@@ -941,7 +947,9 @@ namespace NuGet.Build.Tasks.Console
             };
         }
 
+#if NET
         [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
+#endif
         private DependencyGraphSpec GetDependencyGraphSpec<TProject>(
             string entryProjectPath,
             IDictionary<string, string> globalProperties,
@@ -1229,7 +1237,9 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="updateProjectFactory">A factory method that updates a project adapter with a target framework and MSBuild ProjectInstance.</param>
         /// <param name="projectFinalizeDelegate">An option delegate to finalize a project adapter once all projects have been evaluated.</param>
         /// <returns>An <see cref="ICollection{ProjectWithInnerNodes}" /> object containing projects and their inner nodes if they are targeting multiple frameworks.</returns>
+#if NET
         [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
+#endif
         private ConcurrentDictionary<string, TProject> LoadProjects<TProject>(
             IEnumerable<ProjectGraphEntryPoint> entryProjects,
             bool interactive,
@@ -1483,3 +1493,4 @@ namespace NuGet.Build.Tasks.Console
         }
     }
 }
+

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
@@ -43,9 +43,13 @@ namespace NuGet.Build.Tasks.Console
         {
             // Suppress IL2026: Main is the application entry point and cannot carry [RequiresUnreferencedCode].
             // This exe intentionally runs MSBuild in-process; the annotation chain terminates here.
+#if NET
 #pragma warning disable IL2026
+#endif
             return await MainInternal(args, EnvironmentVariableWrapper.Instance);
+#if NET
 #pragma warning restore IL2026
+#endif
         }
 
         /// <summary>
@@ -54,7 +58,9 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="args">The command-line arguments.</param>
         /// <param name="environmentVariableReader">An <see cref="IEnvironmentVariableReader" /> to use when reading environment variables.</param>
         /// <returns><c>0</c> if the application ran successfully with no errors, otherwise <c>1</c>.</returns>
+#if NET
         [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
+#endif
         internal static async Task<int> MainInternal(string[] args, IEnvironmentVariableReader environmentVariableReader)
         {
             try
@@ -298,3 +304,4 @@ namespace NuGet.Build.Tasks.Console
         }
     }
 }
+

--- a/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -40,7 +41,11 @@ namespace NuGet.Build.Tasks.Console
         /// <returns><c>0</c> if the application ran successfully with no errors, otherwise <c>1</c>.</returns>
         public static async Task<int> Main(string[] args)
         {
+            // Suppress IL2026: Main is the application entry point and cannot carry [RequiresUnreferencedCode].
+            // This exe intentionally runs MSBuild in-process; the annotation chain terminates here.
+#pragma warning disable IL2026
             return await MainInternal(args, EnvironmentVariableWrapper.Instance);
+#pragma warning restore IL2026
         }
 
         /// <summary>
@@ -49,6 +54,7 @@ namespace NuGet.Build.Tasks.Console
         /// <param name="args">The command-line arguments.</param>
         /// <param name="environmentVariableReader">An <see cref="IEnvironmentVariableReader" /> to use when reading environment variables.</param>
         /// <returns><c>0</c> if the application ran successfully with no errors, otherwise <c>1</c>.</returns>
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         internal static async Task<int> MainInternal(string[] args, IEnvironmentVariableReader environmentVariableReader)
         {
             try

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/IListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/IListPackageCommandRunner.cs
@@ -3,12 +3,14 @@
 
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace NuGet.CommandLine.XPlat
 {
     internal interface IListPackageCommandRunner
     {
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         Task<int> ExecuteCommandAsync(ListPackageArgs packageRefArgs);
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommand.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -20,6 +21,7 @@ namespace NuGet.CommandLine.XPlat
 {
     internal static class ListPackageCommand
     {
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         internal static void Register(
             Command parent,
             Func<ILoggerWithColor> getLogger,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackage/ListPackageCommandRunner.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -40,6 +41,7 @@ namespace NuGet.CommandLine.XPlat
             _sourceRepositoryCache = new Dictionary<PackageSource, SourceRepository>();
         }
 
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         public async Task<int> ExecuteCommandAsync(ListPackageArgs listPackageArgs)
         {
             IReportRenderer reportRenderer = listPackageArgs.Renderer;
@@ -48,6 +50,7 @@ namespace NuGet.CommandLine.XPlat
             return exitCode;
         }
 
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         internal async Task<(int, ListPackageReportModel)> GetReportDataAsync(ListPackageArgs listPackageArgs)
         {
             // It's important not to print anything to console from below methods and sub method calls, because it'll affect both json/console outputs.
@@ -87,6 +90,7 @@ namespace NuGet.CommandLine.XPlat
             return (exitCode, listPackageReportModel);
         }
 
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         private async Task GetProjectMetadataAsync(
             string projectPath,
             ListPackageReportModel listPackageReportModel,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.CommandLine;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using NuGet.CommandLine.XPlat.Commands;
@@ -31,14 +32,18 @@ namespace NuGet.CommandLine.XPlat
 
         internal static int Main(string[] args)
         {
+#pragma warning disable IL2026 // Main is the entry point and cannot carry [RequiresUnreferencedCode]; this exe intentionally runs MSBuild in-process.
             return MainInternal(args, virtualProjectBuilder: null);
+#pragma warning restore IL2026
         }
 
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         public static int Run(string[] args, IVirtualProjectBuilder virtualProjectBuilder)
         {
             return MainInternal(args, virtualProjectBuilder);
         }
 
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         private static int MainInternal(string[] args, IVirtualProjectBuilder? virtualProjectBuilder)
         {
             var log = new CommandOutputLogger(LogLevel.Information);
@@ -119,7 +124,9 @@ namespace NuGet.CommandLine.XPlat
                 PackageSearchCommand.Register(packageCommand, getHidePrefixLogger);
                 AddPackageReferenceCommand.Register(packageCommand, () => log, () => new AddPackageReferenceCommandRunner(), () => msbuild.VirtualProjectBuilder);
                 RemovePackageReferenceCommand.Register(packageCommand, () => log, () => new RemovePackageReferenceCommandRunner(), () => msbuild.VirtualProjectBuilder);
+#pragma warning disable IL2026 // ListPackageCommand.Register intentionally uses MSBuild in-process for list package; annotated at the public boundary (Run/IListPackageCommandRunner).
                 ListPackageCommand.Register(packageCommand, getHidePrefixLogger, setLogLevel, () => new ListPackageCommandRunner(msbuild));
+#pragma warning restore IL2026
 #if DEBUG
                 PackageUpdateCommand.Register(packageCommand, interactiveOption, virtualProjectBuilder);
                 PackageDownloadCommand.Register(packageCommand, interactiveOption);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -723,6 +724,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="transitive">Include transitive packages/projects in the result</param>
         /// <returns>FrameworkPackages collection with top-level and transitive package/project
         /// references for each framework, or null on error</returns>
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         internal static List<FrameworkPackages> GetResolvedVersions(
             Project project, IEnumerable<string> userInputFrameworks, LockFile assetsFile, bool transitive)
         {
@@ -924,7 +926,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="framework">Framework to get reference(s) for</param>
         /// <returns>List of Items containing the package reference for the package.
         /// If the libraryDependency is null then it returns all package references</returns>
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Temporary VMR unblock: the NuGet CLI intentionally runs MSBuild in-process. Replace with proper annotations in NuGet/Home#14987.")]
+        [RequiresUnreferencedCode("In-process MSBuild execution loads task assemblies and loggers via reflection and is not trim-safe.")]
         private static IEnumerable<InstalledPackageReference> GetPackageReferencesFromTargets(Project project, string framework)
         {
             var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14987

## Description

 dotnet/msbuild#14064  added  `[RequiresUnreferencedCode]`  to MSBuild's build execution APIs. This caused IL2026 errors in NuGet.Client's source build because both  NuGet.Build.Tasks.Console  and  NuGet.CommandLine.XPlat 

FYI a temporary fix was merged in the VMR by suppressing these warnings.  This PR annotates the methods with RUC making them more honest instead of suppressing.

This PR will wait for backflow to avoid conflicts.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
