### PR TITLE
restore should not scan all versions for GPF

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
@@ -142,6 +142,7 @@ namespace NuGet.Commands
                     ignoreFailedSources: true,
                     ignoreWarning: true,
                     fileCache: _fileCache,
+                    isGlobalPackagesFolder: true,
                     isFallbackFolderSource: false,
                     environmentVariableReader: environmentVariableReader);
             });
@@ -164,6 +165,7 @@ namespace NuGet.Commands
                         ignoreFailedSources: false,
                         ignoreWarning: false,
                         fileCache: _fileCache,
+                        isGlobalPackagesFolder: false,
                         isFallbackFolderSource: true,
                         environmentVariableReader: environmentVariableReader);
                 });
@@ -187,6 +189,7 @@ namespace NuGet.Commands
                     cacheContext.IgnoreFailedSources,
                     ignoreWarning: false,
                     fileCache: _fileCache,
+                    isGlobalPackagesFolder: false,
                     isFallbackFolderSource: false,
                     environmentVariableReader: environmentVariableReader));
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -40,6 +40,7 @@ namespace NuGet.Commands
         private bool _ignoreFailedSources;
         private bool _ignoreWarning;
         private bool _isFallbackFolderSource;
+        private bool _isGlobalPackagesFolder;
         private bool _useLegacyAssetTargetFallbackBehavior;
 
         private readonly TaskResultCache<LibraryRangeCacheKey, LibraryDependencyInfo> _dependencyInfoCache = new();
@@ -131,6 +132,7 @@ namespace NuGet.Commands
                 ignoreFailedSources,
                 ignoreWarning,
                 fileCache,
+                isGlobalPackagesFolder: false,
                 isFallbackFolderSource,
                 environmentVariableReader: EnvironmentVariableWrapper.Instance)
         {
@@ -143,6 +145,7 @@ namespace NuGet.Commands
             bool ignoreFailedSources,
             bool ignoreWarning,
             LocalPackageFileCache fileCache,
+            bool isGlobalPackagesFolder,
             bool isFallbackFolderSource,
             IEnvironmentVariableReader environmentVariableReader)
         {
@@ -153,6 +156,7 @@ namespace NuGet.Commands
             _ignoreWarning = ignoreWarning;
             _packageFileCache = fileCache;
             _isFallbackFolderSource = isFallbackFolderSource;
+            _isGlobalPackagesFolder = isGlobalPackagesFolder;
             _useLegacyAssetTargetFallbackBehavior = MSBuildStringUtility.IsTrue(environmentVariableReader.GetEnvironmentVariable("NUGET_USE_LEGACY_ASSET_TARGET_FALLBACK_DEPENDENCY_RESOLUTION"));
         }
 
@@ -286,6 +290,11 @@ namespace NuGet.Commands
                         Type = LibraryType.Package
                     };
                 }
+            }
+
+            if (_isGlobalPackagesFolder || _isFallbackFolderSource)
+            {
+                return null;
             }
 
             // Discover all versions from the feed

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -294,6 +295,17 @@ namespace NuGet.Commands
 
             if (_isGlobalPackagesFolder || _isFallbackFolderSource)
             {
+                if (_isFallbackFolderSource)
+                {
+                    var sourceRoot = LocalFolderUtility.GetAndVerifyRootDirectory(Source.Source);
+                    if (!sourceRoot.Exists)
+                    {
+                        var message = string.Format(CultureInfo.CurrentCulture, Strings.Error_UnavailableSource, Source.Source);
+
+                        throw new FatalProtocolException(message);
+                    }
+                }
+
                 return null;
             }
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -4675,7 +4675,7 @@ EndGlobal";
             var projectA = SimpleTestProjectContext.CreateNETCore(
                 "projectA",
                 pathContext.SolutionRoot,
-                NuGetFramework.Parse("net8.0"));
+                TestConstants.DefaultTargetFramework);
 
             var packageRef = new SimpleTestPackageContext(packageId, "1.0.0");
             packageRef.Version = "*";
@@ -4722,30 +4722,23 @@ EndGlobal";
             using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
 
             const string packageId = "TestPackage";
-            var package100 = new SimpleTestPackageContext(packageId, "1.0.0");
-            var package200 = new SimpleTestPackageContext(packageId, "2.0.0");
-
             await SimpleTestPackageUtility.CreateFolderFeedV3Async(
                 pathContext.PackageSource,
                 PackageSaveMode.Defaultv3,
-                package100,
-                package200);
+                new SimpleTestPackageContext(packageId, "1.0.0"),
+                new SimpleTestPackageContext(packageId, "2.0.0"));
 
             var projectA = SimpleTestProjectContext.CreateNETCore(
                 "projectA",
                 pathContext.SolutionRoot,
-                NuGetFramework.Parse("net8.0"));
+                TestConstants.DefaultTargetFramework);
 
-            var packageRef = new SimpleTestPackageContext(packageId, "1.0.0");
-            packageRef.Version = "*";
-            projectA.AddPackageToAllFrameworks(packageRef);
-            projectA.Properties.Add("RestoreSources", pathContext.PackageSource);
+            projectA.AddPackageToAllFrameworks(new SimpleTestPackageContext(packageId, "*"));
 
-            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
-            solution.Projects.Add(projectA);
-            solution.Create();
+            new SimpleTestSolutionContext(pathContext.SolutionRoot, projectA).Create();
 
             string arguments = $"restore projectA{Path.DirectorySeparatorChar}projectA.csproj";
+            string higherVersionGlobalPackageDirectory = GetPackageVersionDirectory(pathContext.UserPackagesFolder, packageId, "2.0.0");
 
             _dotnetFixture.RunDotnetExpectSuccess(
                 pathContext.SolutionRoot,
@@ -4753,10 +4746,8 @@ EndGlobal";
                 testOutputHelper: _testOutputHelper);
 
             AssertRestoredPackageVersion(projectA, packageId, "2.0.0");
-            string higherVersionGlobalPackageDirectory = Path.Combine(pathContext.UserPackagesFolder, packageId.ToLowerInvariant(), "2.0.0");
-            Directory.Exists(higherVersionGlobalPackageDirectory).Should().BeTrue($"expected {packageId} 2.0.0 to be in the global packages folder");
 
-            Directory.Delete(Path.Combine(pathContext.PackageSource, packageId.ToLowerInvariant(), "2.0.0"), recursive: true);
+            Directory.Delete(GetPackageVersionDirectory(pathContext.PackageSource, packageId, "2.0.0"), recursive: true);
 
             // Act
             _dotnetFixture.RunDotnetExpectSuccess(
@@ -4766,9 +4757,12 @@ EndGlobal";
 
             // Assert
             AssertRestoredPackageVersion(projectA, packageId, "1.0.0");
-            string lowerVersionGlobalPackageDirectory = Path.Combine(pathContext.UserPackagesFolder, packageId.ToLowerInvariant(), "1.0.0");
-            Directory.Exists(lowerVersionGlobalPackageDirectory).Should().BeTrue($"expected {packageId} 1.0.0 to be in the global packages folder");
             Directory.Exists(higherVersionGlobalPackageDirectory).Should().BeTrue($"expected {packageId} 2.0.0 to remain in the global packages folder");
+        }
+
+        private static string GetPackageVersionDirectory(string source, string packageId, string version)
+        {
+            return Path.Combine(source, packageId.ToLowerInvariant(), version);
         }
 
         private static void AssertRestoredPackageVersion(SimpleTestProjectContext project, string packageId, string expectedVersion)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetRestoreTests.cs
@@ -4714,5 +4714,71 @@ EndGlobal";
             var packageDirectory = Path.Combine(pathContext.UserPackagesFolder, packageId.ToLowerInvariant(), expectedVersion);
             Directory.Exists(packageDirectory).Should().BeTrue($"expected {packageId} {expectedVersion} to be in the global packages folder");
         }
+
+        [Fact]
+        public async Task DotnetRestore_FloatingVersionWithForceRestore_DowngradesWhenHigherVersionIsRemovedFromSource()
+        {
+            // Arrange
+            using SimpleTestPathContext pathContext = _dotnetFixture.CreateSimpleTestPathContext();
+
+            const string packageId = "TestPackage";
+            var package100 = new SimpleTestPackageContext(packageId, "1.0.0");
+            var package200 = new SimpleTestPackageContext(packageId, "2.0.0");
+
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(
+                pathContext.PackageSource,
+                PackageSaveMode.Defaultv3,
+                package100,
+                package200);
+
+            var projectA = SimpleTestProjectContext.CreateNETCore(
+                "projectA",
+                pathContext.SolutionRoot,
+                NuGetFramework.Parse("net8.0"));
+
+            var packageRef = new SimpleTestPackageContext(packageId, "1.0.0");
+            packageRef.Version = "*";
+            projectA.AddPackageToAllFrameworks(packageRef);
+            projectA.Properties.Add("RestoreSources", pathContext.PackageSource);
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            solution.Projects.Add(projectA);
+            solution.Create();
+
+            string arguments = $"restore projectA{Path.DirectorySeparatorChar}projectA.csproj";
+
+            _dotnetFixture.RunDotnetExpectSuccess(
+                pathContext.SolutionRoot,
+                arguments,
+                testOutputHelper: _testOutputHelper);
+
+            AssertRestoredPackageVersion(projectA, packageId, "2.0.0");
+            string higherVersionGlobalPackageDirectory = Path.Combine(pathContext.UserPackagesFolder, packageId.ToLowerInvariant(), "2.0.0");
+            Directory.Exists(higherVersionGlobalPackageDirectory).Should().BeTrue($"expected {packageId} 2.0.0 to be in the global packages folder");
+
+            Directory.Delete(Path.Combine(pathContext.PackageSource, packageId.ToLowerInvariant(), "2.0.0"), recursive: true);
+
+            // Act
+            _dotnetFixture.RunDotnetExpectSuccess(
+                pathContext.SolutionRoot,
+                arguments + " --force",
+                testOutputHelper: _testOutputHelper);
+
+            // Assert
+            AssertRestoredPackageVersion(projectA, packageId, "1.0.0");
+            string lowerVersionGlobalPackageDirectory = Path.Combine(pathContext.UserPackagesFolder, packageId.ToLowerInvariant(), "1.0.0");
+            Directory.Exists(lowerVersionGlobalPackageDirectory).Should().BeTrue($"expected {packageId} 1.0.0 to be in the global packages folder");
+            Directory.Exists(higherVersionGlobalPackageDirectory).Should().BeTrue($"expected {packageId} 2.0.0 to remain in the global packages folder");
+        }
+
+        private static void AssertRestoredPackageVersion(SimpleTestProjectContext project, string packageId, string expectedVersion)
+        {
+            string assetsFilePath = Path.Combine(Path.GetDirectoryName(project.ProjectPath), "obj", LockFileFormat.AssetsFileName);
+            LockFile assetsFile = new LockFileFormat().Read(assetsFilePath);
+            assetsFile.Libraries.Single(e => e.Name.Equals(packageId, StringComparison.OrdinalIgnoreCase))
+                .Version
+                .Should()
+                .Be(NuGetVersion.Parse(expectedVersion));
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
@@ -471,6 +471,64 @@ namespace NuGet.Commands.Test
             Assert.Equal(1, versionsHitCount);
         }
 
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task FindLibraryAsync_WhenLocalPackagesFolderAndMinVersionDoesNotExist_ReturnsNull(bool isGlobalPackagesFolder, bool isFallbackFolderSource)
+        {
+            // Arrange
+            var testLogger = new TestLogger();
+            var cacheContext = new SourceCacheContext();
+            var findResource = new Mock<FindPackageByIdResource>(MockBehavior.Strict);
+            var minVersion = NuGetVersion.Parse("1.0.0");
+
+            findResource.Setup(s => s.DoesPackageExistAsync(
+                    "x",
+                    minVersion,
+                    cacheContext,
+                    testLogger,
+                    CancellationToken.None))
+                .ReturnsAsync(false);
+
+            var source = new Mock<SourceRepository>();
+            source.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
+                .ReturnsAsync(findResource.Object);
+            source.SetupGet(s => s.PackageSource)
+                .Returns(new PackageSource("http://test/index.json"));
+
+            var libraryRange = new LibraryRange(
+                "x",
+                new VersionRange(minVersion),
+                LibraryDependencyTarget.Package);
+            var provider = new SourceRepositoryDependencyProvider(
+                source.Object,
+                testLogger,
+                cacheContext,
+                ignoreFailedSources: true,
+                ignoreWarning: true,
+                fileCache: null,
+                isGlobalPackagesFolder: isGlobalPackagesFolder,
+                isFallbackFolderSource: isFallbackFolderSource,
+                environmentVariableReader: EnvironmentVariableWrapper.Instance);
+
+            // Act
+            var library = await provider.FindLibraryAsync(
+                libraryRange,
+                NuGetFramework.Parse("net45"),
+                cacheContext,
+                testLogger,
+                CancellationToken.None);
+
+            // Assert
+            Assert.Null(library);
+            findResource.Verify(s => s.GetAllVersionsAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<SourceCacheContext>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
         [Fact]
         public async Task GetPackageDownloaderAsync_ThrowsForNullPackageIdentity()
         {
@@ -916,6 +974,7 @@ namespace NuGet.Commands.Test
                 ignoreFailedSources: true,
                 ignoreWarning: true,
                 fileCache: null,
+                isGlobalPackagesFolder: false,
                 isFallbackFolderSource: false,
                 new TestEnvironmentVariableReader(new Dictionary<string, string>()));
 
@@ -978,6 +1037,7 @@ namespace NuGet.Commands.Test
                 ignoreFailedSources: true,
                 ignoreWarning: true,
                 fileCache: null,
+                isGlobalPackagesFolder: false,
                 isFallbackFolderSource: false,
                 wrapper);
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14963
Fixes: https://github.com/NuGet/Home/issues/14974

## Description

Restore uses the same class for the global packages folder, fallback folders, and local package sources, to check if versions exist and get dependencies. For package sources, when an exact version match doesn't exist, it tries to find the next best version, and raise an NU1601 warning. However, when a fallback folder or global packages folder doesn't contain the exact version, it doesn't matter if a different version exists. There's no scenario where the version list from a fallback folder or global packages folder is used.

Therefore, when the location is a fallback folder or the global packages folder, don't fallback to scanning all versions when an exact version match is not found.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
