### PR TITLE
dotnet package update --vulnerable works with TreatWarningsAsErrors

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -25,6 +25,14 @@ namespace NuGet.CommandLine.XPlat.Commands.Package.Update;
 
 internal static class PackageUpdateCommandRunner
 {
+    private static readonly NuGetLogCode[] AuditWarningCodes =
+    {
+        NuGetLogCode.NU1901,
+        NuGetLogCode.NU1902,
+        NuGetLogCode.NU1903,
+        NuGetLogCode.NU1904,
+    };
+
     // This overload sets static state, so should not be used in tests.
     internal static Task<int> Run(PackageUpdateArgs args, IVirtualProjectBuilder? virtualProjectBuilder, CancellationToken cancellationToken)
     {
@@ -250,21 +258,58 @@ internal static class PackageUpdateCommandRunner
 
     internal static DependencyGraphSpec CreateDgSpecForVulnerabilityScan(DependencyGraphSpec dgSpec)
     {
-        var scanDgSpec = new DependencyGraphSpec();
-
-        foreach (var project in dgSpec.Projects)
+        if (!dgSpec.Projects.Any(ProjectWillFailOnAuditWarnings))
         {
-            var projectClone = project.Clone();
-            projectClone.RestoreMetadata.ProjectWideWarningProperties.AllWarningsAsErrors = false;
-            scanDgSpec.AddProject(projectClone);
+            return dgSpec;
         }
 
-        foreach (var restoreEntry in dgSpec.Restore)
+        var scanDgSpec = new DependencyGraphSpec();
+
+        foreach (PackageSpec project in dgSpec.Projects)
+        {
+            if (ProjectWillFailOnAuditWarnings(project))
+            {
+                PackageSpec projectClone = project.Clone();
+                WarningProperties warningProperties = projectClone.RestoreMetadata.ProjectWideWarningProperties;
+                warningProperties.AllWarningsAsErrors = false;
+                warningProperties.WarningsAsErrors.ExceptWith(AuditWarningCodes);
+                scanDgSpec.AddProject(projectClone);
+            }
+            else
+            {
+                scanDgSpec.AddProject(project);
+            }
+        }
+
+        foreach (string restoreEntry in dgSpec.Restore)
         {
             scanDgSpec.AddRestore(restoreEntry);
         }
 
         return scanDgSpec;
+
+        bool ProjectWillFailOnAuditWarnings(PackageSpec project)
+        {
+            WarningProperties warningProperties = project.RestoreMetadata.ProjectWideWarningProperties;
+
+            bool allAuditWarningsAreNotErrors =
+                warningProperties.WarningsNotAsErrors.Contains(NuGetLogCode.NU1901) &&
+                warningProperties.WarningsNotAsErrors.Contains(NuGetLogCode.NU1902) &&
+                warningProperties.WarningsNotAsErrors.Contains(NuGetLogCode.NU1903) &&
+                warningProperties.WarningsNotAsErrors.Contains(NuGetLogCode.NU1904);
+
+            if (allAuditWarningsAreNotErrors)
+            {
+                return false;
+            }
+
+            if (warningProperties.AllWarningsAsErrors)
+            {
+                return true;
+            }
+
+            return warningProperties.WarningsAsErrors.Overlaps(AuditWarningCodes);
+        }
     }
 
     private static async Task<(int? exitCode, Dictionary<string, List<PackageUpdateResult>> projectPackageUpdates, int totalPackagesScanned)>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Package/Update/PackageUpdateCommandRunner.cs
@@ -132,7 +132,13 @@ internal static class PackageUpdateCommandRunner
         IPackageUpdateIO packageUpdateIO,
         CancellationToken cancellationToken)
     {
-        LockFile assetsFile = await packageUpdateIO.GetProjectAssetsFileAsync(dgSpec, projectPath, logger, cancellationToken);
+        // A lot of people use TreatWarningsAsErrors, and when restore failed because of audit warnings, we need a way for them to fix it.
+        // If the project's restore is already up to date, disabling warnings as errors will cause no-op checks to fail, making the restore longer than
+        // necessary. But if there's a real failure, the assets file might be stale, and we don't want to use it. While it's possible
+        // there are non-vulnerability related warnings that be treated as errors, customers are unlikely to run dotnet package update --vulnerable when
+        // restore fails for other reasons. So, it's a good enough compromise.
+        DependencyGraphSpec scanDgSpec = CreateDgSpecForVulnerabilityScan(dgSpec);
+        LockFile assetsFile = await packageUpdateIO.GetProjectAssetsFileAsync(scanDgSpec, projectPath, logger, cancellationToken);
         PackageSpec projectSpec = assetsFile.PackageSpec;
 
         bool auditModeAll = IsNuGetAuditModeSetToAll(projectSpec);
@@ -240,6 +246,25 @@ internal static class PackageUpdateCommandRunner
             }
             return false;
         }
+    }
+
+    internal static DependencyGraphSpec CreateDgSpecForVulnerabilityScan(DependencyGraphSpec dgSpec)
+    {
+        var scanDgSpec = new DependencyGraphSpec();
+
+        foreach (var project in dgSpec.Projects)
+        {
+            var projectClone = project.Clone();
+            projectClone.RestoreMetadata.ProjectWideWarningProperties.AllWarningsAsErrors = false;
+            scanDgSpec.AddProject(projectClone);
+        }
+
+        foreach (var restoreEntry in dgSpec.Restore)
+        {
+            scanDgSpec.AddRestore(restoreEntry);
+        }
+
+        return scanDgSpec;
     }
 
     private static async Task<(int? exitCode, Dictionary<string, List<PackageUpdateResult>> projectPackageUpdates, int totalPackagesScanned)>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/DotnetPackageUpdateTests.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,8 +15,10 @@ using FluentAssertions;
 using NuGet.CommandLine.Xplat.Tests;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
+using NuGet.Protocol;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+using Test.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -423,6 +426,50 @@ namespace Dotnet.Integration.Test
         private string GetPackageVersionVersion(string projectPath, string packageName)
         {
             return GetItemVersion(projectPath, "PackageVersion", packageName);
+        }
+
+        [Fact]
+        public async Task VulnerablePackageUpdate_WithTreatWarningsAsErrors_Succeeds()
+        {
+            // Arrange
+            using var testContext = _testFixture.CreateSimpleTestPathContext();
+
+            var vulnerable = new SimpleTestPackageContext("NuGet.Internal.Test.Vulnerable", "1.0.0");
+            var safe = new SimpleTestPackageContext("NuGet.Internal.Test.Vulnerable", "2.0.0");
+            await SimpleTestPackageUtility.CreatePackagesAsync(testContext.PackageSource, vulnerable, safe);
+
+            using var mockServer = new FileSystemBackedV3MockServer(testContext.PackageSource, sourceReportsVulnerabilities: true);
+            mockServer.Vulnerabilities.Add(
+                "NuGet.Internal.Test.Vulnerable",
+                new List<(Uri, PackageVulnerabilitySeverity, VersionRange)>
+                {
+                    (new Uri("https://contoso.test/advisories/1"), PackageVulnerabilitySeverity.High, VersionRange.Parse("[1.0.0]"))
+                });
+
+            testContext.Settings.RemoveSource("source");
+            testContext.Settings.AddSource("source", mockServer.ServiceIndexUri, allowInsecureConnectionsValue: "true");
+
+            var project = SimpleTestProjectContext.CreateNETCoreWithSDK("my", testContext.SolutionRoot, TestConstants.ProjectTargetFramework);
+            project.Properties["TreatWarningsAsErrors"] = "true";
+            project.AddPackageToAllFrameworks(vulnerable);
+            project.Save();
+            string csprojPath = project.ProjectPath;
+
+            mockServer.Start();
+
+            // Act
+            var result = _testFixture.RunDotnetExpectSuccess(
+                workingDirectory: Path.GetDirectoryName(project.ProjectPath),
+                args: "package update --vulnerable",
+                testOutputHelper: _testOutputHelper,
+                environmentVariables: _envVars);
+
+            mockServer.Stop();
+
+            // Assert
+            result.ExitCode.Should().Be(0);
+            string version = GetPackageReferenceVersion(csprojPath, "NuGet.Internal.Test.Vulnerable");
+            version.Should().Be("2.0.0");
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Package/Update/PackageUpdateCommandRunnerTests/SingleProjectTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -25,6 +26,129 @@ using Strings = NuGet.CommandLine.XPlat.Strings;
 
 public class SingleProjectTests
 {
+    [Fact]
+    public void CreateDgSpecForVulnerabilityScan_WhenNoAuditWarningsAreErrors_ReturnsOriginalDgSpec()
+    {
+        PackageSpec packageSpec = CreatePackageSpec();
+        DependencyGraphSpec dgSpec = CreateDgSpec(packageSpec);
+
+        DependencyGraphSpec scanDgSpec = PackageUpdateCommandRunner.CreateDgSpecForVulnerabilityScan(dgSpec);
+
+        scanDgSpec.Should().BeSameAs(dgSpec);
+    }
+
+    [Fact]
+    public void CreateDgSpecForVulnerabilityScan_WhenAllAuditWarningsAreNotErrors_ReturnsOriginalDgSpec()
+    {
+        PackageSpec packageSpec = CreatePackageSpec();
+        WarningProperties warningProperties = packageSpec.RestoreMetadata.ProjectWideWarningProperties;
+        warningProperties.AllWarningsAsErrors = true;
+        warningProperties.WarningsNotAsErrors.UnionWith(
+        [
+            NuGetLogCode.NU1901,
+            NuGetLogCode.NU1902,
+            NuGetLogCode.NU1903,
+            NuGetLogCode.NU1904,
+        ]);
+        DependencyGraphSpec dgSpec = CreateDgSpec(packageSpec);
+
+        DependencyGraphSpec scanDgSpec = PackageUpdateCommandRunner.CreateDgSpecForVulnerabilityScan(dgSpec);
+
+        scanDgSpec.Should().BeSameAs(dgSpec);
+    }
+
+    [Fact]
+    public void CreateDgSpecForVulnerabilityScan_WhenAllWarningsAreErrors_ClonesAndRemovesAuditWarningsAsErrors()
+    {
+        PackageSpec packageSpec = CreatePackageSpec();
+        WarningProperties warningProperties = packageSpec.RestoreMetadata.ProjectWideWarningProperties;
+        warningProperties.AllWarningsAsErrors = true;
+        warningProperties.WarningsAsErrors.UnionWith(
+        [
+            NuGetLogCode.NU1901,
+            NuGetLogCode.NU1902,
+            NuGetLogCode.NU1603,
+        ]);
+        DependencyGraphSpec dgSpec = CreateDgSpec(packageSpec);
+
+        DependencyGraphSpec scanDgSpec = PackageUpdateCommandRunner.CreateDgSpecForVulnerabilityScan(dgSpec);
+        PackageSpec scanPackageSpec = scanDgSpec.Projects.Single();
+
+        scanDgSpec.Should().NotBeSameAs(dgSpec);
+        scanPackageSpec.Should().NotBeSameAs(packageSpec);
+        scanPackageSpec.RestoreMetadata.ProjectWideWarningProperties.AllWarningsAsErrors.Should().BeFalse();
+        scanPackageSpec.RestoreMetadata.ProjectWideWarningProperties.WarningsAsErrors.Should().BeEquivalentTo([NuGetLogCode.NU1603]);
+        warningProperties.AllWarningsAsErrors.Should().BeTrue();
+        warningProperties.WarningsAsErrors.Should().BeEquivalentTo(
+        [
+            NuGetLogCode.NU1901,
+            NuGetLogCode.NU1902,
+            NuGetLogCode.NU1603,
+        ]);
+    }
+
+    [Fact]
+    public void CreateDgSpecForVulnerabilityScan_WhenExplicitAuditWarningIsAnError_ClonesAndRemovesAuditWarningAsError()
+    {
+        PackageSpec packageSpec = CreatePackageSpec();
+        packageSpec.RestoreMetadata.ProjectWideWarningProperties.WarningsAsErrors.Add(NuGetLogCode.NU1903);
+        DependencyGraphSpec dgSpec = CreateDgSpec(packageSpec);
+
+        DependencyGraphSpec scanDgSpec = PackageUpdateCommandRunner.CreateDgSpecForVulnerabilityScan(dgSpec);
+        PackageSpec scanPackageSpec = scanDgSpec.Projects.Single();
+
+        scanDgSpec.Should().NotBeSameAs(dgSpec);
+        scanPackageSpec.RestoreMetadata.ProjectWideWarningProperties.WarningsAsErrors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CreateDgSpecForVulnerabilityScan_WhenUnrelatedWarningIsAnError_ReturnsOriginalDgSpec()
+    {
+        PackageSpec packageSpec = CreatePackageSpec();
+        packageSpec.RestoreMetadata.ProjectWideWarningProperties.WarningsAsErrors.Add(NuGetLogCode.NU1603);
+        DependencyGraphSpec dgSpec = CreateDgSpec(packageSpec);
+
+        DependencyGraphSpec scanDgSpec = PackageUpdateCommandRunner.CreateDgSpecForVulnerabilityScan(dgSpec);
+
+        scanDgSpec.Should().BeSameAs(dgSpec);
+    }
+
+    [Fact]
+    public void CreateDgSpecForVulnerabilityScan_WithMixedProjects_OnlyClonesProjectThatFailsOnAuditWarnings()
+    {
+        PackageSpec projectWithAuditErrors = CreatePackageSpec("ProjectWithAuditErrors");
+        projectWithAuditErrors.RestoreMetadata.ProjectWideWarningProperties.AllWarningsAsErrors = true;
+        PackageSpec projectWithoutAuditErrors = CreatePackageSpec("ProjectWithoutAuditErrors");
+        DependencyGraphSpec dgSpec = CreateDgSpec(projectWithAuditErrors, projectWithoutAuditErrors);
+
+        DependencyGraphSpec scanDgSpec = PackageUpdateCommandRunner.CreateDgSpecForVulnerabilityScan(dgSpec);
+
+        scanDgSpec.Projects.Single(project => project.RestoreMetadata.ProjectUniqueName == projectWithAuditErrors.RestoreMetadata.ProjectUniqueName)
+            .Should().NotBeSameAs(projectWithAuditErrors);
+        scanDgSpec.Projects.Single(project => project.RestoreMetadata.ProjectUniqueName == projectWithoutAuditErrors.RestoreMetadata.ProjectUniqueName)
+            .Should().BeSameAs(projectWithoutAuditErrors);
+    }
+
+    private static PackageSpec CreatePackageSpec(string projectName = "TestProject")
+    {
+        return new TestPackageSpecFactory(
+            fullPath: $"{projectName}.csproj",
+            directory: ".",
+            builder => builder.WithProperty("TargetFramework", "net9.0")).Build();
+    }
+
+    private static DependencyGraphSpec CreateDgSpec(params PackageSpec[] packageSpecs)
+    {
+        DependencyGraphSpec dgSpec = new DependencyGraphSpec();
+        foreach (PackageSpec packageSpec in packageSpecs)
+        {
+            dgSpec.AddProject(packageSpec);
+            dgSpec.AddRestore(packageSpec.RestoreMetadata.ProjectUniqueName);
+        }
+
+        return dgSpec;
+    }
+
     [Fact]
     public async Task SingleTarget_SinglePackage_UpdatesCorrectPackageVersion()
     {

--- a/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
+++ b/test/TestUtilities/Test.Utility/TestFileSystemUtility.cs
@@ -141,7 +141,8 @@ namespace NuGet.Test.Utility
 
             if (dir == null)
             {
-                throw new Exception("Failed to determine the path to the .NET SDK");
+                var configureScript = NuGet.Common.RuntimeEnvironmentHelper.IsWindows ? "configure.ps1" : "configure.sh";
+                throw new Exception($"Failed to determine the path to the .NET SDK. Run {configureScript} to set up the test environment.");
             }
 
             return null;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: NuGet/Home#14988

## Description

`dotnet package update --vulnerable` finds packages to update by doing an in-memory restore (not writing assets file, etc), and looking for NU1901-4 restore log messages. But it can't tell the difference between warnings treated as errors causing restore to fail, or if there's some other failure. If there's a different failure, then the assets file on disk could be invalid, so package update should not continue.

One way to avoid this is to disable TreatWarningsAsErrors for the in-memory (preview) restore. If the assets file was already out-of-sync with the project, there's no harm. If the assets file is up to date, then restore's no-op check fails and restore will have a slower code path. But we can be confident that the result will be accurate.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
