### PR TITLE
Read and write cooldown settings in NuGet.Config

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/MinPublishAgeExceptions.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/MinPublishAgeExceptions.cs
@@ -42,7 +42,7 @@ namespace NuGet.Configuration
                 }
 
                 string pattern = item.Pattern;
-                itemsByPattern[pattern] = item;
+                itemsByPattern[pattern.Trim()] = item;
                 patterns[i] = pattern;
             }
 

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/MinPublishAgeExceptions.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/MinPublishAgeExceptions.cs
@@ -6,13 +6,23 @@ using System.Collections.Generic;
 
 namespace NuGet.Configuration
 {
+    /// <summary>
+    /// Matches package IDs against package-specific minimum publish age exception patterns.
+    /// </summary>
     public sealed class MinPublishAgeExceptions
     {
         private readonly SearchTree _searchTree;
         private readonly IReadOnlyDictionary<string, MinPublishAgeExceptionItem> _itemsByPattern;
 
+        /// <summary>
+        /// Gets a value indicating whether at least one exception pattern is configured.
+        /// </summary>
         public bool IsEnabled { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MinPublishAgeExceptions"/> class.
+        /// </summary>
+        /// <param name="items">The exception items to use for matching.</param>
         public MinPublishAgeExceptions(IReadOnlyList<MinPublishAgeExceptionItem> items)
         {
             if (items == null)
@@ -45,6 +55,11 @@ namespace NuGet.Configuration
             _searchTree = new SearchTree(mapping);
         }
 
+        /// <summary>
+        /// Finds the exception that matches a package ID.
+        /// </summary>
+        /// <param name="packageId">The package ID to match.</param>
+        /// <returns>The matching exception, or <see langword="null"/> if no exception matches.</returns>
         public MinPublishAgeExceptionItem? FindException(string packageId)
         {
             string? matchingPattern = _searchTree.SearchForPattern(packageId);

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/MinPublishAgeExceptions.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/MinPublishAgeExceptions.cs
@@ -46,13 +46,13 @@ namespace NuGet.Configuration
                 patterns[i] = pattern;
             }
 
-            var mapping = new PackageSourceMapping(new Dictionary<string, IReadOnlyList<string>>
+            var packageSourceMapping = new PackageSourceMapping(new Dictionary<string, IReadOnlyList<string>>
             {
                 ["minPublishAgeExceptions"] = patterns
             });
 
             _itemsByPattern = itemsByPattern;
-            _searchTree = new SearchTree(mapping);
+            _searchTree = new SearchTree(packageSourceMapping);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/MinPublishAgeExceptions.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/MinPublishAgeExceptions.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Configuration
+{
+    public sealed class MinPublishAgeExceptions
+    {
+        private readonly SearchTree _searchTree;
+        private readonly IReadOnlyDictionary<string, MinPublishAgeExceptionItem> _itemsByPattern;
+
+        public bool IsEnabled { get; }
+
+        public MinPublishAgeExceptions(IReadOnlyList<MinPublishAgeExceptionItem> items)
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            IsEnabled = items.Count > 0;
+            var itemsByPattern = new Dictionary<string, MinPublishAgeExceptionItem>(items.Count, StringComparer.OrdinalIgnoreCase);
+            var patterns = new string[items.Count];
+            for (int i = 0; i < items.Count; i++)
+            {
+                var item = items[i];
+                if (item == null)
+                {
+                    throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(items));
+                }
+
+                string pattern = item.Pattern;
+                itemsByPattern[pattern] = item;
+                patterns[i] = pattern;
+            }
+
+            var mapping = new PackageSourceMapping(new Dictionary<string, IReadOnlyList<string>>
+            {
+                ["minPublishAgeExceptions"] = patterns
+            });
+
+            _itemsByPattern = itemsByPattern;
+            _searchTree = new SearchTree(mapping);
+        }
+
+        public MinPublishAgeExceptionItem? FindException(string packageId)
+        {
+            string? matchingPattern = _searchTree.SearchForPattern(packageId);
+            return matchingPattern != null && _itemsByPattern.TryGetValue(matchingPattern, out var item)
+                ? item
+                : null;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using NuGet.Common;
@@ -20,6 +21,7 @@ namespace NuGet.Configuration
 
         internal const bool DefaultAllowInsecureConnections = false;
         internal const bool DefaultDisableTLSCertificateValidation = false;
+        internal static readonly TimeSpan DefaultMinPublishAge = TimeSpan.Zero;
 
         private int _hashCode;
         private string _source;
@@ -114,6 +116,41 @@ namespace NuGet.Configuration
         public bool DisableTLSCertificateValidation { get; set; } = DefaultDisableTLSCertificateValidation;
 
         /// <summary>
+        /// Gets or sets the minimum age a package must have been published before it can be selected for update.
+        /// Defaults to zero.
+        /// </summary>
+        public TimeSpan MinPublishAge
+        {
+            get => field;
+            set
+            {
+                if (value < TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value,
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Resources.PackageSource_MinPublishAgeCannotBeNegative,
+                            value));
+                }
+
+                if (value.Ticks % TimeSpan.FromHours(1).Ticks != 0)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value,
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Resources.PackageSource_MinPublishAgeMustBeWholeHours,
+                            value));
+                }
+
+                field = value;
+            }
+        } = DefaultMinPublishAge;
+
+        /// <summary>
         /// Whether the source is using the HTTP protocol, including HTTPS.
         /// </summary>
         public bool IsHttp => _isHttp;
@@ -175,7 +212,15 @@ namespace NuGet.Configuration
             {
                 disableTLSCertificateValidation = $"{DisableTLSCertificateValidation}";
             }
-            return new SourceItem(Name, Source, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation);
+            string? minPublishAgeHours = null;
+            if (MinPublishAge != DefaultMinPublishAge)
+            {
+                minPublishAgeHours = MinPublishAge.TotalHours.ToString(CultureInfo.InvariantCulture);
+            }
+            return new SourceItem(Name, Source, protocolVersion, allowInsecureConnections, disableTLSCertificateValidation)
+            {
+                MinPublishAgeHours = minPublishAgeHours
+            };
         }
 
         public bool Equals(PackageSource? other)
@@ -214,6 +259,7 @@ namespace NuGet.Configuration
                 ProtocolVersion = ProtocolVersion,
                 AllowInsecureConnections = AllowInsecureConnections,
                 DisableTLSCertificateValidation = DisableTLSCertificateValidation,
+                MinPublishAge = MinPublishAge,
             };
         }
     }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -200,28 +200,58 @@ namespace NuGet.Configuration
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(exceptions));
             }
 
-            var existingExceptions = GetClosestMinPublishAgeExceptionSectionItems();
-            foreach (var existingException in existingExceptions)
+            if (Settings is Settings concreteSettings
+                && concreteSettings.Priority.FirstOrDefault(settingsFile => !settingsFile.IsReadOnly) is SettingsFile outputSettingsFile)
             {
-                Settings.Remove(ConfigurationConstants.MinPublishAgeExceptions, existingException);
-            }
-
-            if (exceptionList.Count == 0)
-            {
-                if (Settings is Settings concreteSettings)
+                var existingSection = outputSettingsFile.GetSection(ConfigurationConstants.MinPublishAgeExceptions);
+                if (existingSection != null)
                 {
-                    concreteSettings.AddEmptySection(ConfigurationConstants.MinPublishAgeExceptions);
+                    foreach (var existingException in existingSection.Items)
+                    {
+                        outputSettingsFile.Remove(ConfigurationConstants.MinPublishAgeExceptions, existingException);
+                    }
+                }
+
+                if (exceptionList.Count == 0)
+                {
+                    outputSettingsFile.AddEmptySection(ConfigurationConstants.MinPublishAgeExceptions);
                 }
                 else
                 {
-                    Settings.AddOrUpdate(ConfigurationConstants.MinPublishAgeExceptions, new ClearItem());
+                    concreteSettings.AddOrUpdate(
+                        outputSettingsFile,
+                        ConfigurationConstants.MinPublishAgeExceptions,
+                        new ClearItem());
+                    foreach (var exception in exceptionList)
+                    {
+                        concreteSettings.AddOrUpdate(
+                            outputSettingsFile,
+                            ConfigurationConstants.MinPublishAgeExceptions,
+                            exception);
+                    }
                 }
             }
             else
             {
-                foreach (var exception in exceptionList)
+                IReadOnlyCollection<SettingItem> existingExceptions;
+                while ((existingExceptions = GetClosestMinPublishAgeExceptionSectionItems()).Count > 0)
                 {
-                    Settings.AddOrUpdate(ConfigurationConstants.MinPublishAgeExceptions, exception);
+                    foreach (var existingException in existingExceptions)
+                    {
+                        Settings.Remove(ConfigurationConstants.MinPublishAgeExceptions, existingException);
+                    }
+                }
+
+                if (exceptionList.Count == 0)
+                {
+                    Settings.AddOrUpdate(ConfigurationConstants.MinPublishAgeExceptions, new ClearItem());
+                }
+                else
+                {
+                    foreach (var exception in exceptionList)
+                    {
+                        Settings.AddOrUpdate(ConfigurationConstants.MinPublishAgeExceptions, exception);
+                    }
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -190,7 +190,8 @@ namespace NuGet.Configuration
         {
             return GetClosestMinPublishAgeExceptionSectionItems()
                 .OfType<MinPublishAgeExceptionItem>()
-                .ToList();
+                .ToList()
+                .AsReadOnly();
         }
 
         /// <summary>
@@ -284,7 +285,7 @@ namespace NuGet.Configuration
                 : sectionItems.Where(item => string.Equals(
                     item.Origin?.ConfigFilePath,
                     closestConfigFilePath,
-                    StringComparison.OrdinalIgnoreCase)).ToList();
+                    StringComparison.OrdinalIgnoreCase)).ToList().AsReadOnly();
         }
 
         internal IReadOnlyList<PackageSource> LoadAuditSources(IEnvironmentVariableReader environmentVariableReader)

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -201,42 +201,41 @@ namespace NuGet.Configuration
         /// to clear exceptions inherited from parent configuration files.
         /// </remarks>
         /// <param name="exceptions">The package-specific minimum publish age exceptions to save.</param>
-        public void SaveMinPublishAgeExceptions(IEnumerable<MinPublishAgeExceptionItem> exceptions)
+        public void SaveMinPublishAgeExceptions(IReadOnlyList<MinPublishAgeExceptionItem> exceptions)
         {
             if (exceptions == null)
             {
                 throw new ArgumentNullException(nameof(exceptions));
             }
 
-            var exceptionList = exceptions.ToList();
-            if (exceptionList.Any(exception => exception == null))
+            if (Settings is not Settings concreteSettings)
+            {
+                throw new NotSupportedException();
+            }
+
+            if (exceptions.Any(exception => exception == null))
             {
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(exceptions));
             }
 
-            if (Settings is Settings concreteSettings
-                && concreteSettings.Priority.FirstOrDefault(settingsFile => !settingsFile.IsReadOnly) is SettingsFile outputSettingsFile)
+            if (concreteSettings.Priority.FirstOrDefault(settingsFile => !settingsFile.IsReadOnly) is SettingsFile outputSettingsFile)
             {
                 var existingSection = outputSettingsFile.GetSection(ConfigurationConstants.MinPublishAgeExceptions);
                 if (existingSection != null)
                 {
                     foreach (var existingException in existingSection.Items)
                     {
-                        outputSettingsFile.Remove(ConfigurationConstants.MinPublishAgeExceptions, existingException);
+                        concreteSettings.Remove(ConfigurationConstants.MinPublishAgeExceptions, existingException);
                     }
                 }
 
-                if (exceptionList.Count == 0)
+                if (exceptions.Count == 0)
                 {
-                    outputSettingsFile.AddEmptySection(ConfigurationConstants.MinPublishAgeExceptions);
+                    concreteSettings.AddEmptySection(ConfigurationConstants.MinPublishAgeExceptions);
                 }
                 else
                 {
-                    concreteSettings.AddOrUpdate(
-                        outputSettingsFile,
-                        ConfigurationConstants.MinPublishAgeExceptions,
-                        new ClearItem());
-                    foreach (var exception in exceptionList)
+                    foreach (var exception in exceptions)
                     {
                         concreteSettings.AddOrUpdate(
                             outputSettingsFile,
@@ -245,31 +244,8 @@ namespace NuGet.Configuration
                     }
                 }
             }
-            else
-            {
-                IReadOnlyCollection<SettingItem> existingExceptions;
-                while ((existingExceptions = GetClosestMinPublishAgeExceptionSectionItems()).Count > 0)
-                {
-                    foreach (var existingException in existingExceptions)
-                    {
-                        Settings.Remove(ConfigurationConstants.MinPublishAgeExceptions, existingException);
-                    }
-                }
 
-                if (exceptionList.Count == 0)
-                {
-                    Settings.AddOrUpdate(ConfigurationConstants.MinPublishAgeExceptions, new ClearItem());
-                }
-                else
-                {
-                    foreach (var exception in exceptionList)
-                    {
-                        Settings.AddOrUpdate(ConfigurationConstants.MinPublishAgeExceptions, exception);
-                    }
-                }
-            }
-
-            Settings.SaveToDisk();
+            concreteSettings.SaveToDisk();
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -174,6 +174,114 @@ namespace NuGet.Configuration
         {
             return LoadAuditSources(EnvironmentVariableWrapper.Instance);
         }
+
+        public MinPublishAgeExceptions GetMinPublishAgeExceptions()
+        {
+            return new MinPublishAgeExceptions(GetMinPublishAgeExceptionItems());
+        }
+
+        public IReadOnlyList<MinPublishAgeExceptionItem> GetMinPublishAgeExceptionItems()
+        {
+            return GetClosestMinPublishAgeExceptionSectionItems()
+                .OfType<MinPublishAgeExceptionItem>()
+                .ToList();
+        }
+
+        public void SaveMinPublishAgeExceptions(IEnumerable<MinPublishAgeExceptionItem> exceptions)
+        {
+            if (exceptions == null)
+            {
+                throw new ArgumentNullException(nameof(exceptions));
+            }
+
+            var exceptionList = exceptions.ToList();
+            if (exceptionList.Any(exception => exception == null))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(exceptions));
+            }
+
+            var existingExceptions = GetClosestMinPublishAgeExceptionSectionItems();
+            foreach (var existingException in existingExceptions)
+            {
+                Settings.Remove(ConfigurationConstants.MinPublishAgeExceptions, existingException);
+            }
+
+            if (exceptionList.Count == 0)
+            {
+                if (Settings is Settings concreteSettings)
+                {
+                    concreteSettings.AddEmptySection(ConfigurationConstants.MinPublishAgeExceptions);
+                }
+                else
+                {
+                    Settings.AddOrUpdate(ConfigurationConstants.MinPublishAgeExceptions, new ClearItem());
+                }
+            }
+            else
+            {
+                foreach (var exception in exceptionList)
+                {
+                    Settings.AddOrUpdate(ConfigurationConstants.MinPublishAgeExceptions, exception);
+                }
+            }
+
+            Settings.SaveToDisk();
+        }
+
+        public void RemoveMinPublishAgeException(MinPublishAgeExceptionItem exception)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            var existingException = GetClosestMinPublishAgeExceptionSectionItems()
+                .OfType<MinPublishAgeExceptionItem>()
+                .FirstOrDefault(item => item.Equals(exception));
+
+            if (existingException != null)
+            {
+                Settings.Remove(ConfigurationConstants.MinPublishAgeExceptions, existingException);
+                Settings.SaveToDisk();
+            }
+        }
+
+        public void RemoveMinPublishAgeExceptions()
+        {
+            foreach (var existingException in GetClosestMinPublishAgeExceptionSectionItems())
+            {
+                Settings.Remove(ConfigurationConstants.MinPublishAgeExceptions, existingException);
+            }
+
+            Settings.SaveToDisk();
+        }
+
+        private IReadOnlyCollection<SettingItem> GetClosestMinPublishAgeExceptionSectionItems()
+        {
+            var sectionItems = Settings.GetSection(ConfigurationConstants.MinPublishAgeExceptions)?
+                .Items ??
+                Array.Empty<SettingItem>();
+
+            if (sectionItems.Count <= 1 || sectionItems.All(item => item.Origin?.ConfigFilePath == null))
+            {
+                return sectionItems;
+            }
+
+            var configFilePaths = Settings.GetConfigFilePaths();
+            string? closestConfigFilePath = configFilePaths.FirstOrDefault(configFilePath =>
+                sectionItems.Any(item => string.Equals(
+                    item.Origin?.ConfigFilePath,
+                    configFilePath,
+                    StringComparison.OrdinalIgnoreCase)));
+
+            return closestConfigFilePath == null
+                ? sectionItems
+                : sectionItems.Where(item => string.Equals(
+                    item.Origin?.ConfigFilePath,
+                    closestConfigFilePath,
+                    StringComparison.OrdinalIgnoreCase)).ToList();
+        }
+
         internal IReadOnlyList<PackageSource> LoadAuditSources(IEnvironmentVariableReader environmentVariableReader)
         {
             return LoadPackageSources(Settings, ConfigurationConstants.AuditSources, _configurationDefaultAuditSources, environmentVariableReader);
@@ -255,6 +363,7 @@ namespace NuGet.Configuration
             packageSource.ProtocolVersion = ReadProtocolVersion(setting);
             packageSource.AllowInsecureConnections = ReadAllowInsecureConnections(setting);
             packageSource.DisableTLSCertificateValidation = ReadDisableTLSCertificateValidation(setting);
+            packageSource.MinPublishAge = ReadMinPublishAge(setting);
 
             return packageSource;
         }
@@ -287,6 +396,32 @@ namespace NuGet.Configuration
             }
 
             return PackageSource.DefaultAllowInsecureConnections;
+        }
+
+        private static TimeSpan ReadMinPublishAge(SourceItem setting)
+        {
+            string? value = setting.MinPublishAgeHours;
+            if (value is null)
+            {
+                return PackageSource.DefaultMinPublishAge;
+            }
+
+            if (uint.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out uint hours) &&
+                hours <= TimeSpan.MaxValue.TotalHours)
+            {
+                return TimeSpan.FromHours(hours);
+            }
+
+            throw new NuGetConfigurationException(string.Format(
+                CultureInfo.CurrentCulture,
+                Resources.UserSettings_UnableToParseConfigFile,
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resources.AttributeValueNotAllowed,
+                    $"{setting.Key}:{ConfigurationConstants.MinPublishAgeHours}",
+                    value,
+                    ConfigurationConstants.PackageSources),
+                setting.ConfigPath));
         }
 
         private static void AddOrUpdateIndexedSource(
@@ -627,7 +762,8 @@ namespace NuGet.Configuration
                 if ((!string.Equals(newSource.Source, existingSource.Source, StringComparison.OrdinalIgnoreCase) ||
                     newSource.ProtocolVersion != existingSource.ProtocolVersion ||
                     newSource.AllowInsecureConnections != existingSource.AllowInsecureConnections ||
-                    newSource.DisableTLSCertificateValidation != existingSource.DisableTLSCertificateValidation) && newSource.IsPersistable)
+                    newSource.DisableTLSCertificateValidation != existingSource.DisableTLSCertificateValidation ||
+                    newSource.MinPublishAge != existingSource.MinPublishAge) && newSource.IsPersistable)
                 {
                     Settings.AddOrUpdate(ConfigurationConstants.AuditSources, newSource.AsSourceItem());
                     isDirty = true;
@@ -657,7 +793,8 @@ namespace NuGet.Configuration
                 if ((!string.Equals(newSource.Source, existingSource.Source, StringComparison.OrdinalIgnoreCase) ||
                     newSource.ProtocolVersion != existingSource.ProtocolVersion ||
                     newSource.AllowInsecureConnections != existingSource.AllowInsecureConnections ||
-                    newSource.DisableTLSCertificateValidation != existingSource.DisableTLSCertificateValidation) && newSource.IsPersistable)
+                    newSource.DisableTLSCertificateValidation != existingSource.DisableTLSCertificateValidation ||
+                    newSource.MinPublishAge != existingSource.MinPublishAge) && newSource.IsPersistable)
                 {
                     Settings.AddOrUpdate(ConfigurationConstants.PackageSources, newSource.AsSourceItem());
                     isDirty = true;

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -175,11 +175,17 @@ namespace NuGet.Configuration
             return LoadAuditSources(EnvironmentVariableWrapper.Instance);
         }
 
+        /// <summary>
+        /// Gets the package-specific minimum publish age exceptions used by this provider.
+        /// </summary>
         public MinPublishAgeExceptions GetMinPublishAgeExceptions()
         {
             return new MinPublishAgeExceptions(GetMinPublishAgeExceptionItems());
         }
 
+        /// <summary>
+        /// Gets the package-specific minimum publish age exception items from the closest applicable configuration.
+        /// </summary>
         public IReadOnlyList<MinPublishAgeExceptionItem> GetMinPublishAgeExceptionItems()
         {
             return GetClosestMinPublishAgeExceptionSectionItems()
@@ -187,6 +193,14 @@ namespace NuGet.Configuration
                 .ToList();
         }
 
+        /// <summary>
+        /// Saves the package-specific minimum publish age exceptions.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="exceptions"/> is empty, an empty <c>minPublishAgeExceptions</c> element is written
+        /// to clear exceptions inherited from parent configuration files.
+        /// </remarks>
+        /// <param name="exceptions">The package-specific minimum publish age exceptions to save.</param>
         public void SaveMinPublishAgeExceptions(IEnumerable<MinPublishAgeExceptionItem> exceptions)
         {
             if (exceptions == null)
@@ -258,24 +272,9 @@ namespace NuGet.Configuration
             Settings.SaveToDisk();
         }
 
-        public void RemoveMinPublishAgeException(MinPublishAgeExceptionItem exception)
-        {
-            if (exception == null)
-            {
-                throw new ArgumentNullException(nameof(exception));
-            }
-
-            var existingException = GetClosestMinPublishAgeExceptionSectionItems()
-                .OfType<MinPublishAgeExceptionItem>()
-                .FirstOrDefault(item => item.Equals(exception));
-
-            if (existingException != null)
-            {
-                Settings.Remove(ConfigurationConstants.MinPublishAgeExceptions, existingException);
-                Settings.SaveToDisk();
-            }
-        }
-
+        /// <summary>
+        /// Removes all package-specific minimum publish age exceptions from the closest applicable configuration.
+        /// </summary>
         public void RemoveMinPublishAgeExceptions()
         {
             foreach (var existingException in GetClosestMinPublishAgeExceptionSectionItems())

--- a/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/SearchTree.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSourceMapping/SearchTree.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Text;
 
 namespace NuGet.Configuration
@@ -46,7 +45,7 @@ namespace NuGet.Configuration
             }
 
             packageSourceKey = packageSourceKey.Trim();
-            packagePattern = packagePattern.ToLower(CultureInfo.CurrentCulture).Trim();
+            packagePattern = packagePattern.ToLowerInvariant().Trim();
 
             for (int i = 0; i < packagePattern.Length; i++)
             {
@@ -110,7 +109,7 @@ namespace NuGet.Configuration
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Empty_Or_WhiteSpaceOnly, nameof(term));
             }
 
-            term = term.ToLower(CultureInfo.CurrentCulture).Trim();
+            term = term.ToLowerInvariant().Trim();
 
             SearchNode currentNode = _root;
             SearchNode? longestMatchingPrefixNode = null;
@@ -154,7 +153,7 @@ namespace NuGet.Configuration
                 throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Empty_Or_WhiteSpaceOnly, nameof(term));
             }
 
-            term = term.ToLower(CultureInfo.CurrentCulture).Trim();
+            term = term.ToLowerInvariant().Trim();
 
             StringBuilder sb = new StringBuilder();
             SearchNode currentNode = _root;

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -1,1 +1,25 @@
 #nullable enable
+NuGet.Configuration.PackageSource.MinPublishAge.get -> System.TimeSpan
+NuGet.Configuration.PackageSource.MinPublishAge.set -> void
+NuGet.Configuration.SourceItem.MinPublishAgeHours.get -> string?
+NuGet.Configuration.SourceItem.MinPublishAgeHours.set -> void
+static readonly NuGet.Configuration.ConfigurationConstants.MinPublishAgeHours -> string!
+static readonly NuGet.Configuration.ConfigurationConstants.MinPublishAgeExceptions -> string!
+NuGet.Configuration.MinPublishAgeExceptionItem
+NuGet.Configuration.MinPublishAgeExceptionItem.MinPublishAgeExceptionItem() -> void
+override NuGet.Configuration.MinPublishAgeExceptionItem.Clone() -> NuGet.Configuration.SettingBase!
+override NuGet.Configuration.MinPublishAgeExceptionItem.ElementName.get -> string!
+override NuGet.Configuration.MinPublishAgeExceptionItem.Equals(object? other) -> bool
+override NuGet.Configuration.MinPublishAgeExceptionItem.GetHashCode() -> int
+NuGet.Configuration.MinPublishAgeExceptionItem.Pattern.get -> string!
+NuGet.Configuration.MinPublishAgeExceptionItem.Pattern.init -> void
+NuGet.Configuration.MinPublishAgeExceptions
+NuGet.Configuration.MinPublishAgeExceptions.MinPublishAgeExceptions(System.Collections.Generic.IReadOnlyList<NuGet.Configuration.MinPublishAgeExceptionItem!>! items) -> void
+NuGet.Configuration.MinPublishAgeExceptions.IsEnabled.get -> bool
+NuGet.Configuration.MinPublishAgeExceptions.FindException(string! packageId) -> NuGet.Configuration.MinPublishAgeExceptionItem?
+NuGet.Configuration.PackageSourceProvider.GetMinPublishAgeExceptionItems() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.MinPublishAgeExceptionItem!>!
+NuGet.Configuration.PackageSourceProvider.GetMinPublishAgeExceptions() -> NuGet.Configuration.MinPublishAgeExceptions!
+NuGet.Configuration.PackageSourceProvider.RemoveMinPublishAgeException(NuGet.Configuration.MinPublishAgeExceptionItem! exception) -> void
+NuGet.Configuration.PackageSourceProvider.RemoveMinPublishAgeExceptions() -> void
+NuGet.Configuration.PackageSourceProvider.SaveMinPublishAgeExceptions(System.Collections.Generic.IEnumerable<NuGet.Configuration.MinPublishAgeExceptionItem!>! exceptions) -> void
+NuGet.Configuration.SettingElementType.MinPublishAgeExceptions = 21 -> NuGet.Configuration.SettingElementType

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -19,7 +19,6 @@ NuGet.Configuration.MinPublishAgeExceptions.IsEnabled.get -> bool
 NuGet.Configuration.MinPublishAgeExceptions.FindException(string! packageId) -> NuGet.Configuration.MinPublishAgeExceptionItem?
 NuGet.Configuration.PackageSourceProvider.GetMinPublishAgeExceptionItems() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.MinPublishAgeExceptionItem!>!
 NuGet.Configuration.PackageSourceProvider.GetMinPublishAgeExceptions() -> NuGet.Configuration.MinPublishAgeExceptions!
-NuGet.Configuration.PackageSourceProvider.RemoveMinPublishAgeException(NuGet.Configuration.MinPublishAgeExceptionItem! exception) -> void
 NuGet.Configuration.PackageSourceProvider.RemoveMinPublishAgeExceptions() -> void
 NuGet.Configuration.PackageSourceProvider.SaveMinPublishAgeExceptions(System.Collections.Generic.IEnumerable<NuGet.Configuration.MinPublishAgeExceptionItem!>! exceptions) -> void
 NuGet.Configuration.SettingElementType.MinPublishAgeExceptions = 21 -> NuGet.Configuration.SettingElementType

--- a/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
+++ b/src/NuGet.Core/NuGet.Configuration/PublicAPI.Unshipped.txt
@@ -20,5 +20,5 @@ NuGet.Configuration.MinPublishAgeExceptions.FindException(string! packageId) -> 
 NuGet.Configuration.PackageSourceProvider.GetMinPublishAgeExceptionItems() -> System.Collections.Generic.IReadOnlyList<NuGet.Configuration.MinPublishAgeExceptionItem!>!
 NuGet.Configuration.PackageSourceProvider.GetMinPublishAgeExceptions() -> NuGet.Configuration.MinPublishAgeExceptions!
 NuGet.Configuration.PackageSourceProvider.RemoveMinPublishAgeExceptions() -> void
-NuGet.Configuration.PackageSourceProvider.SaveMinPublishAgeExceptions(System.Collections.Generic.IEnumerable<NuGet.Configuration.MinPublishAgeExceptionItem!>! exceptions) -> void
+NuGet.Configuration.PackageSourceProvider.SaveMinPublishAgeExceptions(System.Collections.Generic.IReadOnlyList<NuGet.Configuration.MinPublishAgeExceptionItem!>! exceptions) -> void
 NuGet.Configuration.SettingElementType.MinPublishAgeExceptions = 21 -> NuGet.Configuration.SettingElementType

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -194,6 +194,15 @@ namespace NuGet.Configuration {
                 return ResourceManager.GetString("Error_InvalidAttribute", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Minimum publish age exception pattern '{0}' is invalid..
+        /// </summary>
+        internal static string Error_InvalidMinPublishAgeExceptionPattern {
+            get {
+                return ResourceManager.GetString("Error_InvalidMinPublishAgeExceptionPattern", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Package source &apos;{0}&apos; must have at least one package pattern..

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -158,6 +158,24 @@ namespace NuGet.Configuration {
                 return ResourceManager.GetString("Error_DuplicatePackageSource", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The minimum publish age cannot be negative. Value: &apos;{0}&apos;..
+        /// </summary>
+        internal static string PackageSource_MinPublishAgeCannotBeNegative {
+            get {
+                return ResourceManager.GetString("PackageSource_MinPublishAgeCannotBeNegative", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The minimum publish age must be specified in whole hours. Value: &apos;{0}&apos;..
+        /// </summary>
+        internal static string PackageSource_MinPublishAgeMustBeWholeHours {
+            get {
+                return ResourceManager.GetString("PackageSource_MinPublishAgeMustBeWholeHours", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Encryption is not supported on non-Windows platforms..

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -307,6 +307,10 @@
   <data name="Argument_Cannot_Be_Null_Empty_Or_WhiteSpaceOnly" xml:space="preserve">
     <value>Argument cannot be null, empty, or whitespace only.</value>
   </data>
+  <data name="Error_InvalidMinPublishAgeExceptionPattern" xml:space="preserve">
+    <value>Minimum publish age exception pattern '{0}' is invalid.</value>
+    <comment>0 - invalid package ID pattern</comment>
+  </data>
   <data name="Error_DuplicatePackageSource" xml:space="preserve">
     <value>PackageSourceMapping is enabled and there are multiple package sources associated with the same key(s): {0}. Path: {1}</value>
     <comment>0 - package sources separated with comma 1 - path</comment>

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -220,6 +220,14 @@
 1 - package source value
 2 - original exception message</comment>
   </data>
+  <data name="PackageSource_MinPublishAgeCannotBeNegative" xml:space="preserve">
+    <value>The minimum publish age cannot be negative. Value: '{0}'.</value>
+    <comment>0 - minimum publish age</comment>
+  </data>
+  <data name="PackageSource_MinPublishAgeMustBeWholeHours" xml:space="preserve">
+    <value>The minimum publish age must be specified in whole hours. Value: '{0}'.</value>
+    <comment>0 - minimum publish age</comment>
+  </data>
   <data name="ShowError_ConfigInvalidOperation" xml:space="preserve">
     <value>NuGet.Config is malformed. Path: '{0}'.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/MinPublishAgeExceptionItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/MinPublishAgeExceptionItem.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Xml.Linq;
+
+namespace NuGet.Configuration
+{
+    public sealed class MinPublishAgeExceptionItem : SettingItem
+    {
+        private string _pattern = string.Empty;
+
+        public override string ElementName => "add";
+
+        public required string Pattern
+        {
+            get => _pattern;
+            init
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Empty_Or_WhiteSpaceOnly, nameof(value));
+                }
+
+                if (value.Length > PackageSourceMapping.PackageIdMaxLength)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                AddOrUpdateAttribute(ConfigurationConstants.PatternAttribute, value);
+                _pattern = value;
+            }
+        }
+
+        protected override IReadOnlyCollection<string> RequiredAttributes { get; } =
+            new HashSet<string>(new[] { ConfigurationConstants.PatternAttribute });
+
+        public MinPublishAgeExceptionItem()
+            : base()
+        {
+        }
+
+        [SetsRequiredMembers]
+        internal MinPublishAgeExceptionItem(XElement element, SettingsFile origin)
+            : base(element, origin)
+        {
+            Pattern = Attributes[ConfigurationConstants.PatternAttribute];
+        }
+
+        public override SettingBase Clone()
+        {
+            var newItem = new MinPublishAgeExceptionItem
+            {
+                Pattern = Pattern
+            };
+
+            if (Origin != null)
+            {
+                newItem.SetOrigin(Origin);
+            }
+
+            return newItem;
+        }
+
+        public override bool Equals(object? other)
+        {
+            if (other is MinPublishAgeExceptionItem item)
+            {
+                return string.Equals(Pattern, item.Pattern, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Pattern);
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/MinPublishAgeExceptionItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/MinPublishAgeExceptionItem.cs
@@ -16,7 +16,7 @@ namespace NuGet.Configuration
     {
         private string _pattern = string.Empty;
 
-        public override string ElementName => "add";
+        public override string ElementName => "package";
 
         /// <summary>
         /// Gets the package ID pattern.

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/MinPublishAgeExceptionItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/MinPublishAgeExceptionItem.cs
@@ -4,16 +4,23 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Xml.Linq;
 
 namespace NuGet.Configuration
 {
+    /// <summary>
+    /// Defines a package ID pattern that is exempt from minimum publish age enforcement.
+    /// </summary>
     public sealed class MinPublishAgeExceptionItem : SettingItem
     {
         private string _pattern = string.Empty;
 
         public override string ElementName => "add";
 
+        /// <summary>
+        /// Gets the package ID pattern.
+        /// </summary>
         public required string Pattern
         {
             get => _pattern;
@@ -37,6 +44,9 @@ namespace NuGet.Configuration
         protected override IReadOnlyCollection<string> RequiredAttributes { get; } =
             new HashSet<string>(new[] { ConfigurationConstants.PatternAttribute });
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MinPublishAgeExceptionItem"/> class.
+        /// </summary>
         public MinPublishAgeExceptionItem()
             : base()
         {
@@ -46,7 +56,25 @@ namespace NuGet.Configuration
         internal MinPublishAgeExceptionItem(XElement element, SettingsFile origin)
             : base(element, origin)
         {
-            Pattern = Attributes[ConfigurationConstants.PatternAttribute];
+            string pattern = Attributes[ConfigurationConstants.PatternAttribute];
+            try
+            {
+                Pattern = pattern;
+            }
+            catch (ArgumentException exception)
+            {
+                string reason = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resources.Error_InvalidMinPublishAgeExceptionPattern,
+                    pattern);
+                throw new NuGetConfigurationException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.UserSettings_UnableToParseConfigFile,
+                        reason,
+                        origin.ConfigFilePath),
+                    exception);
+            }
         }
 
         public override SettingBase Clone()

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Items/SourceItem.cs
@@ -49,6 +49,20 @@ namespace NuGet.Configuration
             set => AddOrUpdateAttribute(ConfigurationConstants.DisableTLSCertificateValidation, value);
         }
 
+        public string? MinPublishAgeHours
+        {
+            get
+            {
+                if (Attributes.TryGetValue(ConfigurationConstants.MinPublishAgeHours, out var attribute))
+                {
+                    return Settings.ApplyEnvironmentTransform(attribute);
+                }
+
+                return null;
+            }
+            set => AddOrUpdateAttribute(ConfigurationConstants.MinPublishAgeHours, value);
+        }
+
         public SourceItem(string key, string value)
             : this(key, value, protocolVersion: "", allowInsecureConnections: "", disableTLSCertificateValidation: "")
         {
@@ -88,7 +102,10 @@ namespace NuGet.Configuration
 
         public override SettingBase Clone()
         {
-            var newSetting = new SourceItem(Key, Value, ProtocolVersion, AllowInsecureConnections, DisableTLSCertificateValidation);
+            var newSetting = new SourceItem(Key, Value, ProtocolVersion, AllowInsecureConnections, DisableTLSCertificateValidation)
+            {
+                MinPublishAgeHours = MinPublishAgeHours
+            };
 
             if (Origin != null)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NuGetConfiguration.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NuGetConfiguration.cs
@@ -94,6 +94,29 @@ namespace NuGet.Configuration
             Add(new ParsedSettingSection(sectionName, item));
         }
 
+        internal void AddEmptySection(string sectionName, SettingsFile origin)
+        {
+            if (string.IsNullOrEmpty(sectionName))
+            {
+                throw new ArgumentException(Resources.Argument_Cannot_Be_Null_Or_Empty, nameof(sectionName));
+            }
+
+            if (Sections.ContainsKey(sectionName))
+            {
+                return;
+            }
+
+            var section = new ParsedSettingSection(sectionName)
+            {
+                Parent = this
+            };
+            section.SetOrigin(origin);
+            section.SetNode(section.AsXNode());
+            Children.Add(section);
+            XElementUtility.AddIndented(Node as XElement, section.Node);
+            origin.IsDirty = true;
+        }
+
         public void Remove(string sectionName, SettingItem item)
         {
             if (string.IsNullOrEmpty(sectionName))

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingElementType.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingElementType.cs
@@ -50,5 +50,7 @@ namespace NuGet.Configuration
         Package,
 
         AuditSources,
+
+        MinPublishAgeExceptions,
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -58,7 +58,7 @@ namespace NuGet.Configuration
                         break;
 
                     case SettingElementType.MinPublishAgeExceptions:
-                        if (elementType == SettingElementType.Add)
+                        if (elementType == SettingElementType.Package)
                         {
                             return new MinPublishAgeExceptionItem(element, origin);
                         }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingFactory.cs
@@ -57,6 +57,13 @@ namespace NuGet.Configuration
                         }
                         break;
 
+                    case SettingElementType.MinPublishAgeExceptions:
+                        if (elementType == SettingElementType.Add)
+                        {
+                            return new MinPublishAgeExceptionItem(element, origin);
+                        }
+                        break;
+
                     case SettingElementType.PackageSource:
                         if (elementType == SettingElementType.Package)
                         {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -140,6 +140,27 @@ namespace NuGet.Configuration
             }
         }
 
+        internal void AddEmptySection(string sectionName)
+        {
+            var outputSettingsFile = GetOutputSettingFileForSection(sectionName);
+            if (outputSettingsFile == null)
+            {
+                throw new InvalidOperationException(Resources.NoWritteableConfig);
+            }
+
+            outputSettingsFile.AddEmptySection(sectionName);
+
+            if (_computedSections.TryGetValue(sectionName, out _))
+            {
+                outputSettingsFile.TryGetSection(sectionName, out SettingSection? settingFileSection);
+                _computedSections[sectionName] = new VirtualSettingSection(settingFileSection!);
+            }
+            else if (outputSettingsFile.TryGetSection(sectionName, out SettingSection? settingFileSection))
+            {
+                _computedSections.Add(sectionName, new VirtualSettingSection(settingFileSection));
+            }
+        }
+
         public void Remove(string sectionName, SettingItem item)
         {
             if (string.IsNullOrEmpty(sectionName))

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingsFile.cs
@@ -154,6 +154,11 @@ namespace NuGet.Configuration
             _rootElement.AddOrUpdate(sectionName, item);
         }
 
+        internal void AddEmptySection(string sectionName)
+        {
+            _rootElement.AddEmptySection(sectionName, this);
+        }
+
         /// <summary>
         /// Removes the given <paramref name="item"/> from the settings.
         /// If the <paramref name="item"/> is the last item in the section, the section will also be removed.

--- a/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
@@ -34,10 +34,9 @@ namespace NuGet.Configuration
             }
 
             if (other.ElementName.Equals(ConfigurationConstants.MinPublishAgeExceptions, StringComparison.OrdinalIgnoreCase)
-                && other.Items.Count == 0)
+                && !other.Items.OfType<ClearItem>().Any())
             {
                 Children.Clear();
-                return this;
             }
 
             foreach (var item in other.Items.Where(item => item != null))

--- a/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/VirtualSettingSection.cs
@@ -33,6 +33,13 @@ namespace NuGet.Configuration
                 throw new ArgumentException(Resources.Error_MergeTwoDifferentSections);
             }
 
+            if (other.ElementName.Equals(ConfigurationConstants.MinPublishAgeExceptions, StringComparison.OrdinalIgnoreCase)
+                && other.Items.Count == 0)
+            {
+                Children.Clear();
+                return this;
+            }
+
             foreach (var item in other.Items.Where(item => item != null))
             {
                 if (item is ClearItem)

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -87,6 +87,10 @@ namespace NuGet.Configuration
 
         public static readonly string MaxHttpRequestsPerSource = "maxHttpRequestsPerSource";
 
+        public static readonly string MinPublishAgeHours = "minPublishAgeHours";
+
+        public static readonly string MinPublishAgeExceptions = "minPublishAgeExceptions";
+
         public static readonly string NameAttribute = "name";
 
         public static readonly string NoProxy = "no_proxy";

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.cs.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.cs.xlf
@@ -178,6 +178,16 @@
         <target state="translated">Položka vlastníků musí mít jenom textový obsah a nemůže být prázdná.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">Vlastnost {0} nemůže být null nebo prázdná.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.cs.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.cs.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">Zdroj balíčku {0} musí mít alespoň jeden vzor balíčku.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.de.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.de.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">Die Paketquelle "{0}" muss mindestens ein Paketmuster aufweisen.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.de.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.de.xlf
@@ -178,6 +178,16 @@
         <target state="translated">Das Besitzerelement darf nur Textinhalt aufweisen und darf nicht leer sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">"{0}" darf nicht NULL oder leer sein.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.es.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.es.xlf
@@ -178,6 +178,16 @@
         <target state="translated">El elemento Propietarios solo debe tener contenido de texto y no puede estar vacío.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">{0} no puede ser nulo ni estar vacío.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.es.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.es.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">El origen del paquete "{0}" debe tener al menos un patrón de paquete.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.fr.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.fr.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">La source du paquet '{0}' doit avoir au moins un modèle de paquet.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.fr.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.fr.xlf
@@ -178,6 +178,16 @@
         <target state="translated">L'élément relatif aux propriétaires doit avoir uniquement du contenu textuel, et ne doit pas être vide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">{0} ne peut pas être null ou vide.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.it.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.it.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">L'origine del pacchetto '{0}' deve includere almeno un criterio pacchetti.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.it.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.it.xlf
@@ -178,6 +178,16 @@
         <target state="translated">L'elemento owners deve includere solo contenuto di testo e non può essere vuoto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">La proprietà {0} non può essere Null o vuota.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ja.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ja.xlf
@@ -178,6 +178,16 @@
         <target state="translated">所有者項目に使用できるのはテキスト コンテンツのみであり、空にすることはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">{0} を null または空に設定することはできません。</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ja.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ja.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">パッケージ ソース '{0}' には、少なくとも 1 つのパッケージ パターンが必要です。</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ko.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ko.xlf
@@ -178,6 +178,16 @@
         <target state="translated">소유자 항목에는 텍스트 콘텐츠만 있어야 하고 비워 둘 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">{0}은(는) null이거나 비워 둘 수 없습니다.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ko.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ko.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">‘{0}’ 패키지 소스에 한 개 이상의 패키지 패턴이 있어야 합니다.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.pl.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.pl.xlf
@@ -178,6 +178,16 @@
         <target state="translated">Element właścicieli może mieć jedynie zawartość tekstową i nie może być pusty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">Element {0} nie może mieć wartości null ani być pusty.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.pl.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.pl.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">Źródło pakietu "{0}" musi mieć co najmniej jeden wzorzec pakietu.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.pt-BR.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">A origem do pacote '{0}' deve ter pelo menos um padrão de pacote.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.pt-BR.xlf
@@ -178,6 +178,16 @@
         <target state="translated">O item do proprietário só deve ter conteúdo de texto e não pode estar vazio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">{0} não pode ser nulo ou estar vazio.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ru.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ru.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">Источник пакета "{0}" должен иметь по крайней мере один шаблон пакета.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ru.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.ru.xlf
@@ -178,6 +178,16 @@
         <target state="translated">Элемент "Владельцы" должен включать только текстовое содержимое и не может быть пустым.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">{0} не может быть пустым или равным NULL.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.tr.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.tr.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">Paket kaynağı '{0}' en az bir paket desenine sahip olmalıdır.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.tr.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.tr.xlf
@@ -178,6 +178,16 @@
         <target state="translated">Sahipler öğesinin yalnızca metin içeriği olmalı ve öğe boş olmamalıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">{0} özelliği null veya boş olamaz.</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.zh-Hans.xlf
@@ -178,6 +178,16 @@
         <target state="translated">所有者项只能有文本内容，并且不能为空。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">{0} 不能为 Null 或为空。</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.zh-Hans.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">包源 "{0}" 必须至少有一个包模式。</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.zh-Hant.xlf
@@ -71,6 +71,11 @@
         <note>0 - attribute name
 1 - attribute value</note>
       </trans-unit>
+      <trans-unit id="Error_InvalidMinPublishAgeExceptionPattern">
+        <source>Minimum publish age exception pattern '{0}' is invalid.</source>
+        <target state="new">Minimum publish age exception pattern '{0}' is invalid.</target>
+        <note>0 - invalid package ID pattern</note>
+      </trans-unit>
       <trans-unit id="Error_ItemNeedsAtLeastOnePackagePattern">
         <source>Package source '{0}' must have at least one package pattern.</source>
         <target state="translated">套件來源 '{0}' 至少必須有一個套件模式。</target>

--- a/src/NuGet.Core/NuGet.Configuration/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Core/NuGet.Configuration/xlf/Resources.zh-Hant.xlf
@@ -178,6 +178,16 @@
         <target state="translated">擁有者項目只能有文字內容且不可空白。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeCannotBeNegative">
+        <source>The minimum publish age cannot be negative. Value: '{0}'.</source>
+        <target state="new">The minimum publish age cannot be negative. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
+      <trans-unit id="PackageSource_MinPublishAgeMustBeWholeHours">
+        <source>The minimum publish age must be specified in whole hours. Value: '{0}'.</source>
+        <target state="new">The minimum publish age must be specified in whole hours. Value: '{0}'.</target>
+        <note>0 - minimum publish age</note>
+      </trans-unit>
       <trans-unit id="PropertyCannotBeNullOrEmpty">
         <source>{0} cannot be null or empty.</source>
         <target state="translated">{0} 不得為 null 或空白。</target>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -193,7 +193,8 @@ namespace NuGet.Configuration.Test
                         {
                         new PackageSource("http://a.test", "a")
                             {
-                                IsEnabled = true
+                                IsEnabled = true,
+                                MinPublishAge = TimeSpan.FromHours(48)
                             },
                         new PackageSource("http://b.test", "b")
                             {
@@ -213,7 +214,7 @@ namespace NuGet.Configuration.Test
                 var result = SettingsTestUtils.RemoveWhitespace(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
-    <add key=""a"" value=""http://a.test"" />
+    <add key=""a"" value=""http://a.test"" minPublishAgeHours=""48"" />
     <add key=""b"" value=""http://b.test"" />
   </packageSources>
   <disabledPackageSources>
@@ -1160,6 +1161,286 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void SaveMinPublishAgeExceptions_SavesAndLoadsPatterns()
+        {
+            // Arrange
+            using var directory = TestDirectory.Create();
+            File.WriteAllText(
+                Path.Combine(directory.Path, "NuGet.Config"),
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                </configuration>
+                """);
+
+            var settings = new Settings(directory);
+            var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            // Act
+            packageSourceProvider.SaveMinPublishAgeExceptions(new[]
+            {
+                new MinPublishAgeExceptionItem { Pattern = "System.*" },
+                new MinPublishAgeExceptionItem { Pattern = "Fabrikam.WebApi.Client" },
+            });
+
+            settings = new Settings(directory);
+            var provider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+            var exceptions = provider.GetMinPublishAgeExceptions();
+
+            // Assert
+            exceptions.IsEnabled.Should().BeTrue();
+            exceptions.FindException("System.Text.Json")!.Pattern.Should().Be("System.*");
+            exceptions.FindException("Fabrikam.WebApi.Client")!.Pattern.Should().Be("Fabrikam.WebApi.Client");
+            exceptions.FindException("Newtonsoft.Json").Should().BeNull();
+
+            provider.GetMinPublishAgeExceptionItems()
+                .Select(exception => exception.Pattern)
+                .Should()
+                .BeEquivalentTo("System.*", "Fabrikam.WebApi.Client");
+
+            var config = File.ReadAllText(Path.Combine(directory.Path, "NuGet.Config"));
+            config.Should().Contain("<minPublishAgeExceptions>");
+            config.Should().Contain("<add pattern=\"System.*\" />");
+            config.Should().Contain("<add pattern=\"Fabrikam.WebApi.Client\" />");
+        }
+
+        [Fact]
+        public void LoadMinPublishAgeExceptions_WithoutPattern_ThrowsClearError()
+        {
+            // Arrange
+            using var directory = TestDirectory.Create();
+            const string fileName = "NuGet.Config";
+            SettingsTestUtils.CreateConfigurationFile(
+                fileName,
+                directory,
+                """
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <add />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """);
+
+            // Act
+            var exception = Record.Exception(() => new SettingsFile(directory));
+
+            // Assert
+            exception.Should().BeOfType<NuGetConfigurationException>();
+            exception!.Message.Should().Contain("'pattern'");
+            exception.Message.Should().Contain("'add'");
+            exception.Message.Should().Contain(Path.Combine(directory.Path, fileName));
+        }
+
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("\t")]
+        public void MinPublishAgeException_WhitespacePattern_Throws(string pattern)
+        {
+            // Arrange
+            using var directory = TestDirectory.Create();
+            File.WriteAllText(
+                Path.Combine(directory.Path, "NuGet.Config"),
+                $"""
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <add pattern="{pattern}" />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """);
+
+            // Act
+            var fileException = Record.Exception(() => new SettingsFile(directory));
+            var inMemoryException = Record.Exception(() => new MinPublishAgeExceptionItem { Pattern = pattern });
+
+            // Assert
+            fileException.Should().BeOfType<ArgumentException>();
+            inMemoryException.Should().BeOfType<ArgumentException>();
+        }
+
+        [Fact]
+        public void MinPublishAgeException_TooLongPattern_Throws()
+        {
+            // Arrange
+            using var directory = TestDirectory.Create();
+            string pattern = new string('a', 101);
+            File.WriteAllText(
+                Path.Combine(directory.Path, "NuGet.Config"),
+                $"""
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <add pattern="{pattern}" />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """);
+
+            // Act
+            var fileException = Record.Exception(() => new SettingsFile(directory));
+            var inMemoryException = Record.Exception(() => new MinPublishAgeExceptionItem { Pattern = pattern });
+
+            // Assert
+            fileException.Should().BeOfType<ArgumentOutOfRangeException>();
+            inMemoryException.Should().BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void SaveMinPublishAgeExceptions_WithEmptyList_SavesEmptySection()
+        {
+            // Arrange
+            using var directory = TestDirectory.Create();
+            File.WriteAllText(
+                Path.Combine(directory.Path, "NuGet.Config"),
+                """
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <add pattern="System.*" />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """);
+
+            var provider = new PackageSourceProvider(
+                new Settings(directory),
+                TestConfigurationDefaults.NullInstance);
+
+            // Act
+            provider.SaveMinPublishAgeExceptions(Array.Empty<MinPublishAgeExceptionItem>());
+
+            // Assert
+            var config = File.ReadAllText(Path.Combine(directory.Path, "NuGet.Config"));
+            config.Should().Contain("<minPublishAgeExceptions />");
+            config.Should().NotContain("<clear />");
+            new PackageSourceProvider(new Settings(directory), TestConfigurationDefaults.NullInstance)
+                .GetMinPublishAgeExceptions()
+                .IsEnabled.Should().BeFalse();
+        }
+
+        [Fact]
+        public void RemoveMinPublishAgeException_RemovesMatchingException()
+        {
+            // Arrange
+            using var directory = TestDirectory.Create();
+            File.WriteAllText(
+                Path.Combine(directory.Path, "NuGet.Config"),
+                """
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <add pattern="System.*" />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """);
+
+            var provider = new PackageSourceProvider(
+                new Settings(directory),
+                TestConfigurationDefaults.NullInstance);
+
+            // Act
+            provider.RemoveMinPublishAgeException(new MinPublishAgeExceptionItem { Pattern = "System.*" });
+
+            // Assert
+            provider.GetMinPublishAgeExceptionItems().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void RemoveMinPublishAgeExceptions_RemovesAllExceptions()
+        {
+            // Arrange
+            using var directory = TestDirectory.Create();
+            File.WriteAllText(
+                Path.Combine(directory.Path, "NuGet.Config"),
+                """
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <add pattern="System.*" />
+                        <add pattern="Fabrikam.*" />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """);
+
+            var provider = new PackageSourceProvider(
+                new Settings(directory),
+                TestConfigurationDefaults.NullInstance);
+
+            // Act
+            provider.RemoveMinPublishAgeExceptions();
+
+            // Assert
+            provider.GetMinPublishAgeExceptionItems().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LoadMinPublishAgeExceptions_ChildConfigReplacesParentConfig()
+        {
+            // Arrange
+            using var directory = TestDirectory.Create();
+            var childDirectory = Path.Combine(directory.Path, "child");
+            var configContents = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <add pattern="System.*" />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """;
+
+            SettingsTestUtils.CreateConfigurationFile("NuGet.Config", directory, configContents);
+
+            configContents = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <add pattern="Fabrikam.*" />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """;
+
+            SettingsTestUtils.CreateConfigurationFile("NuGet.Config", childDirectory, configContents);
+
+            // Act
+            var settings = Settings.LoadDefaultSettings(childDirectory);
+            var exceptions = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance)
+                .GetMinPublishAgeExceptions();
+
+            // Assert
+            exceptions.FindException("Fabrikam.WebApi.Client").Should().NotBeNull();
+            exceptions.FindException("System.Text.Json").Should().BeNull();
+        }
+
+        [Fact]
+        public void LoadMinPublishAgeExceptions_EmptyChildConfigClearsParentConfig()
+        {
+            // Arrange
+            using var directory = TestDirectory.Create();
+            var childDirectory = Path.Combine(directory.Path, "child");
+            var configContents = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <add pattern="System.*" />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """;
+
+            SettingsTestUtils.CreateConfigurationFile("NuGet.Config", directory, configContents);
+
+            configContents = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                    <minPublishAgeExceptions />
+                </configuration>
+                """;
+
+            SettingsTestUtils.CreateConfigurationFile("NuGet.Config", childDirectory, configContents);
+
+            // Act
+            var settings = Settings.LoadDefaultSettings(childDirectory);
+            var exceptions = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance)
+                .GetMinPublishAgeExceptions();
+
+            // Assert
+            exceptions.IsEnabled.Should().BeFalse();
+            exceptions.FindException("System.Text.Json").Should().BeNull();
+        }
+
+        [Fact]
         public void SavePackage_KeepsBothNewAndOldSources()
         {
             using (var directory = TestDirectory.Create())
@@ -1462,6 +1743,41 @@ namespace NuGet.Configuration.Test
             var parsedSource = children[0];
             parsedSource.Key.Should().Be("default-http");
             parsedSource.DisableTLSCertificateValidation.Should().Be("True");
+        }
+
+        [Fact]
+        public void UpdatePackageSource_ShouldSaveMinPublishAgeHours()
+        {
+            using var directory = TestDirectory.Create();
+
+            // Arrange
+            var configContents = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                    <packageSources>
+                        <add key="default-http" value="http://api.nuget.org/v3/index.json" />
+                    </packageSources>
+                </configuration>
+                """;
+
+            File.WriteAllText(Path.Combine(directory.Path, "NuGet.Config"), configContents);
+
+            var settings = new Settings(directory);
+            var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+            var source = packageSourceProvider.GetPackageSourceByName("default-http")!;
+
+            // Act
+            source.MinPublishAge = TimeSpan.FromDays(2);
+            packageSourceProvider.UpdatePackageSource(source, false, false);
+
+            // Assert
+            settings = new Settings(directory);
+            var packageSourcesSection = settings.GetSection("packageSources");
+            packageSourcesSection.Should().NotBeNull();
+            packageSourcesSection!.Items.Should().ContainSingle();
+
+            var parsedSource = packageSourcesSection.Items.Cast<SourceItem>().Single();
+            parsedSource.MinPublishAgeHours.Should().Be("48");
         }
 
         // Test that a source added in a high priority config file is not

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1202,6 +1202,53 @@ namespace NuGet.Configuration.Test
             config.Should().Contain("<minPublishAgeExceptions>");
             config.Should().Contain("<package pattern=\"System.*\" />");
             config.Should().Contain("<package pattern=\"Fabrikam.WebApi.Client\" />");
+            config.Should().NotContain("<clear />");
+        }
+
+        [Fact]
+        public void SaveMinPublishAgeExceptions_UpdatesExistingProvider()
+        {
+            // Arrange
+            using var directory = TestDirectory.Create();
+            File.WriteAllText(
+                Path.Combine(directory.Path, "NuGet.Config"),
+                """
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <package pattern="Legacy.*" />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """);
+
+            var provider = new PackageSourceProvider(
+                new Settings(directory),
+                TestConfigurationDefaults.NullInstance);
+
+            // Act
+            provider.SaveMinPublishAgeExceptions(new[]
+            {
+                new MinPublishAgeExceptionItem { Pattern = "Contoso.*" },
+            });
+
+            // Assert
+            provider.GetMinPublishAgeExceptionItems()
+                .Select(exception => exception.Pattern)
+                .Should()
+                .BeEquivalentTo("Contoso.*");
+        }
+
+        [Fact]
+        public void SaveMinPublishAgeExceptions_WithUnsupportedSettings_Throws()
+        {
+            // Arrange
+            var settings = new Mock<ISettings>();
+            var provider = new PackageSourceProvider(settings.Object, TestConfigurationDefaults.NullInstance);
+
+            // Act
+            var exception = Record.Exception(() => provider.SaveMinPublishAgeExceptions(Array.Empty<MinPublishAgeExceptionItem>()));
+
+            // Assert
+            exception.Should().BeOfType<NotSupportedException>();
         }
 
         [Fact]
@@ -1311,9 +1358,24 @@ namespace NuGet.Configuration.Test
             var config = File.ReadAllText(Path.Combine(directory.Path, "NuGet.Config"));
             config.Should().Contain("<minPublishAgeExceptions />");
             config.Should().NotContain("<clear />");
-            new PackageSourceProvider(new Settings(directory), TestConfigurationDefaults.NullInstance)
-                .GetMinPublishAgeExceptions()
-                .IsEnabled.Should().BeFalse();
+            provider.GetMinPublishAgeExceptions().IsEnabled.Should().BeFalse();
+        }
+
+        [Fact]
+        public void MinPublishAgeExceptions_FindException_TrimsPattern()
+        {
+            // Arrange
+            var exceptions = new MinPublishAgeExceptions(new[]
+            {
+                new MinPublishAgeExceptionItem { Pattern = " System.* " },
+            });
+
+            // Act
+            var exception = exceptions.FindException("System.Text.Json");
+
+            // Assert
+            exception.Should().NotBeNull();
+            exception!.Pattern.Should().Be(" System.* ");
         }
 
         [Fact]
@@ -1474,6 +1536,9 @@ namespace NuGet.Configuration.Test
                 .Select(exception => exception.Pattern)
                 .Should()
                 .BeEquivalentTo("Contoso.*", "Microsoft.*");
+            File.ReadAllText(Path.Combine(childDirectory, Settings.DefaultSettingsFileName))
+                .Should()
+                .NotContain("<clear />");
             File.ReadAllText(parentConfigPath).Should().Be(originalParentConfig);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1395,7 +1395,12 @@ namespace NuGet.Configuration.Test
             SettingsTestUtils.CreateConfigurationFile("NuGet.Config", childDirectory, configContents);
 
             // Act
-            var settings = Settings.LoadDefaultSettings(childDirectory);
+            var settings = Settings.LoadSettings(
+                childDirectory,
+                configFileName: null,
+                machineWideSettings: null,
+                loadUserWideSettings: false,
+                useTestingGlobalPath: false);
             var exceptions = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance)
                 .GetMinPublishAgeExceptions();
 
@@ -1438,6 +1443,61 @@ namespace NuGet.Configuration.Test
             // Assert
             exceptions.IsEnabled.Should().BeFalse();
             exceptions.FindException("System.Text.Json").Should().BeNull();
+        }
+
+        [Fact]
+        public void SaveMinPublishAgeExceptions_ReplacesExceptionsAcrossHierarchy()
+        {
+            // Arrange
+            using var directory = TestDirectory.Create();
+            var childDirectory = Path.Combine(directory.Path, "child");
+            var parentConfigPath = Path.Combine(directory.Path, Settings.DefaultSettingsFileName);
+            SettingsTestUtils.CreateConfigurationFile(
+                Settings.DefaultSettingsFileName,
+                directory,
+                """
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <add pattern="Legacy.*" />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """);
+            var originalParentConfig = File.ReadAllText(parentConfigPath);
+            SettingsTestUtils.CreateConfigurationFile(
+                Settings.DefaultSettingsFileName,
+                childDirectory,
+                """
+                <configuration>
+                    <minPublishAgeExceptions>
+                        <add pattern="Contoso.*" />
+                    </minPublishAgeExceptions>
+                </configuration>
+                """);
+
+            var settings = Settings.LoadDefaultSettings(childDirectory);
+            var provider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+
+            // Act
+            provider.SaveMinPublishAgeExceptions(new[]
+            {
+                new MinPublishAgeExceptionItem { Pattern = "Contoso.*" },
+                new MinPublishAgeExceptionItem { Pattern = "Microsoft.*" },
+            });
+
+            // Assert
+            var reloadedProvider = new PackageSourceProvider(
+                Settings.LoadSettings(
+                    childDirectory,
+                    configFileName: null,
+                    machineWideSettings: null,
+                    loadUserWideSettings: false,
+                    useTestingGlobalPath: false),
+                TestConfigurationDefaults.NullInstance);
+            reloadedProvider.GetMinPublishAgeExceptionItems()
+                .Select(exception => exception.Pattern)
+                .Should()
+                .BeEquivalentTo("Contoso.*", "Microsoft.*");
+            File.ReadAllText(parentConfigPath).Should().Be(originalParentConfig);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1200,8 +1200,8 @@ namespace NuGet.Configuration.Test
 
             var config = File.ReadAllText(Path.Combine(directory.Path, "NuGet.Config"));
             config.Should().Contain("<minPublishAgeExceptions>");
-            config.Should().Contain("<add pattern=\"System.*\" />");
-            config.Should().Contain("<add pattern=\"Fabrikam.WebApi.Client\" />");
+            config.Should().Contain("<package pattern=\"System.*\" />");
+            config.Should().Contain("<package pattern=\"Fabrikam.WebApi.Client\" />");
         }
 
         [Fact]
@@ -1216,7 +1216,7 @@ namespace NuGet.Configuration.Test
                 """
                 <configuration>
                     <minPublishAgeExceptions>
-                        <add />
+                        <package />
                     </minPublishAgeExceptions>
                 </configuration>
                 """);
@@ -1227,7 +1227,7 @@ namespace NuGet.Configuration.Test
             // Assert
             exception.Should().BeOfType<NuGetConfigurationException>();
             exception!.Message.Should().Contain("'pattern'");
-            exception.Message.Should().Contain("'add'");
+            exception.Message.Should().Contain("'package'");
             exception.Message.Should().Contain(Path.Combine(directory.Path, fileName));
         }
 
@@ -1243,7 +1243,7 @@ namespace NuGet.Configuration.Test
                 $"""
                 <configuration>
                     <minPublishAgeExceptions>
-                        <add pattern="{pattern}" />
+                        <package pattern="{pattern}" />
                     </minPublishAgeExceptions>
                 </configuration>
                 """);
@@ -1269,7 +1269,7 @@ namespace NuGet.Configuration.Test
                 $"""
                 <configuration>
                     <minPublishAgeExceptions>
-                        <add pattern="{pattern}" />
+                        <package pattern="{pattern}" />
                     </minPublishAgeExceptions>
                 </configuration>
                 """);
@@ -1295,7 +1295,7 @@ namespace NuGet.Configuration.Test
                 """
                 <configuration>
                     <minPublishAgeExceptions>
-                        <add pattern="System.*" />
+                        <package pattern="System.*" />
                     </minPublishAgeExceptions>
                 </configuration>
                 """);
@@ -1326,8 +1326,8 @@ namespace NuGet.Configuration.Test
                 """
                 <configuration>
                     <minPublishAgeExceptions>
-                        <add pattern="System.*" />
-                        <add pattern="Fabrikam.*" />
+                        <package pattern="System.*" />
+                        <package pattern="Fabrikam.*" />
                     </minPublishAgeExceptions>
                 </configuration>
                 """);
@@ -1353,7 +1353,7 @@ namespace NuGet.Configuration.Test
                 <?xml version="1.0" encoding="utf-8"?>
                 <configuration>
                     <minPublishAgeExceptions>
-                        <add pattern="System.*" />
+                        <package pattern="System.*" />
                     </minPublishAgeExceptions>
                 </configuration>
                 """;
@@ -1364,7 +1364,7 @@ namespace NuGet.Configuration.Test
                 <?xml version="1.0" encoding="utf-8"?>
                 <configuration>
                     <minPublishAgeExceptions>
-                        <add pattern="Fabrikam.*" />
+                        <package pattern="Fabrikam.*" />
                     </minPublishAgeExceptions>
                 </configuration>
                 """;
@@ -1396,7 +1396,7 @@ namespace NuGet.Configuration.Test
                 <?xml version="1.0" encoding="utf-8"?>
                 <configuration>
                     <minPublishAgeExceptions>
-                        <add pattern="System.*" />
+                        <package pattern="System.*" />
                     </minPublishAgeExceptions>
                 </configuration>
                 """;
@@ -1435,7 +1435,7 @@ namespace NuGet.Configuration.Test
                 """
                 <configuration>
                     <minPublishAgeExceptions>
-                        <add pattern="Legacy.*" />
+                        <package pattern="Legacy.*" />
                     </minPublishAgeExceptions>
                 </configuration>
                 """);
@@ -1446,7 +1446,7 @@ namespace NuGet.Configuration.Test
                 """
                 <configuration>
                     <minPublishAgeExceptions>
-                        <add pattern="Contoso.*" />
+                        <package pattern="Contoso.*" />
                     </minPublishAgeExceptions>
                 </configuration>
                 """);

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1253,7 +1253,8 @@ namespace NuGet.Configuration.Test
             var inMemoryException = Record.Exception(() => new MinPublishAgeExceptionItem { Pattern = pattern });
 
             // Assert
-            fileException.Should().BeOfType<ArgumentException>();
+            fileException.Should().BeOfType<NuGetConfigurationException>();
+            fileException!.Message.Should().Contain(Path.Combine(directory.Path, "NuGet.Config"));
             inMemoryException.Should().BeOfType<ArgumentException>();
         }
 
@@ -1278,7 +1279,9 @@ namespace NuGet.Configuration.Test
             var inMemoryException = Record.Exception(() => new MinPublishAgeExceptionItem { Pattern = pattern });
 
             // Assert
-            fileException.Should().BeOfType<ArgumentOutOfRangeException>();
+            fileException.Should().BeOfType<NuGetConfigurationException>();
+            fileException!.Message.Should().Contain(Path.Combine(directory.Path, "NuGet.Config"));
+            fileException.Message.Should().Contain(pattern);
             inMemoryException.Should().BeOfType<ArgumentOutOfRangeException>();
         }
 
@@ -1311,32 +1314,6 @@ namespace NuGet.Configuration.Test
             new PackageSourceProvider(new Settings(directory), TestConfigurationDefaults.NullInstance)
                 .GetMinPublishAgeExceptions()
                 .IsEnabled.Should().BeFalse();
-        }
-
-        [Fact]
-        public void RemoveMinPublishAgeException_RemovesMatchingException()
-        {
-            // Arrange
-            using var directory = TestDirectory.Create();
-            File.WriteAllText(
-                Path.Combine(directory.Path, "NuGet.Config"),
-                """
-                <configuration>
-                    <minPublishAgeExceptions>
-                        <add pattern="System.*" />
-                    </minPublishAgeExceptions>
-                </configuration>
-                """);
-
-            var provider = new PackageSourceProvider(
-                new Settings(directory),
-                TestConfigurationDefaults.NullInstance);
-
-            // Act
-            provider.RemoveMinPublishAgeException(new MinPublishAgeExceptionItem { Pattern = "System.*" });
-
-            // Assert
-            provider.GetMinPublishAgeExceptionItems().Should().BeEmpty();
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1273,7 +1273,7 @@ namespace NuGet.Configuration.Test
 
             // Assert
             exception.Should().BeOfType<NuGetConfigurationException>();
-            exception!.Message.Should().Contain("'pattern'");
+            exception.Message.Should().Contain("'pattern'");
             exception.Message.Should().Contain("'package'");
             exception.Message.Should().Contain(Path.Combine(directory.Path, fileName));
         }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -1,8 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.IO;
+using System.Linq;
 using FluentAssertions;
 using NuGet.Common;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.Configuration.Test
@@ -56,6 +60,72 @@ namespace NuGet.Configuration.Test
             var expectedItem = new SourceItem("SourceName", "Source", "43", "True", "True");
 
             SettingsTestUtils.DeepEquals(result, expectedItem).Should().BeTrue();
+        }
+
+        [Fact]
+        public void MinPublishAge_IsReadAsTimeSpanAndWrittenAsHours()
+        {
+            var source = new PackageSource("Source", "SourceName")
+            {
+                MinPublishAge = TimeSpan.FromHours(72)
+            };
+
+            var result = source.AsSourceItem();
+
+            result.MinPublishAgeHours.Should().Be("72");
+            source.Clone().MinPublishAge.Should().Be(TimeSpan.FromHours(72));
+        }
+
+        [Fact]
+        public void MinPublishAge_WhenSetToNegativeTimeSpan_ThrowsArgumentOutOfRangeException()
+        {
+            var source = new PackageSource("Source", "SourceName");
+
+            Action action = () => source.MinPublishAge = TimeSpan.FromHours(-1);
+
+            action.Should().Throw<ArgumentOutOfRangeException>()
+                .Which.ParamName.Should().Be("value");
+        }
+
+        [Fact]
+        public void MinPublishAge_WhenSetToFractionalHour_ThrowsArgumentOutOfRangeException()
+        {
+            var source = new PackageSource("Source", "SourceName");
+
+            Action action = () => source.MinPublishAge = TimeSpan.FromMinutes(30);
+
+            action.Should().Throw<ArgumentOutOfRangeException>()
+                .Which.ParamName.Should().Be("value");
+        }
+
+        [Theory]
+        [InlineData("-1")]
+        [InlineData("not-a-number")]
+        public void ReadPackageSource_InvalidMinPublishAge_ThrowsWithSourceValueAndPath(string value)
+        {
+            using var directory = TestDirectory.Create();
+            string fileName = Settings.DefaultSettingsFileName;
+            SettingsTestUtils.CreateConfigurationFile(
+                fileName,
+                directory,
+                $"""
+                <configuration>
+                    <packageSources>
+                        <add key="test-source" value="https://test.test/v3/index.json" minPublishAgeHours="{value}" />
+                    </packageSources>
+                </configuration>
+                """);
+
+            var settingsFile = new SettingsFile(directory);
+            var sourceItem = settingsFile.GetSection(ConfigurationConstants.PackageSources)!.Items.Cast<SourceItem>().Single();
+
+            var exception = Record.Exception(() =>
+                PackageSourceProvider.ReadPackageSource(sourceItem, isEnabled: true, NullSettings.Instance, EnvironmentVariableWrapper.Instance));
+
+            exception.Should().BeOfType<NuGetConfigurationException>();
+            exception.Message.Should().Contain("test-source");
+            exception.Message.Should().Contain(value);
+            exception.Message.Should().Contain(Path.Combine(directory, fileName));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/15026
Feature: https://github.com/NuGet/Home/issues/14657

## Description

feature spec: https://github.com/NuGet/Home/pull/14983

Read and write `minPublishAgeHours` on package source items, and the new `<minPublishAgeExceptions>` section. 
Added new APIs to NuGet.Configuration to read and write the files programatically.
Error cases are tested, and error messages should contain sufficient information to figure out what's wrong (for example which source an invalid value of `minPublishAgeHours` is attached to).

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. https://github.com/NuGet/Home/issues/15036
