### PR TITLE
Disable dotnet cli AoT when running .net integration tests

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetIntegrationTestFixture.cs
@@ -201,7 +201,8 @@ namespace Dotnet.Integration.Test
                 // We need to ensure that this points to the correct SDK directory because this value
                 // is used to locate many Tasks - especially those located by relative path or name.
                 ["MSBuildExtensionsPath"] = SdkDirectory.FullName,
-                ["PATH"] = $"{_cliDirectory}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}"
+                ["PATH"] = $"{_cliDirectory}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}",
+                ["DOTNET_CLI_ENABLEAOT"] = "false"
             };
 
             if (enableDiagnostics)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

The SDK is increasingly using AoT in the SDK. This PR appears to make `dotnet restore` run with AoT:
* https://github.com/dotnet/sdk/pull/55497

The way the NuGet.Client repo Dotnet.Integration.Tests works is to downloads a .NET SDK with dotnet-install.[ps1|sh], makes a copy of it in a test directory, then replaces all the NuGet.*.dll files with the local build. But if the SDK runs AoT, it's not going to run those NuGet assemblies. So, we have to instruct the SDK not to use AoT for our tests to run the correct binaries.

Here are the docs saying that this is the environment variable to set: https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet-aot/DESIGN.md#opting-out-dotnet_cli_enableaot

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
