### PR TITLE
Fallback to PackageVersion if NuspecReader.GetVersion() returns null

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/GetPackOutputItemsTask.cs
@@ -99,7 +99,7 @@ namespace NuGet.Build.Tasks.Pack
                 return (packageId, ParseVersion(packArgs.Version));
             }
 
-            return (packageId, nuspecReader.GetVersion());
+            return (packageId, nuspecReader.GetVersion() ?? ParseVersion(PackageVersion));
 
             static NuGetVersion ParseVersion(string packageVersion)
             {

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/GetPackOutputItemsTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/GetPackOutputItemsTaskTests.cs
@@ -94,6 +94,42 @@ namespace NuGet.Build.Tasks.Pack.Test
         }
 
         [Fact]
+        public void GetPackOutputItemsTaskTests_Execute_NuspecHasNoVersion_FallsBackToProjectVersion()
+        {
+            using var testDirectory = TestDirectory.Create();
+            var nuspecPath = Path.Combine(testDirectory.Path, "test-no-version.nuspec");
+            File.WriteAllText(nuspecPath, """
+                <?xml version="1.0" encoding="utf-8"?>
+                <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+                  <metadata>
+                    <id>NuspecPackage</id>
+                    <authors>Test</authors>
+                    <description>desc</description>
+                  </metadata>
+                </package>
+                """);
+
+            var outputItemTask = new GetPackOutputItemsTask
+            {
+                PackageId = "ProjectPackageId",
+                PackageVersion = "1.2.3",
+                PackageOutputPath = testDirectory.Path,
+                NuspecOutputPath = testDirectory.Path,
+                SymbolPackageFormat = "snupkg",
+                NuspecFile = nuspecPath,
+            };
+
+            Assert.True(outputItemTask.Execute());
+
+            string[] actualPackageFiles = outputItemTask.OutputPackItems
+                .Select(item => Path.GetFileName(item.ItemSpec))
+                .Where(name => name.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            actualPackageFiles.Should().BeEquivalentTo(new[] { "NuspecPackage.1.2.3.nupkg" });
+        }
+
+        [Fact]
         public void GetPackOutputItemsTaskTests_Execute_EntireMetadataFromNuspecPropertiesToken_ResolvesIdAndVersion()
         {
             using var testDirectory = TestDirectory.Create();


### PR DESCRIPTION
The missing fallback is one reason why https://github.com/dotnet/dotnet/pull/8138 failed in preview 7.

In the above specific case, there is also a wrong MSBuild target ordering originating from Arcade (for which a fix flowed already to main branch in VMR and that's why the same insertion isn't failing in VMR main).

However, keeping the fallback is probably safest. This fallback was unintentionally dropped in https://github.com/NuGet/NuGet.Client/pull/7612