### PR TITLE
Guard null active projects in migration commands

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -695,6 +695,12 @@ namespace NuGetVSExtension
 
             Project project = VsMonitorSelection.GetActiveProject();
 
+            if (project == null)
+            {
+                MessageHelper.ShowWarningMessage(Resources.ProjectJsonMigrateErrorMessage, Resources.ErrorDialogBoxTitle);
+                return;
+            }
+
             string uniqueName = await project.GetCustomUniqueNameAsync();
             NuGetProject nuGetProject = await SolutionManager.Value.GetNuGetProjectAsync(uniqueName);
 
@@ -1211,7 +1217,15 @@ namespace NuGetVSExtension
                     isConsoleBusy = ConsoleStatus.Value.IsBusy;
                 }
 
-                string uniqueName = VsMonitorSelection.GetActiveProject().GetUniqueName();
+                Project project = VsMonitorSelection.GetActiveProject();
+                if (project == null)
+                {
+                    command.Visible = false;
+                    command.Enabled = false;
+                    return;
+                }
+
+                string uniqueName = project.GetUniqueName();
                 NuGetProject nuGetProject = await SolutionManager.Value.GetNuGetProjectAsync(uniqueName);
 
                 command.Visible = GetIsSolutionOpen() && nuGetProject != null && nuGetProject is ProjectJsonNuGetProject;
@@ -1250,6 +1264,11 @@ namespace NuGetVSExtension
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var dteProject = VsMonitorSelection.GetActiveProject();
+
+            if (dteProject == null)
+            {
+                return false;
+            }
 
             var uniqueName = dteProject.GetUniqueName();
             var nuGetProject = await SolutionManager.Value.GetNuGetProjectAsync(uniqueName);


### PR DESCRIPTION
Handle missing Visual Studio project selections before querying or executing migration commands, preventing EnvDTE project extension NREs.

<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3034576

## Description

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
