### PR TITLE
Enable nullable for NuGet.Protocol V2Feed leaves, and trivial V3 metadata leaves

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Extensions/FactoryExtensionsVS.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Extensions/FactoryExtensionsVS.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using NuGet.Protocol.Core.Types;

--- a/src/NuGet.Core/NuGet.Protocol/FactoryExtensionsV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/FactoryExtensionsV3.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using NuGet.Configuration;

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -22,14 +20,14 @@ namespace NuGet.Protocol
     {
         private readonly HttpSource _httpSource;
         private readonly Uri _baseUri;
-        private readonly IEnvironmentVariableReader _environmentVariableReader;
+        private readonly IEnvironmentVariableReader? _environmentVariableReader;
 
         public AutoCompleteResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource)
             : this(httpSourceResource, baseAddress, packageSource, environmentVariableReader: null)
         {
         }
 
-        internal AutoCompleteResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource, IEnvironmentVariableReader environmentVariableReader)
+        internal AutoCompleteResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource, IEnvironmentVariableReader? environmentVariableReader)
         {
             if (httpSourceResource == null)
             {
@@ -93,8 +91,13 @@ namespace NuGet.Protocol
                     new HttpSourceRequest(apiEndpointUri, logger),
                     async stream =>
                     {
-                        var seekableStream = await stream.AsSeekableStreamAsync(token);
-                        return await System.Text.Json.JsonSerializer.DeserializeAsync(seekableStream, JsonContext.Default.StringArray, token);
+                        if (stream == null)
+                        {
+                            return Array.Empty<string>();
+                        }
+
+                        var seekableStream = (await stream.AsSeekableStreamAsync(token))!;
+                        return await System.Text.Json.JsonSerializer.DeserializeAsync(seekableStream, JsonContext.Default.StringArray, token) ?? Array.Empty<string>();
                     },
                     logger,
                     token);
@@ -105,18 +108,23 @@ namespace NuGet.Protocol
                     new HttpSourceRequest(apiEndpointUri, logger),
                     async stream =>
                     {
+                        if (stream == null)
+                        {
+                            return Array.Empty<string>();
+                        }
+
                         if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
                         {
-                            var seekableStream = await stream.AsSeekableStreamAsync(token);
-                            return await System.Text.Json.JsonSerializer.DeserializeAsync(seekableStream, JsonContext.Default.StringArray, token);
+                            var seekableStream = (await stream.AsSeekableStreamAsync(token))!;
+                            return await System.Text.Json.JsonSerializer.DeserializeAsync(seekableStream, JsonContext.Default.StringArray, token) ?? Array.Empty<string>();
                         }
                         else
                         {
-                            using var reader = new StreamReader(await stream.AsSeekableStreamAsync(token));
+                            using var reader = new StreamReader((await stream.AsSeekableStreamAsync(token))!);
                             using var jsonReader = new JsonTextReader(reader);
 #pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
                             var serializer = Newtonsoft.Json.JsonSerializer.Create();
-                            return serializer.Deserialize<string[]>(jsonReader);
+                            return serializer.Deserialize<string[]>(jsonReader) ?? Array.Empty<string>();
 #pragma warning restore IL2026, IL3050
                         }
                     },

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2FeedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2FeedProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,20 +18,22 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            AutoCompleteResourceV2Feed resource = null;
+            AutoCompleteResourceV2Feed? resource = null;
 
             if (await source.GetFeedType(token) == FeedType.HttpV2)
             {
-                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
+                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(ODataServiceDocumentResourceV2)}.");
 
-                var httpSource = await source.GetResourceAsync<HttpSourceResource>(token);
+                var httpSource = await source.GetResourceAsync<HttpSourceResource>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
 
                 resource = new AutoCompleteResourceV2Feed(httpSource, serviceDocument.BaseAddress, source.PackageSource);
             }
 
-            return new Tuple<bool, INuGetResource>(resource != null, resource);
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DependencyInfoResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DependencyInfoResourceV2Feed.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -34,7 +32,7 @@ namespace NuGet.Protocol
             _source = source;
         }
 
-        public override async Task<SourcePackageDependencyInfo> ResolvePackage(
+        public override async Task<SourcePackageDependencyInfo?> ResolvePackage(
             PackageIdentity package,
             NuGetFramework projectFramework,
             SourceCacheContext sourceCacheContext,
@@ -122,7 +120,7 @@ namespace NuGet.Protocol
                 deps,
                 packageVersion.IsListed,
                 _source,
-                new Uri(packageVersion.DownloadUrl),
+                packageVersion.DownloadUrl != null ? new Uri(packageVersion.DownloadUrl) : null,
                 packageVersion.PackageHash);
 
             return result;

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DependencyInfoResourceV2FeedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DependencyInfoResourceV2FeedProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,21 +15,23 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            DependencyInfoResource resource = null;
+            DependencyInfoResource? resource = null;
 
             if (await source.GetFeedType(token) == FeedType.HttpV2)
             {
-                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
+                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(ODataServiceDocumentResourceV2)}.");
 
-                var httpSource = await source.GetResourceAsync<HttpSourceResource>(token);
+                var httpSource = await source.GetResourceAsync<HttpSourceResource>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
                 var parser = new V2FeedParser(httpSource.HttpSource, serviceDocument.BaseAddress, source.PackageSource.Source);
 
                 resource = new DependencyInfoResourceV2Feed(parser, source);
             }
 
-            return new Tuple<bool, INuGetResource>(resource != null, resource);
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DownloadResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DownloadResourceV2Feed.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -22,7 +20,7 @@ namespace NuGet.Protocol
 
         [Obsolete("Use constructor with source parameter")]
         public DownloadResourceV2Feed(V2FeedParser feedParser)
-            : this(feedParser, source: null)
+            : this(feedParser, source: string.Empty)
         {
         }
 
@@ -65,12 +63,10 @@ namespace NuGet.Protocol
                 token.ThrowIfCancellationRequested();
 
                 var sourcePackage = identity as SourcePackageDependencyInfo;
-                bool isFromUri = sourcePackage?.PackageHash != null
-                                && sourcePackage?.DownloadUri != null;
 
                 try
                 {
-                    if (isFromUri)
+                    if (sourcePackage?.PackageHash != null && sourcePackage.DownloadUri != null)
                     {
                         // If this is a SourcePackageDependencyInfo object with everything populated
                         // and it is from an online source, use the machine cache and download it using the

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DownloadResourceV2FeedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DownloadResourceV2FeedProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,21 +15,23 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            DownloadResource resource = null;
+            DownloadResource? resource = null;
 
             if (await source.GetFeedType(token) == FeedType.HttpV2)
             {
-                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
+                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(ODataServiceDocumentResourceV2)}.");
 
-                var httpSource = await source.GetResourceAsync<HttpSourceResource>(token);
+                var httpSource = await source.GetResourceAsync<HttpSourceResource>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
                 var parser = new V2FeedParser(httpSource.HttpSource, serviceDocument.BaseAddress, source.PackageSource.Source);
 
                 resource = new DownloadResourceV2Feed(parser, source.PackageSource.Source);
             }
 
-            return new Tuple<bool, INuGetResource>(resource != null, resource);
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/LegacyFeedCapabilityResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/LegacyFeedCapabilityResourceV2Feed.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -69,7 +67,7 @@ namespace NuGet.Protocol
                 SupportsSearch = true
             };
 
-            XDocument document;
+            XDocument? document;
             try
             {
                 document = await _feedParser.LoadXmlAsync(
@@ -80,15 +78,21 @@ namespace NuGet.Protocol
                     log: log,
                     token: token);
 
-                var metadata = DataServiceMetadataExtractor.Extract(document);
+                if (document != null)
+                {
+                    var metadata = DataServiceMetadataExtractor.Extract(document);
 
-                capabilities.SupportsIsAbsoluteLatestVersion = metadata
-                    .SupportedProperties
-                    .Contains("IsAbsoluteLatestVersion");
+                    if (metadata != null)
+                    {
+                        capabilities.SupportsIsAbsoluteLatestVersion = metadata
+                            .SupportedProperties
+                            .Contains("IsAbsoluteLatestVersion");
 
-                capabilities.SupportsSearch = metadata
-                    .SupportedMethodNames
-                    .Contains("Search");
+                        capabilities.SupportsSearch = metadata
+                            .SupportedMethodNames
+                            .Contains("Search");
+                    }
+                }
             }
             catch
             {
@@ -100,16 +104,16 @@ namespace NuGet.Protocol
 
         private class Capabilities
         {
-            public string MetadataUri { get; set; }
+            public string? MetadataUri { get; set; }
             public bool SupportsIsAbsoluteLatestVersion { get; set; }
             public bool SupportsSearch { get; set; }
         }
 
         private class DataServiceMetadata
         {
-            public HashSet<string> SupportedMethodNames { get; set; }
+            public HashSet<string> SupportedMethodNames { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            public HashSet<string> SupportedProperties { get; set; }
+            public HashSet<string> SupportedProperties { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -117,7 +121,7 @@ namespace NuGet.Protocol
         /// </summary>
         private static class DataServiceMetadataExtractor
         {
-            public static DataServiceMetadata Extract(XDocument schemaDocument)
+            public static DataServiceMetadata? Extract(XDocument schemaDocument)
             {
                 // Get all entity containers
                 var entityContainers = from e in schemaDocument.Descendants()
@@ -127,7 +131,7 @@ namespace NuGet.Protocol
                 // Find the entity container with the Packages entity set
                 var result = (from e in entityContainers
                               let entitySet = e.Elements().FirstOrDefault(el => el.Name.LocalName == "EntitySet")
-                              let name = entitySet != null ? entitySet.Attribute("Name").Value : null
+                              let name = entitySet != null ? entitySet.Attribute("Name")?.Value : null
                               where name != null && name.Equals("Packages", StringComparison.OrdinalIgnoreCase)
                               select new { Container = e, EntitySet = entitySet }).FirstOrDefault();
 
@@ -137,9 +141,9 @@ namespace NuGet.Protocol
                 }
 
                 var packageEntityContainer = result.Container;
-                var packageEntityTypeAttribute = result.EntitySet.Attribute("EntityType");
+                var packageEntityTypeAttribute = result.EntitySet?.Attribute("EntityType");
 
-                string packageEntityName = null;
+                string? packageEntityName = null;
                 if (packageEntityTypeAttribute != null)
                 {
                     packageEntityName = packageEntityTypeAttribute.Value;
@@ -148,7 +152,7 @@ namespace NuGet.Protocol
                 var methodNames =
                     from e in packageEntityContainer.Elements()
                     where e.Name.LocalName == "FunctionImport"
-                    select e.Attribute("Name").Value;
+                    select e.Attribute("Name")!.Value;
 
                 var metadata = new DataServiceMetadata
                 {
@@ -166,7 +170,7 @@ namespace NuGet.Protocol
 
             private static IEnumerable<string> ExtractSupportedProperties(
                 XDocument schemaDocument,
-                string packageEntityName)
+                string? packageEntityName)
             {
                 packageEntityName = TrimNamespace(packageEntityName);
 
@@ -182,14 +186,19 @@ namespace NuGet.Protocol
                 {
                     return from e in packageEntity.Elements()
                            where e.Name.LocalName == "Property"
-                           select e.Attribute("Name").Value;
+                           select e.Attribute("Name")!.Value;
                 }
 
                 return Enumerable.Empty<string>();
             }
 
-            private static string TrimNamespace(string packageEntityName)
+            private static string? TrimNamespace(string? packageEntityName)
             {
+                if (packageEntityName == null)
+                {
+                    return null;
+                }
+
                 var lastIndex = packageEntityName.LastIndexOf('.');
                 if (lastIndex > 0 && lastIndex < packageEntityName.Length)
                 {

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/PackageSearchResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/PackageSearchResourceV2Feed.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/PackageSearchResourceV2FeedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/PackageSearchResourceV2FeedProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,21 +15,23 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source,
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source,
                                                                           CancellationToken token)
         {
-            PackageSearchResourceV2Feed resource = null;
+            PackageSearchResourceV2Feed? resource = null;
 
             if (await source.GetFeedType(token) == FeedType.HttpV2)
             {
-                var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
+                var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
 
-                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
+                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(ODataServiceDocumentResourceV2)}.");
 
                 resource = new PackageSearchResourceV2Feed(httpSourceResource, serviceDocument.BaseAddress, source.PackageSource);
             }
 
-            return new Tuple<bool, INuGetResource>(resource != null, resource);
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedListResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedListResource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -38,7 +36,7 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             var isSearchSupported = await _feedCapabilities.SupportsSearchAsync(logger, token);
-            SearchFilter filter = null;
+            SearchFilter? filter = null;
             if (isSearchSupported)
             {
                 if (allVersions)
@@ -158,8 +156,8 @@ internal class EnumeratorAsync : IEnumeratorAsync<IPackageSearchMetadata>
     private readonly bool _allVersions;
 
 
-    private IEnumerator<IPackageSearchMetadata> _currentEnumerator;
-    private V2FeedPage _currentPage;
+    private IEnumerator<IPackageSearchMetadata>? _currentEnumerator;
+    private V2FeedPage? _currentPage;
 
     public EnumeratorAsync(IV2FeedParser feedParser, string searchTerm, SearchFilter filter, int skip, int take, bool isSearchAvailable, bool allVersions,
         ILogger logger, CancellationToken token)
@@ -179,7 +177,7 @@ internal class EnumeratorAsync : IEnumeratorAsync<IPackageSearchMetadata>
     {
         get
         {
-            return _currentEnumerator?.Current;
+            return _currentEnumerator!.Current;
         }
     }
 
@@ -218,7 +216,7 @@ internal class EnumeratorAsync : IEnumeratorAsync<IPackageSearchMetadata>
         }
         else
         {
-            if (!_currentEnumerator.MoveNext())
+            if (!_currentEnumerator!.MoveNext())
             {
                 if (_currentPage.Items.Count != _take) // Last page not filled completely, no more pages left
                 {

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedListResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedListResourceProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,14 +18,15 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source,
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source,
             CancellationToken token)
         {
-            ListResource resource = null;
+            ListResource? resource = null;
 
             if (await source.GetFeedType(token) == FeedType.HttpV2)
             {
-                var httpSource = await source.GetResourceAsync<HttpSourceResource>(token);
+                var httpSource = await source.GetResourceAsync<HttpSourceResource>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
 
                 var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
                 if (serviceDocument != null)
@@ -39,7 +38,7 @@ namespace NuGet.Protocol
                     resource = new V2FeedListResource(parser, feedCapabilityResource, serviceDocument.BaseAddress);
                 }
             }
-            return new Tuple<bool, INuGetResource>(resource != null, resource);
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedParser.cs
@@ -517,7 +517,7 @@ namespace NuGet.Protocol
 
         internal async Task<XDocument?> LoadXmlAsync(
             string uri,
-            string cacheKey,
+            string? cacheKey,
             bool ignoreNotFounds,
             SourceCacheContext? sourceCacheContext,
             ILogger log,

--- a/src/NuGet.Core/NuGet.Protocol/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalPackageArchiveDownloader.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using System.IO;
@@ -28,7 +26,7 @@ namespace NuGet.Protocol
         private readonly PackageIdentity _packageIdentity;
         private Lazy<PackageArchiveReader> _packageReader;
         private Lazy<FileStream> _sourceStream;
-        private SemaphoreSlim _throttle;
+        private SemaphoreSlim? _throttle;
 
         /// <summary>
         /// Gets an asynchronous package content reader.
@@ -83,6 +81,11 @@ namespace NuGet.Protocol
         /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" />
         /// is <see langword="null" />.</exception>
+        /// <remarks>
+        /// NULL_INC: <paramref name="source" /> is annotated as non-null but no runtime check is
+        /// enforced in the constructor to avoid introducing a new throw in a previously-permissive
+        /// code path. Revisit with telemetry to confirm callers never pass null.
+        /// </remarks>
         public LocalPackageArchiveDownloader(
             string source,
             string packageFilePath,
@@ -267,7 +270,7 @@ namespace NuGet.Protocol
         /// Sets a throttle for package downloads.
         /// </summary>
         /// <param name="throttle">A throttle.  Can be <see langword="null" />.</param>
-        public void SetThrottle(SemaphoreSlim throttle)
+        public void SetThrottle(SemaphoreSlim? throttle)
         {
             _throttle = throttle;
         }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/FeedTypeResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/FeedTypeResourceProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -27,9 +25,9 @@ namespace NuGet.Protocol
         {
         }
 
-        public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            FeedTypeResource curResource = null;
+            FeedTypeResource? curResource = null;
 
             if (source.FeedTypeOverride == FeedType.Undefined)
             {
@@ -62,7 +60,7 @@ namespace NuGet.Protocol
                 curResource = new FeedTypeResource(source.FeedTypeOverride);
             }
 
-            return Task.FromResult(new Tuple<bool, INuGetResource>(curResource != null, curResource));
+            return Task.FromResult(new Tuple<bool, INuGetResource?>(curResource != null, curResource));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/MetadataResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/MetadataResourceV3Provider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,9 +17,9 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            MetadataResourceV3 curResource = null;
+            MetadataResourceV3? curResource = null;
             var regResource = await source.GetResourceAsync<RegistrationResourceV3>(token);
 
             if (regResource != null)
@@ -29,7 +27,7 @@ namespace NuGet.Protocol
                 curResource = new MetadataResourceV3(regResource);
             }
 
-            return new Tuple<bool, INuGetResource>(curResource != null, curResource);
+            return new Tuple<bool, INuGetResource?>(curResource != null, curResource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageDetailsUriResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageDetailsUriResourceV3Provider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,9 +17,9 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            PackageDetailsUriResourceV3 resource = null;
+            PackageDetailsUriResourceV3? resource = null;
             var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
             if (serviceIndex != null)
             {
@@ -29,7 +27,7 @@ namespace NuGet.Protocol
                 resource = PackageDetailsUriResourceV3.CreateOrNull(uri?.OriginalString);
             }
 
-            return new Tuple<bool, INuGetResource>(resource != null, resource);
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ReportAbuseResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ReportAbuseResourceV3Provider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,9 +17,9 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            ReportAbuseResourceV3 resource = null;
+            ReportAbuseResourceV3? resource = null;
             var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
             if (serviceIndex != null)
             {
@@ -31,7 +29,7 @@ namespace NuGet.Protocol
                 resource = new ReportAbuseResourceV3(uriTemplate);
             }
 
-            return new Tuple<bool, INuGetResource>(resource != null, resource);
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -10,7 +10,7 @@ NuGet.Protocol.AmbientAuthenticationState.Block() -> void
 NuGet.Protocol.AmbientAuthenticationState.Increment() -> void
 NuGet.Protocol.AmbientAuthenticationState.IsBlocked.get -> bool
 NuGet.Protocol.AutoCompleteResourceV2Feed
-~NuGet.Protocol.AutoCompleteResourceV2Feed.AutoCompleteResourceV2Feed(NuGet.Protocol.HttpSourceResource httpSourceResource, string baseAddress, NuGet.Configuration.PackageSource packageSource) -> void
+NuGet.Protocol.AutoCompleteResourceV2Feed.AutoCompleteResourceV2Feed(NuGet.Protocol.HttpSourceResource! httpSourceResource, string! baseAddress, NuGet.Configuration.PackageSource! packageSource) -> void
 NuGet.Protocol.AutoCompleteResourceV2FeedProvider
 NuGet.Protocol.AutoCompleteResourceV2FeedProvider.AutoCompleteResourceV2FeedProvider() -> void
 NuGet.Protocol.AutoCompleteResourceV3
@@ -336,7 +336,7 @@ NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion!
 NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion! version, long? downloadCount) -> void
 NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion! version, string? downloadCount) -> void
 NuGet.Protocol.DependencyInfoResourceV2Feed
-~NuGet.Protocol.DependencyInfoResourceV2Feed.DependencyInfoResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser, NuGet.Protocol.Core.Types.SourceRepository source) -> void
+NuGet.Protocol.DependencyInfoResourceV2Feed.DependencyInfoResourceV2Feed(NuGet.Protocol.V2FeedParser! feedParser, NuGet.Protocol.Core.Types.SourceRepository! source) -> void
 NuGet.Protocol.DependencyInfoResourceV2FeedProvider
 NuGet.Protocol.DependencyInfoResourceV2FeedProvider.DependencyInfoResourceV2FeedProvider() -> void
 NuGet.Protocol.DependencyInfoResourceV3
@@ -348,8 +348,8 @@ NuGet.Protocol.DownloadResourcePlugin.DownloadResourcePlugin(NuGet.Protocol.Plug
 NuGet.Protocol.DownloadResourcePluginProvider
 NuGet.Protocol.DownloadResourcePluginProvider.DownloadResourcePluginProvider() -> void
 NuGet.Protocol.DownloadResourceV2Feed
-~NuGet.Protocol.DownloadResourceV2Feed.DownloadResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser) -> void
-~NuGet.Protocol.DownloadResourceV2Feed.DownloadResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser, string source) -> void
+NuGet.Protocol.DownloadResourceV2Feed.DownloadResourceV2Feed(NuGet.Protocol.V2FeedParser! feedParser) -> void
+NuGet.Protocol.DownloadResourceV2Feed.DownloadResourceV2Feed(NuGet.Protocol.V2FeedParser! feedParser, string! source) -> void
 NuGet.Protocol.DownloadResourceV2FeedProvider
 NuGet.Protocol.DownloadResourceV2FeedProvider.DownloadResourceV2FeedProvider() -> void
 NuGet.Protocol.DownloadResourceV3
@@ -589,7 +589,7 @@ NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(strin
 NuGet.Protocol.JsonExtensions
 NuGet.Protocol.JsonProperties
 NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed
-~NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.LegacyFeedCapabilityResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser, string baseAddress) -> void
+NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.LegacyFeedCapabilityResourceV2Feed(NuGet.Protocol.V2FeedParser! feedParser, string! baseAddress) -> void
 NuGet.Protocol.LocalAutoCompleteResource
 NuGet.Protocol.LocalAutoCompleteResource.GetPackageVersionsFromLocalPackageRepository(string! packageId, string! versionPrefix, bool includePrerelease, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
 NuGet.Protocol.LocalAutoCompleteResource.LocalAutoCompleteResource(NuGet.Protocol.FindLocalPackagesResource! localResource) -> void
@@ -823,7 +823,7 @@ NuGet.Protocol.PackageSearchMetadataV2Feed.Title.get -> string!
 NuGet.Protocol.PackageSearchMetadataV2Feed.Version.get -> NuGet.Versioning.NuGetVersion!
 NuGet.Protocol.PackageSearchMetadataV2Feed.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
 NuGet.Protocol.PackageSearchResourceV2Feed
-~NuGet.Protocol.PackageSearchResourceV2Feed.PackageSearchResourceV2Feed(NuGet.Protocol.HttpSourceResource httpSourceResource, string baseAddress, NuGet.Configuration.PackageSource packageSource) -> void
+NuGet.Protocol.PackageSearchResourceV2Feed.PackageSearchResourceV2Feed(NuGet.Protocol.HttpSourceResource! httpSourceResource, string! baseAddress, NuGet.Configuration.PackageSource! packageSource) -> void
 NuGet.Protocol.PackageSearchResourceV2FeedProvider
 NuGet.Protocol.PackageSearchResourceV2FeedProvider.PackageSearchResourceV2FeedProvider() -> void
 NuGet.Protocol.PackageSearchResourceV3
@@ -1457,7 +1457,7 @@ NuGet.Protocol.TokenStore.GetToken(System.Uri! sourceUri) -> string?
 NuGet.Protocol.TokenStore.TokenStore() -> void
 NuGet.Protocol.TokenStore.Version.get -> System.Guid
 NuGet.Protocol.V2FeedListResource
-~NuGet.Protocol.V2FeedListResource.V2FeedListResource(NuGet.Protocol.IV2FeedParser feedParser, NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource feedCapabilities, string baseAddress) -> void
+NuGet.Protocol.V2FeedListResource.V2FeedListResource(NuGet.Protocol.IV2FeedParser! feedParser, NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource! feedCapabilities, string! baseAddress) -> void
 NuGet.Protocol.V2FeedListResourceProvider
 NuGet.Protocol.V2FeedListResourceProvider.V2FeedListResourceProvider() -> void
 NuGet.Protocol.V2FeedPackageInfo
@@ -1639,9 +1639,9 @@ const NuGet.Protocol.JsonProperties.Vulnerabilities = "vulnerabilities" -> strin
 const NuGet.Protocol.StsAuthenticationHandler.STSEndPointHeader = "X-NuGet-STS-EndPoint" -> string!
 const NuGet.Protocol.StsAuthenticationHandler.STSRealmHeader = "X-NuGet-STS-Realm" -> string!
 const NuGet.Protocol.StsAuthenticationHandler.STSTokenHeader = "X-NuGet-STS-Token" -> string!
-~override NuGet.Protocol.AutoCompleteResourceV2Feed.IdStartsWith(string packageIdPrefix, bool includePrerelease, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
-~override NuGet.Protocol.AutoCompleteResourceV2Feed.VersionStartsWith(string packageId, string versionPrefix, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
-~override NuGet.Protocol.AutoCompleteResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.AutoCompleteResourceV2Feed.IdStartsWith(string! packageIdPrefix, bool includePrerelease, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
+override NuGet.Protocol.AutoCompleteResourceV2Feed.VersionStartsWith(string! packageId, string! versionPrefix, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
+override NuGet.Protocol.AutoCompleteResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.AutoCompleteResourceV3.IdStartsWith(string! packageIdPrefix, bool includePrerelease, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
 override NuGet.Protocol.AutoCompleteResourceV3.VersionStartsWith(string! packageId, string! versionPrefix, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
 override NuGet.Protocol.AutoCompleteResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
@@ -1658,17 +1658,17 @@ override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.Equals(object? obj
 override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.GetHashCode() -> int
 override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.ToString() -> string!
 override NuGet.Protocol.Core.Types.SourceRepository.ToString() -> string!
-~override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackage(NuGet.Packaging.Core.PackageIdentity package, NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo>
-~override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackages(string packageId, NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo>>
-~override NuGet.Protocol.DependencyInfoResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackage(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Frameworks.NuGetFramework! projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo?>!
+override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackages(string! packageId, NuGet.Frameworks.NuGetFramework! projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo!>!>!
+override NuGet.Protocol.DependencyInfoResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.DependencyInfoResourceV3.ResolvePackage(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Frameworks.NuGetFramework! projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo?>!
 override NuGet.Protocol.DependencyInfoResourceV3.ResolvePackages(string! packageId, NuGet.Frameworks.NuGetFramework! projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo!>!>!
 override NuGet.Protocol.DependencyInfoResourceV3.ResolvePackages(string! packageId, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo!>!>!
 override NuGet.Protocol.DependencyInfoResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.DownloadResourcePlugin.GetDownloadResourceResultAsync(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
 override NuGet.Protocol.DownloadResourcePluginProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.DownloadResourceV2Feed.GetDownloadResourceResultAsync(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Protocol.Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult>
-~override NuGet.Protocol.DownloadResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.DownloadResourceV2Feed.GetDownloadResourceResultAsync(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
+override NuGet.Protocol.DownloadResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.DownloadResourceV3.GetDownloadResourceResultAsync(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
 override NuGet.Protocol.DownloadResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.DownloadTimeoutStream.BeginRead(byte[]! buffer, int offset, int count, System.AsyncCallback! callback, object! state) -> System.IAsyncResult!
@@ -1724,8 +1724,8 @@ override NuGet.Protocol.HttpHandlerResourceV3Provider.TryCreate(NuGet.Protocol.C
 override NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) -> void
 override NuGet.Protocol.HttpSourceAuthenticationHandler.SendAsync(System.Net.Http.HttpRequestMessage! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
 override NuGet.Protocol.HttpSourceResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.SupportsIsAbsoluteLatestVersionAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.SupportsSearchAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
+override NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.SupportsIsAbsoluteLatestVersionAsync(NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.SupportsSearchAsync(NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
 override NuGet.Protocol.LocalAutoCompleteResource.IdStartsWith(string! packageIdPrefix, bool includePrerelease, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
 override NuGet.Protocol.LocalAutoCompleteResource.VersionStartsWith(string! packageId, string! versionPrefix, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
 override NuGet.Protocol.LocalAutoCompleteResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
@@ -1787,9 +1787,9 @@ override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Prot
 ~override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
 ~override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
 ~override NuGet.Protocol.PackageMetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.PackageSearchResourceV2Feed.SearchAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
+override NuGet.Protocol.PackageSearchResourceV2Feed.SearchAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 override NuGet.Protocol.PackageSearchResourceV2Feed.SupportsPackageTypeFiltering.get -> bool
-~override NuGet.Protocol.PackageSearchResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.PackageSearchResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.PackageSearchResourceV3.SearchAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filter, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 override NuGet.Protocol.PackageSearchResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.PackageSearchResourceV3.SupportsPackageTypeFiltering.get -> bool
@@ -1889,9 +1889,9 @@ override NuGet.Protocol.ServerWarningLogHandler.SendAsync(System.Net.Http.HttpRe
 override NuGet.Protocol.ServiceIndexResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.StsAuthenticationHandler.SendAsync(System.Net.Http.HttpRequestMessage! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
 override NuGet.Protocol.SymbolPackageUpdateResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.V2FeedListResource.ListAsync(string searchTerm, bool prerelease, bool allVersions, bool includeDelisted, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Common.IEnumerableAsync<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
-~override NuGet.Protocol.V2FeedListResource.Source.get -> string
-~override NuGet.Protocol.V2FeedListResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.V2FeedListResource.ListAsync(string! searchTerm, bool prerelease, bool allVersions, bool includeDelisted, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Common.IEnumerableAsync<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
+override NuGet.Protocol.V2FeedListResource.Source.get -> string!
+override NuGet.Protocol.V2FeedListResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.V3FeedListResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.VersionInfoConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.VersionInfoConverter.CanWrite.get -> bool

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1383,8 +1383,8 @@ NuGet.Protocol.RemoteV3FindPackageByIdResource.SourceRepository.get -> NuGet.Pro
 NuGet.Protocol.RemoteV3FindPackageByIdResourceProvider
 NuGet.Protocol.RemoteV3FindPackageByIdResourceProvider.RemoteV3FindPackageByIdResourceProvider() -> void
 NuGet.Protocol.ReportAbuseResourceV3
-~NuGet.Protocol.ReportAbuseResourceV3.GetReportAbuseUrl(string id, NuGet.Versioning.NuGetVersion version) -> System.Uri
-~NuGet.Protocol.ReportAbuseResourceV3.ReportAbuseResourceV3(string uriTemplate) -> void
+NuGet.Protocol.ReportAbuseResourceV3.GetReportAbuseUrl(string! id, NuGet.Versioning.NuGetVersion! version) -> System.Uri!
+NuGet.Protocol.ReportAbuseResourceV3.ReportAbuseResourceV3(string? uriTemplate) -> void
 NuGet.Protocol.ReportAbuseResourceV3Provider
 NuGet.Protocol.ReportAbuseResourceV3Provider.ReportAbuseResourceV3Provider() -> void
 NuGet.Protocol.RepositoryCertificateInfo
@@ -1773,14 +1773,14 @@ override NuGet.Protocol.MetadataFieldConverter.WriteJson(Newtonsoft.Json.JsonWri
 ~override NuGet.Protocol.MetadataResourceV3.Exists(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
 ~override NuGet.Protocol.MetadataResourceV3.GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NuGet.Versioning.NuGetVersion>>>
 ~override NuGet.Protocol.MetadataResourceV3.GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
-~override NuGet.Protocol.MetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.MetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
 override NuGet.Protocol.NuGetVersionConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.NuGetVersionConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 override NuGet.Protocol.ODataServiceDocumentResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 ~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
 ~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
 ~override NuGet.Protocol.PackageMetadataResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
@@ -1870,7 +1870,7 @@ override NuGet.Protocol.RemoteV3FindPackageByIdResource.GetAllVersionsAsync(stri
 override NuGet.Protocol.RemoteV3FindPackageByIdResource.GetDependencyInfoAsync(string! id, NuGet.Versioning.NuGetVersion! version, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo?>!
 override NuGet.Protocol.RemoteV3FindPackageByIdResource.GetPackageDownloaderAsync(NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.IPackageDownloader?>!
 override NuGet.Protocol.RemoteV3FindPackageByIdResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! sourceRepository, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.ReportAbuseResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.ReportAbuseResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.RepositorySignatureResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.SafeBoolConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.SafeBoolConverter.CanRead.get -> bool

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -609,16 +609,16 @@ NuGet.Protocol.LocalMetadataResource.LocalMetadataResource(NuGet.Protocol.FindLo
 NuGet.Protocol.LocalMetadataResourceProvider
 NuGet.Protocol.LocalMetadataResourceProvider.LocalMetadataResourceProvider() -> void
 NuGet.Protocol.LocalPackageArchiveDownloader
-~NuGet.Protocol.LocalPackageArchiveDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader
-~NuGet.Protocol.LocalPackageArchiveDownloader.CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.LocalPackageArchiveDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader
+NuGet.Protocol.LocalPackageArchiveDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader!
+NuGet.Protocol.LocalPackageArchiveDownloader.CopyNupkgFileToAsync(string! destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.LocalPackageArchiveDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader!
 NuGet.Protocol.LocalPackageArchiveDownloader.Dispose() -> void
-~NuGet.Protocol.LocalPackageArchiveDownloader.GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
-~NuGet.Protocol.LocalPackageArchiveDownloader.LocalPackageArchiveDownloader(string source, string packageFilePath, NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Common.ILogger logger) -> void
-~NuGet.Protocol.LocalPackageArchiveDownloader.SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) -> void
-~NuGet.Protocol.LocalPackageArchiveDownloader.SetThrottle(System.Threading.SemaphoreSlim throttle) -> void
-~NuGet.Protocol.LocalPackageArchiveDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader
-~NuGet.Protocol.LocalPackageArchiveDownloader.Source.get -> string
+NuGet.Protocol.LocalPackageArchiveDownloader.GetPackageHashAsync(string! hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+NuGet.Protocol.LocalPackageArchiveDownloader.LocalPackageArchiveDownloader(string! source, string! packageFilePath, NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Common.ILogger! logger) -> void
+NuGet.Protocol.LocalPackageArchiveDownloader.SetExceptionHandler(System.Func<System.Exception!, System.Threading.Tasks.Task<bool>!>! handleExceptionAsync) -> void
+NuGet.Protocol.LocalPackageArchiveDownloader.SetThrottle(System.Threading.SemaphoreSlim? throttle) -> void
+NuGet.Protocol.LocalPackageArchiveDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader!
+NuGet.Protocol.LocalPackageArchiveDownloader.Source.get -> string!
 NuGet.Protocol.LocalPackageFileCache
 NuGet.Protocol.LocalPackageFileCache.LocalPackageFileCache() -> void
 NuGet.Protocol.LocalPackageFileCache.UpdateLastAccessTime(string! nupkgMetadataPath) -> void
@@ -1362,16 +1362,16 @@ NuGet.Protocol.RegistrationResourceV3Provider
 NuGet.Protocol.RegistrationResourceV3Provider.RegistrationResourceV3Provider() -> void
 NuGet.Protocol.RegistrationUtility
 NuGet.Protocol.RemotePackageArchiveDownloader
-~NuGet.Protocol.RemotePackageArchiveDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader
-~NuGet.Protocol.RemotePackageArchiveDownloader.CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.RemotePackageArchiveDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader
+NuGet.Protocol.RemotePackageArchiveDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader!
+NuGet.Protocol.RemotePackageArchiveDownloader.CopyNupkgFileToAsync(string! destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.RemotePackageArchiveDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader!
 NuGet.Protocol.RemotePackageArchiveDownloader.Dispose() -> void
-~NuGet.Protocol.RemotePackageArchiveDownloader.GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
-~NuGet.Protocol.RemotePackageArchiveDownloader.RemotePackageArchiveDownloader(string source, NuGet.Protocol.Core.Types.FindPackageByIdResource resource, NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger logger) -> void
-~NuGet.Protocol.RemotePackageArchiveDownloader.SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) -> void
-~NuGet.Protocol.RemotePackageArchiveDownloader.SetThrottle(System.Threading.SemaphoreSlim throttle) -> void
-~NuGet.Protocol.RemotePackageArchiveDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader
-~NuGet.Protocol.RemotePackageArchiveDownloader.Source.get -> string
+NuGet.Protocol.RemotePackageArchiveDownloader.GetPackageHashAsync(string! hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+NuGet.Protocol.RemotePackageArchiveDownloader.RemotePackageArchiveDownloader(string! source, NuGet.Protocol.Core.Types.FindPackageByIdResource! resource, NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger) -> void
+NuGet.Protocol.RemotePackageArchiveDownloader.SetExceptionHandler(System.Func<System.Exception!, System.Threading.Tasks.Task<bool>!>! handleExceptionAsync) -> void
+NuGet.Protocol.RemotePackageArchiveDownloader.SetThrottle(System.Threading.SemaphoreSlim? throttle) -> void
+NuGet.Protocol.RemotePackageArchiveDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader!
+NuGet.Protocol.RemotePackageArchiveDownloader.Source.get -> string!
 NuGet.Protocol.RemoteV2FindPackageByIdResource
 NuGet.Protocol.RemoteV2FindPackageByIdResource.PackageSource.get -> NuGet.Configuration.PackageSource!
 NuGet.Protocol.RemoteV2FindPackageByIdResource.RemoteV2FindPackageByIdResource(NuGet.Configuration.PackageSource! packageSource, NuGet.Protocol.HttpSource! httpSource) -> void
@@ -1686,7 +1686,7 @@ override NuGet.Protocol.DownloadTimeoutStream.ReadAsync(byte[]! buffer, int offs
 override NuGet.Protocol.DownloadTimeoutStream.Seek(long offset, System.IO.SeekOrigin origin) -> long
 override NuGet.Protocol.DownloadTimeoutStream.SetLength(long value) -> void
 override NuGet.Protocol.DownloadTimeoutStream.Write(byte[]! buffer, int offset, int count) -> void
-~override NuGet.Protocol.FeedTypeResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.FeedTypeResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
 override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
 override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
@@ -1938,11 +1938,11 @@ static NuGet.Protocol.Events.ProtocolDiagnostics.HttpEvent -> NuGet.Protocol.Eve
 static NuGet.Protocol.Events.ProtocolDiagnostics.NupkgCopiedEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticsNupkgCopiedEventHandler?
 static NuGet.Protocol.Events.ProtocolDiagnostics.ResourceEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticResourceEventHandler?
 static NuGet.Protocol.Events.ProtocolDiagnostics.ServiceIndexEntryEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticServiceIndexEntryEventHandler?
-~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV2(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.ProviderFactory factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>
-~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, string source) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, string source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
+static NuGet.Protocol.FactoryExtensionsV3.GetCoreV2(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.ProviderFactory! factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>!
+static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, string! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, string! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
 static NuGet.Protocol.FeedTypeUtility.GetFeedType(NuGet.Configuration.PackageSource! packageSource) -> NuGet.Protocol.FeedType
 static NuGet.Protocol.GetDownloadResultUtility.CleanUpDirectDownloads(NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext) -> void
 static NuGet.Protocol.GetDownloadResultUtility.GetDownloadResultAsync(NuGet.Protocol.HttpSource! client, NuGet.Packaging.Core.PackageIdentity! identity, System.Uri! uri, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
@@ -2046,9 +2046,9 @@ static NuGet.Protocol.TimeoutUtility.StartWithTimeout(System.Func<System.Threadi
 static NuGet.Protocol.TimeoutUtility.StartWithTimeout<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>!>! getTask, System.TimeSpan timeout, string? timeoutMessage, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
 static NuGet.Protocol.TokenStore.Instance.get -> NuGet.Protocol.TokenStore!
 static NuGet.Protocol.V2FeedUtilities.CreatePackageSearchResult(NuGet.Protocol.V2FeedPackageInfo! package, NuGet.Protocol.MetadataReferenceCache! metadataCache, NuGet.Protocol.Core.Types.SearchFilter! filter, NuGet.Protocol.V2FeedParser! feedParser, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
-~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.ProviderFactory factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>
-~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, string source) -> NuGet.Protocol.Core.Types.SourceRepository
+static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.ProviderFactory! factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>!
+static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, string! source) -> NuGet.Protocol.Core.Types.SourceRepository!
 static NuGet.Repositories.NuGetv3LocalRepositoryUtility.GetPackage(System.Collections.Generic.IReadOnlyList<NuGet.Repositories.NuGetv3LocalRepository!>! repositories, string! id, NuGet.Versioning.NuGetVersion! version) -> NuGet.Repositories.LocalPackageSourceInfo?
 static readonly NuGet.Protocol.Core.Types.UserAgentStringBuilder.DefaultNuGetClientName -> string!
 static readonly NuGet.Protocol.HttpRequestMessageConfiguration.Default -> NuGet.Protocol.HttpRequestMessageConfiguration!

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -735,7 +735,7 @@ NuGet.Protocol.PackageDeprecationMetadata.Message.get -> string?
 NuGet.Protocol.PackageDeprecationMetadata.PackageDeprecationMetadata() -> void
 NuGet.Protocol.PackageDeprecationMetadata.Reasons.get -> System.Collections.Generic.IEnumerable<string!>!
 NuGet.Protocol.PackageDetailsUriResourceV3
-~NuGet.Protocol.PackageDetailsUriResourceV3.GetUri(string id, NuGet.Versioning.NuGetVersion version) -> System.Uri
+NuGet.Protocol.PackageDetailsUriResourceV3.GetUri(string! id, NuGet.Versioning.NuGetVersion! version) -> System.Uri!
 NuGet.Protocol.PackageDetailsUriResourceV3Provider
 NuGet.Protocol.PackageDetailsUriResourceV3Provider.PackageDetailsUriResourceV3Provider() -> void
 NuGet.Protocol.PackageMetadataResourceV2Feed
@@ -2012,7 +2012,7 @@ static NuGet.Protocol.LocalFolderUtility.IsPossiblePackageMatch(System.IO.FileIn
 static NuGet.Protocol.LocalFolderUtility.IsPossiblePackageMatch(System.IO.FileInfo! file, string! id) -> bool
 static NuGet.Protocol.LocalFolderUtility.ResolvePackageFromPath(string! packagePath, bool isSnupkg = false) -> System.Collections.Generic.IEnumerable<string!>!
 static NuGet.Protocol.NullThrottle.Instance.get -> NuGet.Protocol.NullThrottle!
-~static NuGet.Protocol.PackageDetailsUriResourceV3.CreateOrNull(string uriTemplate) -> NuGet.Protocol.PackageDetailsUriResourceV3
+static NuGet.Protocol.PackageDetailsUriResourceV3.CreateOrNull(string? uriTemplate) -> NuGet.Protocol.PackageDetailsUriResourceV3?
 static NuGet.Protocol.Plugins.AutomaticProgressReporter.Create(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Plugins.AutomaticProgressReporter!
 static NuGet.Protocol.Plugins.ConnectionOptions.CreateDefault(NuGet.Common.IEnvironmentVariableReader? reader = null) -> NuGet.Protocol.Plugins.ConnectionOptions!
 static NuGet.Protocol.Plugins.JsonSerializationUtilities.Deserialize<T>(string! json) -> T?

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -735,7 +735,7 @@ NuGet.Protocol.PackageDeprecationMetadata.Message.get -> string?
 NuGet.Protocol.PackageDeprecationMetadata.PackageDeprecationMetadata() -> void
 NuGet.Protocol.PackageDeprecationMetadata.Reasons.get -> System.Collections.Generic.IEnumerable<string!>!
 NuGet.Protocol.PackageDetailsUriResourceV3
-~NuGet.Protocol.PackageDetailsUriResourceV3.GetUri(string id, NuGet.Versioning.NuGetVersion version) -> System.Uri
+NuGet.Protocol.PackageDetailsUriResourceV3.GetUri(string! id, NuGet.Versioning.NuGetVersion! version) -> System.Uri!
 NuGet.Protocol.PackageDetailsUriResourceV3Provider
 NuGet.Protocol.PackageDetailsUriResourceV3Provider.PackageDetailsUriResourceV3Provider() -> void
 NuGet.Protocol.PackageMetadataResourceV2Feed
@@ -2002,7 +2002,7 @@ static NuGet.Protocol.LocalFolderUtility.IsPossiblePackageMatch(System.IO.FileIn
 static NuGet.Protocol.LocalFolderUtility.IsPossiblePackageMatch(System.IO.FileInfo! file, string! id) -> bool
 static NuGet.Protocol.LocalFolderUtility.ResolvePackageFromPath(string! packagePath, bool isSnupkg = false) -> System.Collections.Generic.IEnumerable<string!>!
 static NuGet.Protocol.NullThrottle.Instance.get -> NuGet.Protocol.NullThrottle!
-~static NuGet.Protocol.PackageDetailsUriResourceV3.CreateOrNull(string uriTemplate) -> NuGet.Protocol.PackageDetailsUriResourceV3
+static NuGet.Protocol.PackageDetailsUriResourceV3.CreateOrNull(string? uriTemplate) -> NuGet.Protocol.PackageDetailsUriResourceV3?
 static NuGet.Protocol.Plugins.AutomaticProgressReporter.Create(NuGet.Protocol.Plugins.IConnection! connection, NuGet.Protocol.Plugins.Message! request, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Plugins.AutomaticProgressReporter!
 static NuGet.Protocol.Plugins.ConnectionOptions.CreateDefault(NuGet.Common.IEnvironmentVariableReader? reader = null) -> NuGet.Protocol.Plugins.ConnectionOptions!
 static NuGet.Protocol.Plugins.JsonSerializationUtilities.Deserialize<T>(string! json) -> T?

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1383,8 +1383,8 @@ NuGet.Protocol.RemoteV3FindPackageByIdResource.SourceRepository.get -> NuGet.Pro
 NuGet.Protocol.RemoteV3FindPackageByIdResourceProvider
 NuGet.Protocol.RemoteV3FindPackageByIdResourceProvider.RemoteV3FindPackageByIdResourceProvider() -> void
 NuGet.Protocol.ReportAbuseResourceV3
-~NuGet.Protocol.ReportAbuseResourceV3.GetReportAbuseUrl(string id, NuGet.Versioning.NuGetVersion version) -> System.Uri
-~NuGet.Protocol.ReportAbuseResourceV3.ReportAbuseResourceV3(string uriTemplate) -> void
+NuGet.Protocol.ReportAbuseResourceV3.GetReportAbuseUrl(string! id, NuGet.Versioning.NuGetVersion! version) -> System.Uri!
+NuGet.Protocol.ReportAbuseResourceV3.ReportAbuseResourceV3(string? uriTemplate) -> void
 NuGet.Protocol.ReportAbuseResourceV3Provider
 NuGet.Protocol.ReportAbuseResourceV3Provider.ReportAbuseResourceV3Provider() -> void
 NuGet.Protocol.RepositoryCertificateInfo
@@ -1764,14 +1764,14 @@ override NuGet.Protocol.MetadataFieldConverter.WriteJson(Newtonsoft.Json.JsonWri
 ~override NuGet.Protocol.MetadataResourceV3.Exists(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
 ~override NuGet.Protocol.MetadataResourceV3.GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NuGet.Versioning.NuGetVersion>>>
 ~override NuGet.Protocol.MetadataResourceV3.GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
-~override NuGet.Protocol.MetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.MetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
 override NuGet.Protocol.NuGetVersionConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.NuGetVersionConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 override NuGet.Protocol.ODataServiceDocumentResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 ~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
 ~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
 ~override NuGet.Protocol.PackageMetadataResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
@@ -1861,7 +1861,7 @@ override NuGet.Protocol.RemoteV3FindPackageByIdResource.GetAllVersionsAsync(stri
 override NuGet.Protocol.RemoteV3FindPackageByIdResource.GetDependencyInfoAsync(string! id, NuGet.Versioning.NuGetVersion! version, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.FindPackageByIdDependencyInfo?>!
 override NuGet.Protocol.RemoteV3FindPackageByIdResource.GetPackageDownloaderAsync(NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Packaging.IPackageDownloader?>!
 override NuGet.Protocol.RemoteV3FindPackageByIdResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! sourceRepository, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.ReportAbuseResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.ReportAbuseResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.RepositorySignatureResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.SafeBoolConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.SafeBoolConverter.CanRead.get -> bool

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -609,16 +609,16 @@ NuGet.Protocol.LocalMetadataResource.LocalMetadataResource(NuGet.Protocol.FindLo
 NuGet.Protocol.LocalMetadataResourceProvider
 NuGet.Protocol.LocalMetadataResourceProvider.LocalMetadataResourceProvider() -> void
 NuGet.Protocol.LocalPackageArchiveDownloader
-~NuGet.Protocol.LocalPackageArchiveDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader
-~NuGet.Protocol.LocalPackageArchiveDownloader.CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.LocalPackageArchiveDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader
+NuGet.Protocol.LocalPackageArchiveDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader!
+NuGet.Protocol.LocalPackageArchiveDownloader.CopyNupkgFileToAsync(string! destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.LocalPackageArchiveDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader!
 NuGet.Protocol.LocalPackageArchiveDownloader.Dispose() -> void
-~NuGet.Protocol.LocalPackageArchiveDownloader.GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
-~NuGet.Protocol.LocalPackageArchiveDownloader.LocalPackageArchiveDownloader(string source, string packageFilePath, NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Common.ILogger logger) -> void
-~NuGet.Protocol.LocalPackageArchiveDownloader.SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) -> void
-~NuGet.Protocol.LocalPackageArchiveDownloader.SetThrottle(System.Threading.SemaphoreSlim throttle) -> void
-~NuGet.Protocol.LocalPackageArchiveDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader
-~NuGet.Protocol.LocalPackageArchiveDownloader.Source.get -> string
+NuGet.Protocol.LocalPackageArchiveDownloader.GetPackageHashAsync(string! hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+NuGet.Protocol.LocalPackageArchiveDownloader.LocalPackageArchiveDownloader(string! source, string! packageFilePath, NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Common.ILogger! logger) -> void
+NuGet.Protocol.LocalPackageArchiveDownloader.SetExceptionHandler(System.Func<System.Exception!, System.Threading.Tasks.Task<bool>!>! handleExceptionAsync) -> void
+NuGet.Protocol.LocalPackageArchiveDownloader.SetThrottle(System.Threading.SemaphoreSlim? throttle) -> void
+NuGet.Protocol.LocalPackageArchiveDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader!
+NuGet.Protocol.LocalPackageArchiveDownloader.Source.get -> string!
 NuGet.Protocol.LocalPackageFileCache
 NuGet.Protocol.LocalPackageFileCache.LocalPackageFileCache() -> void
 NuGet.Protocol.LocalPackageFileCache.UpdateLastAccessTime(string! nupkgMetadataPath) -> void
@@ -1362,16 +1362,16 @@ NuGet.Protocol.RegistrationResourceV3Provider
 NuGet.Protocol.RegistrationResourceV3Provider.RegistrationResourceV3Provider() -> void
 NuGet.Protocol.RegistrationUtility
 NuGet.Protocol.RemotePackageArchiveDownloader
-~NuGet.Protocol.RemotePackageArchiveDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader
-~NuGet.Protocol.RemotePackageArchiveDownloader.CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.RemotePackageArchiveDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader
+NuGet.Protocol.RemotePackageArchiveDownloader.ContentReader.get -> NuGet.Packaging.IAsyncPackageContentReader!
+NuGet.Protocol.RemotePackageArchiveDownloader.CopyNupkgFileToAsync(string! destinationFilePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.RemotePackageArchiveDownloader.CoreReader.get -> NuGet.Packaging.Core.IAsyncPackageCoreReader!
 NuGet.Protocol.RemotePackageArchiveDownloader.Dispose() -> void
-~NuGet.Protocol.RemotePackageArchiveDownloader.GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
-~NuGet.Protocol.RemotePackageArchiveDownloader.RemotePackageArchiveDownloader(string source, NuGet.Protocol.Core.Types.FindPackageByIdResource resource, NuGet.Packaging.Core.PackageIdentity packageIdentity, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger logger) -> void
-~NuGet.Protocol.RemotePackageArchiveDownloader.SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) -> void
-~NuGet.Protocol.RemotePackageArchiveDownloader.SetThrottle(System.Threading.SemaphoreSlim throttle) -> void
-~NuGet.Protocol.RemotePackageArchiveDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader
-~NuGet.Protocol.RemotePackageArchiveDownloader.Source.get -> string
+NuGet.Protocol.RemotePackageArchiveDownloader.GetPackageHashAsync(string! hashAlgorithm, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+NuGet.Protocol.RemotePackageArchiveDownloader.RemotePackageArchiveDownloader(string! source, NuGet.Protocol.Core.Types.FindPackageByIdResource! resource, NuGet.Packaging.Core.PackageIdentity! packageIdentity, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger) -> void
+NuGet.Protocol.RemotePackageArchiveDownloader.SetExceptionHandler(System.Func<System.Exception!, System.Threading.Tasks.Task<bool>!>! handleExceptionAsync) -> void
+NuGet.Protocol.RemotePackageArchiveDownloader.SetThrottle(System.Threading.SemaphoreSlim? throttle) -> void
+NuGet.Protocol.RemotePackageArchiveDownloader.SignedPackageReader.get -> NuGet.Packaging.Signing.ISignedPackageReader!
+NuGet.Protocol.RemotePackageArchiveDownloader.Source.get -> string!
 NuGet.Protocol.RemoteV2FindPackageByIdResource
 NuGet.Protocol.RemoteV2FindPackageByIdResource.PackageSource.get -> NuGet.Configuration.PackageSource!
 NuGet.Protocol.RemoteV2FindPackageByIdResource.RemoteV2FindPackageByIdResource(NuGet.Configuration.PackageSource! packageSource, NuGet.Protocol.HttpSource! httpSource) -> void
@@ -1677,7 +1677,7 @@ override NuGet.Protocol.DownloadTimeoutStream.ReadAsync(byte[]! buffer, int offs
 override NuGet.Protocol.DownloadTimeoutStream.Seek(long offset, System.IO.SeekOrigin origin) -> long
 override NuGet.Protocol.DownloadTimeoutStream.SetLength(long value) -> void
 override NuGet.Protocol.DownloadTimeoutStream.Write(byte[]! buffer, int offset, int count) -> void
-~override NuGet.Protocol.FeedTypeResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.FeedTypeResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.FindPackagesById(string! id, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Collections.Generic.IEnumerable<NuGet.Protocol.LocalPackageInfo!>!
 override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
 override NuGet.Protocol.FindLocalPackagesResourcePackagesConfig.GetPackage(System.Uri! path, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> NuGet.Protocol.LocalPackageInfo?
@@ -1928,11 +1928,11 @@ static NuGet.Protocol.Events.ProtocolDiagnostics.HttpEvent -> NuGet.Protocol.Eve
 static NuGet.Protocol.Events.ProtocolDiagnostics.NupkgCopiedEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticsNupkgCopiedEventHandler?
 static NuGet.Protocol.Events.ProtocolDiagnostics.ResourceEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticResourceEventHandler?
 static NuGet.Protocol.Events.ProtocolDiagnostics.ServiceIndexEntryEvent -> NuGet.Protocol.Events.ProtocolDiagnostics.ProtocolDiagnosticServiceIndexEntryEventHandler?
-~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV2(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.ProviderFactory factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>
-~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, string source) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, string source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository
+static NuGet.Protocol.FactoryExtensionsV3.GetCoreV2(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.ProviderFactory! factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>!
+static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, string! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.FactoryExtensionsV3.GetCoreV3(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, string! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
 static NuGet.Protocol.FeedTypeUtility.GetFeedType(NuGet.Configuration.PackageSource! packageSource) -> NuGet.Protocol.FeedType
 static NuGet.Protocol.GetDownloadResultUtility.CleanUpDirectDownloads(NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext) -> void
 static NuGet.Protocol.GetDownloadResultUtility.GetDownloadResultAsync(NuGet.Protocol.HttpSource! client, NuGet.Packaging.Core.PackageIdentity! identity, System.Uri! uri, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
@@ -2034,9 +2034,9 @@ static NuGet.Protocol.TimeoutUtility.StartWithTimeout(System.Func<System.Threadi
 static NuGet.Protocol.TimeoutUtility.StartWithTimeout<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>!>! getTask, System.TimeSpan timeout, string? timeoutMessage, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
 static NuGet.Protocol.TokenStore.Instance.get -> NuGet.Protocol.TokenStore!
 static NuGet.Protocol.V2FeedUtilities.CreatePackageSearchResult(NuGet.Protocol.V2FeedPackageInfo! package, NuGet.Protocol.MetadataReferenceCache! metadataCache, NuGet.Protocol.Core.Types.SearchFilter! filter, NuGet.Protocol.V2FeedParser! feedParser, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
-~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.ProviderFactory factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider>>
-~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, NuGet.Configuration.PackageSource source) -> NuGet.Protocol.Core.Types.SourceRepository
-~static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory factory, string source) -> NuGet.Protocol.Core.Types.SourceRepository
+static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.ProviderFactory! factory) -> System.Collections.Generic.IEnumerable<System.Lazy<NuGet.Protocol.Core.Types.INuGetResourceProvider!>!>!
+static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
+static NuGet.Protocol.VisualStudio.FactoryExtensionsVS.GetVisualStudio(this NuGet.Protocol.Core.Types.Repository.RepositoryFactory! factory, string! source) -> NuGet.Protocol.Core.Types.SourceRepository!
 static NuGet.Repositories.NuGetv3LocalRepositoryUtility.GetPackage(System.Collections.Generic.IReadOnlyList<NuGet.Repositories.NuGetv3LocalRepository!>! repositories, string! id, NuGet.Versioning.NuGetVersion! version) -> NuGet.Repositories.LocalPackageSourceInfo?
 static readonly NuGet.Protocol.Core.Types.UserAgentStringBuilder.DefaultNuGetClientName -> string!
 static readonly NuGet.Protocol.HttpRequestMessageConfiguration.Default -> NuGet.Protocol.HttpRequestMessageConfiguration!

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -10,7 +10,7 @@ NuGet.Protocol.AmbientAuthenticationState.Block() -> void
 NuGet.Protocol.AmbientAuthenticationState.Increment() -> void
 NuGet.Protocol.AmbientAuthenticationState.IsBlocked.get -> bool
 NuGet.Protocol.AutoCompleteResourceV2Feed
-~NuGet.Protocol.AutoCompleteResourceV2Feed.AutoCompleteResourceV2Feed(NuGet.Protocol.HttpSourceResource httpSourceResource, string baseAddress, NuGet.Configuration.PackageSource packageSource) -> void
+NuGet.Protocol.AutoCompleteResourceV2Feed.AutoCompleteResourceV2Feed(NuGet.Protocol.HttpSourceResource! httpSourceResource, string! baseAddress, NuGet.Configuration.PackageSource! packageSource) -> void
 NuGet.Protocol.AutoCompleteResourceV2FeedProvider
 NuGet.Protocol.AutoCompleteResourceV2FeedProvider.AutoCompleteResourceV2FeedProvider() -> void
 NuGet.Protocol.AutoCompleteResourceV3
@@ -336,7 +336,7 @@ NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion!
 NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion! version, long? downloadCount) -> void
 NuGet.Protocol.Core.Types.VersionInfo.VersionInfo(NuGet.Versioning.NuGetVersion! version, string? downloadCount) -> void
 NuGet.Protocol.DependencyInfoResourceV2Feed
-~NuGet.Protocol.DependencyInfoResourceV2Feed.DependencyInfoResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser, NuGet.Protocol.Core.Types.SourceRepository source) -> void
+NuGet.Protocol.DependencyInfoResourceV2Feed.DependencyInfoResourceV2Feed(NuGet.Protocol.V2FeedParser! feedParser, NuGet.Protocol.Core.Types.SourceRepository! source) -> void
 NuGet.Protocol.DependencyInfoResourceV2FeedProvider
 NuGet.Protocol.DependencyInfoResourceV2FeedProvider.DependencyInfoResourceV2FeedProvider() -> void
 NuGet.Protocol.DependencyInfoResourceV3
@@ -348,8 +348,8 @@ NuGet.Protocol.DownloadResourcePlugin.DownloadResourcePlugin(NuGet.Protocol.Plug
 NuGet.Protocol.DownloadResourcePluginProvider
 NuGet.Protocol.DownloadResourcePluginProvider.DownloadResourcePluginProvider() -> void
 NuGet.Protocol.DownloadResourceV2Feed
-~NuGet.Protocol.DownloadResourceV2Feed.DownloadResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser) -> void
-~NuGet.Protocol.DownloadResourceV2Feed.DownloadResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser, string source) -> void
+NuGet.Protocol.DownloadResourceV2Feed.DownloadResourceV2Feed(NuGet.Protocol.V2FeedParser! feedParser) -> void
+NuGet.Protocol.DownloadResourceV2Feed.DownloadResourceV2Feed(NuGet.Protocol.V2FeedParser! feedParser, string! source) -> void
 NuGet.Protocol.DownloadResourceV2FeedProvider
 NuGet.Protocol.DownloadResourceV2FeedProvider.DownloadResourceV2FeedProvider() -> void
 NuGet.Protocol.DownloadResourceV3
@@ -589,7 +589,7 @@ NuGet.Protocol.InvalidCacheProtocolException.InvalidCacheProtocolException(strin
 NuGet.Protocol.JsonExtensions
 NuGet.Protocol.JsonProperties
 NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed
-~NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.LegacyFeedCapabilityResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser, string baseAddress) -> void
+NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.LegacyFeedCapabilityResourceV2Feed(NuGet.Protocol.V2FeedParser! feedParser, string! baseAddress) -> void
 NuGet.Protocol.LocalAutoCompleteResource
 NuGet.Protocol.LocalAutoCompleteResource.GetPackageVersionsFromLocalPackageRepository(string! packageId, string! versionPrefix, bool includePrerelease, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
 NuGet.Protocol.LocalAutoCompleteResource.LocalAutoCompleteResource(NuGet.Protocol.FindLocalPackagesResource! localResource) -> void
@@ -823,7 +823,7 @@ NuGet.Protocol.PackageSearchMetadataV2Feed.Title.get -> string!
 NuGet.Protocol.PackageSearchMetadataV2Feed.Version.get -> NuGet.Versioning.NuGetVersion!
 NuGet.Protocol.PackageSearchMetadataV2Feed.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
 NuGet.Protocol.PackageSearchResourceV2Feed
-~NuGet.Protocol.PackageSearchResourceV2Feed.PackageSearchResourceV2Feed(NuGet.Protocol.HttpSourceResource httpSourceResource, string baseAddress, NuGet.Configuration.PackageSource packageSource) -> void
+NuGet.Protocol.PackageSearchResourceV2Feed.PackageSearchResourceV2Feed(NuGet.Protocol.HttpSourceResource! httpSourceResource, string! baseAddress, NuGet.Configuration.PackageSource! packageSource) -> void
 NuGet.Protocol.PackageSearchResourceV2FeedProvider
 NuGet.Protocol.PackageSearchResourceV2FeedProvider.PackageSearchResourceV2FeedProvider() -> void
 NuGet.Protocol.PackageSearchResourceV3
@@ -1453,7 +1453,7 @@ NuGet.Protocol.TokenStore.GetToken(System.Uri! sourceUri) -> string?
 NuGet.Protocol.TokenStore.TokenStore() -> void
 NuGet.Protocol.TokenStore.Version.get -> System.Guid
 NuGet.Protocol.V2FeedListResource
-~NuGet.Protocol.V2FeedListResource.V2FeedListResource(NuGet.Protocol.IV2FeedParser feedParser, NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource feedCapabilities, string baseAddress) -> void
+NuGet.Protocol.V2FeedListResource.V2FeedListResource(NuGet.Protocol.IV2FeedParser! feedParser, NuGet.Protocol.Core.Types.ILegacyFeedCapabilityResource! feedCapabilities, string! baseAddress) -> void
 NuGet.Protocol.V2FeedListResourceProvider
 NuGet.Protocol.V2FeedListResourceProvider.V2FeedListResourceProvider() -> void
 NuGet.Protocol.V2FeedPackageInfo
@@ -1632,9 +1632,9 @@ const NuGet.Protocol.JsonProperties.Url = "url" -> string!
 const NuGet.Protocol.JsonProperties.Version = "version" -> string!
 const NuGet.Protocol.JsonProperties.Versions = "versions" -> string!
 const NuGet.Protocol.JsonProperties.Vulnerabilities = "vulnerabilities" -> string!
-~override NuGet.Protocol.AutoCompleteResourceV2Feed.IdStartsWith(string packageIdPrefix, bool includePrerelease, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>>
-~override NuGet.Protocol.AutoCompleteResourceV2Feed.VersionStartsWith(string packageId, string versionPrefix, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
-~override NuGet.Protocol.AutoCompleteResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.AutoCompleteResourceV2Feed.IdStartsWith(string! packageIdPrefix, bool includePrerelease, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
+override NuGet.Protocol.AutoCompleteResourceV2Feed.VersionStartsWith(string! packageId, string! versionPrefix, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
+override NuGet.Protocol.AutoCompleteResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.AutoCompleteResourceV3.IdStartsWith(string! packageIdPrefix, bool includePrerelease, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
 override NuGet.Protocol.AutoCompleteResourceV3.VersionStartsWith(string! packageId, string! versionPrefix, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
 override NuGet.Protocol.AutoCompleteResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
@@ -1651,17 +1651,17 @@ override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.Equals(object? obj
 override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.GetHashCode() -> int
 override NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo.ToString() -> string!
 override NuGet.Protocol.Core.Types.SourceRepository.ToString() -> string!
-~override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackage(NuGet.Packaging.Core.PackageIdentity package, NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo>
-~override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackages(string packageId, NuGet.Frameworks.NuGetFramework projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo>>
-~override NuGet.Protocol.DependencyInfoResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackage(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Frameworks.NuGetFramework! projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo?>!
+override NuGet.Protocol.DependencyInfoResourceV2Feed.ResolvePackages(string! packageId, NuGet.Frameworks.NuGetFramework! projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo!>!>!
+override NuGet.Protocol.DependencyInfoResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.DependencyInfoResourceV3.ResolvePackage(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Frameworks.NuGetFramework! projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo?>!
 override NuGet.Protocol.DependencyInfoResourceV3.ResolvePackages(string! packageId, NuGet.Frameworks.NuGetFramework! projectFramework, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.SourcePackageDependencyInfo!>!>!
 override NuGet.Protocol.DependencyInfoResourceV3.ResolvePackages(string! packageId, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.RemoteSourceDependencyInfo!>!>!
 override NuGet.Protocol.DependencyInfoResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.DownloadResourcePlugin.GetDownloadResourceResultAsync(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
 override NuGet.Protocol.DownloadResourcePluginProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.DownloadResourceV2Feed.GetDownloadResourceResultAsync(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Protocol.Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult>
-~override NuGet.Protocol.DownloadResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.DownloadResourceV2Feed.GetDownloadResourceResultAsync(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
+override NuGet.Protocol.DownloadResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.DownloadResourceV3.GetDownloadResourceResultAsync(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Protocol.Core.Types.PackageDownloadContext! downloadContext, string! globalPackagesFolder, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.DownloadResourceResult!>!
 override NuGet.Protocol.DownloadResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.DownloadTimeoutStream.CanRead.get -> bool
@@ -1715,8 +1715,8 @@ override NuGet.Protocol.HttpHandlerResourceV3Provider.TryCreate(NuGet.Protocol.C
 override NuGet.Protocol.HttpSourceAuthenticationHandler.Dispose(bool disposing) -> void
 override NuGet.Protocol.HttpSourceAuthenticationHandler.SendAsync(System.Net.Http.HttpRequestMessage! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
 override NuGet.Protocol.HttpSourceResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.SupportsIsAbsoluteLatestVersionAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.SupportsSearchAsync(NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
+override NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.SupportsIsAbsoluteLatestVersionAsync(NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.LegacyFeedCapabilityResourceV2Feed.SupportsSearchAsync(NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
 override NuGet.Protocol.LocalAutoCompleteResource.IdStartsWith(string! packageIdPrefix, bool includePrerelease, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string!>!>!
 override NuGet.Protocol.LocalAutoCompleteResource.VersionStartsWith(string! packageId, string! versionPrefix, bool includePrerelease, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
 override NuGet.Protocol.LocalAutoCompleteResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
@@ -1778,9 +1778,9 @@ override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Prot
 ~override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
 ~override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
 ~override NuGet.Protocol.PackageMetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.PackageSearchResourceV2Feed.SearchAsync(string searchTerm, NuGet.Protocol.Core.Types.SearchFilter filters, int skip, int take, NuGet.Common.ILogger log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
+override NuGet.Protocol.PackageSearchResourceV2Feed.SearchAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 override NuGet.Protocol.PackageSearchResourceV2Feed.SupportsPackageTypeFiltering.get -> bool
-~override NuGet.Protocol.PackageSearchResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.PackageSearchResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.PackageSearchResourceV3.SearchAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filter, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 override NuGet.Protocol.PackageSearchResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.PackageSearchResourceV3.SupportsPackageTypeFiltering.get -> bool
@@ -1879,9 +1879,9 @@ override NuGet.Protocol.SemanticVersionConverter.WriteJson(Newtonsoft.Json.JsonW
 override NuGet.Protocol.ServerWarningLogHandler.SendAsync(System.Net.Http.HttpRequestMessage! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
 override NuGet.Protocol.ServiceIndexResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.SymbolPackageUpdateResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.V2FeedListResource.ListAsync(string searchTerm, bool prerelease, bool allVersions, bool includeDelisted, NuGet.Common.ILogger logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Common.IEnumerableAsync<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
-~override NuGet.Protocol.V2FeedListResource.Source.get -> string
-~override NuGet.Protocol.V2FeedListResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.V2FeedListResource.ListAsync(string! searchTerm, bool prerelease, bool allVersions, bool includeDelisted, NuGet.Common.ILogger! logger, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Common.IEnumerableAsync<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
+override NuGet.Protocol.V2FeedListResource.Source.get -> string!
+override NuGet.Protocol.V2FeedListResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.V3FeedListResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.VersionInfoConverter.CanConvert(System.Type! objectType) -> bool
 override NuGet.Protocol.VersionInfoConverter.CanWrite.get -> bool

--- a/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Threading;
@@ -21,14 +19,14 @@ namespace NuGet.Protocol
     public sealed class RemotePackageArchiveDownloader : IPackageDownloader
     {
         private readonly SourceCacheContext _cacheContext;
-        private string _destinationFilePath;
+        private string? _destinationFilePath;
         private Func<Exception, Task<bool>> _handleExceptionAsync;
         private bool _isDisposed;
         private readonly ILogger _logger;
         private readonly PackageIdentity _packageIdentity;
         private Lazy<PackageArchiveReader> _packageReader;
         private readonly FindPackageByIdResource _resource;
-        private SemaphoreSlim _throttle;
+        private SemaphoreSlim? _throttle;
 
         /// <summary>
         /// Gets an asynchronous package content reader.
@@ -84,6 +82,11 @@ namespace NuGet.Protocol
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" />
         /// is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <see langword="null" />.</exception>
+        /// <remarks>
+        /// NULL_INC: <paramref name="source" /> is annotated as non-null but no runtime check is
+        /// enforced in the constructor to avoid introducing a new throw in a previously-permissive
+        /// code path. Revisit with telemetry to confirm callers never pass null.
+        /// </remarks>
         public RemotePackageArchiveDownloader(
             string source,
             FindPackageByIdResource resource,
@@ -261,7 +264,7 @@ namespace NuGet.Protocol
         /// Sets a throttle for package downloads.
         /// </summary>
         /// <param name="throttle">A throttle.  Can be <see langword="null" />.</param>
-        public void SetThrottle(SemaphoreSlim throttle)
+        public void SetThrottle(SemaphoreSlim? throttle)
         {
             _throttle = throttle;
         }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageDetailsUriResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageDetailsUriResourceV3.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -13,12 +11,12 @@ namespace NuGet.Protocol
     {
         private readonly string _template;
 
-        private PackageDetailsUriResourceV3(string template)
+        private PackageDetailsUriResourceV3(string? template)
         {
             _template = template ?? throw new ArgumentNullException(nameof(template));
         }
 
-        public static PackageDetailsUriResourceV3 CreateOrNull(string uriTemplate)
+        public static PackageDetailsUriResourceV3? CreateOrNull(string? uriTemplate)
         {
             if (string.IsNullOrWhiteSpace(uriTemplate)
                 || !IsValidUriTemplate(uriTemplate))
@@ -29,13 +27,12 @@ namespace NuGet.Protocol
             return new PackageDetailsUriResourceV3(uriTemplate);
         }
 
-        private static bool IsValidUriTemplate(string uriTemplate)
+        private static bool IsValidUriTemplate(string? uriTemplate)
         {
-            Uri uri;
-            var isValidUri = Uri.TryCreate(uriTemplate, UriKind.Absolute, out uri);
+            var isValidUri = Uri.TryCreate(uriTemplate, UriKind.Absolute, out Uri? uri);
 
             // Only allow HTTPS package details URLs.
-            if (isValidUri && !uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+            if (isValidUri && !uri!.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -744,10 +744,14 @@ namespace NuGet.Protocol.Core.Types
                     return;
                 }
 <<<<<<< HEAD
+<<<<<<< HEAD
                 await DeletePackageFromServer(_source, _httpSource, apiKey, packageId, packageVersion, noServiceEndpoint, logger, token);
 =======
                 await DeletePackageFromServer(source, _httpSource, apiKey, packageId, packageVersion, noServiceEndpoint, logger, token);
 >>>>>>> 26b359b73 (Pass HttpSource into server methods to avoid null suppressions)
+=======
+                await DeletePackageFromServer(_source, _httpSource, apiKey, packageId, packageVersion, noServiceEndpoint, logger, token);
+>>>>>>> 65ef0ff9d (Remove redundant source parameter from DeletePackage)
             }
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -743,15 +743,7 @@ namespace NuGet.Protocol.Core.Types
                     logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Error_HttpServerUsage, "delete", sourceUri));
                     return;
                 }
-<<<<<<< HEAD
-<<<<<<< HEAD
                 await DeletePackageFromServer(_source, _httpSource, apiKey, packageId, packageVersion, noServiceEndpoint, logger, token);
-=======
-                await DeletePackageFromServer(source, _httpSource, apiKey, packageId, packageVersion, noServiceEndpoint, logger, token);
->>>>>>> 26b359b73 (Pass HttpSource into server methods to avoid null suppressions)
-=======
-                await DeletePackageFromServer(_source, _httpSource, apiKey, packageId, packageVersion, noServiceEndpoint, logger, token);
->>>>>>> 65ef0ff9d (Remove redundant source parameter from DeletePackage)
             }
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -369,13 +369,13 @@ namespace NuGet.Protocol.Core.Types
 
             bool wasPackagePushed = true;
 
-            if (IsFileSource())
+            if (sourceUri.IsFile)
             {
                 await PushPackageToFileSystem(sourceUri, packageToPush, skipDuplicate, log, token);
             }
             else
             {
-                wasPackagePushed = await PushPackageToServer(source, _httpSource, apiKey, packageToPush, noServiceEndpoint, skipDuplicate,
+                wasPackagePushed = await PushPackageToServer(source, _httpSource!, apiKey, packageToPush, noServiceEndpoint, skipDuplicate,
                     requestTimeout, logErrorForHttpSources, allowInsecureConnections, log, token);
             }
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -369,13 +369,13 @@ namespace NuGet.Protocol.Core.Types
 
             bool wasPackagePushed = true;
 
-            if (sourceUri.IsFile)
+            if (IsFileSource())
             {
                 await PushPackageToFileSystem(sourceUri, packageToPush, skipDuplicate, log, token);
             }
             else
             {
-                wasPackagePushed = await PushPackageToServer(source, _httpSource!, apiKey, packageToPush, noServiceEndpoint, skipDuplicate,
+                wasPackagePushed = await PushPackageToServer(source, _httpSource, apiKey, packageToPush, noServiceEndpoint, skipDuplicate,
                     requestTimeout, logErrorForHttpSources, allowInsecureConnections, log, token);
             }
 
@@ -432,9 +432,6 @@ namespace NuGet.Protocol.Core.Types
             ILogger logger,
             CancellationToken token)
         {
-            HttpSource httpSource = _httpSource ?? throw new InvalidOperationException(
-                $"The source '{source}' does not provide an {nameof(HttpSource)}.");
-
             Uri serviceEndpointUrl = GetServiceEndpointUrl(source, string.Empty, noServiceEndpoint);
             bool useTempApiKey = IsSourceNuGetSymbolServer(source);
             HttpStatusCode? codeNotToThrow = ConvertSkipDuplicateParamToHttpStatusCode(skipDuplicate);
@@ -746,7 +743,11 @@ namespace NuGet.Protocol.Core.Types
                     logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Error_HttpServerUsage, "delete", sourceUri));
                     return;
                 }
+<<<<<<< HEAD
                 await DeletePackageFromServer(_source, _httpSource, apiKey, packageId, packageVersion, noServiceEndpoint, logger, token);
+=======
+                await DeletePackageFromServer(source, _httpSource, apiKey, packageId, packageVersion, noServiceEndpoint, logger, token);
+>>>>>>> 26b359b73 (Pass HttpSource into server methods to avoid null suppressions)
             }
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageUpdateResource.cs
@@ -432,6 +432,9 @@ namespace NuGet.Protocol.Core.Types
             ILogger logger,
             CancellationToken token)
         {
+            HttpSource httpSource = _httpSource ?? throw new InvalidOperationException(
+                $"The source '{source}' does not provide an {nameof(HttpSource)}.");
+
             Uri serviceEndpointUrl = GetServiceEndpointUrl(source, string.Empty, noServiceEndpoint);
             bool useTempApiKey = IsSourceNuGetSymbolServer(source);
             HttpStatusCode? codeNotToThrow = ConvertSkipDuplicateParamToHttpStatusCode(skipDuplicate);

--- a/src/NuGet.Core/NuGet.Protocol/Resources/ReportAbuseResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/ReportAbuseResourceV3.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -13,7 +11,7 @@ namespace NuGet.Protocol
     {
         private readonly string _uriTemplate;
 
-        public ReportAbuseResourceV3(string uriTemplate)
+        public ReportAbuseResourceV3(string? uriTemplate)
         {
             if (string.IsNullOrEmpty(uriTemplate) || !IsValidUriTemplate(uriTemplate))
             {
@@ -22,7 +20,7 @@ namespace NuGet.Protocol
             }
             else
             {
-                _uriTemplate = uriTemplate;
+                _uriTemplate = uriTemplate!;
             }
         }
 
@@ -48,10 +46,9 @@ namespace NuGet.Protocol
             return new Uri(uriString);
         }
 
-        private static bool IsValidUriTemplate(string uriTemplate)
+        private static bool IsValidUriTemplate(string? uriTemplate)
         {
-            Uri uri;
-            var isValidUri = Uri.TryCreate(uriTemplate, UriKind.Absolute, out uri);
+            var isValidUri = Uri.TryCreate(uriTemplate, UriKind.Absolute, out _);
             return isValidUri;
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/OfflineFeedUtility.cs
@@ -198,7 +198,7 @@ namespace NuGet.Protocol.Core.Types
                     var versionFolderPathResolver = new VersionFolderPathResolver(source);
 
                     using var packageDownloader = new LocalPackageArchiveDownloader(
-                        source: null,
+                        source: source,
                         packageFilePath: packagePath,
                         packageIdentity: packageIdentity,
                         logger: logger);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/FactoryExtensionsV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/FactoryExtensionsV3Tests.cs
@@ -13,7 +13,7 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public void GetCoreV3_WhenFactoryIsNull_Throws()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => FactoryExtensionsV3.GetCoreV3(factory: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => FactoryExtensionsV3.GetCoreV3(factory: null!));
 
             Assert.Equal("factory", exception.ParamName);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageArchiveDownloaderTests.cs
@@ -24,7 +24,7 @@ namespace NuGet.Protocol.Tests
         {
             var exception = Assert.Throws<ArgumentException>(
                 () => new LocalPackageArchiveDownloader(
-                    source: null,
+                    source: null!,
                     packageFilePath: packageFilePath,
                     packageIdentity: new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0")),
                     logger: NullLogger.Instance));
@@ -37,9 +37,9 @@ namespace NuGet.Protocol.Tests
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new LocalPackageArchiveDownloader(
-                    source: null,
+                    source: null!,
                     packageFilePath: "a",
-                    packageIdentity: null,
+                    packageIdentity: null!,
                     logger: NullLogger.Instance));
 
             Assert.Equal("packageIdentity", exception.ParamName);
@@ -50,10 +50,10 @@ namespace NuGet.Protocol.Tests
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new LocalPackageArchiveDownloader(
-                    source: null,
+                    source: null!,
                     packageFilePath: "a",
                     packageIdentity: new PackageIdentity(id: "a", version: NuGetVersion.Parse("1.0.0")),
-                    logger: null));
+                    logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
         }
@@ -328,7 +328,7 @@ namespace NuGet.Protocol.Tests
             using (var test = await LocalPackageArchiveDownloaderTest.CreateAsync())
             {
                 var exception = Assert.Throws<ArgumentNullException>(
-                    () => test.Downloader.SetExceptionHandler(handleExceptionAsync: null));
+                    () => test.Downloader.SetExceptionHandler(handleExceptionAsync: null!));
 
                 Assert.Equal("handleExceptionAsync", exception.ParamName);
             }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageDetailsUriResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageDetailsUriResourceV3Tests.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol.Tests
         {
             var resource = PackageDetailsUriResourceV3.CreateOrNull(template);
 
-            var actual = resource.GetUri("Test", NuGetVersion.Parse("1.0.0.0-ALPHA+git"));
+            var actual = resource!.GetUri("Test", NuGetVersion.Parse("1.0.0.0-ALPHA+git"));
 
             Assert.Equal(expected, actual.ToString());
         }
@@ -39,7 +39,7 @@ namespace NuGet.Protocol.Tests
             var resource = PackageDetailsUriResourceV3.CreateOrNull(template);
 
             // Act & Assert
-            var exception = Assert.Throws<Packaging.InvalidPackageIdException>(() => resource.GetUri(id, NuGetVersion.Parse("1.0.0.0-ALPHA+git")));
+            var exception = Assert.Throws<Packaging.InvalidPackageIdException>(() => resource!.GetUri(id, NuGetVersion.Parse("1.0.0.0-ALPHA+git")));
             exception.Message.Should().Contain(string.Format(Strings.Error_Invalid_package_id, id));
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReportAbuseResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Providers/ReportAbuseResourceV3ProviderTests.cs
@@ -36,7 +36,7 @@ namespace NuGet.Protocol.Tests.Providers
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
 
-            Tuple<bool, INuGetResource> result = await _target.TryCreate(sourceRepository, CancellationToken.None);
+            Tuple<bool, INuGetResource?> result = await _target.TryCreate(sourceRepository, CancellationToken.None);
 
             Assert.True(result.Item1);
             Assert.IsType<ReportAbuseResourceV3>(result.Item2);
@@ -61,7 +61,7 @@ namespace NuGet.Protocol.Tests.Providers
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
 
-            Tuple<bool, INuGetResource> result = await _target.TryCreate(sourceRepository, CancellationToken.None);
+            Tuple<bool, INuGetResource?> result = await _target.TryCreate(sourceRepository, CancellationToken.None);
 
             Assert.True(result.Item1);
             Assert.IsType<ReportAbuseResourceV3>(result.Item2);
@@ -80,7 +80,7 @@ namespace NuGet.Protocol.Tests.Providers
             };
             var sourceRepository = new SourceRepository(_packageSource, resourceProviders);
 
-            Tuple<bool, INuGetResource> result = await _target.TryCreate(sourceRepository, CancellationToken.None);
+            Tuple<bool, INuGetResource?> result = await _target.TryCreate(sourceRepository, CancellationToken.None);
 
             Assert.True(result.Item1);
             Assert.IsType<ReportAbuseResourceV3>(result.Item2);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
@@ -33,8 +33,8 @@ namespace NuGet.Protocol.Tests
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new RemotePackageArchiveDownloader(
-                        null,
-                        resource: null,
+                        null!,
+                        resource: null!,
                         packageIdentity: _packageIdentity,
                         cacheContext: sourceCacheContext,
                         logger: NullLogger.Instance));
@@ -50,9 +50,9 @@ namespace NuGet.Protocol.Tests
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new RemotePackageArchiveDownloader(
-                        null,
+                        null!,
                         Mock.Of<FindPackageByIdResource>(),
-                        packageIdentity: null,
+                        packageIdentity: null!,
                         cacheContext: sourceCacheContext,
                         logger: NullLogger.Instance));
 
@@ -65,10 +65,10 @@ namespace NuGet.Protocol.Tests
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new RemotePackageArchiveDownloader(
-                    null,
+                    null!,
                     Mock.Of<FindPackageByIdResource>(),
                     _packageIdentity,
-                    cacheContext: null,
+                    cacheContext: null!,
                     logger: NullLogger.Instance));
 
             Assert.Equal("cacheContext", exception.ParamName);
@@ -81,11 +81,11 @@ namespace NuGet.Protocol.Tests
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new RemotePackageArchiveDownloader(
-                        null,
+                        null!,
                         Mock.Of<FindPackageByIdResource>(),
                         _packageIdentity,
                         sourceCacheContext,
-                        logger: null));
+                        logger: null!));
 
                 Assert.Equal("logger", exception.ParamName);
             }
@@ -456,7 +456,7 @@ namespace NuGet.Protocol.Tests
             using (var test = await RemotePackageArchiveDownloaderTest.CreateAsync())
             {
                 var exception = Assert.Throws<ArgumentNullException>(
-                    () => test.Downloader.SetExceptionHandler(handleExceptionAsync: null));
+                    () => test.Downloader.SetExceptionHandler(handleExceptionAsync: null!));
 
                 Assert.Equal("handleExceptionAsync", exception.ParamName);
             }


### PR DESCRIPTION
# Bug

Progress: https://github.com/NuGet/Home/issues/14851 (Phases 24 + 27)

## Description

Continues the incremental `NuGet.Protocol` nullable-reference-types enablement by removing `#nullable disable` from a set of isolated leaf resources, providers, and downloaders (Phase 27 wiring, the trivial V3 metadata leaves, and the Phase 24 legacy V2Feed leaves that derive from already-annotated bases).

Notable decisions:

- **Provider `TryCreate` overrides** are widened to `Task<Tuple<bool, INuGetResource?>>` with `?? throw` guards on `GetResourceAsync<T>()`, whose result is genuinely nullable — mirrors the established provider pattern.
- **Genuinely-nullable factories are honest, not suppressed.** `DependencyInfoResourceV2Feed.ResolvePackage` now returns `Task<SourcePackageDependencyInfo?>`, and the `CreateOrNull` factories (`ReportAbuseResourceV3`, `PackageDetailsUriResourceV3`) return nullable.
- **`V2FeedParser.LoadXmlAsync` `cacheKey` becomes `string?`** — it was already null-checked internally and every caller passes null.
- **Minor behavior hardening in `AutoCompleteResourceV2Feed`:** an empty response (204/404 → null stream) now yields an empty result set instead of throwing an `NullReferenceException`.
- **`PublicAPI.Shipped.txt` updated for both `net472` and `net8.0`**, replacing the oblivious (`~`) entries in place.

No public API is added or removed; only nullability annotations change.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
