### PR TITLE
Defer loading ISettings until required

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -51,7 +51,7 @@ namespace NuGet.SolutionRestoreManager
             IComponentModel componentModel = await this.GetServiceAsync<SComponentModel, IComponentModel>();
 
             SolutionRestoreBuildHandler restoreHandler = componentModel.GetService<SolutionRestoreBuildHandler>();
-            await restoreHandler.InitializeAsync(this);
+            await restoreHandler.InitializeAsync(this, componentModel);
             _handler = restoreHandler;
 
             await SolutionRestoreCommand.InitializeAsync(this);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
@@ -41,7 +41,20 @@ namespace NuGet.SolutionRestoreManager
         private Lazy<ISolutionRestoreChecker> SolutionRestoreChecker { get; set; }
 
         private IComponentModel _componentModel;
-        private ISettings _settings;
+        private ISettings Settings
+        {
+            get
+            {
+                if (field is null)
+                {
+                    field = _componentModel.GetService<ISettings>();
+                    Assumes.Present(field);
+                }
+
+                return field;
+            }
+            set;
+        }
 
         /// <summary>
         /// The <see cref="IVsSolutionBuildManager3"/> object controlling the update solution events.
@@ -75,7 +88,7 @@ namespace NuGet.SolutionRestoreManager
             Assumes.Present(buildManager);
             Assumes.Present(solutionRestoreChecker);
 
-            _settings = settings;
+            Settings = settings;
             SolutionRestoreWorker = new Lazy<ISolutionRestoreWorker>(() => restoreWorker);
             SolutionRestoreChecker = new Lazy<ISolutionRestoreChecker>(() => solutionRestoreChecker);
             _solutionBuildManager = buildManager;
@@ -156,13 +169,7 @@ namespace NuGet.SolutionRestoreManager
             // Returns true if automatic package restore on build is enabled.
             bool ShouldRestoreOnBuild()
             {
-                if (_settings is null)
-                {
-                    _settings = _componentModel.GetService<ISettings>();
-                    Assumes.Present(_settings);
-                }
-
-                var packageRestoreConsent = new PackageRestoreConsent(_settings);
+                var packageRestoreConsent = new PackageRestoreConsent(Settings);
                 return packageRestoreConsent.IsAutomatic;
             }
         }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
@@ -8,6 +8,7 @@ using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
@@ -35,11 +36,12 @@ namespace NuGet.SolutionRestoreManager
     {
         private const uint VSCOOKIE_NIL = 0;
 
-        private Lazy<ISettings> Settings { get; set; }
-
         private Lazy<ISolutionRestoreWorker> SolutionRestoreWorker { get; set; }
 
         private Lazy<ISolutionRestoreChecker> SolutionRestoreChecker { get; set; }
+
+        private IComponentModel _componentModel;
+        private ISettings _settings;
 
         /// <summary>
         /// The <see cref="IVsSolutionBuildManager3"/> object controlling the update solution events.
@@ -52,13 +54,11 @@ namespace NuGet.SolutionRestoreManager
         private uint _updateSolutionEventsCookieEx;
 
         [ImportingConstructor]
-        internal SolutionRestoreBuildHandler(Lazy<ISettings> settings, Lazy<ISolutionRestoreWorker> restoreWorker, Lazy<ISolutionRestoreChecker> solutionRestoreChecker)
+        internal SolutionRestoreBuildHandler(Lazy<ISolutionRestoreWorker> restoreWorker, Lazy<ISolutionRestoreChecker> solutionRestoreChecker)
         {
-            Assumes.Present(settings);
             Assumes.Present(restoreWorker);
             Assumes.Present(solutionRestoreChecker);
 
-            Settings = settings;
             SolutionRestoreWorker = restoreWorker;
             SolutionRestoreChecker = solutionRestoreChecker;
         }
@@ -75,7 +75,7 @@ namespace NuGet.SolutionRestoreManager
             Assumes.Present(buildManager);
             Assumes.Present(solutionRestoreChecker);
 
-            Settings = new Lazy<ISettings>(() => settings);
+            _settings = settings;
             SolutionRestoreWorker = new Lazy<ISolutionRestoreWorker>(() => restoreWorker);
             SolutionRestoreChecker = new Lazy<ISolutionRestoreChecker>(() => solutionRestoreChecker);
             _solutionBuildManager = buildManager;
@@ -96,9 +96,12 @@ namespace NuGet.SolutionRestoreManager
         }
 
         // A factory method invoked internally only
-        internal async Task InitializeAsync(Microsoft.VisualStudio.Shell.IAsyncServiceProvider serviceProvider)
+        internal async Task InitializeAsync(Microsoft.VisualStudio.Shell.IAsyncServiceProvider serviceProvider, IComponentModel componentModel)
         {
             Assumes.Present(serviceProvider);
+            Assumes.Present(componentModel);
+
+            _componentModel = componentModel;
 
             // Don't use CPS thread helper because of RPS perf regression
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -134,7 +137,7 @@ namespace NuGet.SolutionRestoreManager
             }
             else if ((buildAction & (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD) != 0 &&
                     (buildAction & (uint)VSSOLNBUILDUPDATEFLAGS3.SBF_FLAGS_UPTODATE_CHECK) == 0 &&
-                    ShouldRestoreOnBuild)
+                    ShouldRestoreOnBuild())
             {
                 // start a restore task
                 var forceRestore = (buildAction & (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_FORCE_UPDATE) != 0;
@@ -149,16 +152,17 @@ namespace NuGet.SolutionRestoreManager
             }
 
             return true;
-        }
 
-        /// <summary>
-        /// Returns true if automatic package restore on build is enabled.
-        /// </summary>
-        private bool ShouldRestoreOnBuild
-        {
-            get
+            // Returns true if automatic package restore on build is enabled.
+            bool ShouldRestoreOnBuild()
             {
-                var packageRestoreConsent = new PackageRestoreConsent(Settings.Value);
+                if (_settings is null)
+                {
+                    _settings = _componentModel.GetService<ISettings>();
+                    Assumes.Present(_settings);
+                }
+
+                var packageRestoreConsent = new PackageRestoreConsent(_settings);
                 return packageRestoreConsent.IsAutomatic;
             }
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: assembly load perf regression

## Description

VS's internal perf monitoring found that in some scenarios where NuGet is otherwise not used, NuGet.Configuration.dll is being loaded, whereas prior to https://github.com/NuGet/NuGet.Client/pull/7454 it was not.

This change should avoid loading NuGet.Configuration.dll unless the build delay callback is made, and the settings is actually used, as it was before.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ Will get tested once inserted into VS
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
