### PR TITLE
fix: address regression in runTests.ps1 caused by missing definitions

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -299,6 +299,13 @@ Function Test-BuildEnvironment {
     }
 }
 
+Function Get-BuildNumber() {
+    $NuGetEpoch = '2010-08-29T23:58:25-07:00' # NuGet client first commit!
+    # Build number is a 16-bit integer. The limitation is imposed by VERSIONINFO.
+    # https://msdn.microsoft.com/en-gb/library/aa381058.aspx
+    [uint16]((((Get-Date) - (Get-Date $NuGetEpoch)).TotalMinutes / 5) % [uint16]::MaxValue)
+}
+
 Function Install-ProcDump {
     [CmdletBinding()]
     param()

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -299,13 +299,6 @@ Function Test-BuildEnvironment {
     }
 }
 
-Function Get-BuildNumber() {
-    $NuGetEpoch = '2010-08-29T23:58:25-07:00' # NuGet client first commit!
-    # Build number is a 16-bit integer. The limitation is imposed by VERSIONINFO.
-    # https://msdn.microsoft.com/en-gb/library/aa381058.aspx
-    [uint16]((((Get-Date) - (Get-Date $NuGetEpoch)).TotalMinutes / 5) % [uint16]::MaxValue)
-}
-
 Function Install-ProcDump {
     [CmdletBinding()]
     param()

--- a/runTests.ps1
+++ b/runTests.ps1
@@ -62,8 +62,9 @@ Write-Host ("`r`n" * 3)
 Trace-Log ('=' * 60)
 
 $startTime = [DateTime]::UtcNow
-if (-not $BuildNumber) {
-    $BuildNumber = Get-BuildNumber
+$pBuildNumber =""
+if ($BuildNumber) {
+    $pBuildNumber = "/p:BuildNumber=$BuildNumber"
 }
 
 Invoke-BuildStep 'Installing .NET CLI for tests' {
@@ -90,7 +91,7 @@ Invoke-BuildStep 'Cleaning package cache' {
 
 Invoke-BuildStep 'Running /t:RestoreVS' {
 
-    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1
+    & $MSBuildExe build\build.proj /t:RestoreVS /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel $pBuildNumber /v:m /m:1
 
     if (-not $?)
     {
@@ -104,7 +105,7 @@ Invoke-BuildStep 'Running /t:RestoreVS' {
 
 Invoke-BuildStep 'Running /t:CoreFuncTests' {
 
-    & $MSBuildExe build\build.proj /t:CoreFuncTests /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1
+    & $MSBuildExe build\build.proj /t:CoreFuncTests /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel $pBuildNumber /v:m /m:1
 
     if (-not $?)
     {

--- a/runTests.ps1
+++ b/runTests.ps1
@@ -74,8 +74,9 @@ Trace-Log "Test suite run #$BuildNumber started at $startTime"
 
 Test-BuildEnvironment -CI:$CI
 
-if (-not $VSToolsetInstalled) {
-    Warning-Log "The build is requested, but no toolset is available"
+$MSBuildExe = Get-MSBuildExe
+if(-not $MSBuildExe){
+    Warning-Log "The build is requested, but no MSBuild is available"
     exit 1
 }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  [Nuget/Home#15003](https://github.com/NuGet/Home/issues/15003)

## Description

Fixes a regression that prevents `runTests.ps1` from running successfully when following the steps documented in `CONTRIBUTING.md`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
