### PR TITLE
Preserve supplementary characters when PMC processes backspace

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsole.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsole.cs
@@ -523,9 +523,19 @@ namespace NuGetConsole.Implementation.Console
 
             // Delete last character from input buffer.
             ITextBuffer textBuffer = WpfTextView.TextBuffer;
-            if (textBuffer.CurrentSnapshot.Length > 0)
+            ITextSnapshot snapshot = textBuffer.CurrentSnapshot;
+            int length = snapshot.Length;
+            if (length > 0)
             {
-                textBuffer.Delete(new Span(textBuffer.CurrentSnapshot.Length - 1, 1));
+                int deleteCount = 1;
+                if (length >= 2
+                    && char.IsLowSurrogate(snapshot[length - 1])
+                    && char.IsHighSurrogate(snapshot[length - 2]))
+                {
+                    deleteCount = 2;
+                }
+
+                textBuffer.Delete(new Span(length - deleteCount, deleteCount));
             }
 
             // Ensure caret visible (scroll)

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetHostUserInterface.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetHostUserInterface.cs
@@ -396,7 +396,15 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                         {
                             if (builder.Length > 0)
                             {
-                                builder.Remove(builder.Length - 1, 1);
+                                int removeCount = 1;
+                                if (builder.Length >= 2
+                                    && char.IsLowSurrogate(builder[builder.Length - 1])
+                                    && char.IsHighSurrogate(builder[builder.Length - 2]))
+                                {
+                                    removeCount = 2;
+                                }
+
+                                builder.Remove(builder.Length - removeCount, removeCount);
                                 NuGetUIThreadHelper.JoinableTaskFactory.Run(() => Console.WriteBackspaceAsync());
                             }
                         }

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
@@ -7,6 +7,8 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using NuGet.VisualStudio;
@@ -107,6 +109,29 @@ namespace NuGet.Console.TestContract
             WaitForActionComplete(() => RunCommandWithoutWait(command), timeout);
         }
 
+        public void RunCommandWithInputAndBackspace(string command, string input, TimeSpan timeout)
+        {
+            WaitForActionComplete(
+                () =>
+                {
+                    RunCommandWithoutWait(command);
+                    WaitForReadKey(timeout);
+
+                    UIInvoke(() =>
+                    {
+                        var commandTarget = (IOleCommandTarget)_wpfConsole.VsTextView;
+                        foreach (char character in input)
+                        {
+                            commandTarget.Execute(VSConstants.VSStd2KCmdID.TYPECHAR, character);
+                        }
+
+                        commandTarget.Execute(VSConstants.VSStd2KCmdID.BACKSPACE);
+                        commandTarget.Execute(VSConstants.VSStd2KCmdID.RETURN);
+                    });
+                },
+                timeout);
+        }
+
         public void RunCommandWithoutWait(string command)
         {
             if (!string.IsNullOrEmpty(command))
@@ -157,6 +182,20 @@ namespace NuGet.Console.TestContract
                     asynchost.ExecuteEnd -= eventHandler;
                     dispatcher.SetExecutingCommand(false);
                 }
+            }
+        }
+
+        private void WaitForReadKey(TimeSpan timeout)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            while (!_wpfConsole.Dispatcher.IsExecutingReadKey && stopwatch.Elapsed < timeout)
+            {
+                Thread.Sleep(100);
+            }
+
+            if (!_wpfConsole.Dispatcher.IsExecutingReadKey)
+            {
+                throw new TimeoutException("The Package Manager Console did not begin waiting for input.");
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
@@ -117,17 +117,19 @@ namespace NuGet.Console.TestContract
                     RunCommandWithoutWait(command);
                     WaitForReadKey(timeout);
 
-                    UIInvoke(() =>
+                    IOleCommandTarget commandTarget = null;
+                    UIInvoke(() => commandTarget = (IOleCommandTarget)_wpfConsole.VsTextView);
+                    foreach (char character in input)
                     {
-                        var commandTarget = (IOleCommandTarget)_wpfConsole.VsTextView;
-                        foreach (char character in input)
-                        {
-                            commandTarget.Execute(VSConstants.VSStd2KCmdID.TYPECHAR, character);
-                        }
+                        ExecuteReadKeyCommand(
+                            commandTarget,
+                            VSConstants.VSStd2KCmdID.TYPECHAR,
+                            timeout,
+                            character);
+                    }
 
-                        commandTarget.Execute(VSConstants.VSStd2KCmdID.BACKSPACE);
-                        commandTarget.Execute(VSConstants.VSStd2KCmdID.RETURN);
-                    });
+                    ExecuteReadKeyCommand(commandTarget, VSConstants.VSStd2KCmdID.BACKSPACE, timeout);
+                    UIInvoke(() => commandTarget.Execute(VSConstants.VSStd2KCmdID.RETURN));
                 },
                 timeout);
         }
@@ -196,6 +198,33 @@ namespace NuGet.Console.TestContract
             if (!_wpfConsole.Dispatcher.IsExecutingReadKey)
             {
                 throw new TimeoutException("The Package Manager Console did not begin waiting for input.");
+            }
+        }
+
+        private void ExecuteReadKeyCommand(
+            IOleCommandTarget commandTarget,
+            VSConstants.VSStd2KCmdID command,
+            TimeSpan timeout,
+            object argument = null)
+        {
+            using var semaphore = new ManualResetEventSlim();
+            EventHandler eventHandler = (sender, args) => semaphore.Set();
+            _wpfConsole.Dispatcher.StartWaitingKey += eventHandler;
+
+            try
+            {
+                UIInvoke(() => commandTarget.Execute(command, argument));
+
+                if (!semaphore.Wait(timeout))
+                {
+                    throw new TimeoutException("The Package Manager Console did not request the next input key.");
+                }
+
+                WaitForReadKey(timeout);
+            }
+            finally
+            {
+                _wpfConsole.Dispatcher.StartWaitingKey -= eventHandler;
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetConsoleTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetConsoleTestExtension.cs
@@ -65,6 +65,11 @@ namespace NuGet.Tests.Apex
             _pmConsole.RunCommand(command, _timeout);
         }
 
+        public void ExecuteWithInputAndBackspace(string command, string input)
+        {
+            _pmConsole.RunCommandWithInputAndBackspace(command, input, _timeout);
+        }
+
         public void Clear()
         {
             _pmConsole.Clear();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -1268,6 +1268,30 @@ namespace NuGet.Tests.Apex
             pmcText.Should().NotContain("FullyQualifiedErrorId", because: pmcText);
         }
 
+        [TestMethod]
+        [Timeout(DefaultTimeout)]
+        public void Console_PreservesGB18030SupplementaryText()
+        {
+            using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger);
+
+            var nugetConsole = GetConsole(testContext.Project);
+            nugetConsole.Clear();
+
+            string sample =
+                char.ConvertFromUtf32(0x20000) +
+                char.ConvertFromUtf32(0x2A6B2) +
+                char.ConvertFromUtf32(0x1F600) +
+                char.ConvertFromUtf32(0xE000) +
+                char.ConvertFromUtf32(0x100000) +
+                "ABC";
+
+            nugetConsole.Execute($"$gb18030 = '{sample}'; Write-Host $gb18030");
+
+            string pmcText = nugetConsole.GetText();
+            pmcText.Should().Contain(sample, because: pmcText);
+            pmcText.Should().NotContain("FullyQualifiedErrorId", because: pmcText);
+        }
+
         public static IEnumerable<object[]> GetNetCoreTemplates()
         {
             yield return new object[] { ProjectTemplate.NetCoreConsoleApp };

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -1270,25 +1270,23 @@ namespace NuGet.Tests.Apex
 
         [TestMethod]
         [Timeout(DefaultTimeout)]
-        public void Console_PreservesGB18030SupplementaryText()
+        public void Console_WhenBackspacingSupplementaryCharacter_PreservesRemainingText()
         {
             using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger);
 
             var nugetConsole = GetConsole(testContext.Project);
             nugetConsole.Clear();
 
-            string sample =
-                char.ConvertFromUtf32(0x20000) +
-                char.ConvertFromUtf32(0x2A6B2) +
-                char.ConvertFromUtf32(0x1F600) +
-                char.ConvertFromUtf32(0xE000) +
-                char.ConvertFromUtf32(0x100000) +
-                "ABC";
+            string supplementaryCharacter = char.ConvertFromUtf32(0x20000);
+            string input = "A" + supplementaryCharacter;
 
-            nugetConsole.Execute($"$gb18030 = '{sample}'; Write-Host $gb18030");
+            nugetConsole.ExecuteWithInputAndBackspace(
+                "$value = Read-Host; Write-Host \"Result=[$value]\"",
+                input);
 
             string pmcText = nugetConsole.GetText();
-            pmcText.Should().Contain(sample, because: pmcText);
+            pmcText.Should().Contain("Result=[A]", because: pmcText);
+            pmcText.Should().NotContain(supplementaryCharacter[0].ToString(), because: pmcText);
             pmcText.Should().NotContain("FullyQualifiedErrorId", because: pmcText);
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

Fixes: https://github.com/NuGet/Home/issues/15025

## Description

Package Manager Console previously processed backspace one UTF-16 code unit at a time. For GB18030 supplementary characters represented by surrogate pairs, this could leave an unpaired surrogate in the console text or PowerShell input buffer.

This change removes a complete trailing surrogate pair in both buffers and adds an Apex regression test covering supplementary-plane GB18030 text in Package Manager Console.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
