### PR TITLE
Add regression test for contentFiles include with leading separator

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFileUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFileUtilsTests.cs
@@ -86,6 +86,38 @@ public sealed class ContentFileUtilsTests
         Assert.Equal(BuildAction.Parse("None"), vbFile.BuildAction);
     }
 
+    /// <summary>
+    /// A contentFiles include beginning with '\' or '/' (e.g. "\any\any\data\*")
+    ///  must still match, honoring buildAction/copyToOutput. Otherwise the entry is silently
+    /// dropped and falls back to the default Compile build action.
+    /// </summary>
+    [Theory]
+    [InlineData("any/any/data/*")]      // canonical
+    [InlineData(@"\any\any\data\*")]    // leading-backslash form
+    [InlineData("/any/any/data/*")]     // leading forward slash
+    [InlineData(@"any\any\data\*")]     // backslash separators, no leading separator
+    public void GetContentFileGroup_IncludeWithLeadingSeparator_MatchesFile(string include)
+    {
+        // Arrange
+        var nuspec = CreateNuspecWithContentFiles((include, null, "None"));
+
+        var group = new ContentItemGroup();
+        group.Properties[ManagedCodeConventions.PropertyNames.CodeLanguage] = "any";
+        group.Items.Add(new ContentItem { Path = "contentFiles/any/any/data/sample.txt" });
+
+        // Act
+        List<LockFileContentFile> result = ContentFileUtils.GetContentFileGroup(
+            nuspec,
+            new List<ContentItemGroup> { group });
+
+        // Assert
+        LockFileContentFile item = Assert.Single(result);
+        Assert.Equal("contentFiles/any/any/data/sample.txt", item.Path);
+
+        // None proves the glob matched. If it didn't match, the default would be Compile.
+        Assert.Equal(BuildAction.Parse("None"), item.BuildAction);
+    }
+
     private static NuspecReader CreateNuspecWithContentFiles(
         params (string include, string? exclude, string buildAction)[] entries)
     {


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3901

## Description

A customer reported that in VS 18.8, a `contentFiles` entry with a leading separator in the `include` path was silently ignored when restoring in Visual Studio. 
e.g.  `\any\net10.0\data\*` had the configured `buildAction` and `copyToOutput` dropped in VS, while `dotnet build` worked correctly.

In VS 18.9, this was already fixed, but no test was added for the scenario.

### Root cause

The content-file globbing introduced in #7338 built match paths as MatcherRoot ("ROOT/" ) + the relative path. When an include starts with a separator, this produced a malformed path (`ROOT/\any` ) that `Microsoft.Extensions.FileSystemGlobbing`  failed to match. The entry was dropped and its build action fell back to the default (`Compile`) silently with no error.

The bug was already fixed by #7405, which reworked matching to use InMemoryDirectoryInfo + Matcher.Execute . However, no test ever covered this scenario, so the fix is unguarded against regression.

### What this adds

This test covers leading forward-slash, leading backslash, interior-backslash, and canonical include forms. Each asserts the resolved build action is `None` (the authored value) rather than the default `Compile` , proving the glob matched.

### Verification

Test passes on dev (has fix from #7405).
Test FAILs on `release/7.8.x` for the leading-separator cases (Expected: None, Actual: Compile) and this confirms it reproduces the customer regression.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
