### PR TITLE
Package Source Mapping VS Settings now has command to invoke GitHub Copilot

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/McpServerConstants.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/McpServerConstants.cs
@@ -10,7 +10,6 @@ namespace NuGet.PackageManagement.VisualStudio
         // Display name of the NuGet "fix vulnerabilities" tool exposed by the NuGet MCP server.
         // Must match the tool name defined in the NuGet MCP Server.
         public const string NuGetSolverToolName = "fix_vulnerable_packages";
-        public const string PackageSourceMappingToolName = "review_supply_chain_security";
 
         // This value must match the server name registered in mcp.json. Keep both in sync.
         public const string NuGetMcpServerName = "NuGet";

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/McpServerConstants.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/McpServerConstants.cs
@@ -10,6 +10,7 @@ namespace NuGet.PackageManagement.VisualStudio
         // Display name of the NuGet "fix vulnerabilities" tool exposed by the NuGet MCP server.
         // Must match the tool name defined in the NuGet MCP Server.
         public const string NuGetSolverToolName = "fix_vulnerable_packages";
+        public const string PackageSourceMappingToolName = "review_supply_chain_security";
 
         // This value must match the server name registered in mcp.json. Keep both in sync.
         public const string NuGetMcpServerName = "NuGet";

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/CopilotToolSessionError.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/CopilotToolSessionError.cs
@@ -14,7 +14,7 @@ namespace NuGet.PackageManagement.Telemetry
         CopilotServiceNotAvailable,
         McpToolServiceNotAvailable,
         CopilotAccessDenied,
-        NuGetSolverNotAvailable,
+        ToolNotAvailable,
         McpServerInfoServiceNotAvailable,
         McpServerNotActive,
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/CopilotToolSessionError.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/CopilotToolSessionError.cs
@@ -1,12 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace NuGetVSExtension
+namespace NuGet.PackageManagement.Telemetry
 {
     /// <summary>
-    /// Represents the pre-flight error states when attempting to create a Copilot tool session.
+    /// Represents the error states when attempting to create or use a Copilot tool session.
     /// </summary>
-    internal enum CopilotToolSessionError
+    public enum CopilotToolSessionError
     {
         None,
         CopilotNotReady,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/CopilotToolSessionError.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/CopilotToolSessionError.cs
@@ -13,7 +13,8 @@ namespace NuGet.PackageManagement.Telemetry
         ServiceBrokerNotAvailable,
         CopilotServiceNotAvailable,
         McpToolServiceNotAvailable,
-        ToolNotAvailable,
+        CopilotAccessDenied,
+        NuGetSolverNotAvailable,
         McpServerInfoServiceNotAvailable,
         McpServerNotActive,
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigatedTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigatedTelemetryEvent.cs
@@ -96,11 +96,11 @@ namespace NuGet.PackageManagement.Telemetry
         }
 
         /// <summary>
-        /// Navigating from the Package Source Mapping VS Options page using the button for the command to Onboard to the feature.
+        /// Navigating from the Package Source Mapping VS Options page using the button for the command to Review current or potential use of the feature.
         /// </summary>
-        public static NavigatedTelemetryEvent CreateWithPackageSourceMapperCommandOnboard(CopilotToolSessionError errorType)
+        public static NavigatedTelemetryEvent CreateWithReviewPackageSourceMappingCommand(CopilotToolSessionError errorType)
         {
-            NavigatedTelemetryEvent navigatedTelemetryEvent = new(NavigationType.Button, NavigationOrigin.Options_PackageSourceMapperCommand_Onboard);
+            NavigatedTelemetryEvent navigatedTelemetryEvent = new(NavigationType.Button, NavigationOrigin.Options_PackageSourceMapping_Review);
             navigatedTelemetryEvent[ErrorTypePropertyName] = errorType;
             return navigatedTelemetryEvent;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigatedTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigatedTelemetryEvent.cs
@@ -96,6 +96,16 @@ namespace NuGet.PackageManagement.Telemetry
         }
 
         /// <summary>
+        /// Navigating from the Package Source Mapping VS Options page using the button for the command to Onboard to the feature.
+        /// </summary>
+        public static NavigatedTelemetryEvent CreateWithPackageSourceMapperCommandOnboard(CopilotToolSessionErrorType errorType)
+        {
+            NavigatedTelemetryEvent navigatedTelemetryEvent = new(NavigationType.Button, NavigationOrigin.Options_PackageSourceMapperCommand_Onboard);
+            navigatedTelemetryEvent[ErrorTypePropertyName] = errorType;
+            return navigatedTelemetryEvent;
+        }
+
+        /// <summary>
         /// Navigating an External hyperlink from VS.
         /// </summary>
         /// <param name="hyperlinkType">Hyperlink origin</param>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigatedTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NavigatedTelemetryEvent.cs
@@ -98,7 +98,7 @@ namespace NuGet.PackageManagement.Telemetry
         /// <summary>
         /// Navigating from the Package Source Mapping VS Options page using the button for the command to Onboard to the feature.
         /// </summary>
-        public static NavigatedTelemetryEvent CreateWithPackageSourceMapperCommandOnboard(CopilotToolSessionErrorType errorType)
+        public static NavigatedTelemetryEvent CreateWithPackageSourceMapperCommandOnboard(CopilotToolSessionError errorType)
         {
             NavigatedTelemetryEvent navigatedTelemetryEvent = new(NavigationType.Button, NavigationOrigin.Options_PackageSourceMapperCommand_Onboard);
             navigatedTelemetryEvent[ErrorTypePropertyName] = errorType;

--- a/src/NuGet.Clients/NuGet.Tools/Commands/PackageSourceMapperCommand.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Commands/PackageSourceMapperCommand.cs
@@ -16,12 +16,12 @@ namespace NuGet.Tools.Commands
         /// <summary>
         /// Command ID.
         /// </summary>
-        public const int CommandID = PkgCmdIDList.cmdidOnboardPackageSourceMapping;
+        public const int CommandID = PkgCmdIDList.cmdidReviewPackageSourceMapping;
 
         /// <summary>
         /// Command menu group (command set GUID).
         /// </summary>
-        public static readonly Guid CommandSet = GuidList.guidOnboardPackageSourceMappingCmdSet;
+        public static readonly Guid CommandSet = GuidList.guidReviewPackageSourceMappingCmdSet;
 
         private readonly OleMenuCommandService _oleMenuCommandService;
         private readonly IPackageSourceMappingService _packageSourceMappingService;
@@ -44,7 +44,7 @@ namespace NuGet.Tools.Commands
         private void ExecutePackageSourceMapperCommand(object sender, EventArgs e)
         {
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>
-                _packageSourceMappingService.LaunchOnboardPackageSourceMappingAsync(CancellationToken.None))
+                _packageSourceMappingService.LaunchReviewPackageSourceMappingAsync(CancellationToken.None))
                 .PostOnFailure(nameof(NuGetPackage), nameof(ExecutePackageSourceMapperCommand));
         }
     }

--- a/src/NuGet.Clients/NuGet.Tools/Commands/PackageSourceMapperCommand.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Commands/PackageSourceMapperCommand.cs
@@ -4,28 +4,15 @@
 using System;
 using System.ComponentModel.Design;
 using System.Threading;
-using System.Threading.Tasks;
-using Microsoft;
-using Microsoft.ServiceHub.Framework;
-using Microsoft.VisualStudio.Copilot;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Threading;
-using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
+using NuGetVSExtension;
 
 namespace NuGet.Tools.Commands
 {
     internal sealed class PackageSourceMapperCommand
     {
-        private const string AgentModeResponderServiceMoniker = "Microsoft.VisualStudio.Copilot.AgentModeResponder";
-        private const string ServiceName = "Microsoft.VisualStudio.Copilot.SolutionContextProvider";
-
-        private static readonly ServiceRpcDescriptor ProviderDescriptor = CopilotDescriptors.CreateContextProviderDescriptor(ServiceName);
-        private static readonly CopilotContextDescriptor ContextDescriptor = new CopilotContextDescriptor(
-                    "SolutionFile",
-                    "solution file context",
-                    CopilotDefaultTypes.StringName);
-
         /// <summary>
         /// Command ID.
         /// </summary>
@@ -37,17 +24,14 @@ namespace NuGet.Tools.Commands
         public static readonly Guid CommandSet = GuidList.guidOnboardPackageSourceMappingCmdSet;
 
         private readonly OleMenuCommandService _oleMenuCommandService;
-        private readonly ICopilotToolInvocationService _toolInvocationService;
-        private readonly IVsSolutionManager _solutionManager;
+        private readonly IPackageSourceMappingService _packageSourceMappingService;
 
         public PackageSourceMapperCommand(
             OleMenuCommandService oleMenuCommandService,
-            ICopilotToolInvocationService toolInvocationService,
-            IVsSolutionManager solutionManager)
+            IPackageSourceMappingService packageSourceMappingService)
         {
             _oleMenuCommandService = oleMenuCommandService ?? throw new ArgumentNullException(nameof(oleMenuCommandService));
-            _toolInvocationService = toolInvocationService ?? throw new ArgumentNullException(nameof(toolInvocationService));
-            _solutionManager = solutionManager ?? throw new ArgumentNullException(nameof(solutionManager));
+            _packageSourceMappingService = packageSourceMappingService ?? throw new ArgumentNullException(nameof(packageSourceMappingService));
         }
 
         public void Initialize()
@@ -59,41 +43,9 @@ namespace NuGet.Tools.Commands
 
         private void ExecutePackageSourceMapperCommand(object sender, EventArgs e)
         {
-            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => ExecuteAsync(CancellationToken.None))
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>
+                _packageSourceMappingService.LaunchOnboardPackageSourceMappingAsync(CancellationToken.None))
                 .PostOnFailure(nameof(NuGetPackage), nameof(ExecutePackageSourceMapperCommand));
         }
-
-        private async Task ExecuteAsync(CancellationToken cancellationToken)
-        {
-            CopilotClientId clientId = new("Microsoft.VisualStudio.NuGet.PackageSourceMapper");
-
-            CopilotRequest request = new("Onboard this repo to package source mapping")
-            {
-                Guidance = "Use absolute paths when invoking MCP Tools.",
-                DirectedResponders = [new(AgentModeResponderServiceMoniker, new(CopilotDescriptors.CurrentResponderVersion))]
-            };
-
-            CopilotToolSessionResult result = await _toolInvocationService.TryCreateToolSessionAsync(
-                clientId,
-                request.CorrelationId,
-                McpServerConstants.PackageSourceMappingFullyQualifiedToolName,
-                cancellationToken);
-
-            if (!result.IsSuccess)
-            {
-                // TODO: Add telemetry and user-facing error messages
-                return;
-            }
-
-            await using CopilotToolSession session = result.Session!;
-
-            string solutionPathContext = $"The current solution file path is: {GetSolutionPath()}.";
-            CopilotContext context = new CopilotContext(ProviderDescriptor.Moniker, ContextDescriptor, request.CorrelationId, solutionPathContext);
-            CopilotRequest requestWithFunctionsAndContext = request.WithFunctions(session.Functions).WithContext(context);
-
-            _ = await session.Thread.Session.SendRequestAsync(requestWithFunctionsAndContext, cancellationToken);
-        }
-
-        private string GetSolutionPath() => _solutionManager?.SolutionDirectory ?? string.Empty;
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/Commands/PackageSourceMapperCommand.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Commands/PackageSourceMapperCommand.cs
@@ -1,0 +1,99 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Design;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Copilot;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.VisualStudio;
+
+namespace NuGet.Tools.Commands
+{
+    internal sealed class PackageSourceMapperCommand
+    {
+        private const string AgentModeResponderServiceMoniker = "Microsoft.VisualStudio.Copilot.AgentModeResponder";
+        private const string ServiceName = "Microsoft.VisualStudio.Copilot.SolutionContextProvider";
+
+        private static readonly ServiceRpcDescriptor ProviderDescriptor = CopilotDescriptors.CreateContextProviderDescriptor(ServiceName);
+        private static readonly CopilotContextDescriptor ContextDescriptor = new CopilotContextDescriptor(
+                    "SolutionFile",
+                    "solution file context",
+                    CopilotDefaultTypes.StringName);
+
+        /// <summary>
+        /// Command ID.
+        /// </summary>
+        public const int CommandID = PkgCmdIDList.cmdidOnboardPackageSourceMapping;
+
+        /// <summary>
+        /// Command menu group (command set GUID).
+        /// </summary>
+        public static readonly Guid CommandSet = GuidList.guidOnboardPackageSourceMappingCmdSet;
+
+        private readonly OleMenuCommandService _oleMenuCommandService;
+        private readonly ICopilotToolInvocationService _toolInvocationService;
+        private readonly IVsSolutionManager _solutionManager;
+
+        public PackageSourceMapperCommand(
+            OleMenuCommandService oleMenuCommandService,
+            ICopilotToolInvocationService toolInvocationService,
+            IVsSolutionManager solutionManager)
+        {
+            _oleMenuCommandService = oleMenuCommandService ?? throw new ArgumentNullException(nameof(oleMenuCommandService));
+            _toolInvocationService = toolInvocationService ?? throw new ArgumentNullException(nameof(toolInvocationService));
+            _solutionManager = solutionManager ?? throw new ArgumentNullException(nameof(solutionManager));
+        }
+
+        public void Initialize()
+        {
+            var commandId = new CommandID(CommandSet, CommandID);
+            var command = new OleMenuCommand(ExecutePackageSourceMapperCommand, commandId);
+            _oleMenuCommandService.AddCommand(command);
+        }
+
+        private void ExecutePackageSourceMapperCommand(object sender, EventArgs e)
+        {
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() => ExecuteAsync(CancellationToken.None))
+                .PostOnFailure(nameof(NuGetPackage), nameof(ExecutePackageSourceMapperCommand));
+        }
+
+        private async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            CopilotClientId clientId = new("Microsoft.VisualStudio.NuGet.PackageSourceMapper");
+
+            CopilotRequest request = new("Onboard this repo to package source mapping")
+            {
+                Guidance = "Use absolute paths when invoking MCP Tools.",
+                DirectedResponders = [new(AgentModeResponderServiceMoniker, new(CopilotDescriptors.CurrentResponderVersion))]
+            };
+
+            CopilotToolSessionResult result = await _toolInvocationService.TryCreateToolSessionAsync(
+                clientId,
+                request.CorrelationId,
+                McpServerConstants.PackageSourceMappingFullyQualifiedToolName,
+                cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                // TODO: Add telemetry and user-facing error messages
+                return;
+            }
+
+            await using CopilotToolSession session = result.Session!;
+
+            string solutionPathContext = $"The current solution file path is: {GetSolutionPath()}.";
+            CopilotContext context = new CopilotContext(ProviderDescriptor.Moniker, ContextDescriptor, request.CorrelationId, solutionPathContext);
+            CopilotRequest requestWithFunctionsAndContext = request.WithFunctions(session.Functions).WithContext(context);
+
+            _ = await session.Thread.Session.SendRequestAsync(requestWithFunctionsAndContext, cancellationToken);
+        }
+
+        private string GetSolutionPath() => _solutionManager?.SolutionDirectory ?? string.Empty;
+    }
+}

--- a/src/NuGet.Clients/NuGet.Tools/Commands/PackageSourceMapperCommand.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Commands/PackageSourceMapperCommand.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel.Design;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
 using NuGet.VisualStudio.Telemetry;
 using NuGetVSExtension;
@@ -25,20 +26,33 @@ namespace NuGet.Tools.Commands
 
         private readonly OleMenuCommandService _oleMenuCommandService;
         private readonly IPackageSourceMappingService _packageSourceMappingService;
+        private readonly Lazy<IVsSolutionManager> _solutionManager;
 
         public PackageSourceMapperCommand(
             OleMenuCommandService oleMenuCommandService,
-            IPackageSourceMappingService packageSourceMappingService)
+            IPackageSourceMappingService packageSourceMappingService,
+            Lazy<IVsSolutionManager> solutionManager)
         {
             _oleMenuCommandService = oleMenuCommandService ?? throw new ArgumentNullException(nameof(oleMenuCommandService));
             _packageSourceMappingService = packageSourceMappingService ?? throw new ArgumentNullException(nameof(packageSourceMappingService));
+            _solutionManager = solutionManager ?? throw new ArgumentNullException(nameof(solutionManager));
         }
 
         public void Initialize()
         {
             var commandId = new CommandID(CommandSet, CommandID);
-            var command = new OleMenuCommand(ExecutePackageSourceMapperCommand, commandId);
+            var command = new OleMenuCommand(ExecutePackageSourceMapperCommand, changeHandler: null, BeforeQueryStatus, commandId);
             _oleMenuCommandService.AddCommand(command);
+        }
+
+        // The Review Package Source Mapping command drives GitHub Copilot and the NuGet MCP tool using the current
+        // solution as context, which does not work without an open solution. Hide the button when no solution is open.
+        private void BeforeQueryStatus(object sender, EventArgs e)
+        {
+            var command = (OleMenuCommand)sender;
+            bool isSolutionOpen = _solutionManager.Value.IsSolutionOpen;
+            command.Visible = isSolutionOpen;
+            command.Enabled = isSolutionOpen;
         }
 
         private void ExecutePackageSourceMapperCommand(object sender, EventArgs e)

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Copilot;
 using Microsoft.VisualStudio.Copilot.Internal.Mcp;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
+using NuGet.Common;
 using NuGet.VisualStudio;
 
 namespace NuGetVSExtension
@@ -115,6 +116,37 @@ namespace NuGetVSExtension
                     (copilotService as IDisposable)?.Dispose();
                 }
             }
+        }
+
+        /// <summary>
+        /// Handles a session creation error by showing a user-facing warning message and emitting a telemetry event.
+        /// </summary>
+        /// <param name="error">The error returned from <see cref="TryCreateToolSessionAsync"/>.</param>
+        /// <param name="toolNotAvailableMessage">The user-facing message to display when <see cref="CopilotToolSessionError.ToolNotAvailable"/>.</param>
+        /// <param name="warningTitle">The title for the warning message box.</param>
+        /// <param name="telemetryEvent">Optional telemetry event to emit. If null, no telemetry is sent.</param>
+        internal static void HandleSessionError(
+            CopilotToolSessionError error,
+            string toolNotAvailableMessage,
+            string warningTitle,
+            TelemetryEvent? telemetryEvent)
+        {
+            string message = error switch
+            {
+                CopilotToolSessionError.CopilotNotReady => Resources.Error_CopilotNotReady,
+                CopilotToolSessionError.ServiceBrokerNotAvailable => Resources.Error_ServiceBrokerNotAvailable,
+                CopilotToolSessionError.CopilotServiceNotAvailable => Resources.Error_CopilotServiceNotAvailable,
+                CopilotToolSessionError.McpToolServiceNotAvailable => Resources.Error_McpToolServiceNotAvailable,
+                CopilotToolSessionError.ToolNotAvailable => toolNotAvailableMessage,
+                _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),
+            };
+
+            if (telemetryEvent is not null)
+            {
+                TelemetryActivity.EmitTelemetryEvent(telemetryEvent);
+            }
+
+            MessageHelper.ShowWarningMessage(message, warningTitle);
         }
 
         internal static bool IsToolAvailable(

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
@@ -138,6 +138,8 @@ namespace NuGetVSExtension
                 CopilotToolSessionError.ServiceBrokerNotAvailable => Resources.Error_ServiceBrokerNotAvailable,
                 CopilotToolSessionError.CopilotServiceNotAvailable => Resources.Error_CopilotServiceNotAvailable,
                 CopilotToolSessionError.McpToolServiceNotAvailable => Resources.Error_McpToolServiceNotAvailable,
+                CopilotToolSessionError.McpServerInfoServiceNotAvailable => Resources.Error_McpServerInfoServiceNotAvailable,
+                CopilotToolSessionError.McpServerNotActive => Resources.Error_McpServerNotActive,
                 CopilotToolSessionError.ToolNotAvailable => toolNotAvailableMessage,
                 _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),
             };

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Copilot.Internal.Mcp;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 using NuGet.Common;
+using NuGet.PackageManagement.Telemetry;
 using NuGet.VisualStudio;
 
 namespace NuGetVSExtension

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolSessionResult.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolSessionResult.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGet.PackageManagement.Telemetry;
+
 namespace NuGetVSExtension
 {
     /// <summary>

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
@@ -101,6 +101,7 @@ namespace NuGetVSExtension
 
         //TODO private static void HandleSessionError(CopilotToolSessionError error, NavigationOrigin navigationOrigin)
         private static FixVulnerabilitiesWithCopilotErrorType MapSessionErrorToTelemetry(CopilotToolSessionError error)
+        private static CopilotToolSessionErrorType MapSessionErrorToTelemetry(CopilotToolSessionError error)
         {
             return error switch
             {
@@ -119,6 +120,7 @@ namespace NuGetVSExtension
         }
 
         private static void ShowWarningMessage(string message)
+        private static void SendTelemetryEvent(CopilotToolSessionErrorType errorType)
         {
             if (string.IsNullOrEmpty(message))
             {

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
@@ -75,7 +75,7 @@ namespace NuGetVSExtension
                     result.Error,
                     Resources.Error_NuGetSolverNotAvailable,
                     Resources.Title_FixVulnerabilitiesWithCopilot,
-                    NavigatedTelemetryEvent.CreateWithVulnerabilityInfoBarFixWithCopilot(MapSessionErrorToTelemetry(result.Error)));
+                    NavigatedTelemetryEvent.CreateWithVulnerabilityInfoBarFixWithCopilot(result.Error));
                 return;
             }
 
@@ -97,43 +97,6 @@ namespace NuGetVSExtension
                 ActivityLogger?.LogError(ex.Message);
                 MessageHelper.ShowWarningMessage(Resources.Error_CopilotAccessDenied, Resources.Title_FixVulnerabilitiesWithCopilot);
             }
-        }
-
-        //TODO private static void HandleSessionError(CopilotToolSessionError error, NavigationOrigin navigationOrigin)
-        private static FixVulnerabilitiesWithCopilotErrorType MapSessionErrorToTelemetry(CopilotToolSessionError error)
-        private static CopilotToolSessionErrorType MapSessionErrorToTelemetry(CopilotToolSessionError error)
-        {
-            return error switch
-            {
-                CopilotToolSessionError.CopilotNotReady => (FixVulnerabilitiesWithCopilotErrorType.CopilotNotReady, Resources.Error_CopilotNotReady),
-                CopilotToolSessionError.ServiceBrokerNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.ServiceBrokerNotAvailable, Resources.Error_ServiceBrokerNotAvailable),
-                CopilotToolSessionError.CopilotServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.CopilotServiceNotAvailable, Resources.Error_CopilotServiceNotAvailable),
-                CopilotToolSessionError.McpToolServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.McpToolServiceNotAvailable, Resources.Error_McpToolServiceNotAvailable),
-                CopilotToolSessionError.McpServerInfoServiceNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.McpServerInfoServiceNotAvailable, Resources.Error_McpServerInfoServiceNotAvailable),
-                CopilotToolSessionError.McpServerNotActive => (FixVulnerabilitiesWithCopilotErrorType.McpServerNotActive, Resources.Error_McpServerNotActive),
-                CopilotToolSessionError.ToolNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.NuGetSolverNotAvailable, Resources.Error_NuGetSolverNotAvailable),
-                _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),
-            };
-
-            SendTelemetryEvent(telemetryError, navigationOrigin);
-            ShowWarningMessage(message);
-        }
-
-        private static void ShowWarningMessage(string message)
-        private static void SendTelemetryEvent(CopilotToolSessionErrorType errorType)
-        {
-            if (string.IsNullOrEmpty(message))
-            {
-                return;
-            }
-
-            MessageHelper.ShowWarningMessage(message, Resources.Title_FixVulnerabilitiesWithCopilot);
-        }
-
-        private static void SendTelemetryEvent(FixVulnerabilitiesWithCopilotErrorType errorType, NavigationOrigin navigationOrigin)
-        {
-            var evt = NavigatedTelemetryEvent.CreateWithFixVulnerabilitiesWithCopilot(navigationOrigin, errorType);
-            TelemetryActivity.EmitTelemetryEvent(evt);
         }
 
         private string GetSolutionPath() => SolutionManager?.SolutionDirectory ?? string.Empty;

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
@@ -69,8 +69,6 @@ namespace NuGetVSExtension
 
             if (!result.IsSuccess)
             {
-                //TODO
-                HandleSessionError(result.Error, navigationOrigin);
                 CopilotToolInvocationService.HandleSessionError(
                     result.Error,
                     Resources.Error_NuGetSolverNotAvailable,

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
@@ -73,7 +73,7 @@ namespace NuGetVSExtension
                     result.Error,
                     Resources.Error_NuGetSolverNotAvailable,
                     Resources.Title_FixVulnerabilitiesWithCopilot,
-                    NavigatedTelemetryEvent.CreateWithVulnerabilityInfoBarFixWithCopilot(result.Error));
+                    NavigatedTelemetryEvent.CreateWithFixVulnerabilitiesWithCopilot(navigationOrigin, MapSessionErrorToTelemetry(result.Error)));
                 return;
             }
 
@@ -95,6 +95,29 @@ namespace NuGetVSExtension
                 ActivityLogger?.LogError(ex.Message);
                 MessageHelper.ShowWarningMessage(Resources.Error_CopilotAccessDenied, Resources.Title_FixVulnerabilitiesWithCopilot);
             }
+        }
+
+        private static void SendTelemetryEvent(FixVulnerabilitiesWithCopilotErrorType errorType, NavigationOrigin navigationOrigin)
+        {
+            TelemetryActivity.EmitTelemetryEvent(
+                NavigatedTelemetryEvent.CreateWithFixVulnerabilitiesWithCopilot(navigationOrigin, errorType));
+        }
+
+        private static FixVulnerabilitiesWithCopilotErrorType MapSessionErrorToTelemetry(CopilotToolSessionError error)
+        {
+            return error switch
+            {
+                CopilotToolSessionError.None => FixVulnerabilitiesWithCopilotErrorType.None,
+                CopilotToolSessionError.CopilotNotReady => FixVulnerabilitiesWithCopilotErrorType.CopilotNotReady,
+                CopilotToolSessionError.ServiceBrokerNotAvailable => FixVulnerabilitiesWithCopilotErrorType.ServiceBrokerNotAvailable,
+                CopilotToolSessionError.CopilotServiceNotAvailable => FixVulnerabilitiesWithCopilotErrorType.CopilotServiceNotAvailable,
+                CopilotToolSessionError.McpToolServiceNotAvailable => FixVulnerabilitiesWithCopilotErrorType.McpToolServiceNotAvailable,
+                CopilotToolSessionError.CopilotAccessDenied => FixVulnerabilitiesWithCopilotErrorType.CopilotAccessDenied,
+                CopilotToolSessionError.ToolNotAvailable => FixVulnerabilitiesWithCopilotErrorType.NuGetSolverNotAvailable,
+                CopilotToolSessionError.McpServerInfoServiceNotAvailable => FixVulnerabilitiesWithCopilotErrorType.McpServerInfoServiceNotAvailable,
+                CopilotToolSessionError.McpServerNotActive => FixVulnerabilitiesWithCopilotErrorType.McpServerNotActive,
+                _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),
+            };
         }
 
         private string GetSolutionPath() => SolutionManager?.SolutionDirectory ?? string.Empty;

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
@@ -69,7 +69,13 @@ namespace NuGetVSExtension
 
             if (!result.IsSuccess)
             {
+                //TODO
                 HandleSessionError(result.Error, navigationOrigin);
+                CopilotToolInvocationService.HandleSessionError(
+                    result.Error,
+                    Resources.Error_NuGetSolverNotAvailable,
+                    Resources.Title_FixVulnerabilitiesWithCopilot,
+                    NavigatedTelemetryEvent.CreateWithVulnerabilityInfoBarFixWithCopilot(MapSessionErrorToTelemetry(result.Error)));
                 return;
             }
 
@@ -89,13 +95,14 @@ namespace NuGetVSExtension
             {
                 SendTelemetryEvent(FixVulnerabilitiesWithCopilotErrorType.CopilotAccessDenied, navigationOrigin);
                 ActivityLogger?.LogError(ex.Message);
-                ShowWarningMessage(Resources.Error_CopilotAccessDenied);
+                MessageHelper.ShowWarningMessage(Resources.Error_CopilotAccessDenied, Resources.Title_FixVulnerabilitiesWithCopilot);
             }
         }
 
-        private static void HandleSessionError(CopilotToolSessionError error, NavigationOrigin navigationOrigin)
+        //TODO private static void HandleSessionError(CopilotToolSessionError error, NavigationOrigin navigationOrigin)
+        private static FixVulnerabilitiesWithCopilotErrorType MapSessionErrorToTelemetry(CopilotToolSessionError error)
         {
-            (FixVulnerabilitiesWithCopilotErrorType telemetryError, string message) = error switch
+            return error switch
             {
                 CopilotToolSessionError.CopilotNotReady => (FixVulnerabilitiesWithCopilotErrorType.CopilotNotReady, Resources.Error_CopilotNotReady),
                 CopilotToolSessionError.ServiceBrokerNotAvailable => (FixVulnerabilitiesWithCopilotErrorType.ServiceBrokerNotAvailable, Resources.Error_ServiceBrokerNotAvailable),

--- a/src/NuGet.Clients/NuGet.Tools/Guids.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Guids.cs
@@ -14,6 +14,7 @@ namespace NuGetVSExtension
         private const string guidNuGetToolsGroupString = "C0D88179-5D25-4982-BFE6-EC5FD59AC103";
         private const string guidNuGetDebugConsoleCmdSetString = "DDC61543-6CA7-4A6F-A5B7-984BE723C52F";
         private const string guidClearNuGetLocalResourcesCmdSetString = "54A0AC88-A025-4A62-8D48-6C1848E4F545";
+        private const string guidOnboardPackageSourceMappingCmdSetString = "98154E19-E6A4-426D-94B8-FB54E73511BA";
 
         // any project system that wants to load NuGet when its project opens needs to activate a UI context with this GUID
         public const string guidAutoLoadNuGetString = "65B1D035-27A5-4BBA-BAB9-5F61C1E2BC4A";
@@ -32,6 +33,7 @@ namespace NuGetVSExtension
         public static readonly Guid guidNuGetDebugConsoleCmdSet = new Guid(guidNuGetDebugConsoleCmdSetString);
         public static readonly Guid guidNuGetEditorType = Guid.Parse(guidNuGetEditorTypeString);
         public static readonly Guid guidClearNuGetLocalResourcesCmdSet = Guid.Parse(guidClearNuGetLocalResourcesCmdSetString);
+        public static readonly Guid guidOnboardPackageSourceMappingCmdSet = Guid.Parse(guidOnboardPackageSourceMappingCmdSetString);
 
         // Visual Studio output tool window (Copied from EnvDTE interop)
         public static Guid guidVsWindowKindOutput = Guid.Parse("34E76E81-EE4A-11D0-AE2E-00A0C90FFFC3");

--- a/src/NuGet.Clients/NuGet.Tools/Guids.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Guids.cs
@@ -14,7 +14,7 @@ namespace NuGetVSExtension
         private const string guidNuGetToolsGroupString = "C0D88179-5D25-4982-BFE6-EC5FD59AC103";
         private const string guidNuGetDebugConsoleCmdSetString = "DDC61543-6CA7-4A6F-A5B7-984BE723C52F";
         private const string guidClearNuGetLocalResourcesCmdSetString = "54A0AC88-A025-4A62-8D48-6C1848E4F545";
-        private const string guidOnboardPackageSourceMappingCmdSetString = "98154E19-E6A4-426D-94B8-FB54E73511BA";
+        private const string guidReviewPackageSourceMappingCmdSetString = "98154E19-E6A4-426D-94B8-FB54E73511BA";
 
         // any project system that wants to load NuGet when its project opens needs to activate a UI context with this GUID
         public const string guidAutoLoadNuGetString = "65B1D035-27A5-4BBA-BAB9-5F61C1E2BC4A";
@@ -33,7 +33,7 @@ namespace NuGetVSExtension
         public static readonly Guid guidNuGetDebugConsoleCmdSet = new Guid(guidNuGetDebugConsoleCmdSetString);
         public static readonly Guid guidNuGetEditorType = Guid.Parse(guidNuGetEditorTypeString);
         public static readonly Guid guidClearNuGetLocalResourcesCmdSet = Guid.Parse(guidClearNuGetLocalResourcesCmdSetString);
-        public static readonly Guid guidOnboardPackageSourceMappingCmdSet = Guid.Parse(guidOnboardPackageSourceMappingCmdSetString);
+        public static readonly Guid guidReviewPackageSourceMappingCmdSet = Guid.Parse(guidReviewPackageSourceMappingCmdSetString);
 
         // Visual Studio output tool window (Copied from EnvDTE interop)
         public static Guid guidVsWindowKindOutput = Guid.Parse("34E76E81-EE4A-11D0-AE2E-00A0C90FFFC3");

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -229,7 +229,7 @@ namespace NuGetVSExtension
             ClearNuGetLocalResourcesCommand clearNuGetLocalResourcesCommand = new(oleMenuCommandService: _mcs, OutputConsoleLogger);
             clearNuGetLocalResourcesCommand.Initialize();
 
-            PackageSourceMapperCommand packageSourceMapperCommand = new(_mcs, PackageSourceMappingService.Value);
+            PackageSourceMapperCommand packageSourceMapperCommand = new(_mcs, PackageSourceMappingService.Value, SolutionManager);
             packageSourceMapperCommand.Initialize();
         }
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -146,6 +146,9 @@ namespace NuGetVSExtension
         private Lazy<IServiceBrokerProvider> ServiceBrokerProvider { get; set; }
 
         [Import]
+        private Lazy<IPackageSourceMappingService> PackageSourceMappingService { get; set; }
+
+        [Import]
         private Lazy<INuGetExperimentationService> NuGetExperimentationService { get; set; }
 
         [Import]
@@ -225,6 +228,9 @@ namespace NuGetVSExtension
 
             ClearNuGetLocalResourcesCommand clearNuGetLocalResourcesCommand = new(oleMenuCommandService: _mcs, OutputConsoleLogger);
             clearNuGetLocalResourcesCommand.Initialize();
+
+            PackageSourceMapperCommand packageSourceMapperCommand = new(_mcs, PackageSourceMappingService.Value);
+            packageSourceMapperCommand.Initialize();
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
@@ -100,6 +100,14 @@
           <ButtonText>ClearLocals</ButtonText>
         </Strings>
       </Button>
+      
+      <Button guid="guidOnboardPackageSourceMappingCmdSet" id="cmdidOnboardPackageSourceMapping" priority="0x0100" type="Button">
+        <Strings>
+          <CommandName>cmdidOnboardPackageSourceMapping</CommandName>
+          <!--This button text is not visible to the user as the command is invoked from Unified Settings-->
+          <ButtonText>OnboardPackageSourceMapping</ButtonText>
+        </Strings>
+      </Button>
 
       <Button guid="guidDialogCmdSet" id="cmdidUpgradeNuGetProject" priority="0x0400" type="Button">
         <Parent guid="guidReferenceContext" id="cmdAddReferenceGroup" />
@@ -306,6 +314,9 @@
     </GuidSymbol>
     <GuidSymbol name="guidClearNuGetLocalResourcesCmdSet" value="{54A0AC88-A025-4A62-8D48-6C1848E4F545}">
       <IDSymbol name="cmdidClearNuGetLocalResources" value="0x0100" />
+    </GuidSymbol>
+    <GuidSymbol name="guidOnboardPackageSourceMappingCmdSet" value="{98154E19-E6A4-426D-94B8-FB54E73511BA}">
+      <IDSymbol name="cmdidOnboardPackageSourceMapping" value="0x0100" />
     </GuidSymbol>
     <GuidSymbol name="guidVenusCmdId" value="{C7547851-4E3A-4E5B-9173-FA6E9C8BD82C}" >
       <IDSymbol name="IDG_VENUS_CTX_REFERENCE" value="27" />

--- a/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetTools.vsct
@@ -101,11 +101,11 @@
         </Strings>
       </Button>
       
-      <Button guid="guidOnboardPackageSourceMappingCmdSet" id="cmdidOnboardPackageSourceMapping" priority="0x0100" type="Button">
+      <Button guid="guidReviewPackageSourceMappingCmdSet" id="cmdidReviewPackageSourceMapping" priority="0x0100" type="Button">
         <Strings>
-          <CommandName>cmdidOnboardPackageSourceMapping</CommandName>
+          <CommandName>cmdidReviewPackageSourceMapping</CommandName>
           <!--This button text is not visible to the user as the command is invoked from Unified Settings-->
-          <ButtonText>OnboardPackageSourceMapping</ButtonText>
+          <ButtonText>ReviewPackageSourceMapping</ButtonText>
         </Strings>
       </Button>
 
@@ -315,8 +315,8 @@
     <GuidSymbol name="guidClearNuGetLocalResourcesCmdSet" value="{54A0AC88-A025-4A62-8D48-6C1848E4F545}">
       <IDSymbol name="cmdidClearNuGetLocalResources" value="0x0100" />
     </GuidSymbol>
-    <GuidSymbol name="guidOnboardPackageSourceMappingCmdSet" value="{98154E19-E6A4-426D-94B8-FB54E73511BA}">
-      <IDSymbol name="cmdidOnboardPackageSourceMapping" value="0x0100" />
+    <GuidSymbol name="guidReviewPackageSourceMappingCmdSet" value="{98154E19-E6A4-426D-94B8-FB54E73511BA}">
+      <IDSymbol name="cmdidReviewPackageSourceMapping" value="0x0100" />
     </GuidSymbol>
     <GuidSymbol name="guidVenusCmdId" value="{C7547851-4E3A-4E5B-9173-FA6E9C8BD82C}" >
       <IDSymbol name="IDG_VENUS_CTX_REFERENCE" value="27" />

--- a/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
@@ -9,6 +9,7 @@ using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Copilot;
 using NuGet.Common;
+using NuGet.PackageManagement.Telemetry;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
 
@@ -61,7 +62,7 @@ namespace NuGetVSExtension
                     result.Error,
                     Resources.Error_PackageSourceMappingToolNotAvailable,
                     Resources.Title_PackageSourceMappingWithCopilot,
-                    telemetryEvent: null); //TODO: Telemetry
+                    telemetryEvent: NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(result.Error));
                 return;
             }
 

--- a/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
@@ -1,0 +1,83 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Copilot;
+using NuGet.Common;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.VisualStudio;
+
+namespace NuGetVSExtension
+{
+    [Export(typeof(IPackageSourceMappingService))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    internal class PackageSourceMappingService : IPackageSourceMappingService
+    {
+        private const string AgentModeResponderServiceMoniker = "Microsoft.VisualStudio.Copilot.AgentModeResponder";
+        private const string ServiceName = "Microsoft.VisualStudio.Copilot.SolutionContextProvider";
+
+        private static readonly ServiceRpcDescriptor ProviderDescriptor = CopilotDescriptors.CreateContextProviderDescriptor(ServiceName);
+        private static readonly CopilotContextDescriptor ContextDescriptor = new CopilotContextDescriptor(
+                    "SolutionFile",
+                    "solution file context",
+                    CopilotDefaultTypes.StringName);
+
+        [Import(typeof(ICopilotToolInvocationService))]
+        public ICopilotToolInvocationService? ToolInvocationService { get; set; }
+
+        [Import(typeof(IVsSolutionManager))]
+        public IVsSolutionManager? SolutionManager { get; set; }
+
+        [Import(typeof(VisualStudioActivityLogger))]
+        public ILogger? ActivityLogger { get; set; }
+
+        public async Task LaunchOnboardPackageSourceMappingAsync(CancellationToken cancellationToken)
+        {
+            CopilotClientId clientId = new("Microsoft.VisualStudio.NuGet.PackageSourceMapper");
+
+            CopilotRequest request = new("Onboard this repository to package source mapping.")
+            {
+                Guidance = "Use absolute paths when invoking MCP Tools.",
+                DirectedResponders = [new(AgentModeResponderServiceMoniker, new(CopilotDescriptors.CurrentResponderVersion))]
+            };
+
+            Assumes.Present(ToolInvocationService);
+
+            CopilotToolSessionResult result = await ToolInvocationService.TryCreateToolSessionAsync(
+                clientId,
+                request.CorrelationId,
+                McpServerConstants.PackageSourceMappingFullyQualifiedToolName,
+                cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                // TODO: Add telemetry and user-facing error messages
+                return;
+            }
+
+            await using CopilotToolSession session = result.Session!;
+
+            string solutionPathContext = $"The current solution file path is: {GetSolutionPath()}.";
+            CopilotContext context = new CopilotContext(ProviderDescriptor.Moniker, ContextDescriptor, request.CorrelationId, solutionPathContext);
+            CopilotRequest requestWithFunctionsAndContext = request.WithFunctions(session.Functions).WithContext(context);
+
+            try
+            {
+                _ = await session.Thread.Session.SendRequestAsync(requestWithFunctionsAndContext, cancellationToken);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                ActivityLogger?.LogError(ex.Message);
+            }
+        }
+
+        //TODO: Telemetry
+
+        private string GetSolutionPath() => SolutionManager?.SolutionDirectory ?? string.Empty;
+    }
+}

--- a/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
@@ -28,12 +28,12 @@ namespace NuGetVSExtension
                     CopilotDefaultTypes.StringName);
 
         [Import(typeof(ICopilotToolInvocationService))]
-        public ICopilotToolInvocationService? ToolInvocationService { get; set; }
+        public ICopilotToolInvocationService ToolInvocationService { get; set; } = null!;
 
-        [Import(typeof(IVsSolutionManager))]
+        [Import(typeof(IVsSolutionManager), AllowDefault = true)]
         public IVsSolutionManager? SolutionManager { get; set; }
 
-        [Import(typeof(VisualStudioActivityLogger))]
+        [Import(typeof(VisualStudioActivityLogger), AllowDefault = true)]
         public ILogger? ActivityLogger { get; set; }
 
         public async Task LaunchOnboardPackageSourceMappingAsync(CancellationToken cancellationToken)

--- a/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
@@ -51,7 +51,8 @@ namespace NuGetVSExtension
             CopilotToolSessionResult result = await ToolInvocationService.TryCreateToolSessionAsync(
                 clientId,
                 request.CorrelationId,
-                McpServerConstants.PackageSourceMappingFullyQualifiedToolName,
+                McpServerConstants.PackageSourceMappingToolName,
+                McpServerConstants.NuGetMcpServerNames,
                 cancellationToken);
 
             if (!result.IsSuccess)

--- a/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
@@ -40,7 +40,7 @@ namespace NuGetVSExtension
         {
             CopilotClientId clientId = new("Microsoft.VisualStudio.NuGet.PackageSourceMapper");
 
-            CopilotRequest request = new("Onboard this repository to package source mapping.")
+            CopilotRequest request = new(Resources.Prompt_PackageSourceMappingOnboard)
             {
                 Guidance = "Use absolute paths when invoking MCP Tools.",
                 DirectedResponders = [new(AgentModeResponderServiceMoniker, new(CopilotDescriptors.CurrentResponderVersion))]

--- a/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
@@ -37,11 +37,11 @@ namespace NuGetVSExtension
         [Import(typeof(VisualStudioActivityLogger), AllowDefault = true)]
         public ILogger? ActivityLogger { get; set; }
 
-        public async Task LaunchOnboardPackageSourceMappingAsync(CancellationToken cancellationToken)
+        public async Task LaunchReviewPackageSourceMappingAsync(CancellationToken cancellationToken)
         {
             CopilotClientId clientId = new("Microsoft.VisualStudio.NuGet.PackageSourceMapper");
 
-            CopilotRequest request = new(Resources.Prompt_PackageSourceMappingOnboard)
+            CopilotRequest request = new(Resources.Prompt_ReviewPackageSourceMapping)
             {
                 Guidance = "Use absolute paths when invoking MCP Tools.",
                 DirectedResponders = [new(AgentModeResponderServiceMoniker, new(CopilotDescriptors.CurrentResponderVersion))]
@@ -62,7 +62,7 @@ namespace NuGetVSExtension
                     result.Error,
                     Resources.Error_PackageSourceMappingToolNotAvailable,
                     Resources.Title_PackageSourceMappingWithCopilot,
-                    NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(result.Error));
+                    NavigatedTelemetryEvent.CreateWithReviewPackageSourceMappingCommand(result.Error));
                 return;
             }
 
@@ -76,12 +76,12 @@ namespace NuGetVSExtension
             {
                 _ = await session.Thread.Session.SendRequestAsync(requestWithFunctionsAndContext, cancellationToken);
                 TelemetryActivity.EmitTelemetryEvent(
-                    NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(CopilotToolSessionError.None));
+                    NavigatedTelemetryEvent.CreateWithReviewPackageSourceMappingCommand(CopilotToolSessionError.None));
             }
             catch (UnauthorizedAccessException ex)
             {
                 TelemetryActivity.EmitTelemetryEvent(
-                    NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(CopilotToolSessionError.CopilotAccessDenied));
+                    NavigatedTelemetryEvent.CreateWithReviewPackageSourceMappingCommand(CopilotToolSessionError.CopilotAccessDenied));
                 ActivityLogger?.LogError(ex.Message);
                 MessageHelper.ShowWarningMessage(Resources.Error_CopilotAccessDenied, Resources.Title_PackageSourceMappingWithCopilot);
             }

--- a/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
@@ -62,7 +62,7 @@ namespace NuGetVSExtension
                     result.Error,
                     Resources.Error_PackageSourceMappingToolNotAvailable,
                     Resources.Title_PackageSourceMappingWithCopilot,
-                    telemetryEvent: NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(result.Error));
+                    NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(result.Error));
                 return;
             }
 
@@ -75,10 +75,15 @@ namespace NuGetVSExtension
             try
             {
                 _ = await session.Thread.Session.SendRequestAsync(requestWithFunctionsAndContext, cancellationToken);
+                TelemetryActivity.EmitTelemetryEvent(
+                    NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(CopilotToolSessionError.None));
             }
             catch (UnauthorizedAccessException ex)
             {
+                TelemetryActivity.EmitTelemetryEvent(
+                    NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(CopilotToolSessionError.CopilotAccessDenied));
                 ActivityLogger?.LogError(ex.Message);
+                MessageHelper.ShowWarningMessage(Resources.Error_CopilotAccessDenied, Resources.Title_PackageSourceMappingWithCopilot);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PackageSourceMappingService.cs
@@ -57,7 +57,11 @@ namespace NuGetVSExtension
 
             if (!result.IsSuccess)
             {
-                // TODO: Add telemetry and user-facing error messages
+                CopilotToolInvocationService.HandleSessionError(
+                    result.Error,
+                    Resources.Error_PackageSourceMappingToolNotAvailable,
+                    Resources.Title_PackageSourceMappingWithCopilot,
+                    telemetryEvent: null); //TODO: Telemetry
                 return;
             }
 
@@ -76,8 +80,6 @@ namespace NuGetVSExtension
                 ActivityLogger?.LogError(ex.Message);
             }
         }
-
-        //TODO: Telemetry
 
         private string GetSolutionPath() => SolutionManager?.SolutionDirectory ?? string.Empty;
     }

--- a/src/NuGet.Clients/NuGet.Tools/PkgCmdID.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PkgCmdID.cs
@@ -19,5 +19,6 @@ namespace NuGetVSExtension
         public const int cmdidUpdatePackage = 0x0500;
         public const int cmdidUpdatePackages = 0x0600;
         public const int cmdidClearNuGetLocalResources = 0x0100;
+        public const int cmdidOnboardPackageSourceMapping = 0x0100;
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/PkgCmdID.cs
+++ b/src/NuGet.Clients/NuGet.Tools/PkgCmdID.cs
@@ -19,6 +19,6 @@ namespace NuGetVSExtension
         public const int cmdidUpdatePackage = 0x0500;
         public const int cmdidUpdatePackages = 0x0600;
         public const int cmdidClearNuGetLocalResources = 0x0100;
-        public const int cmdidOnboardPackageSourceMapping = 0x0100;
+        public const int cmdidReviewPackageSourceMapping = 0x0100;
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -590,5 +590,14 @@ namespace NuGetVSExtension {
                 return ResourceManager.GetString("Title_FixVulnerabilitiesWithCopilot", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Onboard with GitHub Copilot.
+        /// </summary>
+        internal static string VSOptions_Button_PackageSourceMappingOnboard {
+            get {
+                return ResourceManager.GetString("VSOptions_Button_PackageSourceMappingOnboard", resourceCulture);
+            }
+        }
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -385,11 +385,11 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Onboard this repository to package source mapping..
+        ///   Looks up a localized string similar to Review this repository&apos;s package source mappings..
         /// </summary>
-        internal static string Prompt_PackageSourceMappingOnboard {
+        internal static string Prompt_ReviewPackageSourceMapping {
             get {
-                return ResourceManager.GetString("Prompt_PackageSourceMappingOnboard", resourceCulture);
+                return ResourceManager.GetString("Prompt_ReviewPackageSourceMapping", resourceCulture);
             }
         }
         
@@ -619,11 +619,11 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Onboard with GitHub Copilot.
+        ///   Looks up a localized string similar to Review with GitHub Copilot.
         /// </summary>
-        internal static string VSOptions_Button_PackageSourceMappingOnboard {
+        internal static string VSOptions_Button_PackageSourceMappingReview {
             get {
-                return ResourceManager.GetString("VSOptions_Button_PackageSourceMappingOnboard", resourceCulture);
+                return ResourceManager.GetString("VSOptions_Button_PackageSourceMappingReview", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -376,6 +376,15 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Onboard this repository to package source mapping..
+        /// </summary>
+        internal static string Prompt_PackageSourceMappingOnboard {
+            get {
+                return ResourceManager.GetString("Prompt_PackageSourceMappingOnboard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to These settings are stored in %NuGet.Config% files.
         /// </summary>
         internal static string SettingsStoredInNuGetConfiguration {

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -187,6 +187,15 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again..
+        /// </summary>
+        internal static string Error_PackageSourceMappingToolNotAvailable {
+            get {
+                return ResourceManager.GetString("Error_PackageSourceMappingToolNotAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A name must be provided..
         /// </summary>
         internal static string Error_PackageSourceName_Missing {
@@ -597,6 +606,15 @@ namespace NuGetVSExtension {
         internal static string Title_FixVulnerabilitiesWithCopilot {
             get {
                 return ResourceManager.GetString("Title_FixVulnerabilitiesWithCopilot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package Source Mapping with GitHub Copilot.
+        /// </summary>
+        internal static string Title_PackageSourceMappingWithCopilot {
+            get {
+                return ResourceManager.GetString("Title_PackageSourceMappingWithCopilot", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -304,12 +304,12 @@
     <value>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
-  <data name="VSOptions_Button_PackageSourceMappingOnboard" xml:space="preserve">
-    <value>Onboard with GitHub Copilot</value>
+  <data name="VSOptions_Button_PackageSourceMappingReview" xml:space="preserve">
+    <value>Review with GitHub Copilot</value>
     <comment>Do not translate "GitHub Copilot"</comment>
   </data>
-  <data name="Prompt_PackageSourceMappingOnboard" xml:space="preserve">
-    <value>Onboard this repository to package source mapping.</value>
+  <data name="Prompt_ReviewPackageSourceMapping" xml:space="preserve">
+    <value>Review this repository's package source mappings.</value>
   </data>
   <data name="Error_PackageSourceMappingToolNotAvailable" xml:space="preserve">
     <value>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -311,4 +311,12 @@
   <data name="Prompt_PackageSourceMappingOnboard" xml:space="preserve">
     <value>Onboard this repository to package source mapping.</value>
   </data>
+  <data name="Error_PackageSourceMappingToolNotAvailable" xml:space="preserve">
+    <value>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
+    <comment>Do not translate GitHub or Copilot</comment>
+  </data>
+  <data name="Title_PackageSourceMappingWithCopilot" xml:space="preserve">
+    <value>Package Source Mapping with GitHub Copilot</value>
+    <comment>Do not translate "GitHub Copilot"</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -304,4 +304,8 @@
     <value>The NuGet MCP Server is not active. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
+  <data name="VSOptions_Button_PackageSourceMappingOnboard" xml:space="preserve">
+    <value>Onboard with GitHub Copilot</value>
+    <comment>Do not translate "GitHub Copilot"</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -308,4 +308,7 @@
     <value>Onboard with GitHub Copilot</value>
     <comment>Do not translate "GitHub Copilot"</comment>
   </data>
+  <data name="Prompt_PackageSourceMappingOnboard" xml:space="preserve">
+    <value>Onboard this repository to package source mapping.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.cs.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">K&amp;onzola Správce balíčků</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.cs.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">K&amp;onzola Správce balíčků</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.de.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">Paket-Manager-K&amp;onsole</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.de.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">Paket-Manager-K&amp;onsole</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.es.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">C&amp;onsola del Administrador de paquetes</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.es.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">C&amp;onsola del Administrador de paquetes</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.fr.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">C&amp;onsole du Gestionnaire de package</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.fr.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">C&amp;onsole du Gestionnaire de package</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.it.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">C&amp;onsole di Gestione pacchetti</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.it.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">C&amp;onsole di Gestione pacchetti</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ja.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">パッケージ マネージャー コンソール(&amp;O)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ja.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">パッケージ マネージャー コンソール(&amp;O)</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ko.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">패키지 관리자 콘솔(&amp;O)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ko.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">패키지 관리자 콘솔(&amp;O)</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.pl.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">K&amp;onsola menedżera pakietów</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.pl.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">K&amp;onsola menedżera pakietów</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.pt-BR.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">C&amp;onsole do Gerenciador de Pacotes</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.pt-BR.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">C&amp;onsole do Gerenciador de Pacotes</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ru.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">Консол&amp;ь диспетчера пакетов</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.ru.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">Консол&amp;ь диспетчера пакетов</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.tr.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">Paket Yöneticisi &amp;Konsolu</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.tr.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">Paket Yöneticisi &amp;Konsolu</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.zh-Hans.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">程序包管理器控制台(&amp;O)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.zh-Hans.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">程序包管理器控制台(&amp;O)</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.zh-Hant.xlf
@@ -37,16 +37,6 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
-        <source>OnboardPackageSourceMapping</source>
-        <target state="new">OnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
-        <source>cmdidOnboardPackageSourceMapping</source>
-        <target state="new">cmdidOnboardPackageSourceMapping</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">套件管理器主控台(&amp;O)</target>
@@ -65,6 +55,16 @@
       <trans-unit id="cmdidRestorePackages|CommandName">
         <source>cmdRestorePackages</source>
         <target state="translated">cmdRestorePackages</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|ButtonText">
+        <source>ReviewPackageSourceMapping</source>
+        <target state="new">ReviewPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidReviewPackageSourceMapping|CommandName">
+        <source>cmdidReviewPackageSourceMapping</source>
+        <target state="new">cmdidReviewPackageSourceMapping</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidSourceSettings|ButtonText">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/NuGetTools.vsct.zh-Hant.xlf
@@ -37,6 +37,16 @@
         <target state="translated">cmdidClearNuGetLocalResources</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|ButtonText">
+        <source>OnboardPackageSourceMapping</source>
+        <target state="new">OnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidOnboardPackageSourceMapping|CommandName">
+        <source>cmdidOnboardPackageSourceMapping</source>
+        <target state="new">cmdidOnboardPackageSourceMapping</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidPowerConsole|ButtonText">
         <source>Package Manager C&amp;onsole</source>
         <target state="translated">套件管理器主控台(&amp;O)</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Musí být vybrán alespoň jeden zdroj.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">Musí být zadán název.</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">Opravit ohrožení zabezpečení balíčku NuGet</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">Opravit ohrožení zabezpečení pomocí GitHub Copilota</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -272,6 +272,11 @@
         <target state="translated">Opravit ohrožení zabezpečení pomocí GitHub Copilota</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">Vymazat místní prostředky NuGet</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -167,9 +167,9 @@
         <target state="translated">Opravit ohrožení zabezpečení balíčku NuGet</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -167,9 +167,9 @@
         <target state="translated">Meine NuGet-Paketsicherheitsrisiken beheben</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Mindestens eine Quelle muss ausgewählt werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">Name muss angegeben werden.</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">Meine NuGet-Paketsicherheitsrisiken beheben</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">Sicherheitsrisiken mit GitHub Copilot beheben</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -272,6 +272,11 @@
         <target state="translated">Sicherheitsrisiken mit GitHub Copilot beheben</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">Lokale NuGet-Ressourcen löschen</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Debe seleccionarse al menos un origen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">Se debe proporcionar un nombre.</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">Corregir las vulnerabilidades de mi paquete NuGet</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">Corrección de vulnerabilidades con GitHub Copilot</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -272,6 +272,11 @@
         <target state="translated">Corrección de vulnerabilidades con GitHub Copilot</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">Borrar recursos locales de NuGet</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -167,9 +167,9 @@
         <target state="translated">Corregir las vulnerabilidades de mi paquete NuGet</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Vous devez sélectionner au moins une source.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">Le nom doit être renseigné.</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">Corrigez les vulnérabilités de mon package NuGet</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">Corrigez les vulnérabilités avec GitHub Copilot</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -272,6 +272,11 @@
         <target state="translated">Corrigez les vulnérabilités avec GitHub Copilot</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">Effacer les ressources locales NuGet</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -167,9 +167,9 @@
         <target state="translated">Corrigez les vulnérabilités de mon package NuGet</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -167,9 +167,9 @@
         <target state="translated">Correggere le vulnerabilità del pacchetto NuGet</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Selezionare almeno un'origine dati.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">È necessario fornire un nome.</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">Correggere le vulnerabilità del pacchetto NuGet</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">Correggi le vulnerabilità con GitHub Copilot</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -272,6 +272,11 @@
         <target state="translated">Correggi le vulnerabilità con GitHub Copilot</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">Cancella risorse locali di NuGet</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -67,6 +67,11 @@
         <target state="translated">1 個以上のソースを選択する必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">名前を指定する必要があります。</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">NuGet パッケージの脆弱性を修正してください</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">GitHub Copilot を使用して脆弱性を修正する</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -167,9 +167,9 @@
         <target state="translated">NuGet パッケージの脆弱性を修正してください</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -272,6 +272,11 @@
         <target state="translated">GitHub Copilot を使用して脆弱性を修正する</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">NuGet ローカル リソースをクリア</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -272,6 +272,11 @@
         <target state="translated">GitHub Copilot으로 취약성 수정</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">NuGet 로컬 리소스 지우기</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -167,9 +167,9 @@
         <target state="translated">NuGet 패키지 취약성 수정</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -67,6 +67,11 @@
         <target state="translated">원본을 하나 이상 선택해야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">이름을 제공해야 합니다.</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">NuGet 패키지 취약성 수정</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">GitHub Copilot으로 취약성 수정</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Należy wybrać co najmniej jedno źródło.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">Należy podać nazwę.</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">Napraw luki w zabezpieczeniach pakietu NuGet</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">Napraw luki w zabezpieczeniach z usługą GitHub Copilot</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -167,9 +167,9 @@
         <target state="translated">Napraw luki w zabezpieczeniach pakietu NuGet</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -272,6 +272,11 @@
         <target state="translated">Napraw luki w zabezpieczeniach z usługą GitHub Copilot</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">Wyczyść zasoby lokalne menedżera pakietów NuGet</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Pelo menos uma fonte deve ser selecionada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">Um nome deve ser fornecido.</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">Corrigir minhas vulnerabilidades de pacote NuGet</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">Corrigir vulnerabilidades com o GitHub Copilot</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -167,9 +167,9 @@
         <target state="translated">Corrigir minhas vulnerabilidades de pacote NuGet</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -272,6 +272,11 @@
         <target state="translated">Corrigir vulnerabilidades com o GitHub Copilot</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">Limpar recursos locais do NuGet</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -272,6 +272,11 @@
         <target state="translated">Исправить уязвимости с помощью GitHub Copilot</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">Очистить локальные ресурсы NuGet</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -167,9 +167,9 @@
         <target state="translated">Исправить уязвимости в пакете NuGet</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Необходимо выбрать по крайней мере один источник.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">Необходимо указать имя.</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">Исправить уязвимости в пакете NuGet</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">Исправить уязвимости с помощью GitHub Copilot</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -167,9 +167,9 @@
         <target state="translated">NuGet paketimdeki güvenlik açıklarını düzelt</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">En az bir kaynak seçilmelidir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">Bir ad sağlanmalıdır.</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">NuGet paketimdeki güvenlik açıklarını düzelt</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">GitHub Copilot ile güvenlik açıklarını düzelt</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -272,6 +272,11 @@
         <target state="translated">GitHub Copilot ile güvenlik açıklarını düzelt</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">NuGet yerel kaynaklarını temizle</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -272,6 +272,11 @@
         <target state="translated">使用 GitHub Copilot 修复漏洞</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">清除 NuGet 本地资源</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="translated">必须至少选择一个源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">必须提供名称。</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">修复我的 NuGet 包漏洞</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">使用 GitHub Copilot 修复漏洞</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -167,9 +167,9 @@
         <target state="translated">修复我的 NuGet 包漏洞</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -272,6 +272,11 @@
         <target state="translated">使用 GitHub Copilot 修復漏洞</target>
         <note />
       </trans-unit>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
+        <source>Onboard with GitHub Copilot</source>
+        <target state="new">Onboard with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
+      </trans-unit>
       <trans-unit id="clearLocalResources">
         <source>Clear NuGet local resources</source>
         <target state="translated">清除 NuGet 本機資源</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -167,9 +167,9 @@
         <target state="translated">修復我的 NuGet 套件漏洞</target>
         <note />
       </trans-unit>
-      <trans-unit id="Prompt_PackageSourceMappingOnboard">
-        <source>Onboard this repository to package source mapping.</source>
-        <target state="new">Onboard this repository to package source mapping.</target>
+      <trans-unit id="Prompt_ReviewPackageSourceMapping">
+        <source>Review this repository's package source mappings.</source>
+        <target state="new">Review this repository's package source mappings.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -287,9 +287,9 @@
         <target state="new">Package Source Mapping with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
-      <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
-        <source>Onboard with GitHub Copilot</source>
-        <target state="new">Onboard with GitHub Copilot</target>
+      <trans-unit id="VSOptions_Button_PackageSourceMappingReview">
+        <source>Review with GitHub Copilot</source>
+        <target state="new">Review with GitHub Copilot</target>
         <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="clearLocalResources">

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="translated">至少必須選取一個來源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_PackageSourceMappingToolNotAvailable">
+        <source>The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</source>
+        <target state="new">The Package Source Mapping tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_PackageSourceName_Missing">
         <source>A name must be provided.</source>
         <target state="translated">必須提供名稱。</target>
@@ -160,6 +165,11 @@
       <trans-unit id="Prompt_FixNuGetPackageVulnerabilities">
         <source>Fix my NuGet package vulnerabilities</source>
         <target state="translated">修復我的 NuGet 套件漏洞</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prompt_PackageSourceMappingOnboard">
+        <source>Onboard this repository to package source mapping.</source>
+        <target state="new">Onboard this repository to package source mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsStoredInNuGetConfiguration">
@@ -271,6 +281,11 @@
         <source>Fix Vulnerabilities with GitHub Copilot</source>
         <target state="translated">使用 GitHub Copilot 修復漏洞</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Title_PackageSourceMappingWithCopilot">
+        <source>Package Source Mapping with GitHub Copilot</source>
+        <target state="new">Package Source Mapping with GitHub Copilot</target>
+        <note>Do not translate "GitHub Copilot"</note>
       </trans-unit>
       <trans-unit id="VSOptions_Button_PackageSourceMappingOnboard">
         <source>Onboard with GitHub Copilot</source>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -387,7 +387,16 @@
           "allowItemEditing": true,
           "allowAdditionsAndRemovals": true
         }
-      }
+      },
+      "commands": [
+        {
+          "vsct": {
+            "text": "Onboard", //TODO
+            "set": "54A0AC88-A025-4A62-8D48-6C1848E4F545", // TODO: guidClearNuGetLocalResourcesCmdSetString
+            "id": 256 // TODO: cmdidClearNuGetLocalResources
+          }
+        }
+      ]
     }
   },
   "categories": {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -391,7 +391,7 @@
       "commands": [
         {
           "vsct": {
-            "text": "Onboard to GitHub Copilot", //TODO
+            "text": "@VSOptions_Button_PackageSourceMappingOnboard;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
             "set": "98154E19-E6A4-426D-94B8-FB54E73511BA", // guidOnboardPackageSourceMappingCmdSetString
             "id": 256 // cmdidOnboardPackageSourceMapping
           }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -385,18 +385,18 @@
           // The actual items that appear by default; in most cases, you'd leave this array empty.
           "default": [],
           "allowItemEditing": true,
-          "allowAdditionsAndRemovals": true
+          "allowAdditionsAndRemovals": true,
+          "commands": [
+            {
+              "vsct": {
+                "text": "@VSOptions_Button_PackageSourceMappingReview;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
+                "set": "98154E19-E6A4-426D-94B8-FB54E73511BA", // guidReviewPackageSourceMappingCmdSetString
+                "id": 256 // cmdidReviewPackageSourceMapping
+              }
+            }
+          ]
         }
-      },
-      "commands": [
-        {
-          "vsct": {
-            "text": "@VSOptions_Button_PackageSourceMappingOnboard;{5fcc8577-4feb-4d04-ad72-d6c629b083cc}",
-            "set": "98154E19-E6A4-426D-94B8-FB54E73511BA", // guidOnboardPackageSourceMappingCmdSetString
-            "id": 256 // cmdidOnboardPackageSourceMapping
-          }
-        }
-      ]
+      }
     }
   },
   "categories": {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/registration.json
@@ -391,9 +391,9 @@
       "commands": [
         {
           "vsct": {
-            "text": "Onboard", //TODO
-            "set": "54A0AC88-A025-4A62-8D48-6C1848E4F545", // TODO: guidClearNuGetLocalResourcesCmdSetString
-            "id": 256 // TODO: cmdidClearNuGetLocalResources
+            "text": "Onboard to GitHub Copilot", //TODO
+            "set": "98154E19-E6A4-426D-94B8-FB54E73511BA", // guidOnboardPackageSourceMappingCmdSetString
+            "id": 256 // cmdidOnboardPackageSourceMapping
           }
         }
       ]

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IPackageSourceMappingService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IPackageSourceMappingService.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.VisualStudio
+{
+    public interface IPackageSourceMappingService
+    {
+        Task LaunchOnboardPackageSourceMappingAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IPackageSourceMappingService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IPackageSourceMappingService.cs
@@ -8,6 +8,6 @@ namespace NuGet.VisualStudio
 {
     public interface IPackageSourceMappingService
     {
-        Task LaunchOnboardPackageSourceMappingAsync(CancellationToken cancellationToken);
+        Task LaunchReviewPackageSourceMappingAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NavigationOrigin.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NavigationOrigin.cs
@@ -10,7 +10,7 @@ namespace NuGet.PackageManagement.Telemetry
         Options_PackageSourceMapping_Remove,
         Options_PackageSourceMapping_RemoveAll,
         Options_LocalsCommand_ClearAll,
-        Options_PackageSourceMapperCommand_Onboard,
+        Options_PackageSourceMapping_Review,
         PMUI_ExternalLink,
         PMUI_PackageSourceMapping_Configure,
         VulnerabilityInfoBar_ManagePackages,

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NavigationOrigin.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NavigationOrigin.cs
@@ -10,6 +10,7 @@ namespace NuGet.PackageManagement.Telemetry
         Options_PackageSourceMapping_Remove,
         Options_PackageSourceMapping_RemoveAll,
         Options_LocalsCommand_ClearAll,
+        Options_PackageSourceMapperCommand_Onboard,
         PMUI_ExternalLink,
         PMUI_PackageSourceMapping_Configure,
         VulnerabilityInfoBar_ManagePackages,

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
@@ -156,15 +156,15 @@ namespace NuGet.PackageManagement.Test.Telemetry
         }
 
         [Fact]
-        public void CreateWithPackageSourceMapperCommandOnboard_WithValidProperties_CreatedWithoutPiiData()
+        public void CreateWithReviewPackageSourceMappingCommand_WithValidProperties_CreatedWithoutPiiData()
         {
             // Arrange
             var nuGetTelemetryService = SetupTelemetryListener();
 
             var navigationType = NavigationType.Button;
-            var navigationOrigin = NavigationOrigin.Options_PackageSourceMapperCommand_Onboard;
+            var navigationOrigin = NavigationOrigin.Options_PackageSourceMapping_Review;
 
-            var evt = NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(CopilotToolSessionError.None);
+            var evt = NavigatedTelemetryEvent.CreateWithReviewPackageSourceMappingCommand(CopilotToolSessionError.None);
 
             // Act
             nuGetTelemetryService.EmitTelemetryEvent(evt);
@@ -186,20 +186,20 @@ namespace NuGet.PackageManagement.Test.Telemetry
         [InlineData(CopilotToolSessionError.CopilotServiceNotAvailable)]
         [InlineData(CopilotToolSessionError.McpToolServiceNotAvailable)]
         [InlineData(CopilotToolSessionError.CopilotAccessDenied)]
-        public void CreateWithPackageSourceMapperCommandOnboard_WithAllErrorTypes_CreatesEventWithCorrectProperties(CopilotToolSessionError errorType)
+        public void CreateWithReviewPackageSourceMappingCommand_WithAllErrorTypes_CreatesEventWithCorrectProperties(CopilotToolSessionError errorType)
         {
             // Arrange
             var nuGetTelemetryService = SetupTelemetryListener();
 
             // Act
-            var evt = NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(errorType);
+            var evt = NavigatedTelemetryEvent.CreateWithReviewPackageSourceMappingCommand(errorType);
             nuGetTelemetryService.EmitTelemetryEvent(evt);
 
             // Assert
             Assert.NotNull(_lastTelemetryEvent);
             Assert.Equal(3, _lastTelemetryEvent.Count);
             Assert.Equal(NavigationType.Button, _lastTelemetryEvent[NavigatedTelemetryEvent.NavigationTypePropertyName]);
-            Assert.Equal(NavigationOrigin.Options_PackageSourceMapperCommand_Onboard, _lastTelemetryEvent[NavigatedTelemetryEvent.OriginPropertyName]);
+            Assert.Equal(NavigationOrigin.Options_PackageSourceMapping_Review, _lastTelemetryEvent[NavigatedTelemetryEvent.OriginPropertyName]);
             Assert.Equal(errorType, _lastTelemetryEvent[NavigatedTelemetryEvent.ErrorTypePropertyName]);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
@@ -156,6 +156,54 @@ namespace NuGet.PackageManagement.Test.Telemetry
         }
 
         [Fact]
+        public void CreateWithPackageSourceMapperCommandOnboard_WithValidProperties_CreatedWithoutPiiData()
+        {
+            // Arrange
+            var nuGetTelemetryService = SetupTelemetryListener();
+
+            var navigationType = NavigationType.Button;
+            var navigationOrigin = NavigationOrigin.Options_PackageSourceMapperCommand_Onboard;
+
+            var evt = NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(CopilotToolSessionError.None);
+
+            // Act
+            nuGetTelemetryService.EmitTelemetryEvent(evt);
+
+            // Assert
+            Assert.NotNull(_lastTelemetryEvent);
+            Assert.Equal(navigationType, _lastTelemetryEvent[NavigatedTelemetryEvent.NavigationTypePropertyName]);
+            Assert.Equal(navigationOrigin, _lastTelemetryEvent[NavigatedTelemetryEvent.OriginPropertyName]);
+            Assert.Null(_lastTelemetryEvent[NavigatedTelemetryEvent.HyperLinkTypePropertyName]);
+            Assert.Null(_lastTelemetryEvent[NavigatedTelemetryEvent.CurrentTabPropertyName]);
+            Assert.Null(_lastTelemetryEvent[NavigatedTelemetryEvent.IsSolutionViewPropertyName]);
+            Assert.Empty(_lastTelemetryEvent.GetPiiData());
+        }
+
+        [Theory]
+        [InlineData(CopilotToolSessionError.None)]
+        [InlineData(CopilotToolSessionError.CopilotNotReady)]
+        [InlineData(CopilotToolSessionError.ServiceBrokerNotAvailable)]
+        [InlineData(CopilotToolSessionError.CopilotServiceNotAvailable)]
+        [InlineData(CopilotToolSessionError.McpToolServiceNotAvailable)]
+        [InlineData(CopilotToolSessionError.CopilotAccessDenied)]
+        public void CreateWithPackageSourceMapperCommandOnboard_WithAllErrorTypes_CreatesEventWithCorrectProperties(CopilotToolSessionError errorType)
+        {
+            // Arrange
+            var nuGetTelemetryService = SetupTelemetryListener();
+
+            // Act
+            var evt = NavigatedTelemetryEvent.CreateWithPackageSourceMapperCommandOnboard(errorType);
+            nuGetTelemetryService.EmitTelemetryEvent(evt);
+
+            // Assert
+            Assert.NotNull(_lastTelemetryEvent);
+            Assert.Equal(3, _lastTelemetryEvent.Count);
+            Assert.Equal(NavigationType.Button, _lastTelemetryEvent[NavigatedTelemetryEvent.NavigationTypePropertyName]);
+            Assert.Equal(NavigationOrigin.Options_PackageSourceMapperCommand_Onboard, _lastTelemetryEvent[NavigatedTelemetryEvent.OriginPropertyName]);
+            Assert.Equal(errorType, _lastTelemetryEvent[NavigatedTelemetryEvent.ErrorTypePropertyName]);
+        }
+
+        [Fact]
         public void CreateWithAddPackageSourceMapping_WithValidProperties_CreatedWithoutPiiData()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NavigatedTelemetryEventTests.cs
@@ -179,13 +179,16 @@ namespace NuGet.PackageManagement.Test.Telemetry
             Assert.Empty(_lastTelemetryEvent.GetPiiData());
         }
 
+        public static IEnumerable<object[]> CopilotToolSessionErrorTypes()
+        {
+            foreach (CopilotToolSessionError errorType in Enum.GetValues(typeof(CopilotToolSessionError)).Cast<CopilotToolSessionError>())
+            {
+                yield return new object[] { errorType };
+            }
+        }
+
         [Theory]
-        [InlineData(CopilotToolSessionError.None)]
-        [InlineData(CopilotToolSessionError.CopilotNotReady)]
-        [InlineData(CopilotToolSessionError.ServiceBrokerNotAvailable)]
-        [InlineData(CopilotToolSessionError.CopilotServiceNotAvailable)]
-        [InlineData(CopilotToolSessionError.McpToolServiceNotAvailable)]
-        [InlineData(CopilotToolSessionError.CopilotAccessDenied)]
+        [MemberData(nameof(CopilotToolSessionErrorTypes))]
         public void CreateWithReviewPackageSourceMappingCommand_WithAllErrorTypes_CreatesEventWithCorrectProperties(CopilotToolSessionError errorType)
         {
             // Arrange
@@ -390,4 +393,3 @@ namespace NuGet.PackageManagement.Test.Telemetry
         }
     }
 }
-


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/15021

## Description

 Introduce a Button (Command) to the Package Source Mapping VS Settings which attempts to prompt GitHub Copilot with "Review this repository's package source mappings.", invoking the NuGet MCP tool to review supply chain security.

The new button appears below the package source mapping array, highlighted here by a red rectangle:

<img width="1454" height="880" alt="image" src="https://github.com/user-attachments/assets/d2afc940-3a0a-4e5a-9b2d-c8a624ba3a62" />


- Shown when a Solution is open in Visual Studio, hidden otherwise.

### MCP Behavior

- If Package Source Mappings exist in a machine-level NuGet.Config, the MCP Tool will suggest and help to move those into repo-level NuGet.Config.
- It can also help simplify any existing mappings.


### Implementation details

- Adds `PackageSourceMappingService`, modeled after `FixVulnerabilitiesService`, to launch GitHub Copilot with the current solution context and Package Source Mapping MCP tool.
- Refactors `FixVulnerabilitiesService` to use the shared `CopilotToolInvocationService.HandleSessionError` method for error messaging and telemetry.
- Adds Package Source Mapping navigation telemetry and test coverage.
- Adds `PackageSourceMapperCommand` and Unified Settings registration for the button.
  - The command is hidden when no solution is open, which hides the button in the settings page.

- A `PackageSourceMappingService` is added, closely mimicking the `FixVulnerablitiesService`.
- Refactored `FixVulnerablitiesService`:
  - Extract HandleSessionError on CopilotToolInvocationService as a shared static method for error messaging + telemetry, used by both PSM and FixVulnerabilities services
- Introduces `CopilotToolSessionError` as the shared session error model. 
  - Fix Vulnerabilities now maps these errors to its existing telemetry-specific `FixVulnerabilitiesWithCopilotErrorType`.
- Add a NavigatedTelemetryEvent event with matching test coverage

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/15022