### PR TITLE
Enable escrow mode for release/7.10.x

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -22,7 +22,7 @@
     <!-- Preview 3 is typically the last "main branch" preview, so we start using rc at this time -->
     <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">rc</ReleaseLabel>
 
-    <IsEscrowMode Condition="'$(IsEscrowMode)' == ''">false</IsEscrowMode>
+    <IsEscrowMode Condition="'$(IsEscrowMode)' == ''">true</IsEscrowMode>
 
     <!-- Visual Studio Insertion Logic -->
     <VsTargetBranch Condition="'$(VsTargetBranch)' == '' And '$(IsEscrowMode)' != 'true'">main</VsTargetBranch>


### PR DESCRIPTION
# Bug

N/A - engineering change.

## Description

Sets `IsEscrowMode` to `true` by default on `release/7.10.x`, routing Visual Studio insertions from this servicing branch to `rel/insiders` through the `insiders` channel instead of `main`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.

Tests and documentation updates are not applicable for this branch configuration change.