### PR TITLE
[release/7.9.x] Pin .NET 10.0.4xx SDK for tests

### DIFF
--- a/build/DotNetSdkTestVersions.txt
+++ b/build/DotNetSdkTestVersions.txt
@@ -2,4 +2,4 @@
 # To make sure that the right version of dotnet.exe (and maybe other files) is used, always install from lowest version to highest version
 -Channel 8.0 -Runtime dotnet
 -Channel 9.0 -Runtime dotnet
--Channel 10.0.4xx -Quality daily
+-Version 10.0.400-preview.0.26360.120


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:

## Description

Pins the .NET 10.0.4xx SDK used by integration tests to `10.0.400-preview.0.26360.120`.

The moving daily channel currently resolves to `10.0.400-preview.0.26379.116`, which references unpublished .NET 8.0.30 and .NET 9.0.19 reference packs and causes `NU1102` failures on Windows, Linux, and macOS. The pinned SDK is the version used by the corresponding test legs in [build 1507355](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1507355), where those tests passed.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
