### PR TITLE
Fix ConcurrencyUtilities base path reset race

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -243,16 +243,19 @@ namespace NuGet.Common
         {
             get
             {
-                if (_basePath != null)
+                string? basePath = _basePath;
+                if (basePath != null)
                 {
-                    return _basePath;
+                    return basePath;
                 }
 
-                _basePath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), "lock");
+                basePath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), "lock");
 
-                Directory.CreateDirectory(_basePath);
+                Directory.CreateDirectory(basePath);
 
-                return _basePath;
+                _basePath = basePath;
+
+                return basePath;
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/ConcurrencyUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/ConcurrencyUtilitiesTests.cs
@@ -155,14 +155,14 @@ namespace NuGet.Core.FuncTest
             {
                 Func<int, Task<bool>> lockAsync = _ => ConcurrencyUtilities.ExecuteWithFileLockedAsync(
                     path,
-                    token => Task.FromResult(!token.IsCancellationRequested),
+                    _ => Task.FromResult(true),
                     CancellationToken.None);
 
                 // Act
                 var results = await Task.WhenAll(Enumerable.Range(0, 200).Select(lockAsync));
 
-                // Assert
-                Assert.DoesNotContain(false, results);
+                // Assert that all lock tasks completed; Task.WhenAll throws if the concurrent reset causes the lock to fail.
+                Assert.Equal(200, results.Length);
             }
             finally
             {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/ConcurrencyUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/ConcurrencyUtilitiesTests.cs
@@ -130,6 +130,48 @@ namespace NuGet.Core.FuncTest
         }
 
         [Fact]
+        public async Task ExecuteWithFileLockedAsync_WhenStaticStateIsResetConcurrently_DoesNotThrow()
+        {
+            // Arrange
+            using var testDirectory = TestDirectory.Create();
+            using var resetCancellationTokenSource = new CancellationTokenSource();
+
+            var path = Path.Combine(testDirectory, nameof(ExecuteWithFileLockedAsync_WhenStaticStateIsResetConcurrently_DoesNotThrow));
+
+            await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
+                path,
+                _ => Task.FromResult(true),
+                CancellationToken.None);
+
+            Task resetTask = Task.Run(() =>
+            {
+                while (!resetCancellationTokenSource.IsCancellationRequested)
+                {
+                    StaticState.RaiseStartMSBuildRestoreTasks();
+                }
+            });
+
+            try
+            {
+                Func<int, Task<bool>> lockAsync = _ => ConcurrencyUtilities.ExecuteWithFileLockedAsync(
+                    path,
+                    token => Task.FromResult(!token.IsCancellationRequested),
+                    CancellationToken.None);
+
+                // Act
+                var results = await Task.WhenAll(Enumerable.Range(0, 200).Select(lockAsync));
+
+                // Assert
+                Assert.DoesNotContain(false, results);
+            }
+            finally
+            {
+                resetCancellationTokenSource.Cancel();
+                await resetTask;
+            }
+        }
+
+        [Fact]
         public async Task ConcurrencyUtilities_LockAllCasings()
         {
             // Arrange


### PR DESCRIPTION
# Bug

Fixes: race condition introduced by https://github.com/NuGet/NuGet.Client/pull/7507

## Description

https://github.com/NuGet/NuGet.Client/pull/7507 introduced a `StaticState` class, used during a restore target run to reset many static variables used by restore, so that `RestoreTask` can run in a reusable MSBuild server process. This has led to the test `ConcurrencyUtilities_LockStress ` failing in some CI runs, when `StaticStateTests` run in parallel.

It's not a likely scenario in production use, but in theory if an MSBuild server is being re-used in multi-threaded mode, and something triggers a restore, this NullReferenceException could happen. Mostly this PR will just make our CI more reliable.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~