### PR TITLE
Fix culture-dependent test failures by setting en-US culture

### DIFF
--- a/build/TestShared/ModuleInitializerAttribute.cs
+++ b/build/TestShared/ModuleInitializerAttribute.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if ! NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    [System.AttributeUsage(System.AttributeTargets.Method, Inherited = false)]
+    sealed class ModuleInitializerAttribute : Attribute
+    {
+    }
+}
+#endif

--- a/build/TestShared/ThreadCulture.cs
+++ b/build/TestShared/ThreadCulture.cs
@@ -1,15 +1,24 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Globalization;
+using System.Threading;
+
 internal static class CommonThreadCultureModule
 {
     [System.Runtime.CompilerServices.ModuleInitializer]
     public static void Initialize()
     {
-        var enus = System.Globalization.CultureInfo.GetCultureInfo("en-us");
-        System.Globalization.CultureInfo.DefaultThreadCurrentCulture = enus;
-        System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = enus;
-        System.Threading.Thread.CurrentThread.CurrentCulture = enus;
-        System.Threading.Thread.CurrentThread.CurrentUICulture = enus;
+        var enus = CultureInfo.GetCultureInfo("en-us");
+        if (enus.LCID != CultureInfo.DefaultThreadCurrentCulture?.LCID)
+        {
+            CultureInfo.DefaultThreadCurrentCulture = enus;
+            CultureInfo.DefaultThreadCurrentUICulture = enus;
+        }
+        if (enus.LCID != Thread.CurrentThread.CurrentCulture.LCID)
+        {
+            Thread.CurrentThread.CurrentCulture = enus;
+            Thread.CurrentThread.CurrentUICulture = enus;
+        }
     }
 }

--- a/build/TestShared/ThreadCulture.cs
+++ b/build/TestShared/ThreadCulture.cs
@@ -10,15 +10,9 @@ internal static class CommonThreadCultureModule
     public static void Initialize()
     {
         var enus = CultureInfo.GetCultureInfo("en-us");
-        if (enus.LCID != CultureInfo.DefaultThreadCurrentCulture?.LCID)
-        {
-            CultureInfo.DefaultThreadCurrentCulture = enus;
-            CultureInfo.DefaultThreadCurrentUICulture = enus;
-        }
-        if (enus.LCID != Thread.CurrentThread.CurrentCulture.LCID)
-        {
-            Thread.CurrentThread.CurrentCulture = enus;
-            Thread.CurrentThread.CurrentUICulture = enus;
-        }
+        CultureInfo.DefaultThreadCurrentCulture = enus;
+        CultureInfo.DefaultThreadCurrentUICulture = enus;
+        Thread.CurrentThread.CurrentCulture = enus;
+        Thread.CurrentThread.CurrentUICulture = enus;
     }
 }

--- a/build/TestShared/ThreadCulture.cs
+++ b/build/TestShared/ThreadCulture.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+internal static class CommonThreadCultureModule
+{
+    [System.Runtime.CompilerServices.ModuleInitializer]
+    public static void Initialize()
+    {
+        var enus = System.Globalization.CultureInfo.GetCultureInfo("en-us");
+        System.Globalization.CultureInfo.DefaultThreadCurrentCulture = enus;
+        System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = enus;
+        System.Threading.Thread.CurrentThread.CurrentCulture = enus;
+        System.Threading.Thread.CurrentThread.CurrentUICulture = enus;
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
-    <SkipShared>true</SkipShared>
     <Description>Unit and integration tests for NuGet.VisualStudio.Implementation.</Description>
   </PropertyGroup>
 

--- a/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/ChildProcess/CommandRunner.cs
+++ b/test/TestUtilities/Microsoft.Internal.NuGet.Testing.SignedPackages/ChildProcess/CommandRunner.cs
@@ -6,8 +6,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Threading;
 using Xunit.Abstractions;
 
 namespace Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess
@@ -71,6 +73,11 @@ namespace Microsoft.Internal.NuGet.Testing.SignedPackages.ChildProcess
                     process.StartInfo.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = bool.TrueString;
                     process.StartInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = bool.TrueString;
                     process.StartInfo.Environment["SuppressNETCoreSdkPreviewMessage"] = bool.TrueString;
+
+                    // inherit culture for output messages
+                    var culture = (CultureInfo.CurrentCulture ?? Thread.CurrentThread.CurrentCulture).IetfLanguageTag;
+                    process.StartInfo.Environment["DOTNET_CLI_UI_LANGUAGE"] = culture;
+                    process.StartInfo.Environment["NUGET_CLI_LANGUAGE"] = culture;
 
                     if (environmentVariables != null)
                     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:  [Nuget/Home#15004](https://github.com/NuGet/Home/issues/15004)

## Description

This PR ensures that tests run under the `en-US` culture by default.

Many existing tests contain assertions that compare localized messages against English-language expected values. Running the test suite under a non-English culture can therefore cause unrelated test failures.

By setting the test culture to `en-US`, test results become consistent across different environments and system locales.


### Note

This PR removes the `SkipShared` setting from `NuGet.VisualStudio.Implementation.Test.csproj`.

I could not determine why `SkipShared` was configured for this project. Other test projects in the solution do not use this setting, and removing it is necessary for the proposed culture configuration to be applied consistently.

However, since I do not know the original reason for this project-specific setting, this change may be unintended.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.

---
## Update

I understand that `UseCultureAttribute` can be applied to individual tests to address culture-related failures. However, the scale of the problem is much larger. On my machine, simply running: `.\build.ps1 -RunUnitTests` results in more than 440 test failures under a non-English culture.

Since -RunUnitTests executes only the unit tests, I would expect the number of failures to be even higher when running the full test suite via: PowerShell1.\runTests.ps1

I cannot provide an exact number that running on CI because much of the full test suite is intended to run on dedicated CI machines and is not readily executable by external contributors.

While it is theoretically possible to fix these failures by adding UseCultureAttribute to each affected test, doing so would require a significant amount of work and would be difficult to maintain over time.
More importantly, the current situation demonstrates that relying on individual developers to remember to apply UseCultureAttribute is not a reliable solution. There are already many tests that contain culture-dependent assertions without the attribute, and it is likely that future tests will continue to be added without it.
The goal of this PR is to address the issue at the test framework level by providing a consistent culture for all test executions. This allows existing tests to pass without requiring hundreds of individual modifications and helps prevent similar issues from being introduced in the future.

## Update 2

I found another issue with the suggestion of simply applying `UseCultureAttribute` to the affected tests.

For example:

https://github.com/NuGet/NuGet.Client/blob/069976ebc8ea515c838b896885480319a0f63e14/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs#L51-L78

This test invokes `nuget.exe` and validates its output by comparing the resulting strings.

Even if `UseCultureAttribute` is applied to the test method, the attribute only affects the test process itself. The spawned `nuget.exe` process still runs using the operating system's culture settings. As a result, any localized messages produced by `nuget.exe` may differ from the English strings expected by the test.

In other words, applying `UseCultureAttribute` to the test method does not necessarily guarantee that child processes use the same culture. Tests that validate the output of external processes can still fail under non-English system cultures.
