### PR TITLE
Disable OptProf in 7.6

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -3,6 +3,10 @@ parameters:
   displayName: Build bits for publishing
   type: boolean
   default: true
+- name: RunOptProf
+  displayName: Run optimization profiling
+  type: boolean
+  default: false
 - name: SigningType
   displayName: Type of signing to use
   type: string
@@ -54,5 +58,6 @@ extends:
       parameters:
         isOfficialBuild: true
         RunBuildForPublishing: ${{parameters.RunBuildForPublishing}}
+        RunOptProf: ${{ parameters.RunOptProf }}
         SigningType: ${{ parameters.SigningType }}
         TryRunOneLocBuild: true

--- a/eng/pipelines/optprof.yml
+++ b/eng/pipelines/optprof.yml
@@ -6,13 +6,7 @@ resources:
   pipelines:
   - pipeline: ComponentBuildUnderTest
     source: NuGet.Client-Official
-    trigger:
-      branches:
-        include:
-        - dev
-        - release-6.14.x
-        - release-6.12.x
-        - release-5.11.x
+    trigger: none
   - pipeline: DartLab
     source: DartLab
     branch: main

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -10,6 +10,10 @@ parameters:
   displayName: Build bits for publishing
   type: boolean
   default: true
+- name: RunOptProf
+  displayName: Run optimization profiling
+  type: boolean
+  default: false
 - name: SigningType
   displayName: Type of signing to use
   type: string
@@ -100,7 +104,7 @@ stages:
         swix:
           enabled: true
         optprof:
-          enabled: ${{ variables['isOfficialBuild'] }}
+          enabled: ${{ parameters.RunOptProf }}
           OptimizationInputsLookupMethod: DropPrefix
           DropNamePrefix: OptimizationInputs/$(System.TeamProject)/$(Build.Repository.Name)
           ShouldSkipOptimize: $(ShouldSkipOptimize)
@@ -143,15 +147,16 @@ stages:
         dropMetadataContainerName: 'DropMetadata-TestGate'
         codeSignValidationEnabled: false
 
-      - output: artifactsDrop
-        displayName: 'OptProfV2:  publish profiling inputs to artifact services'
-        condition: "and(succeeded(), eq(variables['IsOfficialBuild'], 'true'))"
-        dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: '$(ProfilingInputsDropName)'
-        sourcePath: '$(Build.StagingDirectory)\OptProf\ProfilingInputs'
-        toLowerCase: false
-        usePat: true
-        dropMetadataContainerName: 'DropMetadata-ProfilingInputs'
+      - ${{ if eq(parameters.RunOptProf, true) }}:
+        - output: artifactsDrop
+          displayName: 'OptProfV2:  publish profiling inputs to artifact services'
+          condition: "succeeded()"
+          dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+          buildNumber: '$(ProfilingInputsDropName)'
+          sourcePath: '$(Build.StagingDirectory)\OptProf\ProfilingInputs'
+          toLowerCase: false
+          usePat: true
+          dropMetadataContainerName: 'DropMetadata-ProfilingInputs'
 
       - output: pipelineArtifact
         displayName: 'Publish NuGet.exe and VSIX as artifact'


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3872

## Description

The corresponding version of VS is out of support, so VS infrastructure, like OptProf, no longer work and is currently breaking our builds.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
