### PR TITLE
Retarget dev to NuGet 7.11

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -13,13 +13,11 @@
     <!-- **  Change for each new version -->
     <!-- when changing any of the NuGetVersion props below, run tools-local\ship-public-apis -->
     <MajorNuGetVersion Condition="'$(MajorNuGetVersion)' == ''">7</MajorNuGetVersion>
-    <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">10</MinorNuGetVersion>
+    <MinorNuGetVersion Condition="'$(MinorNuGetVersion)' == ''">11</MinorNuGetVersion>
     <PatchNuGetVersion Condition="'$(PatchNuGetVersion)' == ''">0</PatchNuGetVersion>
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">$(MajorNuGetVersion).$(MinorNuGetVersion).$(PatchNuGetVersion)</SemanticVersion>
 
-    <!-- ** Change for each new preview/rc -->
-    <!-- Check the VS schedule and manually enter a preview number here that makes sense. -->
-    <!-- Preview 3 is typically the last "main branch" preview, so we start using rc at this time -->
+    <!-- ReleaseLabel is always rc. -->
     <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">rc</ReleaseLabel>
 
     <IsEscrowMode Condition="'$(IsEscrowMode)' == ''">false</IsEscrowMode>


### PR DESCRIPTION
# Bug

N/A - engineering change.

## Description

Retargets `dev` from NuGet 7.10 to 7.11 for Visual Studio 18.11.

Updates the `ReleaseLabel` comment to reflect that release branding now always uses `rc`. `IsEscrowMode` remains `false` so automatic insertions continue targeting Visual Studio `main`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.

Tests, a NuGet/Home issue, and documentation updates are not applicable for this version configuration change.