### PR TITLE
Revert "Pack: reuse existing evaluations instead of forcing BuildProjectReferences=false (#7541)"

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
@@ -345,7 +345,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       Projects="@(_ProjectReferencesFromAssetsFile)"
       Targets="_GetProjectVersion"
       SkipNonexistentTargets="true"
-      SkipNonexistentProjects="true">
+      SkipNonexistentProjects="true"
+      Properties="BuildProjectReferences=false;">
       <Output
         TaskParameter="TargetOutputs"
         ItemName="_ProjectReferencesWithVersions"/>
@@ -364,21 +365,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_WalkEachTargetPerFramework">
     <ItemGroup>
-        <!-- Cross-targeting: address each inner-framework instance by its TargetFramework global property. -->
-        <_ProjectsWithTFM Condition="'$(TargetFrameworks)' != ''" Include="$(MSBuildProjectFullPath)" AdditionalProperties="TargetFramework=%(_TargetFrameworks.Identity)" />
-        <!-- Single-targeting: reuse the current (already-built) instance. Adding a TargetFramework global property here would fork a redundant evaluation. -->
-        <_ProjectsWithTFM Condition="'$(TargetFrameworks)' == ''" Include="$(MSBuildProjectFullPath)" />
+        <_ProjectsWithTFM Include="$(MSBuildProjectFullPath)" AdditionalProperties="TargetFramework=%(_TargetFrameworks.Identity)" />
+        <_ProjectsWithTFMNoBuild Include="$(MSBuildProjectFullPath)" AdditionalProperties="TargetFramework=%(_TargetFrameworks.Identity);BuildProjectReferences=false" />
 
-        <!-- _GetFrameworkAssemblyReferences depends on ResolveReferences, which participates in the project-to-project
-             reference protocol. During a normal pack the referenced projects have already been built, so ResolveReferences
-             reuses their existing evaluation/build results (no redundant evaluations). During a no-build pack (NoBuild=true)
-             the references were not built, so BuildProjectReferences=false is required to prevent ResolveReferences from
-             invoking the Build target on them (which would fail with NETSDK1085). Reuse the already-computed _ProjectsWithTFM
-             items and just append the BuildProjectReferences=false global property. -->
-        <_FrameworkAssemblyReferenceProjects Include="@(_ProjectsWithTFM)" Condition="'$(NoBuild)' != 'true'" />
-        <_FrameworkAssemblyReferenceProjects Include="@(_ProjectsWithTFM)" Condition="'$(NoBuild)' == 'true'">
-          <AdditionalProperties>%(_ProjectsWithTFM.AdditionalProperties);BuildProjectReferences=false</AdditionalProperties>
-        </_FrameworkAssemblyReferenceProjects>
     </ItemGroup>
     <MSBuild
       Condition="'$(IncludeBuildOutput)' == 'true'"
@@ -415,7 +404,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <MSBuild
       Condition="'$(IncludeSource)' == 'true'"
-      Projects="@(_ProjectsWithTFM)"
+      Projects="@(_ProjectsWithTFMNoBuild)"
       Targets="SourceFilesProjectOutputGroup"
       BuildInParallel="$(BuildInParallel)">
 
@@ -425,7 +414,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </MSBuild>
 
     <MSBuild
-      Projects="@(_FrameworkAssemblyReferenceProjects)"
+      Projects="@(_ProjectsWithTFMNoBuild)"
       Targets="_GetFrameworkAssemblyReferences"
       BuildInParallel="$(BuildInParallel)">
 
@@ -435,7 +424,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </MSBuild>
 
     <MSBuild
-      Projects="@(_ProjectsWithTFM)"
+      Projects="@(_ProjectsWithTFMNoBuild)"
       Targets="_GetFrameworksWithSuppressedDependencies"
       BuildInParallel="$(BuildInParallel)">
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2692,8 +2692,7 @@ namespace ClassLibrary
                     var nuspecReader = nupkgReader.NuspecReader;
                     // Validate the assets.
                     var srcItems = nupkgReader.GetFiles("src").ToArray();
-
-                    // At least the user-authored source files are always included.
+                    Assert.Equal(4, srcItems.Length);
                     Assert.Contains("src/ClassLibrary1/ClassLibrary1.csproj", srcItems);
                     Assert.Contains("src/ClassLibrary1/Class1.cs", srcItems);
                     Assert.Contains("src/ClassLibrary1/Extensions/ExtensionMethods.cs", srcItems);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

This reverts commit ca0a648107f70b8d8507430cd71d392c63c4d475 related to the below NuGet issues.
- https://github.com/NuGet/Home/issues/11530
- https://github.com/NuGet/Home/issues/14998

## Description

NuGet [forward flow PR into dotnet VMR](https://github.com/dotnet/dotnet/pull/7890) is failing with the below error. 

>  /__w/_temp/previously-source-built-sdk/sdk/11.0.100-ci/NuGet.Build.Tasks.Pack.targets(232,5): error : An item with the same key has already been added. Key: /__w/1/s/src/aspnetcore/src/Security/Authorization/Core/src/Microsoft.AspNetCore.Authorization.csproj [/__w/1/s/src/aspnetcore/src/Components/Authorization/src/Microsoft.AspNetCore.Components.Authorization.csproj]
##[error]/mnt/vss/_work/_temp/previously-source-built-sdk/sdk/11.0.100-ci/NuGet.Build.Tasks.Pack.targets(232,5): error : An item with the same key has already been added. Key: /__w/1/s/src/aspnetcore/src/Security/Authorization/Core/src/Microsoft.AspNetCore.Authorization.csproj

Another VMR PR build failed with the same error: https://github.com/dotnet/dotnet/pull/7907

I am not 100% sure yet but I am guessing https://github.com/NuGet/NuGet.Client/commit/ca0a648107f70b8d8507430cd71d392c63c4d475 commit might be the cause. 

This failure is blocking @martinrrm from making progress on [SDK side changes](https://github.com/dotnet/sdk/pull/54646) for https://github.com/NuGet/Home/issues/6279 issue.

cc @baronfel

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~