### PR TITLE
Relax flaky assertion in MsbuildRestore_StaticGraphEvaluation_HandlesInvalidProjectFileException (#7555)

### DIFF
--- a/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
+++ b/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildRestoreTaskTests.cs
@@ -843,7 +843,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 // Assert
                 Assert.True(result.ExitCode == 1, result.AllOutput);
 
-                result.AllOutput.Should().Contain($"error MSB4025: The project file could not be loaded. Could not find file '{projectB.ProjectPath}'");
+                result.AllOutput.Should().Contain($"error MSB4025: The project file");
             }
         }
 


### PR DESCRIPTION
# Bug

<!-- This is an engineering / test-only change, so no NuGet/Home issue is required per the PR template. -->
Fixes: N/A (engineering / test-only change)

## Description

Cherry-pick of #7555 onto `release/7.9.x`.

`MsbuildRestore_StaticGraphEvaluation_HandlesInvalidProjectFileException` is flaky on the release branch: it asserted on the full MSB4025 message including the project path, whose exact shape varies by MSBuild version, so it fails intermittently in CI (observed on the `release/7.9.x` build for the #7581 merge). This relaxes the assertion to the stable `error MSB4025: The project file` prefix, which still verifies the invalid-project-file error is surfaced.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
  - Engineering / test-only change — no issue required per the template.
- [x] Added tests
  - Test-only change; relaxes an assertion in an existing test (came along with the cherry-pick).
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
  - N/A
