### PR TITLE
[WIP] Fix SemaphoreFullException: capture shared restore throttle before Wait/Release

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -48,16 +48,25 @@ namespace NuGet.Commands
         private readonly TaskResultCache<LibraryRange, LibraryIdentity> _libraryMatchCache = new();
 
         // Limiting concurrent requests to limit the amount of files open at a time.
+        // Mutable: ResetCache swaps this at the start of an MSBuild restore. Every use site must therefore
+        // capture it into a local and Wait/Release that same instance - re-reading the field between the two
+        // can release a different, already-full semaphore (SemaphoreFullException). See NuGet/Home#15045.
         private static SemaphoreSlim _throttle = GetThrottleSemaphoreSlim(EnvironmentVariableWrapper.Instance);
 
         /// <summary>
-        /// Recreates the shared concurrency throttle from the current environment (<c>NUGET_CONCURRENCY_LIMIT</c>),
-        /// disposing the previous one. The caller must ensure no restore is in flight.
+        /// Recreates the shared concurrency throttle from the current environment (<c>NUGET_CONCURRENCY_LIMIT</c>)
+        /// so a process reused across builds observes the current value.
         /// </summary>
+        /// <remarks>
+        /// The previous semaphore is deliberately NOT disposed. Restore work started before this reset still holds a
+        /// reference to it and must be able to release its permit; releasing a disposed
+        /// <see cref="SemaphoreSlim" /> throws <see cref="ObjectDisposedException" />. The orphaned instance is
+        /// unreferenced once that work drains and is reclaimed by the GC. <see cref="SemaphoreSlim" /> only needs
+        /// disposal when its <see cref="SemaphoreSlim.AvailableWaitHandle" /> was used, which NuGet never does.
+        /// </remarks>
         internal static void ResetCache()
         {
-            SemaphoreSlim previous = Interlocked.Exchange(ref _throttle, GetThrottleSemaphoreSlim(EnvironmentVariableWrapper.Instance));
-            previous?.Dispose();
+            _ = Interlocked.Exchange(ref _throttle, GetThrottleSemaphoreSlim(EnvironmentVariableWrapper.Instance));
         }
 
         internal static SemaphoreSlim GetThrottleSemaphoreSlim(IEnvironmentVariableReader env)
@@ -263,11 +272,14 @@ namespace NuGet.Commands
             {
                 // first check if the exact min version exist then simply return that
                 bool versionExists = false;
+                SemaphoreSlim throttle = _throttle;
+                bool acquired = false;
                 try
                 {
-                    if (_throttle != null)
+                    if (throttle != null)
                     {
-                        await _throttle.WaitAsync(cancellationToken);
+                        await throttle.WaitAsync(cancellationToken);
+                        acquired = true;
                     }
 
                     versionExists = await _findPackagesByIdResource.DoesPackageExistAsync(
@@ -279,7 +291,10 @@ namespace NuGet.Commands
                 }
                 finally
                 {
-                    _throttle?.Release();
+                    if (acquired)
+                    {
+                        throttle.Release();
+                    }
                 }
 
                 if (versionExists)
@@ -396,11 +411,14 @@ namespace NuGet.Commands
             CancellationToken cancellationToken)
         {
             FindPackageByIdDependencyInfo packageInfo = null;
+            SemaphoreSlim throttle = _throttle;
+            bool acquired = false;
             try
             {
-                if (_throttle != null)
+                if (throttle != null)
                 {
-                    await _throttle.WaitAsync(cancellationToken);
+                    await throttle.WaitAsync(cancellationToken);
+                    acquired = true;
                 }
 
                 await EnsureResource(cancellationToken);
@@ -427,7 +445,10 @@ namespace NuGet.Commands
             }
             finally
             {
-                _throttle?.Release();
+                if (acquired)
+                {
+                    throttle.Release();
+                }
             }
 
             LibraryDependencyInfo libraryDependencyInfo = null;
@@ -494,11 +515,14 @@ namespace NuGet.Commands
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            SemaphoreSlim throttle = _throttle;
+            bool acquired = false;
             try
             {
-                if (_throttle != null)
+                if (throttle != null)
                 {
-                    await _throttle.WaitAsync(cancellationToken);
+                    await throttle.WaitAsync(cancellationToken);
+                    acquired = true;
                 }
 
                 await EnsureResource(cancellationToken);
@@ -511,7 +535,9 @@ namespace NuGet.Commands
                     logger,
                     cancellationToken);
 
-                packageDownloader.SetThrottle(_throttle);
+                // The downloader keeps using this throttle after this method returns, so it must be
+                // handed the same instance this method waited on rather than re-reading the field.
+                packageDownloader.SetThrottle(throttle);
                 packageDownloader.SetExceptionHandler(async exception =>
                 {
                     if (exception is FatalProtocolException e)
@@ -546,7 +572,10 @@ namespace NuGet.Commands
             }
             finally
             {
-                _throttle?.Release();
+                if (acquired)
+                {
+                    throttle.Release();
+                }
             }
 
             return null;
@@ -665,11 +694,14 @@ namespace NuGet.Commands
             bool catchAndLogExceptions,
             CancellationToken cancellationToken)
         {
+            SemaphoreSlim throttle = _throttle;
+            bool acquired = false;
             try
             {
-                if (_throttle != null)
+                if (throttle != null)
                 {
-                    await _throttle.WaitAsync(cancellationToken);
+                    await throttle.WaitAsync(cancellationToken);
+                    acquired = true;
                 }
 
                 await EnsureResource(cancellationToken);
@@ -695,7 +727,10 @@ namespace NuGet.Commands
             }
             finally
             {
-                _throttle?.Release();
+                if (acquired)
+                {
+                    throttle.Release();
+                }
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -66,6 +66,9 @@ namespace NuGet.Commands
         /// </remarks>
         internal static void ResetCache()
         {
+            // Interlocked.Exchange rather than a plain assignment: the result is unused now that the previous
+            // instance is not disposed, but this still publishes the new semaphore atomically with a full fence,
+            // so a concurrent reader cannot observe a partially constructed instance.
             _ = Interlocked.Exchange(ref _throttle, GetThrottleSemaphoreSlim(EnvironmentVariableWrapper.Instance));
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalPackageArchiveDownloader.cs
@@ -168,11 +168,17 @@ namespace NuGet.Protocol
                     nameof(destinationFilePath));
             }
 
+            // _throttle is write-once (SetThrottle, before any use), so its identity cannot change here.
+            // The guard is needed because a canceled WaitAsync must not release a permit it never took -
+            // this semaphore is shared process-wide, so over-releasing it throws SemaphoreFullException
+            // for unrelated callers. See NuGet/Home#15045.
+            bool acquired = false;
             try
             {
                 if (_throttle != null)
                 {
                     await _throttle.WaitAsync(cancellationToken);
+                    acquired = true;
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
@@ -206,7 +212,10 @@ namespace NuGet.Protocol
             }
             finally
             {
-                _throttle?.Release();
+                if (acquired)
+                {
+                    _throttle!.Release();
+                }
             }
 
             return false;

--- a/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
@@ -163,11 +163,17 @@ namespace NuGet.Protocol
                 throw new ArgumentException(Strings.ArgumentCannotBeNullOrEmpty, nameof(destinationFilePath));
             }
 
+            // _throttle is write-once (SetThrottle, before any use), so its identity cannot change here.
+            // The guard is needed because a canceled WaitAsync must not release a permit it never took -
+            // this semaphore is shared process-wide, so over-releasing it throws SemaphoreFullException
+            // for unrelated callers. See NuGet/Home#15045.
+            bool acquired = false;
             try
             {
                 if (_throttle != null)
                 {
                     await _throttle.WaitAsync(cancellationToken);
+                    acquired = true;
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
@@ -201,7 +207,10 @@ namespace NuGet.Protocol
             }
             finally
             {
-                _throttle?.Release();
+                if (acquired)
+                {
+                    _throttle!.Release();
+                }
             }
 
             return false;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
@@ -1061,6 +1061,133 @@ namespace NuGet.Commands.Test
             }
         }
 
+        // Regression tests for NuGet/Home#15045.
+        //
+        // These mutate process-wide state (NUGET_CONCURRENCY_LIMIT and the static throttle behind
+        // ResetCache), so they are serialized against each other via the collection below and always
+        // restore the previous environment value.
+        [Collection(nameof(SharedThrottleTests))]
+        public class SharedThrottleTests
+        {
+            /// <summary>
+            /// Sets NUGET_CONCURRENCY_LIMIT and rebuilds the shared throttle from it, restoring both on dispose.
+            /// A limit is required because the throttle is null unless one is configured (or the OS is macOS).
+            /// </summary>
+            private sealed class ThrottleScope : IDisposable
+            {
+                private const string LimitVariable = "NUGET_CONCURRENCY_LIMIT";
+                private readonly string _previous;
+
+                internal ThrottleScope(int limit)
+                {
+                    _previous = Environment.GetEnvironmentVariable(LimitVariable);
+                    Environment.SetEnvironmentVariable(LimitVariable, limit.ToString());
+                    SourceRepositoryDependencyProvider.ResetCache();
+                }
+
+                internal static void Reset() => SourceRepositoryDependencyProvider.ResetCache();
+
+                public void Dispose()
+                {
+                    Environment.SetEnvironmentVariable(LimitVariable, _previous);
+                    SourceRepositoryDependencyProvider.ResetCache();
+                }
+            }
+
+            private static Mock<FindPackageByIdResource> CreateGatedResource(TaskCompletionSource<bool> gate)
+            {
+                var resource = new Mock<FindPackageByIdResource>();
+
+                resource.Setup(x => x.GetAllVersionsAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<SourceCacheContext>(),
+                        It.IsAny<ILogger>(),
+                        It.IsAny<CancellationToken>()))
+                    .Returns(async () =>
+                    {
+                        await gate.Task;
+                        return Enumerable.Empty<NuGetVersion>();
+                    });
+
+                return resource;
+            }
+
+            [Fact]
+            public async Task GetAllVersionsAsync_WhenThrottleIsResetWhileInFlight_DoesNotOverReleaseAsync()
+            {
+                using (new ThrottleScope(limit: 2))
+                using (var test = SourceRepositoryDependencyProviderTest.Create())
+                {
+                    var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var resource = CreateGatedResource(gate);
+
+                    test.SourceRepository.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
+                        .ReturnsAsync(resource.Object);
+
+                    // Take a permit on the current throttle and stay inside the try/finally.
+                    Task<IEnumerable<NuGetVersion>> inFlight = test.Provider.GetAllVersionsAsync(
+                        "a",
+                        test.SourceCacheContext,
+                        test.Logger,
+                        CancellationToken.None);
+
+                    // A restore starting in this (reused) process swaps the throttle out from under the
+                    // in-flight call. Before the fix the finally released this NEW, already-full semaphore
+                    // and threw SemaphoreFullException.
+                    ThrottleScope.Reset();
+
+                    gate.SetResult(true);
+
+                    Func<Task> act = async () => await inFlight;
+
+                    await act.Should().NotThrowAsync();
+                }
+            }
+
+            [Fact]
+            public async Task GetAllVersionsAsync_WhenWaitIsCanceled_DoesNotReleaseUnacquiredPermitAsync()
+            {
+                using (new ThrottleScope(limit: 1))
+                using (var test = SourceRepositoryDependencyProviderTest.Create())
+                {
+                    var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var resource = CreateGatedResource(gate);
+
+                    test.SourceRepository.Setup(s => s.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None))
+                        .ReturnsAsync(resource.Object);
+
+                    // Occupy the single permit.
+                    Task<IEnumerable<NuGetVersion>> holder = test.Provider.GetAllVersionsAsync(
+                        "a",
+                        test.SourceCacheContext,
+                        test.Logger,
+                        CancellationToken.None);
+
+                    // A second caller cannot acquire, and its wait is canceled. Before the fix the finally
+                    // released a permit that was never acquired, inflating the count.
+                    using (var cts = new CancellationTokenSource())
+                    {
+                        cts.Cancel();
+
+                        Func<Task> canceled = async () => await test.Provider.GetAllVersionsAsync(
+                            "b",
+                            test.SourceCacheContext,
+                            test.Logger,
+                            cts.Token);
+
+                        await canceled.Should().ThrowAsync<OperationCanceledException>();
+                    }
+
+                    gate.SetResult(true);
+
+                    // The leaked permit surfaced here: releasing took the count above its maximum.
+                    Func<Task> act = async () => await holder;
+
+                    await act.Should().NotThrowAsync();
+                }
+            }
+        }
+
         private sealed class SourceRepositoryDependencyProviderTest : IDisposable
         {
             internal TestLogger Logger { get; }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SourceRepositoryDependencyProviderTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -1064,9 +1065,10 @@ namespace NuGet.Commands.Test
         // Regression tests for NuGet/Home#15045.
         //
         // These mutate process-wide state (NUGET_CONCURRENCY_LIMIT and the static throttle behind
-        // ResetCache), so they are serialized against each other via the collection below and always
-        // restore the previous environment value.
-        [Collection(nameof(SharedThrottleTests))]
+        // ResetCache), which other tests in this assembly observe through any provider they construct.
+        // NotThreadSafeResourceCollection is declared with DisableParallelization, so this collection does
+        // not run alongside any other collection. The environment variable is also always restored.
+        [Collection(nameof(NotThreadSafeResourceCollection))]
         public class SharedThrottleTests
         {
             /// <summary>
@@ -1081,7 +1083,7 @@ namespace NuGet.Commands.Test
                 internal ThrottleScope(int limit)
                 {
                     _previous = Environment.GetEnvironmentVariable(LimitVariable);
-                    Environment.SetEnvironmentVariable(LimitVariable, limit.ToString());
+                    Environment.SetEnvironmentVariable(LimitVariable, limit.ToString(CultureInfo.InvariantCulture));
                     SourceRepositoryDependencyProvider.ResetCache();
                 }
 
@@ -1163,8 +1165,11 @@ namespace NuGet.Commands.Test
                         test.Logger,
                         CancellationToken.None);
 
-                    // A second caller cannot acquire, and its wait is canceled. Before the fix the finally
-                    // released a permit that was never acquired, inflating the count.
+                    // A second caller cannot acquire the permit and its wait is canceled, so it never takes
+                    // one. Before the fix the finally released a permit that was never acquired, inflating
+                    // the count. A pre-canceled token is used so the test is deterministic; it makes
+                    // WaitAsync fault without registering a waiter, but both cancellation paths converge on
+                    // the same `acquired` guard.
                     using (var cts = new CancellationTokenSource())
                     {
                         cts.Cancel();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalPackageArchiveDownloaderTests.cs
@@ -264,6 +264,27 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
+        public async Task CopyNupkgFileToAsync_WhenThrottleWaitIsCancelled_DoesNotReleaseThrottleAsync()
+        {
+            using (var test = await LocalPackageArchiveDownloaderTest.CreateAsync())
+            using (var throttle = new SemaphoreSlim(initialCount: 0, maxCount: 1))
+            {
+                test.Downloader.SetThrottle(throttle);
+
+                // SemaphoreSlim.WaitAsync surfaces cancellation as TaskCanceledException, so match the
+                // OperationCanceledException hierarchy rather than an exact type.
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                    () => test.Downloader.CopyNupkgFileToAsync(
+                        destinationFilePath: Path.Combine(test.TestDirectory.Path, "a"),
+                        cancellationToken: new CancellationToken(canceled: true)));
+
+                // The permit was never acquired, so releasing it here would hand a permit to an unrelated
+                // caller and eventually throw SemaphoreFullException. The throttle is shared process-wide.
+                Assert.Equal(0, throttle.CurrentCount);
+            }
+        }
+
+        [Fact]
         public async Task GetPackageHashAsync_ThrowsIfDisposedAsync()
         {
             using (var test = await LocalPackageArchiveDownloaderTest.CreateAsync())

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
@@ -379,6 +379,27 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
+        public async Task CopyNupkgFileToAsync_WhenThrottleWaitIsCancelled_DoesNotReleaseThrottleAsync()
+        {
+            using (var test = await RemotePackageArchiveDownloaderTest.CreateAsync())
+            using (var throttle = new SemaphoreSlim(initialCount: 0, maxCount: 1))
+            {
+                test.Downloader.SetThrottle(throttle);
+
+                // SemaphoreSlim.WaitAsync surfaces cancellation as TaskCanceledException, so match the
+                // OperationCanceledException hierarchy rather than an exact type.
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                    () => test.Downloader.CopyNupkgFileToAsync(
+                        destinationFilePath: Path.Combine(test.TestDirectory.Path, "a"),
+                        cancellationToken: new CancellationToken(canceled: true)));
+
+                // The permit was never acquired, so releasing it here would hand a permit to an unrelated
+                // caller and eventually throw SemaphoreFullException. The throttle is shared process-wide.
+                Assert.Equal(0, throttle.CurrentCount);
+            }
+        }
+
+        [Fact]
         public async Task GetPackageHashAsync_ThrowsIfDisposedAsync()
         {
             using (var test = await RemotePackageArchiveDownloaderTest.CreateAsync())


### PR DESCRIPTION
> [!WARNING]
> **🚧 WIP — DRAFT, DO NOT MERGE 🚧**
>
> Opened early for visibility and discussion because this is currently breaking `dotnet/dotnet` official builds.
> The fix and tests are complete and validated locally, but see **Open questions** below — in particular
> whether NuGet would rather take the simpler revert. Please treat the shape as up for debate.

Fixes https://github.com/NuGet/Home/issues/15045

## Problem

`SourceRepositoryDependencyProvider._throttle` is a process-wide, **bounded** `SemaphoreSlim`. Since 6728fd42 ("Make RestoreTask resettable across builds", #7507) it is no longer `readonly` — `ResetCache` swaps it on `StaticState.StartMSBuildRestoreTasks`, i.e. at the start of every MSBuild restore.

Every use site reads the static field **twice**:

```csharp
try
{
    if (_throttle != null)
    {
        await _throttle.WaitAsync(cancellationToken);   // waits on instance A
    }
    ...
}
finally
{
    _throttle?.Release();                              // releases whatever the field holds NOW
}
```

A reset landing between the two reads releases a different, brand-new, already-full semaphore:

```
NuGet.targets(201,5): error : Adding the specified count to the semaphore would cause it to exceed its maximum count.
```

`ResetCache`'s doc comment required that "the caller must ensure no restore is in flight", but the caller is `RefreshNuGetStaticStateTask`, which runs once **per restoring project**, not once per process — so the precondition cannot be met. In the failing `dotnet/dotnet` build both restores, both resets and the exception are all in **one process** (`NodeId=1`), with restore #1 ending 97 ms before the reset that corrupted its still-running work.

Default-latent everywhere except macOS, where `GetThrottleSemaphoreSlim` hardcodes a limit of 16 (or anywhere `NUGET_CONCURRENCY_LIMIT` is set). The semaphore being bounded (`maxCount == initialCount`) is what turns the mismatched release into an exception rather than silent throttle corruption.

## Change

**`SourceRepositoryDependencyProvider`**

1. **Capture `_throttle` into a local** at all four sites — `FindLibraryCoreAsync`, `GetDependenciesCoreAsync`, `GetPackageDownloaderAsync`, `GetAllVersionsInternalAsync` — and `Wait`/`Release` that same instance.
2. **Only release when the wait actually succeeded** (`acquired` flag). If `WaitAsync` throws — `OperationCanceledException`, or `ObjectDisposedException` if the instance was disposed — the old `finally` released a permit that was never taken, re-creating the same over-release. This part is a pre-existing bug independent of #7507.
3. **Stop disposing the previous semaphore in `ResetCache`.** Work started before the reset still holds a reference and must be able to release its permit; `Release` on a disposed `SemaphoreSlim` throws `ObjectDisposedException`. The orphaned instance is collected once that work drains. (`SemaphoreSlim` only needs disposal if `AvailableWaitHandle` was used — a repo-wide grep confirms NuGet never touches it.)
4. `GetPackageDownloaderAsync` passes the captured local to `SetThrottle`, so the downloader keeps using the same instance the method waited on.

**`RemotePackageArchiveDownloader` / `LocalPackageArchiveDownloader`** *(found during self-review)*

5. Both received that same shared throttle via `SetThrottle` and released it **unconditionally** in their `finally`, including when `WaitAsync` was cancelled before acquiring. Because the semaphore is process-wide, the surplus permit surfaces later as `SemaphoreFullException` for an unrelated caller — the same defect, one layer down. Both now use the `acquired` guard.

Resettability from #7507 is preserved — the swap still happens, it just no longer corrupts in-flight work.

## Tests

All four are genuine regression tests: each **fails on `dev` without the corresponding product change** and passes with it.

| test | covers | fails without fix as |
|---|---|---|
| `SharedThrottleTests.GetAllVersionsAsync_WhenThrottleIsResetWhileInFlight_DoesNotOverReleaseAsync` | reset swaps the throttle while a call is inside the `try`/`finally` | `SemaphoreFullException` |
| `SharedThrottleTests.GetAllVersionsAsync_WhenWaitIsCanceled_DoesNotReleaseUnacquiredPermitAsync` | cancelled `WaitAsync` ⇒ `finally` must not release | `SemaphoreFullException` |
| `RemotePackageArchiveDownloaderTests.CopyNupkgFileToAsync_WhenThrottleWaitIsCancelled_DoesNotReleaseThrottleAsync` | downloader cancelled before acquiring | `CurrentCount` 1, expected 0 |
| `LocalPackageArchiveDownloaderTests.CopyNupkgFileToAsync_WhenThrottleWaitIsCancelled_DoesNotReleaseThrottleAsync` | as above, local variant | `CurrentCount` 1, expected 0 |

The first two mutate process-global state (`NUGET_CONCURRENCY_LIMIT` and the static throttle), so they join the existing `NotThreadSafeResourceCollection`, which is declared `DisableParallelization = true` — matching how `RestoreCommandTests` and others in this assembly handle process-global state. `ThrottleScope` restores the previous environment value, so the tests behave the same on macOS/Linux where the throttle is non-null by default.

Local validation (`net10.0` unless noted):
- `NuGet.Commands.Test` **full suite: 1629 passed, 0 failed, 7 skipped** — confirms the global-state tests don't disturb the rest of the assembly.
- `SourceRepositoryDependencyProviderTests`: 38/38, also green on **net472**.
- `RemotePackageArchiveDownloaderTests` + `LocalPackageArchiveDownloaderTests`: 51/51.

## Open questions

- [ ] **Sibling issue.** NuGet/Home#15044 traces a *different* symptom (credential-provider plugin teardown, surfacing as `NullReferenceException` + 401s) to the same commit, and other `StaticState` subscribers — `DefaultCredentialServiceUtility`, `PluginManager`, `PluginLogger`, `HttpSourceResourceProvider` — have the same "reset while in flight" exposure. Not addressed here; worth considering together since the root pattern is shared.
