### PR TITLE
Fix GetPackOutputItems when nuspec does not exist

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
@@ -79,7 +79,7 @@ namespace NuGet.Build.Tasks.Pack
             NuGetVersion version = null;
 
             // Extract the version from the nuspec file if it exists and is valid, otherwise use the version from the project.
-            if (!string.IsNullOrWhiteSpace(NuspecFile))
+            if (!string.IsNullOrWhiteSpace(NuspecFile) && File.Exists(NuspecFile))
             {
                 bool hasVersionInNuspecProperties = false;
                 if (NuspecProperties != null && NuspecProperties.Length > 0)

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/GetPackOutputItemsTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/GetPackOutputItemsTaskTests.cs
@@ -66,5 +66,31 @@ namespace NuGet.Build.Tasks.Pack.Test
 
             actualPackageFiles.Should().BeEquivalentTo(testCase.OutputNupkgNames);
         }
+
+        [Fact]
+        public void GetPackOutputItemsTaskTests_Execute_NuspecFileDoesNotExist_FallsBackToProjectProperties()
+        {
+            using var testDirectory = TestDirectory.Create();
+
+            var outputItemTask = new GetPackOutputItemsTask
+            {
+                PackageId = "MyPackage",
+                PackageVersion = "1.2.3",
+                PackageOutputPath = testDirectory.Path,
+                NuspecOutputPath = testDirectory.Path,
+                SymbolPackageFormat = "snupkg",
+                // Point at a nuspec path that does not exist on disk (mirrors the source-build scenario).
+                NuspecFile = Path.Combine(testDirectory.Path, "does-not-exist.nuspec")
+            };
+
+            Assert.True(outputItemTask.Execute());
+
+            string[] actualPackageFiles = outputItemTask.OutputPackItems
+                .Select(item => Path.GetFileName(item.ItemSpec))
+                .Where(name => name.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            actualPackageFiles.Should().BeEquivalentTo(new[] { "MyPackage.1.2.3.nupkg" });
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14711
follow up from https://github.com/NuGet/NuGet.Client/pull/7531

## Description
Code flow into the .NET VMR failed: https://github.com/dotnet/dotnet/pull/7703

Copilot says it's because roslyn has build customization where their analyzer packages generate their own nuspec file: https://github.com/dotnet/roslyn/blob/f8235426959cd1ffb2b6cbeb6feb2d21238f61b8/eng/targets/GenerateAnalyzerNuspec.targets#L139-L140

They seemingly do this to avoid restore cyclic references: https://github.com/dotnet/roslyn/blob/f8235426959cd1ffb2b6cbeb6feb2d21238f61b8/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/Microsoft.CodeAnalysis.BannedApiAnalyzers.csproj#L5-L9

Their `GenerateAnalyzerNuspecFile` target uses `BeforeTargets="GenerateNuspec"`, but MSBuild's execution order is DependsOn, then BeforeTargets, then the target itself, followed by AfterTargets.  Since `GenerateNuspec` uses `DependsOn` for `GetPackOutputItems`, it means that it runs before roslyn's `GenerateAnalyzerNuspecFile` target. Therefore, the nuspec file doesn't exist at the time https://github.com/NuGet/NuGet.Client/pull/7531's changes try to read the file.

This means that in the situation where a generated nuspec uses a package name different to what the MSBuild property PackageId value, then `GetPackOutputItemsTask` will generate filenames different to what `GenerateNuspec` (that actually generates nupkgs) creates.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
