### PR TITLE
Update build SDK to .NET 11 preview

### DIFF
--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,2 +1,2 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Channel 10.0.3xx
+-Version 11.0.100-preview.5.26302.115

--- a/build/DotNetSdkVersions.txt
+++ b/build/DotNetSdkVersions.txt
@@ -1,2 +1,3 @@
 # Each line represents arguments for the .NET SDK installer script (https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script)
--Version 11.0.100-preview.5.26302.115
+-Channel 10.0.3xx
+-Channel 11.0.1xx -Quality preview


### PR DESCRIPTION
# Bug

Fixes:

## Description

Adds the build SDK installation `-Channel 11.0.1xx -Quality preview`. This matches the SDK selected by the incoming VMR codeflow update in #7609 and allows standalone NuGet.Client CI to resolve `Microsoft.NET.Sdk`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests (not applicable; infrastructure configuration change)
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. (not applicable)