### PR TITLE
Use App Data Microsoft.DotNet.Sdk.Root for resolving SDK root

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/FallbackCertificateBundleX509ChainFactory.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/TrustStore/FallbackCertificateBundleX509ChainFactory.cs
@@ -59,6 +59,11 @@ namespace NuGet.Packaging.Signing
 
         private static string GetThisAssemblyDirectoryPath()
         {
+            if (AppContext.GetData("Microsoft.DotNet.Sdk.Root") is string sdkRoot && sdkRoot.Length > 0)
+            {
+                return sdkRoot;
+            }
+
             return AppContext.BaseDirectory;
         }
     }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14980

## Description

NuGet.Packaging locates the SDK-provided trusted-root bundles ( trustedroots/codesignctl.pem  and  trustedroots/timestampctl.pem ) via  AppContext.BaseDirectory , assuming it resolves to the versioned SDK directory (e.g.  dotnet/sdk/10.0.301 ).

Under the Native AOT  dotnet  CLI, that assumption breaks:  `dotnet-aot.dll`  is loaded directly by the muxer so the pem bundles can't be found and signature/timestamp verification could fail.

This adopts the resolution pattern from dotnet/sdk#55110: the AOT entry point publishes the resolved versioned SDK directory as the  `Microsoft.DotNet.Sdk.Root`  AppContext value.  `FallbackCertificateBundleX509ChainFactory`  now reads that value first, falling back to  `AppContext.BaseDirectory`  when it is unset 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
