### PR TITLE
Enable nullable for the final NuGet.Protocol metadata files

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Actions/UIActionEngine.cs
@@ -857,7 +857,7 @@ namespace NuGet.PackageManagement.UI
             return new PackageLicenseInfo(
                 metadata.Identity.Id,
                 PackageLicenseUtilities.GenerateLicenseLinks(metadata),
-                metadata.Authors);
+                metadata.Authors ?? string.Empty);
         }
 
         private async ValueTask<bool> ShouldContinueDueToDotnetDeprecationAsync(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SearchObject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/SearchObject.cs
@@ -230,7 +230,10 @@ namespace NuGet.PackageManagement.VisualStudio
                 memoryCacheItem.UpdateSearchMetadata(packageSearchMetadata);
             }
 
-            NuGetPackageFileService.AddIconToCache(packageSearchMetadata.Identity, packageSearchMetadata.IconUrl);
+            if (packageSearchMetadata.IconUrl != null)
+            {
+                NuGetPackageFileService.AddIconToCache(packageSearchMetadata.Identity, packageSearchMetadata.IconUrl);
+            }
             if (localPackageSearchMetadata?.IconUrl != null)
             {
                 NuGetPackageFileService.AddLocalIconToCache(packageSearchMetadata.Identity, localPackageSearchMetadata.IconUrl);
@@ -287,7 +290,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 return null;
             }
 
-            IReadOnlyList<string> ownersList = packageSearchMetadata.OwnersList;
+            IReadOnlyList<string>? ownersList = packageSearchMetadata.OwnersList;
 
             if (ownersList is null || ownersList.Count == 0)
             {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/RecommendedPackageSearchMetadata.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/RecommendedPackageSearchMetadata.cs
@@ -25,32 +25,32 @@ namespace NuGet.VisualStudio.Internal.Contracts
         }
 
         // Implement IPackageSearchMetadata by delegating to the inner instance
-        public string Authors => _inner.Authors;
+        public string? Authors => _inner.Authors;
         public IEnumerable<PackageDependencyGroup> DependencySets => _inner.DependencySets;
-        public string Description => _inner.Description;
+        public string? Description => _inner.Description;
         public long? DownloadCount => _inner.DownloadCount;
-        public Uri IconUrl => _inner.IconUrl;
+        public Uri? IconUrl => _inner.IconUrl;
         public PackageIdentity Identity => _inner.Identity;
-        public Uri LicenseUrl => _inner.LicenseUrl;
-        public Uri ProjectUrl => _inner.ProjectUrl;
-        public string ReadmeFileUrl => _inner.ReadmeFileUrl;
-        public Uri ReadmeUrl => _inner.ReadmeUrl;
-        public Uri ReportAbuseUrl => _inner.ReportAbuseUrl;
-        public Uri PackageDetailsUrl => _inner.PackageDetailsUrl;
+        public Uri? LicenseUrl => _inner.LicenseUrl;
+        public Uri? ProjectUrl => _inner.ProjectUrl;
+        public string? ReadmeFileUrl => _inner.ReadmeFileUrl;
+        public Uri? ReadmeUrl => _inner.ReadmeUrl;
+        public Uri? ReportAbuseUrl => _inner.ReportAbuseUrl;
+        public Uri? PackageDetailsUrl => _inner.PackageDetailsUrl;
         public DateTimeOffset? Published => _inner.Published;
-        public IReadOnlyList<string> OwnersList => _inner.OwnersList;
-        public string Owners => _inner.Owners;
+        public IReadOnlyList<string>? OwnersList => _inner.OwnersList;
+        public string? Owners => _inner.Owners;
         public bool RequireLicenseAcceptance => _inner.RequireLicenseAcceptance;
-        public string Summary => _inner.Summary;
-        public string Tags => _inner.Tags;
+        public string? Summary => _inner.Summary;
+        public string? Tags => _inner.Tags;
         public string Title => _inner.Title;
         public bool IsListed => _inner.IsListed;
         public bool PrefixReserved => _inner.PrefixReserved;
-        public LicenseMetadata LicenseMetadata => _inner.LicenseMetadata;
-        public Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() => _inner.GetDeprecationMetadataAsync();
+        public LicenseMetadata? LicenseMetadata => _inner.LicenseMetadata;
+        public Task<PackageDeprecationMetadata?> GetDeprecationMetadataAsync() => _inner.GetDeprecationMetadataAsync();
 
         public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => _inner.GetVersionsAsync();
 
-        public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities => _inner.Vulnerabilities;
+        public IEnumerable<PackageVulnerabilityMetadata>? Vulnerabilities => _inner.Vulnerabilities;
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/TransitivePackageSearchMetadata.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Internal.Contracts/TransitivePackageSearchMetadata.cs
@@ -15,41 +15,41 @@ namespace NuGet.VisualStudio.Internal.Contracts
     {
         public IReadOnlyCollection<PackageIdentity> TransitiveOrigins { get; private set; }
 
-        public string Authors => _packageSearchMetadata.Authors;
+        public string? Authors => _packageSearchMetadata.Authors;
 
         public IEnumerable<PackageDependencyGroup> DependencySets => _packageSearchMetadata.DependencySets;
 
-        public string Description => _packageSearchMetadata.Description;
+        public string? Description => _packageSearchMetadata.Description;
 
         public long? DownloadCount => _packageSearchMetadata.DownloadCount;
 
-        public Uri IconUrl => _packageSearchMetadata.IconUrl;
+        public Uri? IconUrl => _packageSearchMetadata.IconUrl;
 
         public PackageIdentity Identity => _packageSearchMetadata.Identity;
 
-        public Uri LicenseUrl => _packageSearchMetadata.LicenseUrl;
+        public Uri? LicenseUrl => _packageSearchMetadata.LicenseUrl;
 
-        public Uri ProjectUrl => _packageSearchMetadata.ProjectUrl;
+        public Uri? ProjectUrl => _packageSearchMetadata.ProjectUrl;
 
-        public Uri ReadmeUrl => _packageSearchMetadata.ReadmeUrl;
+        public Uri? ReadmeUrl => _packageSearchMetadata.ReadmeUrl;
 
-        public string ReadmeFileUrl => _packageSearchMetadata.ReadmeFileUrl;
+        public string? ReadmeFileUrl => _packageSearchMetadata.ReadmeFileUrl;
 
-        public Uri ReportAbuseUrl => _packageSearchMetadata.ReportAbuseUrl;
+        public Uri? ReportAbuseUrl => _packageSearchMetadata.ReportAbuseUrl;
 
-        public Uri PackageDetailsUrl => _packageSearchMetadata.PackageDetailsUrl;
+        public Uri? PackageDetailsUrl => _packageSearchMetadata.PackageDetailsUrl;
 
         public DateTimeOffset? Published => _packageSearchMetadata.Published;
 
-        public IReadOnlyList<string> OwnersList => _packageSearchMetadata.OwnersList;
+        public IReadOnlyList<string>? OwnersList => _packageSearchMetadata.OwnersList;
 
-        public string Owners => _packageSearchMetadata.Owners;
+        public string? Owners => _packageSearchMetadata.Owners;
 
         public bool RequireLicenseAcceptance => _packageSearchMetadata.RequireLicenseAcceptance;
 
-        public string Summary => _packageSearchMetadata.Summary;
+        public string? Summary => _packageSearchMetadata.Summary;
 
-        public string Tags => _packageSearchMetadata.Tags;
+        public string? Tags => _packageSearchMetadata.Tags;
 
         public string Title => _packageSearchMetadata.Title;
 
@@ -57,9 +57,9 @@ namespace NuGet.VisualStudio.Internal.Contracts
 
         public bool PrefixReserved => _packageSearchMetadata.PrefixReserved;
 
-        public LicenseMetadata LicenseMetadata => _packageSearchMetadata.LicenseMetadata;
+        public LicenseMetadata? LicenseMetadata => _packageSearchMetadata.LicenseMetadata;
 
-        public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities => _packageSearchMetadata.Vulnerabilities;
+        public IEnumerable<PackageVulnerabilityMetadata>? Vulnerabilities => _packageSearchMetadata.Vulnerabilities;
 
         private readonly IPackageSearchMetadata _packageSearchMetadata;
 
@@ -69,7 +69,7 @@ namespace NuGet.VisualStudio.Internal.Contracts
             TransitiveOrigins = transitiveOrigins ?? throw new ArgumentNullException(nameof(transitiveOrigins));
         }
 
-        public Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync()
+        public Task<PackageDeprecationMetadata?> GetDeprecationMetadataAsync()
         {
             return _packageSearchMetadata.GetDeprecationMetadataAsync();
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/JsonFormat/SearchResultPackagesConverter.cs
@@ -71,7 +71,7 @@ namespace NuGet.CommandLine.XPlat
                 }
 
                 WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.ProjectUrl, value.ProjectUrl?.ToString());
-                PackageDeprecationMetadata packageDeprecationMetadata = value.GetDeprecationMetadataAsync().Result;
+                PackageDeprecationMetadata? packageDeprecationMetadata = value.GetDeprecationMetadataAsync().Result;
                 WriteStringIfNotNullOrWhiteSpace(writer, JsonProperties.Deprecation, packageDeprecationMetadata?.Message);
             }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultTableRenderer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageSearch/PackageSearchResultTableRenderer.cs
@@ -83,7 +83,7 @@ namespace NuGet.CommandLine.XPlat
             {
                 string packageId = result.Identity.Id;
                 string version = result.Identity.Version.ToNormalizedString();
-                string owners = result.Owners;
+                string? owners = result.Owners;
                 string downloads = "N/A";
 
                 if (result.DownloadCount != null)
@@ -97,7 +97,7 @@ namespace NuGet.CommandLine.XPlat
                 }
                 else if (verbosity == PackageSearchVerbosity.Detailed)
                 {
-                    PackageDeprecationMetadata packageDeprecationMetadata = await result.GetDeprecationMetadataAsync();
+                    PackageDeprecationMetadata? packageDeprecationMetadata = await result.GetDeprecationMetadataAsync();
                     string vulnerable = "N/A";
                     string projectUri = "N/A";
                     string deprecation = "N/A";

--- a/src/NuGet.Core/NuGet.Protocol/Converters/V3SearchResultsConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Converters/V3SearchResultsConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 using NuGet.Protocol.Model;
@@ -22,7 +20,7 @@ namespace NuGet.Protocol.Converters
 
         public override bool CanConvert(Type objectType) => objectType == typeof(V3SearchResults);
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             if (objectType != typeof(V3SearchResults))
             {
@@ -45,7 +43,7 @@ namespace NuGet.Protocol.Converters
                 switch (reader.TokenType)
                 {
                     case JsonToken.PropertyName:
-                        switch ((string)reader.Value)
+                        switch ((string)reader.Value!)
                         {
                             case "totalHits":
                                 if (long.TryParse(reader.ReadAsString(), out var totalHits))
@@ -73,7 +71,10 @@ namespace NuGet.Protocol.Converters
                                 {
                                     var searchResult = serializer.Deserialize<PackageSearchMetadata>(reader);
 
-                                    searchResults.Data.Add(searchResult);
+                                    if (searchResult != null)
+                                    {
+                                        searchResults.Data.Add(searchResult);
+                                    }
 
                                     if (searchResults.Data.Count >= _take)
                                     {
@@ -104,7 +105,7 @@ namespace NuGet.Protocol.Converters
             return searchResults;
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/MetadataResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/MetadataResourceV2Feed.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -32,10 +30,10 @@ namespace NuGet.Protocol
             _source = source;
         }
 
-        public override async Task<IEnumerable<KeyValuePair<string, NuGetVersion>>> GetLatestVersions(IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted,
+        public override async Task<IEnumerable<KeyValuePair<string, NuGetVersion?>>> GetLatestVersions(IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted,
             SourceCacheContext sourceCacheContext, ILogger log, CancellationToken token)
         {
-            var results = new List<KeyValuePair<string, NuGetVersion>>();
+            var results = new List<KeyValuePair<string, NuGetVersion?>>();
 
             var tasks = new Stack<KeyValuePair<string, Task<IEnumerable<NuGetVersion>>>>();
 
@@ -53,14 +51,14 @@ namespace NuGet.Protocol
 
                 if (versions == null || !versions.Any())
                 {
-                    results.Add(new KeyValuePair<string, NuGetVersion>(pair.Key, null));
+                    results.Add(new KeyValuePair<string, NuGetVersion?>(pair.Key, null));
                 }
                 else
                 {
                     // sort and take only the highest version
-                    NuGetVersion latestVersion = versions.OrderByDescending(p => p, VersionComparer.VersionRelease).FirstOrDefault();
+                    NuGetVersion? latestVersion = versions.OrderByDescending(p => p, VersionComparer.VersionRelease).FirstOrDefault();
 
-                    results.Add(new KeyValuePair<string, NuGetVersion>(pair.Key, latestVersion));
+                    results.Add(new KeyValuePair<string, NuGetVersion?>(pair.Key, latestVersion));
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/MetadataResourceV2FeedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/MetadataResourceV2FeedProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,21 +15,23 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            MetadataResource resource = null;
+            MetadataResource? resource = null;
 
             if (await source.GetFeedType(token) == FeedType.HttpV2)
             {
-                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
+                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(ODataServiceDocumentResourceV2)}.");
 
-                var httpSource = await source.GetResourceAsync<HttpSourceResource>(token);
+                var httpSource = await source.GetResourceAsync<HttpSourceResource>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
                 var parser = new V2FeedParser(httpSource.HttpSource, serviceDocument.BaseAddress, source.PackageSource.Source);
 
                 resource = new MetadataResourceV2Feed(parser, source);
             }
 
-            return new Tuple<bool, INuGetResource>(resource != null, resource);
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/PackageMetadataResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/PackageMetadataResourceV2Feed.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -55,7 +53,7 @@ namespace NuGet.Protocol
             return packages.Select(p => V2FeedUtilities.CreatePackageSearchResult(p, metadataCache, filter, _feedParser, log, token)).ToList();
         }
 
-        public override async Task<IPackageSearchMetadata> GetMetadataAsync(
+        public override async Task<IPackageSearchMetadata?> GetMetadataAsync(
             PackageIdentity package,
             SourceCacheContext sourceCacheContext,
             Common.ILogger log,

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/PackageMetadataResourceV2FeedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/PackageMetadataResourceV2FeedProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,20 +17,22 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            PackageMetadataResourceV2Feed resource = null;
+            PackageMetadataResourceV2Feed? resource = null;
 
             if (await source.GetFeedType(token) == FeedType.HttpV2)
             {
-                var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
+                var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
 
-                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
+                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(ODataServiceDocumentResourceV2)}.");
 
                 resource = new PackageMetadataResourceV2Feed(httpSourceResource, serviceDocument.BaseAddress, source.PackageSource);
             }
 
-            return new Tuple<bool, INuGetResource>(resource != null, resource);
+            return new Tuple<bool, INuGetResource?>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/IPackageSearchMetadata.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -17,30 +15,30 @@ namespace NuGet.Protocol.Core.Types
     /// </summary>
     public interface IPackageSearchMetadata
     {
-        string Authors { get; }
+        string? Authors { get; }
         IEnumerable<PackageDependencyGroup> DependencySets { get; }
-        string Description { get; }
+        string? Description { get; }
         long? DownloadCount { get; }
-        Uri IconUrl { get; }
+        Uri? IconUrl { get; }
         PackageIdentity Identity { get; }
-        Uri LicenseUrl { get; }
-        Uri ProjectUrl { get; }
-        Uri ReadmeUrl { get; }
-        string ReadmeFileUrl { get; }
-        Uri ReportAbuseUrl { get; }
-        Uri PackageDetailsUrl { get; }
+        Uri? LicenseUrl { get; }
+        Uri? ProjectUrl { get; }
+        Uri? ReadmeUrl { get; }
+        string? ReadmeFileUrl { get; }
+        Uri? ReportAbuseUrl { get; }
+        Uri? PackageDetailsUrl { get; }
         DateTimeOffset? Published { get; }
-        IReadOnlyList<string> OwnersList { get; }
-        string Owners { get; }
+        IReadOnlyList<string>? OwnersList { get; }
+        string? Owners { get; }
         bool RequireLicenseAcceptance { get; }
-        string Summary { get; }
-        string Tags { get; }
+        string? Summary { get; }
+        string? Tags { get; }
         string Title { get; }
 
         bool IsListed { get; }
         bool PrefixReserved { get; }
 
-        LicenseMetadata LicenseMetadata { get; }
+        LicenseMetadata? LicenseMetadata { get; }
 
         /// <summary>
         /// Gets the deprecation metadata for the package.
@@ -49,7 +47,7 @@ namespace NuGet.Protocol.Core.Types
         /// Deprecation metadata is only available through remote feeds, not local feeds. Some servers do not return deprecation information via
         /// <see cref="PackageSearchResource" /> results, only through <see cref="PackageMetadataResource" /> or <see cref="FindPackageByIdResource" />.
         /// </remarks>
-        Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync();
+        Task<PackageDeprecationMetadata?> GetDeprecationMetadataAsync();
 
         /// <summary>
         /// Lists the available versions of the package on the source.
@@ -63,6 +61,6 @@ namespace NuGet.Protocol.Core.Types
         /// Vulnerability metadata is only available through remote feeds, not local feeds. Some servers do not return vulnerability information via
         /// <see cref="PackageSearchResource" /> results, only through <see cref="PackageMetadataResource" /> or <see cref= "FindPackageByIdResource" />.
         /// </remarks>
-        IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; }
+        IEnumerable<PackageVulnerabilityMetadata>? Vulnerabilities { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadata.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -27,12 +25,12 @@ namespace NuGet.Protocol
         [JsonPropertyName(JsonProperties.Authors)]
         [System.Text.Json.Serialization.JsonConverter(typeof(MetadataFieldStjConverter))]
         [JsonInclude]
-        public string Authors { get; internal set; }
+        public string? Authors { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.DependencyGroups)]
         [JsonPropertyName(JsonProperties.DependencyGroups)]
         [JsonInclude]
-        public IEnumerable<PackageDependencyGroup> DependencySetsInternal { get; internal set; }
+        public IEnumerable<PackageDependencyGroup>? DependencySetsInternal { get; internal set; }
 
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
@@ -47,7 +45,7 @@ namespace NuGet.Protocol
         [JsonProperty(PropertyName = JsonProperties.Description)]
         [JsonPropertyName(JsonProperties.Description)]
         [JsonInclude]
-        public string Description { get; internal set; }
+        public string? Description { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.DownloadCount)]
         [JsonPropertyName(JsonProperties.DownloadCount)]
@@ -58,9 +56,9 @@ namespace NuGet.Protocol
         [JsonProperty(PropertyName = JsonProperties.IconUrl)]
         [JsonPropertyName(JsonProperties.IconUrl)]
         [JsonInclude]
-        public Uri IconUrl { get; internal set; }
+        public Uri? IconUrl { get; internal set; }
 
-        private PackageIdentity _packageIdentity = null;
+        private PackageIdentity? _packageIdentity = null;
 
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
@@ -81,16 +79,16 @@ namespace NuGet.Protocol
         [JsonPropertyName(JsonProperties.LicenseUrl)]
         [System.Text.Json.Serialization.JsonConverter(typeof(SafeUriStjConverter))]
         [JsonInclude]
-        public Uri LicenseUrl { get; internal set; }
+        public Uri? LicenseUrl { get; internal set; }
 
-        private IReadOnlyList<string> _ownersList;
+        private IReadOnlyList<string>? _ownersList;
 
         [JsonProperty(PropertyName = JsonProperties.Owners)]
         [Newtonsoft.Json.JsonConverter(typeof(MetadataStringOrArrayConverter))]
         [JsonPropertyName(JsonProperties.Owners)]
         [System.Text.Json.Serialization.JsonConverter(typeof(MetadataStringOrArrayStjConverter))]
         [JsonInclude]
-        public IReadOnlyList<string> OwnersList
+        public IReadOnlyList<string>? OwnersList
         {
             get { return _ownersList; }
             internal set
@@ -103,9 +101,9 @@ namespace NuGet.Protocol
             }
         }
 
-        private string _owners;
+        private string? _owners;
         [System.Text.Json.Serialization.JsonIgnore]
-        public string Owners
+        public string? Owners
         {
             get
             {
@@ -120,14 +118,14 @@ namespace NuGet.Protocol
         [JsonProperty(PropertyName = JsonProperties.PackageId)]
         [JsonPropertyName(JsonProperties.PackageId)]
         [JsonInclude]
-        public string PackageId { get; internal set; }
+        public string PackageId { get; internal set; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.ProjectUrl)]
         [Newtonsoft.Json.JsonConverter(typeof(SafeUriConverter))]
         [JsonPropertyName(JsonProperties.ProjectUrl)]
         [System.Text.Json.Serialization.JsonConverter(typeof(SafeUriStjConverter))]
         [JsonInclude]
-        public Uri ProjectUrl { get; internal set; }
+        public Uri? ProjectUrl { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.Published)]
         [JsonPropertyName(JsonProperties.Published)]
@@ -139,19 +137,19 @@ namespace NuGet.Protocol
         [JsonPropertyName(JsonProperties.ReadmeUrl)]
         [System.Text.Json.Serialization.JsonConverter(typeof(SafeUriStjConverter))]
         [JsonInclude]
-        public Uri ReadmeUrl { get; internal set; }
+        public Uri? ReadmeUrl { get; internal set; }
 
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
-        public string ReadmeFileUrl { get; internal set; }
+        public string? ReadmeFileUrl { get; internal set; }
 
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
-        public Uri ReportAbuseUrl { get; set; }
+        public Uri? ReportAbuseUrl { get; set; }
 
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
-        public Uri PackageDetailsUrl { get; set; }
+        public Uri? PackageDetailsUrl { get; set; }
 
         [JsonProperty(PropertyName = JsonProperties.RequireLicenseAcceptance, DefaultValueHandling = DefaultValueHandling.Populate)]
         [DefaultValue(false)]
@@ -161,12 +159,12 @@ namespace NuGet.Protocol
         [JsonInclude]
         public bool RequireLicenseAcceptance { get; internal set; }
 
-        private string _summaryValue;
+        private string? _summaryValue;
 
         [JsonProperty(PropertyName = JsonProperties.Summary)]
         [JsonPropertyName(JsonProperties.Summary)]
         [JsonInclude]
-        public string Summary
+        public string? Summary
         {
             get { return !string.IsNullOrEmpty(_summaryValue) ? _summaryValue : Description; }
             internal set { _summaryValue = value; }
@@ -177,28 +175,28 @@ namespace NuGet.Protocol
         [JsonPropertyName(JsonProperties.Tags)]
         [System.Text.Json.Serialization.JsonConverter(typeof(MetadataFieldStjConverter))]
         [JsonInclude]
-        public string Tags { get; internal set; }
+        public string? Tags { get; internal set; }
 
-        private string _titleValue;
+        private string? _titleValue;
 
         [JsonProperty(PropertyName = JsonProperties.Title)]
         [JsonPropertyName(JsonProperties.Title)]
         [JsonInclude]
         public string Title
         {
-            get { return !string.IsNullOrEmpty(_titleValue) ? _titleValue : PackageId; }
+            get { return string.IsNullOrEmpty(_titleValue) ? PackageId : _titleValue!; }
             internal set { _titleValue = value; }
         }
 
         [JsonProperty(PropertyName = JsonProperties.Version)]
         [JsonPropertyName(JsonProperties.Version)]
         [JsonInclude]
-        public NuGetVersion Version { get; internal set; }
+        public NuGetVersion Version { get; internal set; } = null!;
 
         [JsonProperty(PropertyName = JsonProperties.Versions)]
         [JsonPropertyName(JsonProperties.Versions)]
         [JsonInclude]
-        public VersionInfo[] ParsedVersions { get; internal set; }
+        public VersionInfo[]? ParsedVersions { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.PrefixReserved)]
         [JsonPropertyName(JsonProperties.PrefixReserved)]
@@ -209,16 +207,16 @@ namespace NuGet.Protocol
         [JsonProperty(PropertyName = JsonProperties.LicenseExpression)]
         [JsonPropertyName(JsonProperties.LicenseExpression)]
         [JsonInclude]
-        public string LicenseExpression { get; internal set; }
+        public string? LicenseExpression { get; internal set; }
 
         [JsonProperty(PropertyName = JsonProperties.LicenseExpressionVersion)]
         [JsonPropertyName(JsonProperties.LicenseExpressionVersion)]
         [JsonInclude]
-        public string LicenseExpressionVersion { get; internal set; }
+        public string? LicenseExpressionVersion { get; internal set; }
 
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
-        public LicenseMetadata LicenseMetadata
+        public LicenseMetadata? LicenseMetadata
         {
             get
             {
@@ -227,13 +225,13 @@ namespace NuGet.Protocol
                     return null;
                 }
 
-                var trimmedLicenseExpression = LicenseExpression.Trim();
+                var trimmedLicenseExpression = LicenseExpression!.Trim();
 
                 _ = System.Version.TryParse(LicenseExpressionVersion, out var effectiveVersion);
                 effectiveVersion = effectiveVersion ?? LicenseMetadata.EmptyVersion;
 
-                List<string> errors = null;
-                NuGetLicenseExpression parsedExpression = null;
+                List<string>? errors = null;
+                NuGetLicenseExpression? parsedExpression = null;
 
                 if (effectiveVersion.CompareTo(LicenseMetadata.CurrentVersion) <= 0)
                 {
@@ -280,9 +278,9 @@ namespace NuGet.Protocol
             }
         }
 
-        private static IList<string> GetNonStandardLicenseIdentifiers(NuGetLicenseExpression expression)
+        private static IList<string>? GetNonStandardLicenseIdentifiers(NuGetLicenseExpression expression)
         {
-            IList<string> invalidLicenseIdentifiers = null;
+            IList<string>? invalidLicenseIdentifiers = null;
             Action<NuGetLicense> licenseProcessor = delegate (NuGetLicense nugetLicense)
             {
                 if (!nugetLicense.IsStandardLicense)
@@ -300,7 +298,7 @@ namespace NuGet.Protocol
         }
 
         /// <inheritdoc cref="IPackageSearchMetadata.GetVersionsAsync" />
-        public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => Task.FromResult<IEnumerable<VersionInfo>>(ParsedVersions);
+        public Task<IEnumerable<VersionInfo>> GetVersionsAsync() => Task.FromResult<IEnumerable<VersionInfo>>(ParsedVersions ?? Enumerable.Empty<VersionInfo>());
 
         [JsonProperty(PropertyName = JsonProperties.Listed)]
         [JsonPropertyName(JsonProperties.Listed)]
@@ -311,26 +309,26 @@ namespace NuGet.Protocol
         [JsonProperty(PropertyName = JsonProperties.Deprecation)]
         [JsonPropertyName(JsonProperties.Deprecation)]
         [JsonInclude]
-        public PackageDeprecationMetadata DeprecationMetadata { get; internal set; }
+        public PackageDeprecationMetadata? DeprecationMetadata { get; internal set; }
 
         /// <inheritdoc cref="IPackageSearchMetadata.GetDeprecationMetadataAsync" />
-        public Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() => Task.FromResult(DeprecationMetadata);
+        public Task<PackageDeprecationMetadata?> GetDeprecationMetadataAsync() => Task.FromResult(DeprecationMetadata);
 
         /// <inheritdoc cref="IPackageSearchMetadata.Vulnerabilities" />
         [JsonProperty(PropertyName = JsonProperties.Vulnerabilities)]
         [JsonPropertyName(JsonProperties.Vulnerabilities)]
         [JsonInclude]
-        public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; internal set; }
+        public IEnumerable<PackageVulnerabilityMetadata>? Vulnerabilities { get; internal set; }
 
         internal void CacheStrings(MetadataReferenceCache cache)
         {
             Authors = cache.GetString(Authors);
             Description = cache.GetString(Description);
-            PackageId = cache.GetString(PackageId);
+            PackageId = cache.GetString(PackageId)!;
             ReadmeFileUrl = cache.GetString(ReadmeFileUrl);
             Tags = cache.GetString(Tags);
             Summary = cache.GetString(Summary);
-            Title = cache.GetString(Title);
+            Title = cache.GetString(Title)!;
             LicenseExpression = cache.GetString(LicenseExpression);
             LicenseExpressionVersion = cache.GetString(LicenseExpressionVersion);
         }

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataBuilder.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,49 +17,49 @@ namespace NuGet.Protocol.Core.Types
     public class PackageSearchMetadataBuilder
     {
         private readonly IPackageSearchMetadata _metadata;
-        private AsyncLazy<IEnumerable<VersionInfo>> _lazyVersionsFactory;
-        private AsyncLazy<PackageDeprecationMetadata> _lazyDeprecationFactory;
+        private AsyncLazy<IEnumerable<VersionInfo>>? _lazyVersionsFactory;
+        private AsyncLazy<PackageDeprecationMetadata?>? _lazyDeprecationFactory;
 
         public class ClonedPackageSearchMetadata : IPackageSearchMetadata
         {
             private static readonly AsyncLazy<IEnumerable<VersionInfo>> LazyEmptyVersionInfo =
                 AsyncLazy.New(Enumerable.Empty<VersionInfo>());
 
-            private static readonly AsyncLazy<PackageDeprecationMetadata> LazyNullDeprecationMetadata =
-                AsyncLazy.New((PackageDeprecationMetadata)null);
+            private static readonly AsyncLazy<PackageDeprecationMetadata?> LazyNullDeprecationMetadata =
+                AsyncLazy.New((PackageDeprecationMetadata?)null);
 
-            public string Authors { get; set; }
-            public IEnumerable<PackageDependencyGroup> DependencySets { get; set; }
-            public string Description { get; set; }
+            public string? Authors { get; set; }
+            public IEnumerable<PackageDependencyGroup> DependencySets { get; set; } = Enumerable.Empty<PackageDependencyGroup>();
+            public string? Description { get; set; }
             public long? DownloadCount { get; set; }
-            public Uri IconUrl { get; set; }
-            public PackageIdentity Identity { get; set; }
-            public Uri LicenseUrl { get; set; }
-            public IReadOnlyList<string> OwnersList { get; set; }
-            public string Owners { get; set; }
-            public Uri ProjectUrl { get; set; }
+            public Uri? IconUrl { get; set; }
+            public PackageIdentity Identity { get; set; } = null!;
+            public Uri? LicenseUrl { get; set; }
+            public IReadOnlyList<string>? OwnersList { get; set; }
+            public string? Owners { get; set; }
+            public Uri? ProjectUrl { get; set; }
             public DateTimeOffset? Published { get; set; }
-            public Uri ReadmeUrl { get; set; }
-            public string ReadmeFileUrl { get; set; }
-            public Uri ReportAbuseUrl { get; set; }
-            public Uri PackageDetailsUrl { get; set; }
+            public Uri? ReadmeUrl { get; set; }
+            public string? ReadmeFileUrl { get; set; }
+            public Uri? ReportAbuseUrl { get; set; }
+            public Uri? PackageDetailsUrl { get; set; }
             public bool RequireLicenseAcceptance { get; set; }
-            public string Summary { get; set; }
-            public string Tags { get; set; }
-            public string Title { get; set; }
+            public string? Summary { get; set; }
+            public string? Tags { get; set; }
+            public string Title { get; set; } = null!;
             public bool PrefixReserved { get; set; }
-            public LicenseMetadata LicenseMetadata { get; set; }
+            public LicenseMetadata? LicenseMetadata { get; set; }
 
-            internal AsyncLazy<IEnumerable<VersionInfo>> LazyVersionsFactory { get; set; }
+            internal AsyncLazy<IEnumerable<VersionInfo>>? LazyVersionsFactory { get; set; }
             public async Task<IEnumerable<VersionInfo>> GetVersionsAsync() => await (LazyVersionsFactory ?? LazyEmptyVersionInfo);
 
-            internal AsyncLazy<PackageDeprecationMetadata> LazyDeprecationFactory { get; set; }
-            public async Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() => await (LazyDeprecationFactory ?? LazyNullDeprecationMetadata);
-            public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; set; }
+            internal AsyncLazy<PackageDeprecationMetadata?>? LazyDeprecationFactory { get; set; }
+            public async Task<PackageDeprecationMetadata?> GetDeprecationMetadataAsync() => await (LazyDeprecationFactory ?? LazyNullDeprecationMetadata);
+            public IEnumerable<PackageVulnerabilityMetadata>? Vulnerabilities { get; set; }
             public bool IsListed { get; set; }
             [Obsolete("PackagePath is recommended in place of PackageReader")]
-            public Func<PackageReaderBase> PackageReader { get; set; }
-            public string PackagePath { get; set; }
+            public Func<PackageReaderBase>? PackageReader { get; set; }
+            public string? PackagePath { get; set; }
 
             internal void CacheStrings(MetadataReferenceCache cache)
             {
@@ -71,7 +69,7 @@ namespace NuGet.Protocol.Core.Types
                 ReadmeFileUrl = cache.GetString(ReadmeFileUrl);
                 Summary = cache.GetString(Summary);
                 Tags = cache.GetString(Tags);
-                Title = cache.GetString(Title);
+                Title = cache.GetString(Title)!;
                 PackagePath = cache.GetString(PackagePath);
             }
         }
@@ -91,7 +89,7 @@ namespace NuGet.Protocol.Core.Types
             return this;
         }
 
-        public PackageSearchMetadataBuilder WithDeprecation(AsyncLazy<PackageDeprecationMetadata> lazyDeprecationFactory)
+        public PackageSearchMetadataBuilder WithDeprecation(AsyncLazy<PackageDeprecationMetadata?> lazyDeprecationFactory)
         {
             _lazyDeprecationFactory = lazyDeprecationFactory;
             return this;

--- a/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataRegistration.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Model/PackageSearchMetadataRegistration.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Newtonsoft.Json;
 
@@ -20,6 +18,6 @@ namespace NuGet.Protocol
         [JsonProperty(PropertyName = JsonProperties.SubjectId)]
         [System.Text.Json.Serialization.JsonPropertyName("@id")]
         [System.Text.Json.Serialization.JsonInclude]
-        public Uri CatalogUri { get; internal set; }
+        public Uri? CatalogUri { get; internal set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/PackageMetadataResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PackageMetadataResourceV3Provider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,31 +11,33 @@ namespace NuGet.Protocol
 {
     public class PackageMetadataResourceV3Provider : ResourceProvider
     {
-        private readonly IEnvironmentVariableReader _environmentVariableReader;
+        private readonly IEnvironmentVariableReader? _environmentVariableReader;
 
         public PackageMetadataResourceV3Provider()
             : this(null)
         {
         }
 
-        internal PackageMetadataResourceV3Provider(IEnvironmentVariableReader environmentVariableReader)
+        internal PackageMetadataResourceV3Provider(IEnvironmentVariableReader? environmentVariableReader)
             : base(typeof(PackageMetadataResource), nameof(PackageMetadataResourceV3Provider), nameof(PackageMetadataResourceV2FeedProvider))
         {
             _environmentVariableReader = environmentVariableReader;
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            PackageMetadataResourceV3 curResource = null;
+            PackageMetadataResourceV3? curResource = null;
 
             if (await source.GetResourceAsync<ServiceIndexResourceV3>(token) != null)
             {
-                var regResource = await source.GetResourceAsync<RegistrationResourceV3>(token);
+                var regResource = await source.GetResourceAsync<RegistrationResourceV3>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(RegistrationResourceV3)}.");
                 var reportAbuseResource = await source.GetResourceAsync<ReportAbuseResourceV3>(token);
                 var readmeResource = await source.GetResourceAsync<ReadmeUriTemplateResource>(token);
                 var packageDetailsUriResource = await source.GetResourceAsync<PackageDetailsUriResourceV3>(token);
 
-                var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
+                var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token)
+                    ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
 
                 // construct a new resource
                 curResource = new PackageMetadataResourceV3(
@@ -49,7 +49,7 @@ namespace NuGet.Protocol
                     _environmentVariableReader);
             }
 
-            return new Tuple<bool, INuGetResource>(curResource != null, curResource);
+            return new Tuple<bool, INuGetResource?>(curResource != null, curResource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Providers/RegistrationResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/RegistrationResourceV3Provider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,9 +17,9 @@ namespace NuGet.Protocol
         {
         }
 
-        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            RegistrationResourceV3 regResource = null;
+            RegistrationResourceV3? regResource = null;
             var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
 
             if (serviceIndex != null)
@@ -31,14 +29,15 @@ namespace NuGet.Protocol
 
                 if (baseUrl != null)
                 {
-                    var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
+                    var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token)
+                        ?? throw new InvalidOperationException($"The source '{source.PackageSource.Source}' does not provide {nameof(HttpSourceResource)}.");
 
                     // construct a new resource
                     regResource = new RegistrationResourceV3(httpSourceResource.HttpSource, baseUrl);
                 }
             }
 
-            return new Tuple<bool, INuGetResource>(regResource != null, regResource);
+            return new Tuple<bool, INuGetResource?>(regResource != null, regResource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 NuGet.Protocol.AlternatePackageMetadata
 NuGet.Protocol.AlternatePackageMetadata.AlternatePackageMetadata() -> void
 NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string?

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 NuGet.Protocol.AlternatePackageMetadata
 NuGet.Protocol.AlternatePackageMetadata.AlternatePackageMetadata() -> void
 NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string?
@@ -78,31 +78,31 @@ NuGet.Protocol.Core.Types.INuGetResourceProvider.Name.get -> string!
 NuGet.Protocol.Core.Types.INuGetResourceProvider.ResourceType.get -> System.Type!
 NuGet.Protocol.Core.Types.INuGetResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 NuGet.Protocol.Core.Types.IPackageSearchMetadata
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Authors.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Description.get -> string
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Authors.get -> string?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Description.get -> string?
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.DownloadCount.get -> long?
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata>
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.IconUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata?>!
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.IconUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.IsListed.get -> bool
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.LicenseUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Owners.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.LicenseUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Owners.get -> string?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri?
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.PrefixReserved.get -> bool
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ProjectUrl.get -> System.Uri
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.ProjectUrl.get -> System.Uri?
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.Published.get -> System.DateTimeOffset?
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> string?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri?
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.RequireLicenseAcceptance.get -> bool
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Summary.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Tags.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Title.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Summary.get -> string?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Tags.get -> string?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Title.get -> string!
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
 NuGet.Protocol.Core.Types.ISourceRepositoryProvider
 NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
 NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
@@ -113,10 +113,10 @@ NuGet.Protocol.Core.Types.LegacyFeedCapabilityResource.LegacyFeedCapabilityResou
 NuGet.Protocol.Core.Types.ListResource
 NuGet.Protocol.Core.Types.ListResource.ListResource() -> void
 NuGet.Protocol.Core.Types.MetadataResource
-~NuGet.Protocol.Core.Types.MetadataResource.Exists(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.Core.Types.MetadataResource.Exists(string packageId, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.Core.Types.MetadataResource.GetLatestVersion(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Versioning.NuGetVersion>
-~NuGet.Protocol.Core.Types.MetadataResource.GetVersions(string packageId, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
+NuGet.Protocol.Core.Types.MetadataResource.Exists(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.Core.Types.MetadataResource.Exists(string! packageId, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.Core.Types.MetadataResource.GetLatestVersion(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Versioning.NuGetVersion?>!
+NuGet.Protocol.Core.Types.MetadataResource.GetVersions(string! packageId, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
 NuGet.Protocol.Core.Types.MetadataResource.MetadataResource() -> void
 NuGet.Protocol.Core.Types.NuGetProtocolException
 NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
@@ -159,63 +159,63 @@ NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageIdentity.get -> NuGet.
 NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageProgressEventArgs(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Configuration.PackageSource? source, double complete) -> void
 NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageSource.get -> NuGet.Configuration.PackageSource?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.Build() -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.Build() -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Authors.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Authors.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Authors.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Authors.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ClonedPackageSearchMetadata() -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DependencySets.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Description.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Description.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DependencySets.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Description.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Description.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DownloadCount.get -> long?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DownloadCount.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IconUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IconUrl.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Identity.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata?>!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IconUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IconUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Identity.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IsListed.get -> bool
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IsListed.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseMetadata.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseUrl.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Owners.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Owners.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageDetailsUrl.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackagePath.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackagePath.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageReader.get -> System.Func<NuGet.Packaging.PackageReaderBase>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageReader.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseMetadata.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Owners.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Owners.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageDetailsUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackagePath.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackagePath.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageReader.get -> System.Func<NuGet.Packaging.PackageReaderBase!>?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageReader.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PrefixReserved.get -> bool
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PrefixReserved.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ProjectUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ProjectUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ProjectUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ProjectUrl.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Published.get -> System.DateTimeOffset?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Published.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeUrl.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReportAbuseUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReportAbuseUrl.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.RequireLicenseAcceptance.get -> bool
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.RequireLicenseAcceptance.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Summary.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Summary.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Tags.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Tags.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Title.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Title.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Vulnerabilities.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.WithDeprecation(NuGet.Common.AsyncLazy<NuGet.Protocol.PackageDeprecationMetadata> lazyDeprecationFactory) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.WithVersions(NuGet.Common.AsyncLazy<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>> lazyVersionsFactory) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Summary.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Summary.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Tags.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Tags.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Title.get -> string!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Title.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Vulnerabilities.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.WithDeprecation(NuGet.Common.AsyncLazy<NuGet.Protocol.PackageDeprecationMetadata?>! lazyDeprecationFactory) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.WithVersions(NuGet.Common.AsyncLazy<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>! lazyVersionsFactory) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder!
 NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions
 NuGet.Protocol.Core.Types.PackageSearchResource
 NuGet.Protocol.Core.Types.PackageSearchResource.PackageSearchResource() -> void
@@ -687,11 +687,11 @@ NuGet.Protocol.MetadataReferenceCache.GetString(string? s) -> string?
 NuGet.Protocol.MetadataReferenceCache.GetVersion(string! s) -> NuGet.Versioning.NuGetVersion!
 NuGet.Protocol.MetadataReferenceCache.MetadataReferenceCache() -> void
 NuGet.Protocol.MetadataResourceV2Feed
-~NuGet.Protocol.MetadataResourceV2Feed.MetadataResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser, NuGet.Protocol.Core.Types.SourceRepository source) -> void
+NuGet.Protocol.MetadataResourceV2Feed.MetadataResourceV2Feed(NuGet.Protocol.V2FeedParser! feedParser, NuGet.Protocol.Core.Types.SourceRepository! source) -> void
 NuGet.Protocol.MetadataResourceV2FeedProvider
 NuGet.Protocol.MetadataResourceV2FeedProvider.MetadataResourceV2FeedProvider() -> void
 NuGet.Protocol.MetadataResourceV3
-~NuGet.Protocol.MetadataResourceV3.MetadataResourceV3(NuGet.Protocol.RegistrationResourceV3 regResource) -> void
+NuGet.Protocol.MetadataResourceV3.MetadataResourceV3(NuGet.Protocol.RegistrationResourceV3! regResource) -> void
 NuGet.Protocol.MetadataResourceV3Provider
 NuGet.Protocol.MetadataResourceV3Provider.MetadataResourceV3Provider() -> void
 NuGet.Protocol.Model.GetVulnerabilityInfoResult
@@ -739,11 +739,11 @@ NuGet.Protocol.PackageDetailsUriResourceV3.GetUri(string! id, NuGet.Versioning.N
 NuGet.Protocol.PackageDetailsUriResourceV3Provider
 NuGet.Protocol.PackageDetailsUriResourceV3Provider.PackageDetailsUriResourceV3Provider() -> void
 NuGet.Protocol.PackageMetadataResourceV2Feed
-~NuGet.Protocol.PackageMetadataResourceV2Feed.PackageMetadataResourceV2Feed(NuGet.Protocol.HttpSourceResource httpSourceResource, string baseAddress, NuGet.Configuration.PackageSource packageSource) -> void
+NuGet.Protocol.PackageMetadataResourceV2Feed.PackageMetadataResourceV2Feed(NuGet.Protocol.HttpSourceResource! httpSourceResource, string! baseAddress, NuGet.Configuration.PackageSource! packageSource) -> void
 NuGet.Protocol.PackageMetadataResourceV2FeedProvider
 NuGet.Protocol.PackageMetadataResourceV2FeedProvider.PackageMetadataResourceV2FeedProvider() -> void
 NuGet.Protocol.PackageMetadataResourceV3
-~NuGet.Protocol.PackageMetadataResourceV3.PackageMetadataResourceV3(NuGet.Protocol.HttpSource client, NuGet.Protocol.RegistrationResourceV3 regResource, NuGet.Protocol.ReportAbuseResourceV3 reportAbuseResource, NuGet.Protocol.PackageDetailsUriResourceV3 packageDetailsUriResource) -> void
+NuGet.Protocol.PackageMetadataResourceV3.PackageMetadataResourceV3(NuGet.Protocol.HttpSource! client, NuGet.Protocol.RegistrationResourceV3! regResource, NuGet.Protocol.ReportAbuseResourceV3? reportAbuseResource, NuGet.Protocol.PackageDetailsUriResourceV3? packageDetailsUriResource) -> void
 NuGet.Protocol.PackageMetadataResourceV3Provider
 NuGet.Protocol.PackageMetadataResourceV3Provider.PackageMetadataResourceV3Provider() -> void
 NuGet.Protocol.PackageNotFoundProtocolException
@@ -751,43 +751,43 @@ NuGet.Protocol.PackageNotFoundProtocolException.PackageIdentity.get -> NuGet.Pac
 NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity! package) -> void
 NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity! package, System.Exception! innerException) -> void
 NuGet.Protocol.PackageSearchMetadata
-~NuGet.Protocol.PackageSearchMetadata.Authors.get -> string
-~NuGet.Protocol.PackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.PackageSearchMetadata.DependencySetsInternal.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.PackageSearchMetadata.DeprecationMetadata.get -> NuGet.Protocol.PackageDeprecationMetadata
-~NuGet.Protocol.PackageSearchMetadata.Description.get -> string
+NuGet.Protocol.PackageSearchMetadata.Authors.get -> string?
+NuGet.Protocol.PackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.PackageSearchMetadata.DependencySetsInternal.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>?
+NuGet.Protocol.PackageSearchMetadata.DeprecationMetadata.get -> NuGet.Protocol.PackageDeprecationMetadata?
+NuGet.Protocol.PackageSearchMetadata.Description.get -> string?
 NuGet.Protocol.PackageSearchMetadata.DownloadCount.get -> long?
-~NuGet.Protocol.PackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata>
-~NuGet.Protocol.PackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>
-~NuGet.Protocol.PackageSearchMetadata.IconUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.PackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata?>!
+NuGet.Protocol.PackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!
+NuGet.Protocol.PackageSearchMetadata.IconUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
 NuGet.Protocol.PackageSearchMetadata.IsListed.get -> bool
-~NuGet.Protocol.PackageSearchMetadata.LicenseExpression.get -> string
-~NuGet.Protocol.PackageSearchMetadata.LicenseExpressionVersion.get -> string
-~NuGet.Protocol.PackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata
-~NuGet.Protocol.PackageSearchMetadata.LicenseUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.Owners.get -> string
-~NuGet.Protocol.PackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.PackageSearchMetadata.PackageDetailsUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.PackageDetailsUrl.set -> void
-~NuGet.Protocol.PackageSearchMetadata.PackageId.get -> string
+NuGet.Protocol.PackageSearchMetadata.LicenseExpression.get -> string?
+NuGet.Protocol.PackageSearchMetadata.LicenseExpressionVersion.get -> string?
+NuGet.Protocol.PackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata?
+NuGet.Protocol.PackageSearchMetadata.LicenseUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadata.Owners.get -> string?
+NuGet.Protocol.PackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.PackageSearchMetadata.PackageDetailsUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadata.PackageDetailsUrl.set -> void
+NuGet.Protocol.PackageSearchMetadata.PackageId.get -> string!
 NuGet.Protocol.PackageSearchMetadata.PackageSearchMetadata() -> void
-~NuGet.Protocol.PackageSearchMetadata.ParsedVersions.get -> NuGet.Protocol.Core.Types.VersionInfo[]
+NuGet.Protocol.PackageSearchMetadata.ParsedVersions.get -> NuGet.Protocol.Core.Types.VersionInfo![]?
 NuGet.Protocol.PackageSearchMetadata.PrefixReserved.get -> bool
-~NuGet.Protocol.PackageSearchMetadata.ProjectUrl.get -> System.Uri
+NuGet.Protocol.PackageSearchMetadata.ProjectUrl.get -> System.Uri?
 NuGet.Protocol.PackageSearchMetadata.Published.get -> System.DateTimeOffset?
-~NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> string
-~NuGet.Protocol.PackageSearchMetadata.ReadmeUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.ReportAbuseUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.ReportAbuseUrl.set -> void
+NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> string?
+NuGet.Protocol.PackageSearchMetadata.ReadmeUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadata.ReportAbuseUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadata.ReportAbuseUrl.set -> void
 NuGet.Protocol.PackageSearchMetadata.RequireLicenseAcceptance.get -> bool
-~NuGet.Protocol.PackageSearchMetadata.Summary.get -> string
-~NuGet.Protocol.PackageSearchMetadata.Tags.get -> string
-~NuGet.Protocol.PackageSearchMetadata.Title.get -> string
-~NuGet.Protocol.PackageSearchMetadata.Version.get -> NuGet.Versioning.NuGetVersion
-~NuGet.Protocol.PackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
+NuGet.Protocol.PackageSearchMetadata.Summary.get -> string?
+NuGet.Protocol.PackageSearchMetadata.Tags.get -> string?
+NuGet.Protocol.PackageSearchMetadata.Title.get -> string!
+NuGet.Protocol.PackageSearchMetadata.Version.get -> NuGet.Versioning.NuGetVersion!
+NuGet.Protocol.PackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
 NuGet.Protocol.PackageSearchMetadataRegistration
-~NuGet.Protocol.PackageSearchMetadataRegistration.CatalogUri.get -> System.Uri
+NuGet.Protocol.PackageSearchMetadataRegistration.CatalogUri.get -> System.Uri?
 NuGet.Protocol.PackageSearchMetadataRegistration.PackageSearchMetadataRegistration() -> void
 NuGet.Protocol.PackageSearchMetadataV2Feed
 NuGet.Protocol.PackageSearchMetadataV2Feed.Authors.get -> string!
@@ -1356,8 +1356,8 @@ NuGet.Protocol.RawSearchResourceV3.RawSearchResourceV3(NuGet.Protocol.HttpSource
 NuGet.Protocol.RawSearchResourceV3Provider
 NuGet.Protocol.RawSearchResourceV3Provider.RawSearchResourceV3Provider() -> void
 NuGet.Protocol.RegistrationResourceV3
-~NuGet.Protocol.RegistrationResourceV3.BaseUri.get -> System.Uri
-~NuGet.Protocol.RegistrationResourceV3.RegistrationResourceV3(NuGet.Protocol.HttpSource client, System.Uri baseUrl) -> void
+NuGet.Protocol.RegistrationResourceV3.BaseUri.get -> System.Uri!
+NuGet.Protocol.RegistrationResourceV3.RegistrationResourceV3(NuGet.Protocol.HttpSource! client, System.Uri! baseUrl) -> void
 NuGet.Protocol.RegistrationResourceV3Provider
 NuGet.Protocol.RegistrationResourceV3Provider.RegistrationResourceV3Provider() -> void
 NuGet.Protocol.RegistrationUtility
@@ -1561,12 +1561,12 @@ abstract NuGet.Protocol.Core.Types.LegacyFeedCapabilityResource.SupportsIsAbsolu
 abstract NuGet.Protocol.Core.Types.LegacyFeedCapabilityResource.SupportsSearchAsync(NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
 abstract NuGet.Protocol.Core.Types.ListResource.ListAsync(string! searchTerm, bool prerelease, bool allVersions, bool includeDelisted, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Common.IEnumerableAsync<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 abstract NuGet.Protocol.Core.Types.ListResource.Source.get -> string!
-~abstract NuGet.Protocol.Core.Types.MetadataResource.Exists(NuGet.Packaging.Core.PackageIdentity identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~abstract NuGet.Protocol.Core.Types.MetadataResource.Exists(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~abstract NuGet.Protocol.Core.Types.MetadataResource.GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NuGet.Versioning.NuGetVersion>>>
-~abstract NuGet.Protocol.Core.Types.MetadataResource.GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
-~abstract NuGet.Protocol.Core.Types.PackageMetadataResource.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
-~abstract NuGet.Protocol.Core.Types.PackageMetadataResource.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
+abstract NuGet.Protocol.Core.Types.MetadataResource.Exists(NuGet.Packaging.Core.PackageIdentity! identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+abstract NuGet.Protocol.Core.Types.MetadataResource.Exists(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+abstract NuGet.Protocol.Core.Types.MetadataResource.GetLatestVersions(System.Collections.Generic.IEnumerable<string!>! packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, NuGet.Versioning.NuGetVersion?>>!>!
+abstract NuGet.Protocol.Core.Types.MetadataResource.GetVersions(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
+abstract NuGet.Protocol.Core.Types.PackageMetadataResource.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata?>!
+abstract NuGet.Protocol.Core.Types.PackageMetadataResource.GetMetadataAsync(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 abstract NuGet.Protocol.Core.Types.PackageSearchResource.SearchAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 abstract NuGet.Protocol.Core.Types.PackageSearchResource.SupportsPackageTypeFiltering.get -> bool
 abstract NuGet.Protocol.Core.Types.ResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
@@ -1764,15 +1764,15 @@ override NuGet.Protocol.MetadataFieldConverter.CanConvert(System.Type! objectTyp
 override NuGet.Protocol.MetadataFieldConverter.CanWrite.get -> bool
 override NuGet.Protocol.MetadataFieldConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.MetadataFieldConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
-~override NuGet.Protocol.MetadataResourceV2Feed.Exists(NuGet.Packaging.Core.PackageIdentity identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.MetadataResourceV2Feed.Exists(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.MetadataResourceV2Feed.GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NuGet.Versioning.NuGetVersion>>>
-~override NuGet.Protocol.MetadataResourceV2Feed.GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
-~override NuGet.Protocol.MetadataResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.MetadataResourceV3.Exists(NuGet.Packaging.Core.PackageIdentity identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.MetadataResourceV3.Exists(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.MetadataResourceV3.GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NuGet.Versioning.NuGetVersion>>>
-~override NuGet.Protocol.MetadataResourceV3.GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
+override NuGet.Protocol.MetadataResourceV2Feed.Exists(NuGet.Packaging.Core.PackageIdentity! identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.MetadataResourceV2Feed.Exists(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.MetadataResourceV2Feed.GetLatestVersions(System.Collections.Generic.IEnumerable<string!>! packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, NuGet.Versioning.NuGetVersion?>>!>!
+override NuGet.Protocol.MetadataResourceV2Feed.GetVersions(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
+override NuGet.Protocol.MetadataResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+override NuGet.Protocol.MetadataResourceV3.Exists(NuGet.Packaging.Core.PackageIdentity! identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.MetadataResourceV3.Exists(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.MetadataResourceV3.GetLatestVersions(System.Collections.Generic.IEnumerable<string!>! packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, NuGet.Versioning.NuGetVersion?>>!>!
+override NuGet.Protocol.MetadataResourceV3.GetVersions(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
 override NuGet.Protocol.MetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
@@ -1781,12 +1781,12 @@ override NuGet.Protocol.NuGetVersionConverter.ReadJson(Newtonsoft.Json.JsonReade
 override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 override NuGet.Protocol.ODataServiceDocumentResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
-~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
-~override NuGet.Protocol.PackageMetadataResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
-~override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
-~override NuGet.Protocol.PackageMetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata?>!
+override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
+override NuGet.Protocol.PackageMetadataResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata?>!
+override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
+override NuGet.Protocol.PackageMetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.PackageSearchResourceV2Feed.SearchAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 override NuGet.Protocol.PackageSearchResourceV2Feed.SupportsPackageTypeFiltering.get -> bool
 override NuGet.Protocol.PackageSearchResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
@@ -1857,7 +1857,7 @@ override NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.TryCreate(Nu
 override NuGet.Protocol.Providers.VulnerabilityInfoResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.ProxyAuthenticationHandler.SendAsync(System.Net.Http.HttpRequestMessage! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
 override NuGet.Protocol.RawSearchResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.RegistrationResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.RegistrationResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.RemoteV2FindPackageByIdResource.CopyNupkgToStreamAsync(string! id, NuGet.Versioning.NuGetVersion! version, System.IO.Stream! destination, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 override NuGet.Protocol.RemoteV2FindPackageByIdResource.DoesPackageExistAsync(string! id, NuGet.Versioning.NuGetVersion! version, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 override NuGet.Protocol.RemoteV2FindPackageByIdResource.GetAllVersionsAsync(string! id, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
@@ -1916,11 +1916,11 @@ static NuGet.Protocol.Core.Types.OfflineFeedUtility.GetPackageDirectory(NuGet.Pa
 static NuGet.Protocol.Core.Types.OfflineFeedUtility.PackageExists(NuGet.Packaging.Core.PackageIdentity! packageIdentity, string! offlineFeed, out bool isValidPackage) -> bool
 static NuGet.Protocol.Core.Types.OfflineFeedUtility.ThrowIfInvalid(string! path) -> void
 static NuGet.Protocol.Core.Types.OfflineFeedUtility.ThrowIfInvalidOrNotFound(string! path, bool isDirectory, string! resourceString) -> void
-~static NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.FromIdentity(NuGet.Packaging.Core.PackageIdentity identity) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
-~static NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.FromMetadata(NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
-~static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata, System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo> versions) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
-~static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata, System.Func<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>> valueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
-~static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata, System.Func<System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>> asyncValueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
+static NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.FromIdentity(NuGet.Packaging.Core.PackageIdentity! identity) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder!
+static NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.FromMetadata(NuGet.Protocol.Core.Types.IPackageSearchMetadata! metadata) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder!
+static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata! metadata, System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>! versions) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
+static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata! metadata, System.Func<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>! valueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
+static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata! metadata, System.Func<System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!>! asyncValueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
 static NuGet.Protocol.Core.Types.PackageUpdateResource.ForceDeleteDirectory(string! path) -> void
 static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider!>! resourceProviders) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider!
 static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider!>! resourceProviders, string? rootPath) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider!
@@ -2134,13 +2134,13 @@ virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plu
 virtual NuGet.Protocol.Plugins.Receiver.Close() -> void
 virtual NuGet.Protocol.RawSearchResourceV3.Search(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject!>!>!
 virtual NuGet.Protocol.RawSearchResourceV3.SearchPage(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject!>!
-~virtual NuGet.Protocol.RegistrationResourceV3.GetPackageEntries(string packageId, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>>
-~virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject>
-~virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(string packageId, NuGet.Versioning.VersionRange range, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>>
-~virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>>
-~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(NuGet.Packaging.Core.PackageIdentity package) -> System.Uri
-~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string id, NuGet.Versioning.NuGetVersion version) -> System.Uri
-~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string packageId) -> System.Uri
+virtual NuGet.Protocol.RegistrationResourceV3.GetPackageEntries(string! packageId, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject!>!>!
+virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject?>!
+virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(string! packageId, NuGet.Versioning.VersionRange! range, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject!>!>!
+virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject!>!>!
+virtual NuGet.Protocol.RegistrationResourceV3.GetUri(NuGet.Packaging.Core.PackageIdentity! package) -> System.Uri!
+virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string! id, NuGet.Versioning.NuGetVersion! version) -> System.Uri!
+virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string! packageId) -> System.Uri!
 virtual NuGet.Protocol.ServiceIndexResourceV3.Entries.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!
 virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(NuGet.Versioning.NuGetVersion! clientVersion, params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!
 virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 NuGet.Protocol.AlternatePackageMetadata
 NuGet.Protocol.AlternatePackageMetadata.AlternatePackageMetadata() -> void
 NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string?
@@ -78,31 +78,31 @@ NuGet.Protocol.Core.Types.INuGetResourceProvider.Name.get -> string!
 NuGet.Protocol.Core.Types.INuGetResourceProvider.ResourceType.get -> System.Type!
 NuGet.Protocol.Core.Types.INuGetResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 NuGet.Protocol.Core.Types.IPackageSearchMetadata
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Authors.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Description.get -> string
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Authors.get -> string?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Description.get -> string?
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.DownloadCount.get -> long?
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata>
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.IconUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata?>!
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.IconUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.IsListed.get -> bool
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.LicenseUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Owners.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.LicenseUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Owners.get -> string?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri?
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.PrefixReserved.get -> bool
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ProjectUrl.get -> System.Uri
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.ProjectUrl.get -> System.Uri?
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.Published.get -> System.DateTimeOffset?
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeFileUrl.get -> string?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReadmeUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri?
 NuGet.Protocol.Core.Types.IPackageSearchMetadata.RequireLicenseAcceptance.get -> bool
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Summary.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Tags.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Title.get -> string
-~NuGet.Protocol.Core.Types.IPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Summary.get -> string?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Tags.get -> string?
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Title.get -> string!
+NuGet.Protocol.Core.Types.IPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
 NuGet.Protocol.Core.Types.ISourceRepositoryProvider
 NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source) -> NuGet.Protocol.Core.Types.SourceRepository!
 NuGet.Protocol.Core.Types.ISourceRepositoryProvider.CreateRepository(NuGet.Configuration.PackageSource! source, NuGet.Protocol.FeedType type) -> NuGet.Protocol.Core.Types.SourceRepository!
@@ -113,10 +113,10 @@ NuGet.Protocol.Core.Types.LegacyFeedCapabilityResource.LegacyFeedCapabilityResou
 NuGet.Protocol.Core.Types.ListResource
 NuGet.Protocol.Core.Types.ListResource.ListResource() -> void
 NuGet.Protocol.Core.Types.MetadataResource
-~NuGet.Protocol.Core.Types.MetadataResource.Exists(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.Core.Types.MetadataResource.Exists(string packageId, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~NuGet.Protocol.Core.Types.MetadataResource.GetLatestVersion(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Versioning.NuGetVersion>
-~NuGet.Protocol.Core.Types.MetadataResource.GetVersions(string packageId, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
+NuGet.Protocol.Core.Types.MetadataResource.Exists(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.Core.Types.MetadataResource.Exists(string! packageId, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+NuGet.Protocol.Core.Types.MetadataResource.GetLatestVersion(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Versioning.NuGetVersion?>!
+NuGet.Protocol.Core.Types.MetadataResource.GetVersions(string! packageId, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
 NuGet.Protocol.Core.Types.MetadataResource.MetadataResource() -> void
 NuGet.Protocol.Core.Types.NuGetProtocolException
 NuGet.Protocol.Core.Types.NuGetProtocolException.NuGetProtocolException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
@@ -159,63 +159,63 @@ NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageIdentity.get -> NuGet.
 NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageProgressEventArgs(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Configuration.PackageSource? source, double complete) -> void
 NuGet.Protocol.Core.Types.PackageProgressEventArgs.PackageSource.get -> NuGet.Configuration.PackageSource?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.Build() -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.Build() -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Authors.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Authors.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Authors.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Authors.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ClonedPackageSearchMetadata() -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DependencySets.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Description.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Description.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DependencySets.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Description.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Description.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DownloadCount.get -> long?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.DownloadCount.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IconUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IconUrl.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Identity.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata?>!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IconUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IconUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Identity.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IsListed.get -> bool
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.IsListed.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseMetadata.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseUrl.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Owners.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Owners.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageDetailsUrl.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackagePath.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackagePath.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageReader.get -> System.Func<NuGet.Packaging.PackageReaderBase>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageReader.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseMetadata.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.LicenseUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Owners.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Owners.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.OwnersList.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageDetailsUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageDetailsUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackagePath.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackagePath.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageReader.get -> System.Func<NuGet.Packaging.PackageReaderBase!>?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PackageReader.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PrefixReserved.get -> bool
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.PrefixReserved.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ProjectUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ProjectUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ProjectUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ProjectUrl.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Published.get -> System.DateTimeOffset?
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Published.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeUrl.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReportAbuseUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeFileUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReadmeUrl.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReportAbuseUrl.get -> System.Uri?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.ReportAbuseUrl.set -> void
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.RequireLicenseAcceptance.get -> bool
 NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.RequireLicenseAcceptance.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Summary.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Summary.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Tags.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Tags.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Title.get -> string
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Title.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Vulnerabilities.set -> void
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.WithDeprecation(NuGet.Common.AsyncLazy<NuGet.Protocol.PackageDeprecationMetadata> lazyDeprecationFactory) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
-~NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.WithVersions(NuGet.Common.AsyncLazy<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>> lazyVersionsFactory) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Summary.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Summary.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Tags.get -> string?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Tags.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Title.get -> string!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Title.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.ClonedPackageSearchMetadata.Vulnerabilities.set -> void
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.WithDeprecation(NuGet.Common.AsyncLazy<NuGet.Protocol.PackageDeprecationMetadata?>! lazyDeprecationFactory) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder!
+NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.WithVersions(NuGet.Common.AsyncLazy<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>! lazyVersionsFactory) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder!
 NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions
 NuGet.Protocol.Core.Types.PackageSearchResource
 NuGet.Protocol.Core.Types.PackageSearchResource.PackageSearchResource() -> void
@@ -687,11 +687,11 @@ NuGet.Protocol.MetadataReferenceCache.GetString(string? s) -> string?
 NuGet.Protocol.MetadataReferenceCache.GetVersion(string! s) -> NuGet.Versioning.NuGetVersion!
 NuGet.Protocol.MetadataReferenceCache.MetadataReferenceCache() -> void
 NuGet.Protocol.MetadataResourceV2Feed
-~NuGet.Protocol.MetadataResourceV2Feed.MetadataResourceV2Feed(NuGet.Protocol.V2FeedParser feedParser, NuGet.Protocol.Core.Types.SourceRepository source) -> void
+NuGet.Protocol.MetadataResourceV2Feed.MetadataResourceV2Feed(NuGet.Protocol.V2FeedParser! feedParser, NuGet.Protocol.Core.Types.SourceRepository! source) -> void
 NuGet.Protocol.MetadataResourceV2FeedProvider
 NuGet.Protocol.MetadataResourceV2FeedProvider.MetadataResourceV2FeedProvider() -> void
 NuGet.Protocol.MetadataResourceV3
-~NuGet.Protocol.MetadataResourceV3.MetadataResourceV3(NuGet.Protocol.RegistrationResourceV3 regResource) -> void
+NuGet.Protocol.MetadataResourceV3.MetadataResourceV3(NuGet.Protocol.RegistrationResourceV3! regResource) -> void
 NuGet.Protocol.MetadataResourceV3Provider
 NuGet.Protocol.MetadataResourceV3Provider.MetadataResourceV3Provider() -> void
 NuGet.Protocol.Model.GetVulnerabilityInfoResult
@@ -739,11 +739,11 @@ NuGet.Protocol.PackageDetailsUriResourceV3.GetUri(string! id, NuGet.Versioning.N
 NuGet.Protocol.PackageDetailsUriResourceV3Provider
 NuGet.Protocol.PackageDetailsUriResourceV3Provider.PackageDetailsUriResourceV3Provider() -> void
 NuGet.Protocol.PackageMetadataResourceV2Feed
-~NuGet.Protocol.PackageMetadataResourceV2Feed.PackageMetadataResourceV2Feed(NuGet.Protocol.HttpSourceResource httpSourceResource, string baseAddress, NuGet.Configuration.PackageSource packageSource) -> void
+NuGet.Protocol.PackageMetadataResourceV2Feed.PackageMetadataResourceV2Feed(NuGet.Protocol.HttpSourceResource! httpSourceResource, string! baseAddress, NuGet.Configuration.PackageSource! packageSource) -> void
 NuGet.Protocol.PackageMetadataResourceV2FeedProvider
 NuGet.Protocol.PackageMetadataResourceV2FeedProvider.PackageMetadataResourceV2FeedProvider() -> void
 NuGet.Protocol.PackageMetadataResourceV3
-~NuGet.Protocol.PackageMetadataResourceV3.PackageMetadataResourceV3(NuGet.Protocol.HttpSource client, NuGet.Protocol.RegistrationResourceV3 regResource, NuGet.Protocol.ReportAbuseResourceV3 reportAbuseResource, NuGet.Protocol.PackageDetailsUriResourceV3 packageDetailsUriResource) -> void
+NuGet.Protocol.PackageMetadataResourceV3.PackageMetadataResourceV3(NuGet.Protocol.HttpSource! client, NuGet.Protocol.RegistrationResourceV3! regResource, NuGet.Protocol.ReportAbuseResourceV3? reportAbuseResource, NuGet.Protocol.PackageDetailsUriResourceV3? packageDetailsUriResource) -> void
 NuGet.Protocol.PackageMetadataResourceV3Provider
 NuGet.Protocol.PackageMetadataResourceV3Provider.PackageMetadataResourceV3Provider() -> void
 NuGet.Protocol.PackageNotFoundProtocolException
@@ -751,43 +751,43 @@ NuGet.Protocol.PackageNotFoundProtocolException.PackageIdentity.get -> NuGet.Pac
 NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity! package) -> void
 NuGet.Protocol.PackageNotFoundProtocolException.PackageNotFoundProtocolException(NuGet.Packaging.Core.PackageIdentity! package, System.Exception! innerException) -> void
 NuGet.Protocol.PackageSearchMetadata
-~NuGet.Protocol.PackageSearchMetadata.Authors.get -> string
-~NuGet.Protocol.PackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.PackageSearchMetadata.DependencySetsInternal.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup>
-~NuGet.Protocol.PackageSearchMetadata.DeprecationMetadata.get -> NuGet.Protocol.PackageDeprecationMetadata
-~NuGet.Protocol.PackageSearchMetadata.Description.get -> string
+NuGet.Protocol.PackageSearchMetadata.Authors.get -> string?
+NuGet.Protocol.PackageSearchMetadata.DependencySets.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>!
+NuGet.Protocol.PackageSearchMetadata.DependencySetsInternal.get -> System.Collections.Generic.IEnumerable<NuGet.Packaging.PackageDependencyGroup!>?
+NuGet.Protocol.PackageSearchMetadata.DeprecationMetadata.get -> NuGet.Protocol.PackageDeprecationMetadata?
+NuGet.Protocol.PackageSearchMetadata.Description.get -> string?
 NuGet.Protocol.PackageSearchMetadata.DownloadCount.get -> long?
-~NuGet.Protocol.PackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata>
-~NuGet.Protocol.PackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>
-~NuGet.Protocol.PackageSearchMetadata.IconUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity
+NuGet.Protocol.PackageSearchMetadata.GetDeprecationMetadataAsync() -> System.Threading.Tasks.Task<NuGet.Protocol.PackageDeprecationMetadata?>!
+NuGet.Protocol.PackageSearchMetadata.GetVersionsAsync() -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!
+NuGet.Protocol.PackageSearchMetadata.IconUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadata.Identity.get -> NuGet.Packaging.Core.PackageIdentity!
 NuGet.Protocol.PackageSearchMetadata.IsListed.get -> bool
-~NuGet.Protocol.PackageSearchMetadata.LicenseExpression.get -> string
-~NuGet.Protocol.PackageSearchMetadata.LicenseExpressionVersion.get -> string
-~NuGet.Protocol.PackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata
-~NuGet.Protocol.PackageSearchMetadata.LicenseUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.Owners.get -> string
-~NuGet.Protocol.PackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string>
-~NuGet.Protocol.PackageSearchMetadata.PackageDetailsUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.PackageDetailsUrl.set -> void
-~NuGet.Protocol.PackageSearchMetadata.PackageId.get -> string
+NuGet.Protocol.PackageSearchMetadata.LicenseExpression.get -> string?
+NuGet.Protocol.PackageSearchMetadata.LicenseExpressionVersion.get -> string?
+NuGet.Protocol.PackageSearchMetadata.LicenseMetadata.get -> NuGet.Packaging.LicenseMetadata?
+NuGet.Protocol.PackageSearchMetadata.LicenseUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadata.Owners.get -> string?
+NuGet.Protocol.PackageSearchMetadata.OwnersList.get -> System.Collections.Generic.IReadOnlyList<string!>?
+NuGet.Protocol.PackageSearchMetadata.PackageDetailsUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadata.PackageDetailsUrl.set -> void
+NuGet.Protocol.PackageSearchMetadata.PackageId.get -> string!
 NuGet.Protocol.PackageSearchMetadata.PackageSearchMetadata() -> void
-~NuGet.Protocol.PackageSearchMetadata.ParsedVersions.get -> NuGet.Protocol.Core.Types.VersionInfo[]
+NuGet.Protocol.PackageSearchMetadata.ParsedVersions.get -> NuGet.Protocol.Core.Types.VersionInfo![]?
 NuGet.Protocol.PackageSearchMetadata.PrefixReserved.get -> bool
-~NuGet.Protocol.PackageSearchMetadata.ProjectUrl.get -> System.Uri
+NuGet.Protocol.PackageSearchMetadata.ProjectUrl.get -> System.Uri?
 NuGet.Protocol.PackageSearchMetadata.Published.get -> System.DateTimeOffset?
-~NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> string
-~NuGet.Protocol.PackageSearchMetadata.ReadmeUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.ReportAbuseUrl.get -> System.Uri
-~NuGet.Protocol.PackageSearchMetadata.ReportAbuseUrl.set -> void
+NuGet.Protocol.PackageSearchMetadata.ReadmeFileUrl.get -> string?
+NuGet.Protocol.PackageSearchMetadata.ReadmeUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadata.ReportAbuseUrl.get -> System.Uri?
+NuGet.Protocol.PackageSearchMetadata.ReportAbuseUrl.set -> void
 NuGet.Protocol.PackageSearchMetadata.RequireLicenseAcceptance.get -> bool
-~NuGet.Protocol.PackageSearchMetadata.Summary.get -> string
-~NuGet.Protocol.PackageSearchMetadata.Tags.get -> string
-~NuGet.Protocol.PackageSearchMetadata.Title.get -> string
-~NuGet.Protocol.PackageSearchMetadata.Version.get -> NuGet.Versioning.NuGetVersion
-~NuGet.Protocol.PackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata>
+NuGet.Protocol.PackageSearchMetadata.Summary.get -> string?
+NuGet.Protocol.PackageSearchMetadata.Tags.get -> string?
+NuGet.Protocol.PackageSearchMetadata.Title.get -> string!
+NuGet.Protocol.PackageSearchMetadata.Version.get -> NuGet.Versioning.NuGetVersion!
+NuGet.Protocol.PackageSearchMetadata.Vulnerabilities.get -> System.Collections.Generic.IEnumerable<NuGet.Protocol.PackageVulnerabilityMetadata!>?
 NuGet.Protocol.PackageSearchMetadataRegistration
-~NuGet.Protocol.PackageSearchMetadataRegistration.CatalogUri.get -> System.Uri
+NuGet.Protocol.PackageSearchMetadataRegistration.CatalogUri.get -> System.Uri?
 NuGet.Protocol.PackageSearchMetadataRegistration.PackageSearchMetadataRegistration() -> void
 NuGet.Protocol.PackageSearchMetadataV2Feed
 NuGet.Protocol.PackageSearchMetadataV2Feed.Authors.get -> string!
@@ -1356,8 +1356,8 @@ NuGet.Protocol.RawSearchResourceV3.RawSearchResourceV3(NuGet.Protocol.HttpSource
 NuGet.Protocol.RawSearchResourceV3Provider
 NuGet.Protocol.RawSearchResourceV3Provider.RawSearchResourceV3Provider() -> void
 NuGet.Protocol.RegistrationResourceV3
-~NuGet.Protocol.RegistrationResourceV3.BaseUri.get -> System.Uri
-~NuGet.Protocol.RegistrationResourceV3.RegistrationResourceV3(NuGet.Protocol.HttpSource client, System.Uri baseUrl) -> void
+NuGet.Protocol.RegistrationResourceV3.BaseUri.get -> System.Uri!
+NuGet.Protocol.RegistrationResourceV3.RegistrationResourceV3(NuGet.Protocol.HttpSource! client, System.Uri! baseUrl) -> void
 NuGet.Protocol.RegistrationResourceV3Provider
 NuGet.Protocol.RegistrationResourceV3Provider.RegistrationResourceV3Provider() -> void
 NuGet.Protocol.RegistrationUtility
@@ -1557,12 +1557,12 @@ abstract NuGet.Protocol.Core.Types.LegacyFeedCapabilityResource.SupportsIsAbsolu
 abstract NuGet.Protocol.Core.Types.LegacyFeedCapabilityResource.SupportsSearchAsync(NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
 abstract NuGet.Protocol.Core.Types.ListResource.ListAsync(string! searchTerm, bool prerelease, bool allVersions, bool includeDelisted, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Common.IEnumerableAsync<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 abstract NuGet.Protocol.Core.Types.ListResource.Source.get -> string!
-~abstract NuGet.Protocol.Core.Types.MetadataResource.Exists(NuGet.Packaging.Core.PackageIdentity identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~abstract NuGet.Protocol.Core.Types.MetadataResource.Exists(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~abstract NuGet.Protocol.Core.Types.MetadataResource.GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NuGet.Versioning.NuGetVersion>>>
-~abstract NuGet.Protocol.Core.Types.MetadataResource.GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
-~abstract NuGet.Protocol.Core.Types.PackageMetadataResource.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
-~abstract NuGet.Protocol.Core.Types.PackageMetadataResource.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
+abstract NuGet.Protocol.Core.Types.MetadataResource.Exists(NuGet.Packaging.Core.PackageIdentity! identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+abstract NuGet.Protocol.Core.Types.MetadataResource.Exists(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+abstract NuGet.Protocol.Core.Types.MetadataResource.GetLatestVersions(System.Collections.Generic.IEnumerable<string!>! packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, NuGet.Versioning.NuGetVersion?>>!>!
+abstract NuGet.Protocol.Core.Types.MetadataResource.GetVersions(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
+abstract NuGet.Protocol.Core.Types.PackageMetadataResource.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata?>!
+abstract NuGet.Protocol.Core.Types.PackageMetadataResource.GetMetadataAsync(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 abstract NuGet.Protocol.Core.Types.PackageSearchResource.SearchAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 abstract NuGet.Protocol.Core.Types.PackageSearchResource.SupportsPackageTypeFiltering.get -> bool
 abstract NuGet.Protocol.Core.Types.ResourceProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
@@ -1755,15 +1755,15 @@ override NuGet.Protocol.MetadataFieldConverter.CanConvert(System.Type! objectTyp
 override NuGet.Protocol.MetadataFieldConverter.CanWrite.get -> bool
 override NuGet.Protocol.MetadataFieldConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, object? existingValue, Newtonsoft.Json.JsonSerializer! serializer) -> object?
 override NuGet.Protocol.MetadataFieldConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
-~override NuGet.Protocol.MetadataResourceV2Feed.Exists(NuGet.Packaging.Core.PackageIdentity identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.MetadataResourceV2Feed.Exists(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.MetadataResourceV2Feed.GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NuGet.Versioning.NuGetVersion>>>
-~override NuGet.Protocol.MetadataResourceV2Feed.GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
-~override NuGet.Protocol.MetadataResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.MetadataResourceV3.Exists(NuGet.Packaging.Core.PackageIdentity identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.MetadataResourceV3.Exists(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>
-~override NuGet.Protocol.MetadataResourceV3.GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NuGet.Versioning.NuGetVersion>>>
-~override NuGet.Protocol.MetadataResourceV3.GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion>>
+override NuGet.Protocol.MetadataResourceV2Feed.Exists(NuGet.Packaging.Core.PackageIdentity! identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.MetadataResourceV2Feed.Exists(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.MetadataResourceV2Feed.GetLatestVersions(System.Collections.Generic.IEnumerable<string!>! packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, NuGet.Versioning.NuGetVersion?>>!>!
+override NuGet.Protocol.MetadataResourceV2Feed.GetVersions(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
+override NuGet.Protocol.MetadataResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+override NuGet.Protocol.MetadataResourceV3.Exists(NuGet.Packaging.Core.PackageIdentity! identity, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.MetadataResourceV3.Exists(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<bool>!
+override NuGet.Protocol.MetadataResourceV3.GetLatestVersions(System.Collections.Generic.IEnumerable<string!>! packageIds, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, NuGet.Versioning.NuGetVersion?>>!>!
+override NuGet.Protocol.MetadataResourceV3.GetVersions(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
 override NuGet.Protocol.MetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.Equals(object? obj) -> bool
 override NuGet.Protocol.Model.PackageVulnerabilityInfo.GetHashCode() -> int
@@ -1772,12 +1772,12 @@ override NuGet.Protocol.NuGetVersionConverter.ReadJson(Newtonsoft.Json.JsonReade
 override NuGet.Protocol.NuGetVersionConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, object? value, Newtonsoft.Json.JsonSerializer! serializer) -> void
 override NuGet.Protocol.ODataServiceDocumentResourceV2Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.PackageDetailsUriResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
-~override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
-~override NuGet.Protocol.PackageMetadataResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
-~override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity package, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata>
-~override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext sourceCacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata>>
-~override NuGet.Protocol.PackageMetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata?>!
+override NuGet.Protocol.PackageMetadataResourceV2Feed.GetMetadataAsync(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
+override NuGet.Protocol.PackageMetadataResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
+override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(NuGet.Packaging.Core.PackageIdentity! package, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<NuGet.Protocol.Core.Types.IPackageSearchMetadata?>!
+override NuGet.Protocol.PackageMetadataResourceV3.GetMetadataAsync(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! sourceCacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
+override NuGet.Protocol.PackageMetadataResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.PackageSearchResourceV2Feed.SearchAsync(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.IPackageSearchMetadata!>!>!
 override NuGet.Protocol.PackageSearchResourceV2Feed.SupportsPackageTypeFiltering.get -> bool
 override NuGet.Protocol.PackageSearchResourceV2FeedProvider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
@@ -1848,7 +1848,7 @@ override NuGet.Protocol.Providers.OwnerDetailsUriResourceV3Provider.TryCreate(Nu
 override NuGet.Protocol.Providers.VulnerabilityInfoResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.ProxyAuthenticationHandler.SendAsync(System.Net.Http.HttpRequestMessage! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
 override NuGet.Protocol.RawSearchResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
-~override NuGet.Protocol.RegistrationResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource>>
+override NuGet.Protocol.RegistrationResourceV3Provider.TryCreate(NuGet.Protocol.Core.Types.SourceRepository! source, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Tuple<bool, NuGet.Protocol.Core.Types.INuGetResource?>!>!
 override NuGet.Protocol.RemoteV2FindPackageByIdResource.CopyNupkgToStreamAsync(string! id, NuGet.Versioning.NuGetVersion! version, System.IO.Stream! destination, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 override NuGet.Protocol.RemoteV2FindPackageByIdResource.DoesPackageExistAsync(string! id, NuGet.Versioning.NuGetVersion! version, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 override NuGet.Protocol.RemoteV2FindPackageByIdResource.GetAllVersionsAsync(string! id, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! logger, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Versioning.NuGetVersion!>!>!
@@ -1906,11 +1906,11 @@ static NuGet.Protocol.Core.Types.OfflineFeedUtility.GetPackageDirectory(NuGet.Pa
 static NuGet.Protocol.Core.Types.OfflineFeedUtility.PackageExists(NuGet.Packaging.Core.PackageIdentity! packageIdentity, string! offlineFeed, out bool isValidPackage) -> bool
 static NuGet.Protocol.Core.Types.OfflineFeedUtility.ThrowIfInvalid(string! path) -> void
 static NuGet.Protocol.Core.Types.OfflineFeedUtility.ThrowIfInvalidOrNotFound(string! path, bool isDirectory, string! resourceString) -> void
-~static NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.FromIdentity(NuGet.Packaging.Core.PackageIdentity identity) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
-~static NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.FromMetadata(NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder
-~static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata, System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo> versions) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
-~static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata, System.Func<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>> valueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
-~static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata metadata, System.Func<System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo>>> asyncValueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata
+static NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.FromIdentity(NuGet.Packaging.Core.PackageIdentity! identity) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder!
+static NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder.FromMetadata(NuGet.Protocol.Core.Types.IPackageSearchMetadata! metadata) -> NuGet.Protocol.Core.Types.PackageSearchMetadataBuilder!
+static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata! metadata, System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>! versions) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
+static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata! metadata, System.Func<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>! valueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
+static NuGet.Protocol.Core.Types.PackageSearchMetadataExtensions.WithVersions(this NuGet.Protocol.Core.Types.IPackageSearchMetadata! metadata, System.Func<System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.VersionInfo!>!>!>! asyncValueFactory) -> NuGet.Protocol.Core.Types.IPackageSearchMetadata!
 static NuGet.Protocol.Core.Types.PackageUpdateResource.ForceDeleteDirectory(string! path) -> void
 static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider!>! resourceProviders) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider!
 static NuGet.Protocol.Core.Types.Repository.CreateProvider(System.Collections.Generic.IEnumerable<NuGet.Protocol.Core.Types.INuGetResourceProvider!>! resourceProviders, string? rootPath) -> NuGet.Protocol.Core.Types.ISourceRepositoryProvider!
@@ -2122,13 +2122,13 @@ virtual NuGet.Protocol.Plugins.PluginFactory.GetOrCreateAsync(NuGet.Protocol.Plu
 virtual NuGet.Protocol.Plugins.Receiver.Close() -> void
 virtual NuGet.Protocol.RawSearchResourceV3.Search(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject!>!>!
 virtual NuGet.Protocol.RawSearchResourceV3.SearchPage(string! searchTerm, NuGet.Protocol.Core.Types.SearchFilter! filters, int skip, int take, NuGet.Common.ILogger! log, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject!>!
-~virtual NuGet.Protocol.RegistrationResourceV3.GetPackageEntries(string packageId, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>>
-~virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(NuGet.Packaging.Core.PackageIdentity identity, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject>
-~virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(string packageId, NuGet.Versioning.VersionRange range, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>>
-~virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(string packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext cacheContext, NuGet.Common.ILogger log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>>
-~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(NuGet.Packaging.Core.PackageIdentity package) -> System.Uri
-~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string id, NuGet.Versioning.NuGetVersion version) -> System.Uri
-~virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string packageId) -> System.Uri
+virtual NuGet.Protocol.RegistrationResourceV3.GetPackageEntries(string! packageId, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject!>!>!
+virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(NuGet.Packaging.Core.PackageIdentity! identity, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject?>!
+virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(string! packageId, NuGet.Versioning.VersionRange! range, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject!>!>!
+virtual NuGet.Protocol.RegistrationResourceV3.GetPackageMetadata(string! packageId, bool includePrerelease, bool includeUnlisted, NuGet.Protocol.Core.Types.SourceCacheContext! cacheContext, NuGet.Common.ILogger! log, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject!>!>!
+virtual NuGet.Protocol.RegistrationResourceV3.GetUri(NuGet.Packaging.Core.PackageIdentity! package) -> System.Uri!
+virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string! id, NuGet.Versioning.NuGetVersion! version) -> System.Uri!
+virtual NuGet.Protocol.RegistrationResourceV3.GetUri(string! packageId) -> System.Uri!
 virtual NuGet.Protocol.ServiceIndexResourceV3.Entries.get -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!
 virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(NuGet.Versioning.NuGetVersion! clientVersion, params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!
 virtual NuGet.Protocol.ServiceIndexResourceV3.GetServiceEntries(params string![]! orderedTypes) -> System.Collections.Generic.IReadOnlyList<NuGet.Protocol.ServiceIndexEntry!>!

--- a/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/NuGet.Core/NuGet.Protocol/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 NuGet.Protocol.AlternatePackageMetadata
 NuGet.Protocol.AlternatePackageMetadata.AlternatePackageMetadata() -> void
 NuGet.Protocol.AlternatePackageMetadata.PackageId.get -> string?

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
@@ -123,7 +123,7 @@ namespace NuGet.Protocol
         private static async Task<Uri?> GetDownloadUrlFromItemAsync(RegistrationResourceV3 regResource, PackageIdentity identity, SourceCacheContext sourceCacheContext, ILogger log, CancellationToken token)
         {
             // Read the url from the registration information
-            RegistrationLeafItem leaf = await regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
+            RegistrationLeafItem? leaf = await regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
 
             return leaf?.PackageContent;
         }
@@ -131,7 +131,7 @@ namespace NuGet.Protocol
         private static async Task<Uri?> GetDownloadUrlFromJObjectAsync(RegistrationResourceV3 regResource, PackageIdentity identity, SourceCacheContext sourceCacheContext, ILogger log, CancellationToken token)
         {
             // Read the url from the registration information
-            JObject blob = await regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
+            JObject? blob = await regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
 
             if (blob != null
                 && blob["packageContent"] != null)

--- a/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -51,9 +49,9 @@ namespace NuGet.Protocol.Core.Types
 
         public abstract Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token);
 
-        public abstract Task<IEnumerable<KeyValuePair<string, NuGetVersion>>> GetLatestVersions(IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token);
+        public abstract Task<IEnumerable<KeyValuePair<string, NuGetVersion?>>> GetLatestVersions(IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token);
 
-        public async Task<NuGetVersion> GetLatestVersion(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
+        public async Task<NuGetVersion?> GetLatestVersion(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
             var results = await GetLatestVersions(new string[] { packageId }, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
             var result = results.SingleOrDefault();

--- a/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResourceV3.cs
@@ -1,11 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,14 +23,14 @@ namespace NuGet.Protocol
     public class MetadataResourceV3 : MetadataResource
     {
         private RegistrationResourceV3 _regResource;
-        private readonly Common.IEnvironmentVariableReader _environmentVariableReader;
+        private readonly Common.IEnvironmentVariableReader? _environmentVariableReader;
 
         public MetadataResourceV3(RegistrationResourceV3 regResource)
             : this(regResource, environmentVariableReader: null)
         {
         }
 
-        internal MetadataResourceV3(RegistrationResourceV3 regResource, Common.IEnvironmentVariableReader environmentVariableReader)
+        internal MetadataResourceV3(RegistrationResourceV3 regResource, Common.IEnvironmentVariableReader? environmentVariableReader)
             : base()
         {
             _regResource = regResource ?? throw new ArgumentNullException(nameof(regResource));
@@ -43,7 +42,7 @@ namespace NuGet.Protocol
         /// </summary>
         /// <param name="includePrerelease">include versions with prerelease labels</param>
         /// <param name="includeUnlisted">not implemented yet</param>
-        public override async Task<IEnumerable<KeyValuePair<string, NuGetVersion>>> GetLatestVersions(
+        public override async Task<IEnumerable<KeyValuePair<string, NuGetVersion?>>> GetLatestVersions(
             IEnumerable<string> packageIds,
             bool includePrerelease,
             bool includeUnlisted,
@@ -51,7 +50,7 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            var results = new List<KeyValuePair<string, NuGetVersion>>();
+            var results = new List<KeyValuePair<string, NuGetVersion?>>();
 
             foreach (var id in packageIds)
             {
@@ -79,7 +78,7 @@ namespace NuGet.Protocol
                 // find the latest
                 var latest = allVersions.OrderByDescending(p => p, VersionComparer.VersionRelease).FirstOrDefault();
 
-                results.Add(new KeyValuePair<string, NuGetVersion>(id, latest));
+                results.Add(new KeyValuePair<string, NuGetVersion?>(id, latest));
             }
 
             return results;
@@ -95,14 +94,14 @@ namespace NuGet.Protocol
             // TODO: get the url and just check the headers?
             if (NuGetFeatureFlags.UseSystemTextJsonDeserializationFeatureSwitch)
             {
-                RegistrationLeafItem item = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
+                RegistrationLeafItem? item = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
 
                 // TODO: listed check
                 return item != null;
             }
             else if (NuGetFeatureFlags.IsSystemTextJsonDeserializationEnabledByEnvironment(_environmentVariableReader))
             {
-                RegistrationLeafItem item = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
+                RegistrationLeafItem? item = await _regResource.GetPackageMetadataItemAsync(identity, sourceCacheContext, log, token);
 
                 // TODO: listed check
                 return item != null;
@@ -163,12 +162,19 @@ namespace NuGet.Protocol
 
             foreach (RegistrationLeafItem item in items.NoAllocEnumerate())
             {
-                NuGetVersion version = item.CatalogEntry.Version;
-
-                if (version != null)
+                if (item.CatalogEntry is null)
                 {
-                    versions.Add(version);
+                    continue;
                 }
+
+                NuGetVersion? version = item.CatalogEntry.Version;
+
+                if (version is null)
+                {
+                    throw new InvalidDataException(packageId);
+                }
+
+                versions.Add(version);
             }
 
             return versions;
@@ -188,15 +194,16 @@ namespace NuGet.Protocol
 
             foreach (var catalogEntry in entries)
             {
-                NuGetVersion version = null;
-
-                if (catalogEntry["version"] != null
-                    && NuGetVersion.TryParse(catalogEntry["version"].ToString(), out version))
+                JToken? versionToken = catalogEntry["version"];
+                if (versionToken == null
+                    || !NuGetVersion.TryParse(versionToken.ToString(), out NuGetVersion? version))
                 {
-                    if (includePrerelease || !version.IsPrerelease)
-                    {
-                        versions.Add(version);
-                    }
+                    throw new InvalidDataException(packageId);
+                }
+
+                if (includePrerelease || !version.IsPrerelease)
+                {
+                    versions.Add(version);
                 }
             }
 
@@ -209,7 +216,7 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            JObject metadata = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
+            JObject? metadata = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
 
             // TODO: listed check
             return metadata != null;

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,7 +24,7 @@ namespace NuGet.Protocol.Core.Types
         /// <summary>
         /// Return package metadata for the input PackageIdentity
         /// </summary>
-        public abstract Task<IPackageSearchMetadata> GetMetadataAsync(
+        public abstract Task<IPackageSearchMetadata?> GetMetadataAsync(
             PackageIdentity package,
             SourceCacheContext sourceCacheContext,
             Common.ILogger log,

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -24,17 +22,17 @@ namespace NuGet.Protocol
     public class PackageMetadataResourceV3 : PackageMetadataResource
     {
         private readonly RegistrationResourceV3 _regResource;
-        private readonly ReportAbuseResourceV3 _reportAbuseResource;
-        private readonly ReadmeUriTemplateResource _readmeUriTemplateResource;
-        private readonly PackageDetailsUriResourceV3 _packageDetailsUriResource;
+        private readonly ReportAbuseResourceV3? _reportAbuseResource;
+        private readonly ReadmeUriTemplateResource? _readmeUriTemplateResource;
+        private readonly PackageDetailsUriResourceV3? _packageDetailsUriResource;
         private readonly HttpSource _client;
-        private readonly IEnvironmentVariableReader _environmentVariableReader;
+        private readonly IEnvironmentVariableReader? _environmentVariableReader;
 
         public PackageMetadataResourceV3(
             HttpSource client,
             RegistrationResourceV3 regResource,
-            ReportAbuseResourceV3 reportAbuseResource,
-            PackageDetailsUriResourceV3 packageDetailsUriResource)
+            ReportAbuseResourceV3? reportAbuseResource,
+            PackageDetailsUriResourceV3? packageDetailsUriResource)
         {
             _regResource = regResource;
             _client = client;
@@ -45,9 +43,9 @@ namespace NuGet.Protocol
         internal PackageMetadataResourceV3(
             HttpSource client,
             RegistrationResourceV3 regResource,
-            ReportAbuseResourceV3 reportAbuseResource,
-            PackageDetailsUriResourceV3 packageDetailsUriResource,
-            ReadmeUriTemplateResource readmeResource) : this(client, regResource, reportAbuseResource, packageDetailsUriResource)
+            ReportAbuseResourceV3? reportAbuseResource,
+            PackageDetailsUriResourceV3? packageDetailsUriResource,
+            ReadmeUriTemplateResource? readmeResource) : this(client, regResource, reportAbuseResource, packageDetailsUriResource)
         {
             _readmeUriTemplateResource = readmeResource;
         }
@@ -55,10 +53,10 @@ namespace NuGet.Protocol
         internal PackageMetadataResourceV3(
             HttpSource client,
             RegistrationResourceV3 regResource,
-            ReportAbuseResourceV3 reportAbuseResource,
-            PackageDetailsUriResourceV3 packageDetailsUriResource,
-            ReadmeUriTemplateResource readmeResource,
-            IEnvironmentVariableReader environmentVariableReader) : this(client, regResource, reportAbuseResource, packageDetailsUriResource, readmeResource)
+            ReportAbuseResourceV3? reportAbuseResource,
+            PackageDetailsUriResourceV3? packageDetailsUriResource,
+            ReadmeUriTemplateResource? readmeResource,
+            IEnvironmentVariableReader? environmentVariableReader) : this(client, regResource, reportAbuseResource, packageDetailsUriResource, readmeResource)
         {
             _environmentVariableReader = environmentVariableReader;
         }
@@ -90,7 +88,7 @@ namespace NuGet.Protocol
         /// <param name="token"></param>
         /// <returns>Package meta data.</returns>
         /// <remarks>The inlined entries are potentially going away soon</remarks>
-        public override async Task<IPackageSearchMetadata> GetMetadataAsync(
+        public override async Task<IPackageSearchMetadata?> GetMetadataAsync(
             PackageIdentity package,
             SourceCacheContext sourceCacheContext,
             Common.ILogger log,
@@ -131,7 +129,7 @@ namespace NuGet.Protocol
 
             var results = new List<PackageSearchMetadataRegistration>();
 
-            foreach (var registrationPage in registrationIndex.Items)
+            foreach (var registrationPage in registrationIndex.Items ?? Enumerable.Empty<RegistrationPage>())
             {
                 if (registrationPage == null)
                 {
@@ -148,7 +146,7 @@ namespace NuGet.Protocol
                         var rangeUri = registrationPage.Url;
                         var leafRegistrationPage = await GetRegistratioIndexPageAsync(_client, rangeUri, packageId, lower, upper, httpSourceCacheContext, log, token);
 
-                        if (registrationPage == null)
+                        if (leafRegistrationPage == null)
                         {
                             throw new InvalidDataException(registrationUri.AbsoluteUri);
                         }
@@ -172,7 +170,7 @@ namespace NuGet.Protocol
         /// <param name="stream">Stream data to read.</param>
         /// <param name="token">Cancellation token.</param>
         /// <returns></returns>
-        private async Task<T> DeserializeStreamDataAsync<T>(Stream stream, CancellationToken token)
+        private async Task<T?> DeserializeStreamDataAsync<T>(Stream? stream, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
@@ -195,13 +193,13 @@ namespace NuGet.Protocol
             }
         }
 
-        private static async Task<T> DeserializeStreamDataWithStjAsync<T>(Stream stream, CancellationToken token)
+        private static async Task<T?> DeserializeStreamDataWithStjAsync<T>(Stream stream, CancellationToken token)
         {
-            var typeInfo = (JsonTypeInfo<T>)Converters.PackageSearchJsonContext.Default.GetTypeInfo(typeof(T));
+            var typeInfo = (JsonTypeInfo<T>)Converters.PackageSearchJsonContext.Default.GetTypeInfo(typeof(T))!;
             return await System.Text.Json.JsonSerializer.DeserializeAsync(stream, typeInfo, token);
         }
 
-        private static T DeserializeStreamDataWithNsj<T>(Stream stream)
+        private static T? DeserializeStreamDataWithNsj<T>(Stream stream)
         {
             using (var streamReader = new StreamReader(stream))
             using (var jsonReader = new JsonTextReader(streamReader))
@@ -221,12 +219,12 @@ namespace NuGet.Protocol
         /// <param name="log">Logger Instance.</param>
         /// <param name="token">Cancellation token.</param>
         /// <returns></returns>
-        private async Task<ValueTuple<RegistrationIndex, HttpSourceCacheContext>> LoadRegistrationIndexAsync(
+        private async Task<ValueTuple<RegistrationIndex?, HttpSourceCacheContext>> LoadRegistrationIndexAsync(
             HttpSource httpSource,
             Uri registrationUri,
             string packageId,
             SourceCacheContext cacheContext,
-            Func<HttpSourceResult, Task<RegistrationIndex>> processAsync,
+            Func<HttpSourceResult, Task<RegistrationIndex?>> processAsync,
             ILogger log,
             CancellationToken token)
         {
@@ -247,7 +245,7 @@ namespace NuGet.Protocol
                 log,
                 token);
 
-            return new ValueTuple<RegistrationIndex, HttpSourceCacheContext>(index, httpSourceCacheContext);
+            return new ValueTuple<RegistrationIndex?, HttpSourceCacheContext>(index, httpSourceCacheContext);
         }
 
         /// <summary>
@@ -262,7 +260,7 @@ namespace NuGet.Protocol
         /// <param name="log">Logger Instance.</param>
         /// <param name="token">Cancellation token.</param>
         /// <returns></returns>
-        private Task<RegistrationPage> GetRegistratioIndexPageAsync(
+        private Task<RegistrationPage?> GetRegistratioIndexPageAsync(
             HttpSource httpSource,
             string rangeUri,
             string packageId,
@@ -303,9 +301,14 @@ namespace NuGet.Protocol
             bool includeUnlisted,
             MetadataReferenceCache metadataCache)
         {
-            foreach (RegistrationLeafItem registrationLeaf in registrationPage.Items)
+            foreach (RegistrationLeafItem registrationLeaf in registrationPage.Items ?? Enumerable.Empty<RegistrationLeafItem>())
             {
-                PackageSearchMetadataRegistration catalogEntry = registrationLeaf.CatalogEntry;
+                PackageSearchMetadataRegistration? catalogEntry = registrationLeaf.CatalogEntry;
+                if (catalogEntry == null)
+                {
+                    continue;
+                }
+
                 NuGetVersion version = catalogEntry.Version;
                 bool listed = catalogEntry.IsListed;
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -76,9 +76,10 @@ namespace NuGet.Protocol
 
         private static IEnumerable<VersionInfo> GetVersions(PackageSearchMetadata metadata, SearchFilter filter)
         {
-            var uniqueVersions = new HashSet<Versioning.NuGetVersion>(metadata.ParsedVersions.Length + 1);
-            var versions = new List<VersionInfo>(metadata.ParsedVersions.Length + 1);
-            foreach (var ver in metadata.ParsedVersions)
+            var parsedVersions = metadata.ParsedVersions ?? Array.Empty<VersionInfo>();
+            var uniqueVersions = new HashSet<Versioning.NuGetVersion>(parsedVersions.Length + 1);
+            var versions = new List<VersionInfo>(parsedVersions.Length + 1);
+            foreach (var ver in parsedVersions)
             {
                 if ((filter.IncludePrerelease || !ver.Version.IsPrerelease) && uniqueVersions.Add(ver.Version))
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -102,7 +100,7 @@ namespace NuGet.Protocol
         /// Returns the registration blob for the id and version
         /// </summary>
         /// <remarks>The inlined entries are potentially going away soon</remarks>
-        public virtual async Task<JObject> GetPackageMetadata(PackageIdentity identity, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
+        public virtual async Task<JObject?> GetPackageMetadata(PackageIdentity identity, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
         {
             return (await GetPackageMetadata(identity.Id, new VersionRange(identity.Version, true, identity.Version, true), true, true, cacheContext, log, token)).SingleOrDefault();
         }
@@ -142,10 +140,10 @@ namespace NuGet.Protocol
                     throw new InvalidDataException(registrationUri.AbsoluteUri);
                 }
 
-                foreach (JObject packageObj in rangeObj["items"])
+                foreach (JObject packageObj in rangeObj["items"]!)
                 {
-                    var catalogEntry = (JObject)packageObj["catalogEntry"];
-                    var version = NuGetVersion.Parse(catalogEntry["version"].ToString());
+                    var catalogEntry = (JObject)packageObj["catalogEntry"]!;
+                    var version = NuGetVersion.Parse(catalogEntry["version"]!.ToString());
                     var listed = catalogEntry.GetBoolean("listed") ?? true;
 
                     if (range.Satisfies(version)
@@ -193,10 +191,13 @@ namespace NuGet.Protocol
 
             Uri registrationUri = GetUri(packageId);
 
-            IReadOnlyList<RegistrationPage> ranges = await RegistrationUtility.LoadRangesAsItemsAsync(_client, registrationUri, packageId, range, cacheContext, log, token);
+            IReadOnlyList<RegistrationPage?> ranges = await RegistrationUtility.LoadRangesAsItemsAsync(_client, registrationUri, packageId, range, cacheContext, log, token);
 
-            foreach (RegistrationPage page in ranges.NoAllocEnumerate())
+            // NoAllocEnumerate can't be used on nullable types, so avoid allocating an enumerator by using a for loop.
+            for (int i = 0; i < ranges.Count; i++)
             {
+                RegistrationPage? page = ranges[i];
+
                 if (page is null || page.Items is null)
                 {
                     throw new InvalidDataException(registrationUri.AbsoluteUri);
@@ -225,7 +226,7 @@ namespace NuGet.Protocol
             return results;
         }
 
-        internal virtual async Task<RegistrationLeafItem> GetPackageMetadataItemAsync(PackageIdentity identity, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
+        internal virtual async Task<RegistrationLeafItem?> GetPackageMetadataItemAsync(PackageIdentity identity, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
         {
             return (await GetPackageMetadataItemsAsync(identity.Id, new VersionRange(identity.Version, true, identity.Version, true), true, true, cacheContext, log, token)).SingleOrDefault();
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/RecommenderPackageFeedTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/RecommenderPackageFeedTests.cs
@@ -180,7 +180,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             // Arrange
             var metadataResource = new Mock<MetadataResource>();
             metadataResource.Setup(e => e.GetLatestVersions(It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<SourceCacheContext>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync([new KeyValuePair<string, NuGetVersion>("packageb", new NuGetVersion(2, 0, 0))]);
+                .ReturnsAsync([new KeyValuePair<string, NuGetVersion?>("packageb", new NuGetVersion(2, 0, 0))]);
 
             var packageMetadataResource = Mock.Of<PackageMetadataResource>();
 

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/SearchResultContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/SearchResultContextInfoFormatterTests.cs
@@ -24,6 +24,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         {
             var formatters = new IMessagePackFormatter[]
             {
+                PackageDependencyGroupFormatter.Instance,
                 PackageSearchMetadataContextInfoFormatter.Instance,
                 PackageVulnerabilityMetadataContextInfoFormatter.Instance,
             };

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/VersionInfoContextInfoFormatterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Internal.Contracts.Test/Formatters/VersionInfoContextInfoFormatterTests.cs
@@ -20,6 +20,7 @@ namespace NuGet.VisualStudio.Internal.Contracts.Test
         {
             var formatters = new IMessagePackFormatter[]
                 {
+                    PackageDependencyGroupFormatter.Instance,
                     PackageSearchMetadataContextInfoFormatter.Instance,
                     PackageVulnerabilityMetadataContextInfoFormatter.Instance
                 };

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalMetadataResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalMetadataResourceTests.cs
@@ -110,7 +110,7 @@ namespace NuGet.Protocol.Tests
                     token: CancellationToken.None);
 
                 // Assert
-                Assert.Equal("2.0.1+githash.0faef", result.ToFullString());
+                Assert.Equal("2.0.1+githash.0faef", result!.ToFullString());
             }
         }
 
@@ -144,7 +144,7 @@ namespace NuGet.Protocol.Tests
                     token: CancellationToken.None);
 
                 // Assert
-                Assert.Equal("2.0.2-alpha.1.2.3+githash.0faef", result.ToFullString());
+                Assert.Equal("2.0.2-alpha.1.2.3+githash.0faef", result!.ToFullString());
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV2FeedTests.cs
@@ -37,7 +37,7 @@ namespace NuGet.Protocol.Tests
             var latestVersion = await metadataResource.GetLatestVersion("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
-            Assert.Equal("6.2.2-preview", latestVersion.ToNormalizedString());
+            Assert.Equal("6.2.2-preview", latestVersion!.ToNormalizedString());
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace NuGet.Protocol.Tests
             var latestVersion = await metadataResource.GetLatestVersion("WindowsAzure.Storage", false, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
-            Assert.Equal("6.2.0", latestVersion.ToNormalizedString());
+            Assert.Equal("6.2.0", latestVersion!.ToNormalizedString());
         }
 
         [Fact]
@@ -185,9 +185,9 @@ namespace NuGet.Protocol.Tests
 
             // Assert
             Assert.Equal("WindowsAzure.Storage", versions[1].Key);
-            Assert.Equal("6.2.2-preview", versions[1].Value.ToNormalizedString());
+            Assert.Equal("6.2.2-preview", versions[1].Value!.ToNormalizedString());
             Assert.Equal("xunit", versions[0].Key);
-            Assert.Equal("2.2.0-beta1-build3239", versions[0].Value.ToNormalizedString());
+            Assert.Equal("2.2.0-beta1-build3239", versions[0].Value!.ToNormalizedString());
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV3Tests.cs
@@ -67,12 +67,12 @@ namespace NuGet.Protocol.Tests
 
             // Act
             using var sourceCacheContext = new SourceCacheContext();
-            IEnumerable<KeyValuePair<string, NuGetVersion>> latest = await resource.GetLatestVersions(new[] { "deepequal" }, includePrerelease: false, includeUnlisted: true, sourceCacheContext, NullLogger.Instance, CancellationToken.None);
+            IEnumerable<KeyValuePair<string, NuGetVersion?>> latest = await resource.GetLatestVersions(new[] { "deepequal" }, includePrerelease: false, includeUnlisted: true, sourceCacheContext, NullLogger.Instance, CancellationToken.None);
 
             // Assert
-            KeyValuePair<string, NuGetVersion> result = Assert.Single(latest);
+            KeyValuePair<string, NuGetVersion?> result = Assert.Single(latest);
             Assert.Equal("deepequal", result.Key);
-            Assert.Equal("1.4.0", result.Value.ToNormalizedString());
+            Assert.Equal("1.4.0", result.Value!.ToNormalizedString());
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -59,13 +59,13 @@ namespace NuGet.Protocol.Tests
                 // Assert
                 Assert.Equal("deepequal", result.Identity.Id, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal("0.9.0", result.Identity.Version.ToNormalizedString());
-                Assert.True(result.Authors.Contains("James Foster"));
+                Assert.True(result.Authors!.Contains("James Foster"));
                 Assert.Equal("An extensible deep comparison library for .NET", result.Description);
                 Assert.Null(result.IconUrl);
                 Assert.Null(result.LicenseUrl);
-                Assert.Equal("http://github.com/jamesfoster/DeepEqual", result.ProjectUrl.ToString());
+                Assert.Equal("http://github.com/jamesfoster/DeepEqual", result.ProjectUrl!.ToString());
                 Assert.Equal("https://api.nuget.org/v3/catalog0/data/2015.02.03.18.34.51/deepequal.0.9.0.json",
-                    result.CatalogUri.ToString());
+                    result.CatalogUri!.ToString());
                 Assert.Equal(DateTimeOffset.Parse("2013-08-28T09:19:10.013Z"), result.Published);
                 Assert.False(result.RequireLicenseAcceptance);
                 Assert.Equal(result.Description, result.Summary);
@@ -73,7 +73,7 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal("DeepEqual", result.Title);
                 Assert.True(result.IsListed);
 
-                var vulnerability = Assert.Single(result.Vulnerabilities);
+                var vulnerability = Assert.Single(result.Vulnerabilities!);
                 Assert.Equal(2, vulnerability.Severity);
                 Assert.Equal("https://contoso.test/advisory/1", vulnerability.AdvisoryUrl.OriginalString);
             }


### PR DESCRIPTION
# Bug

Fixes: https://github.com/NuGet/Home/issues/14851

## Description

Completes the NuGet.Protocol nullable-reference-types enablement. This is the final batch (phases 17, 18, 24): the last 16 `#nullable disable` files are annotated, bringing NuGet.Protocol to zero `#nullable disable` directives. The public metadata cascade (`IPackageSearchMetadata` and its implementations) is propagated through dependent projects, and `PublicAPI.Shipped.txt` is updated for both TFMs (oblivious `~` entries replaced in place).

Notable decision:
- `MetadataResourceV3` now throws `InvalidDataException` when a catalog entry is missing or has an unparseable `version` (a mandatory field), instead of silently dropping the entry — matching the malformed-data pattern already used by `RegistrationResourceV3`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
