### PR TITLE
Use PackageId property in GetPackOutputItemsTask if no id is present in nuspec

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
@@ -96,7 +96,11 @@ namespace NuGet.Build.Tasks.Pack
                 }
 
                 var nuspecReader = new NuspecReader(NuspecFile);
-                packageId = nuspecReader.GetId();
+                if (nuspecReader.GetId() is { } idFromNuspec)
+                {
+                    packageId = idFromNuspec;
+                }
+
                 if (!hasVersionInNuspecProperties)
                 {
                     version = nuspecReader.GetVersion();


### PR DESCRIPTION
This PR basically restores the behavior before https://github.com/NuGet/NuGet.Client/pull/7531 for this scenario.