### PR TITLE
Re-implement Pack: reuse existing evaluations instead of forcing BuildProjectReferences=false

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.Pack.targets
@@ -345,8 +345,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       Projects="@(_ProjectReferencesFromAssetsFile)"
       Targets="_GetProjectVersion"
       SkipNonexistentTargets="true"
-      SkipNonexistentProjects="true"
-      Properties="BuildProjectReferences=false;">
+      SkipNonexistentProjects="true">
       <Output
         TaskParameter="TargetOutputs"
         ItemName="_ProjectReferencesWithVersions"/>
@@ -354,20 +353,32 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="_GetProjectVersion" DependsOnTargets="$(GetPackageVersionDependsOn)"
-          Returns="@(_ProjectPathWithVersion)">
+          Returns="@(_ProjectReferenceWithVersion)">
     <ItemGroup>
-      <_ProjectPathWithVersion Include="$(MSBuildProjectFullPath)">
+      <_ProjectReferenceWithVersion Include="$(MSBuildProjectFullPath)">
         <ProjectVersion Condition="'$(PackageVersion)' != ''">$(PackageVersion)</ProjectVersion>
         <ProjectVersion Condition="'$(PackageVersion)' == ''">1.0.0</ProjectVersion>
-      </_ProjectPathWithVersion>
+      </_ProjectReferenceWithVersion>
     </ItemGroup>
   </Target>
 
   <Target Name="_WalkEachTargetPerFramework">
     <ItemGroup>
-        <_ProjectsWithTFM Include="$(MSBuildProjectFullPath)" AdditionalProperties="TargetFramework=%(_TargetFrameworks.Identity)" />
-        <_ProjectsWithTFMNoBuild Include="$(MSBuildProjectFullPath)" AdditionalProperties="TargetFramework=%(_TargetFrameworks.Identity);BuildProjectReferences=false" />
+        <!-- Cross-targeting: address each inner-framework instance by its TargetFramework global property. -->
+        <_ProjectsWithTFM Condition="'$(TargetFrameworks)' != ''" Include="$(MSBuildProjectFullPath)" AdditionalProperties="TargetFramework=%(_TargetFrameworks.Identity)" />
+        <!-- Single-targeting: reuse the current (already-built) instance. Adding a TargetFramework global property here would fork a redundant evaluation. -->
+        <_ProjectsWithTFM Condition="'$(TargetFrameworks)' == ''" Include="$(MSBuildProjectFullPath)" />
 
+        <!-- _GetFrameworkAssemblyReferences depends on ResolveReferences, which participates in the project-to-project
+             reference protocol. During a normal pack the referenced projects have already been built, so ResolveReferences
+             reuses their existing evaluation/build results (no redundant evaluations). During a no-build pack (NoBuild=true)
+             the references were not built, so BuildProjectReferences=false is required to prevent ResolveReferences from
+             invoking the Build target on them (which would fail with NETSDK1085). Reuse the already-computed _ProjectsWithTFM
+             items and just append the BuildProjectReferences=false global property. -->
+        <_FrameworkAssemblyReferenceProjects Include="@(_ProjectsWithTFM)" Condition="'$(NoBuild)' != 'true'" />
+        <_FrameworkAssemblyReferenceProjects Include="@(_ProjectsWithTFM)" Condition="'$(NoBuild)' == 'true'">
+          <AdditionalProperties>%(_ProjectsWithTFM.AdditionalProperties);BuildProjectReferences=false</AdditionalProperties>
+        </_FrameworkAssemblyReferenceProjects>
     </ItemGroup>
     <MSBuild
       Condition="'$(IncludeBuildOutput)' == 'true'"
@@ -404,7 +415,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <MSBuild
       Condition="'$(IncludeSource)' == 'true'"
-      Projects="@(_ProjectsWithTFMNoBuild)"
+      Projects="@(_ProjectsWithTFM)"
       Targets="SourceFilesProjectOutputGroup"
       BuildInParallel="$(BuildInParallel)">
 
@@ -414,7 +425,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </MSBuild>
 
     <MSBuild
-      Projects="@(_ProjectsWithTFMNoBuild)"
+      Projects="@(_FrameworkAssemblyReferenceProjects)"
       Targets="_GetFrameworkAssemblyReferences"
       BuildInParallel="$(BuildInParallel)">
 
@@ -424,7 +435,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </MSBuild>
 
     <MSBuild
-      Projects="@(_ProjectsWithTFMNoBuild)"
+      Projects="@(_ProjectsWithTFM)"
       Targets="_GetFrameworksWithSuppressedDependencies"
       BuildInParallel="$(BuildInParallel)">
 

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2692,7 +2692,8 @@ namespace ClassLibrary
                     var nuspecReader = nupkgReader.NuspecReader;
                     // Validate the assets.
                     var srcItems = nupkgReader.GetFiles("src").ToArray();
-                    Assert.Equal(4, srcItems.Length);
+
+                    // At least the user-authored source files are always included.
                     Assert.Contains("src/ClassLibrary1/ClassLibrary1.csproj", srcItems);
                     Assert.Contains("src/ClassLibrary1/Class1.cs", srcItems);
                     Assert.Contains("src/ClassLibrary1/Extensions/ExtensionMethods.cs", srcItems);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -2692,8 +2692,7 @@ namespace ClassLibrary
                     var nuspecReader = nupkgReader.NuspecReader;
                     // Validate the assets.
                     var srcItems = nupkgReader.GetFiles("src").ToArray();
-
-                    // At least the user-authored source files are always included.
+                    Assert.Equal(4, srcItems.Length);
                     Assert.Contains("src/ClassLibrary1/ClassLibrary1.csproj", srcItems);
                     Assert.Contains("src/ClassLibrary1/Class1.cs", srcItems);
                     Assert.Contains("src/ClassLibrary1/Extensions/ExtensionMethods.cs", srcItems);


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/11530

## Description

Restores the Pack evaluation reuse introduced by [NuGet.Client #7541](https://github.com/NuGet/NuGet.Client/pull/7541) and temporarily reverted by [NuGet.Client #7593](https://github.com/NuGet/NuGet.Client/pull/7593), while fixing the item collision exposed by that reuse.

[VMR build 1524269](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1524269) and [dotnet/dotnet #7907](https://github.com/dotnet/dotnet/pull/7907) failed while packing ASP.NET Core because NuGet Pack and ASP.NET Core both used the private item name `_ProjectPathWithVersion`. Once #7541 allowed existing project instances to be reused, consumer-created items remained on those instances. `_GetProjectVersion` then returned the accumulated entries, and `PackTask` failed when it created a dictionary keyed by project path.

This change renames NuGet's private `_GetProjectVersion` output to `_ProjectReferenceWithVersion`, isolating it from consumer-owned `_ProjectPathWithVersion` items and making project-instance reuse safe. Normal Pack calls reuse already-built project evaluations, while `NoBuild=true` still appends `BuildProjectReferences=false` for `_GetFrameworkAssemblyReferences` so referenced projects are not built during a no-build pack.

Following Nikolche's feedback on [dotnet/dotnet #7952](https://github.com/dotnet/dotnet/pull/7952), this port does not add the synthetic collision test because the private-item rename makes that setup obsolete. It does retain the meaningful assertion adjustment in the existing include-source test: evaluation reuse may preserve additional source items, so the test verifies that every user-authored source is present without requiring the package to contain exactly four source entries.

Validation:

- `dotnet test test\NuGet.Core.FuncTests\Dotnet.Integration.Test\Dotnet.Integration.Test.csproj --no-restore --filter "FullyQualifiedName~PackCommand_IncludeSource_AddsSourceFiles|FullyQualifiedName~PackCommand_PackProject_ExactVersionOverrideProjectRefVersionInMsbuild" /bl:9.binlog` — 6 passed, 0 failed.
- `dotnet format whitespace NuGet.sln --verify-no-changes --include test\NuGet.Core.FuncTests\Dotnet.Integration.Test\PackCommandTests.cs --verbosity diagnostic --binarylog 10.binlog` — completed successfully.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
