### PR TITLE
Don't use SatisfyImportsOnce for NuGetSolutionManagerService

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSolutionManagerService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/NuGetSolutionManagerService.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
@@ -21,8 +20,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private readonly IServiceBroker _serviceBroker;
         private readonly AuthorizationServiceClient _authorizationServiceClient;
 
-        [Import]
-        private IVsSolutionManager SolutionManager { get; set; } = null!;
+        private IVsSolutionManager SolutionManager { get; }
 
         public event EventHandler<string>? AfterNuGetCacheUpdated;
         public event EventHandler<IProjectContextInfo>? AfterProjectRenamed;
@@ -35,18 +33,16 @@ namespace NuGet.PackageManagement.VisualStudio
             ServiceActivationOptions options,
             IServiceBroker sb,
             AuthorizationServiceClient ac,
-            IComponentModel componentModel)
+            IVsSolutionManager solutionManager)
         {
             Assumes.NotNull(sb);
             Assumes.NotNull(ac);
+            Assumes.NotNull(solutionManager);
 
             _options = options;
             _serviceBroker = sb;
             _authorizationServiceClient = ac;
-
-            componentModel.DefaultCompositionService.SatisfyImportsOnce(this);
-
-            Assumes.NotNull(SolutionManager);
+            SolutionManager = solutionManager;
 
             RegisterEventHandlers();
         }
@@ -66,7 +62,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
             Assumes.NotNull(componentModel);
 
-            return new NuGetSolutionManagerService(options, sb, ac, componentModel);
+            var solutionManager = componentModel.GetService<IVsSolutionManager>();
+            var solutionManagerService = new NuGetSolutionManagerService(options, sb, ac, solutionManager);
+            return solutionManagerService;
         }
 
         public void Dispose()


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: follow VS guidelines, possible minor perf win

## Description

Our internal VS perf guidelines say not to use `SatisfyImportsOnce`: https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/51933/%E2%9D%8C-DO-NOT-call-ICompositionService.SatisfyImportsOnce

So, switch it to use `GetService<T>` instead. 

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ minor refactor, no funcional changes. No existing unit tests, and uses static `ServiceLocator`, making it hard to mock. Tested manually, putting a breakpoint in the code path to ensure that it runs. Apex tests open PM UI, which also tests this code path.
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
