### PR TITLE
Find existing PM UI windows by editor type

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -441,40 +441,39 @@ namespace NuGetVSExtension
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var uiShell = (IVsUIShell)GetService(typeof(SVsUIShell));
-            foreach (var windowFrame in VsUtility.GetDocumentWindows(uiShell))
+            IVsHierarchy projectHierarchy = await project.ToVsHierarchyAsync();
+            return await FindExistingNuGetWindowFrameAsync(
+                (IVsUIHierarchy)projectHierarchy,
+                (uint)VSConstants.VSITEMID.Root,
+                project.FullName);
+        }
+
+        private async Task<IVsWindowFrame> FindExistingNuGetWindowFrameAsync(
+            IVsUIHierarchy hierarchy,
+            uint itemId,
+            string documentName)
+        {
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var uiShellOpenDocument = await this.GetServiceAsync<SVsUIShellOpenDocument, IVsUIShellOpenDocument>();
+            Assumes.Present(uiShellOpenDocument);
+
+            Guid editorType = GuidList.guidNuGetEditorType;
+            var hr = uiShellOpenDocument.IsSpecificDocumentViewOpen(
+                hierarchy,
+                itemId,
+                documentName,
+                ref editorType,
+                null,
+                (uint)__VSIDOFLAGS.IDO_IgnoreLogicalView,
+                out _,
+                out _,
+                out IVsWindowFrame windowFrame,
+                out int isOpen);
+
+            if (ErrorHandler.Succeeded(hr) && isOpen != 0)
             {
-                object docView;
-                var hr = windowFrame.GetProperty(
-                    (int)__VSFPROPID.VSFPROPID_DocView,
-                    out docView);
-                if (hr == VSConstants.S_OK
-                    && docView is PackageManagerWindowPane)
-                {
-                    var packageManagerWindowPane = (PackageManagerWindowPane)docView;
-                    if (packageManagerWindowPane.Model.IsSolution)
-                    {
-                        // the window is the solution package manager
-                        continue;
-                    }
-
-                    var projects = packageManagerWindowPane.Model.Context.Projects;
-                    if (projects.Count() != 1)
-                    {
-                        continue;
-                    }
-
-                    IProjectContextInfo existingProject = projects.First();
-                    IServiceBroker serviceBroker = await ServiceBrokerProvider.Value.GetAsync();
-                    IProjectMetadataContextInfo projectMetadata = await existingProject.GetMetadataAsync(
-                        serviceBroker,
-                        CancellationToken.None);
-
-                    if (string.Equals(projectMetadata.Name, project.Name, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return windowFrame;
-                    }
-                }
+                return windowFrame;
             }
 
             return null;
@@ -802,25 +801,13 @@ namespace NuGetVSExtension
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var uiShell = await this.GetServiceAsync<SVsUIShell, IVsUIShell>();
-            foreach (var windowFrame in VsUtility.GetDocumentWindows(uiShell))
-            {
-                object property;
-                var hr = windowFrame.GetProperty(
-                    (int)__VSFPROPID.VSFPROPID_DocData,
-                    out property);
-                var packageManagerControl = VsUtility.GetPackageManagerControl(windowFrame);
-                if (hr == VSConstants.S_OK
-                    &&
-                    property is IVsSolution
-                    &&
-                    packageManagerControl != null)
-                {
-                    return windowFrame;
-                }
-            }
+            var solution = await this.GetServiceAsync<SVsSolution, IVsSolution>();
+            Assumes.Present(solution);
 
-            return null;
+            return await FindExistingNuGetWindowFrameAsync(
+                (IVsUIHierarchy)solution,
+                (uint)VSConstants.VSITEMID.Root,
+                await SolutionManager.Value.GetSolutionFilePathAsync());
         }
 
         private static string GetSearchText(string parameterString)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14995

## Description

The existing code was enumerating all open windows, getting the doc view, and then checking if the type is NuGet's own PM UI view model.  However, when the tab's docview is not yet loaded, it forces it to load, needlessly and violating the intent of lazy loaded tabs.

This switches to a different API where VS's UI shell already has an API to get the window for a specific document path of a specific editor type. So, by using this API and passing NuGet's editor GUID, NuGet no longer needs to enumerate the windows at all.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ no behavior change, just a refactoring/perf improvement. I did some manual testing, and Apex tests also test PM UI.
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
