### PR TITLE
Fix PMC backspace handling for surrogate pairs

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsole.cs
+++ b/src/NuGet.Clients/NuGet.Console/WpfConsole/WpfConsole.cs
@@ -523,9 +523,19 @@ namespace NuGetConsole.Implementation.Console
 
             // Delete last character from input buffer.
             ITextBuffer textBuffer = WpfTextView.TextBuffer;
-            if (textBuffer.CurrentSnapshot.Length > 0)
+            ITextSnapshot snapshot = textBuffer.CurrentSnapshot;
+            int length = snapshot.Length;
+            if (length > 0)
             {
-                textBuffer.Delete(new Span(textBuffer.CurrentSnapshot.Length - 1, 1));
+                int deleteCount = 1;
+                if (length >= 2
+                    && char.IsLowSurrogate(snapshot[length - 1])
+                    && char.IsHighSurrogate(snapshot[length - 2]))
+                {
+                    deleteCount = 2;
+                }
+
+                textBuffer.Delete(new Span(length - deleteCount, deleteCount));
             }
 
             // Ensure caret visible (scroll)

--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetHostUserInterface.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/NuGetHostUserInterface.cs
@@ -396,7 +396,15 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                         {
                             if (builder.Length > 0)
                             {
-                                builder.Remove(builder.Length - 1, 1);
+                                int removeCount = 1;
+                                if (builder.Length >= 2
+                                    && char.IsLowSurrogate(builder[builder.Length - 1])
+                                    && char.IsHighSurrogate(builder[builder.Length - 2]))
+                                {
+                                    removeCount = 2;
+                                }
+
+                                builder.Remove(builder.Length - removeCount, removeCount);
                                 NuGetUIThreadHelper.JoinableTaskFactory.Run(() => Console.WriteBackspaceAsync());
                             }
                         }

--- a/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/DispatcherThreadCollection.cs
+++ b/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/DispatcherThreadCollection.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Test.Utility.Threading;
+using Xunit;
+
+namespace NuGetConsole.Host.PowerShell.Test
+{
+    [CollectionDefinition(CollectionName)]
+    public class DispatcherThreadCollection : ICollectionFixture<DispatcherThreadFixture>
+    {
+        public const string CollectionName = nameof(DispatcherThreadCollection);
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/NuGetHostUserInterfaceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGetConsole.Host.PowerShell.Test/NuGetHostUserInterfaceTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using System.Windows.Media;
+using Moq;
+using NuGet.VisualStudio;
+using NuGetConsole.Host.PowerShell.Implementation;
+using Test.Utility.Threading;
+using Xunit;
+
+namespace NuGetConsole.Host.PowerShell.Test
+{
+    [Collection(DispatcherThreadCollection.CollectionName)]
+    public class NuGetHostUserInterfaceTests
+    {
+        public NuGetHostUserInterfaceTests(DispatcherThreadFixture fixture)
+        {
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(fixture.JoinableTaskFactory);
+        }
+
+        [Theory]
+        [InlineData(0x20000)]
+        [InlineData(0x2A6B2)]
+        [InlineData(0x1F600)]
+        [InlineData(0xE000)]
+        [InlineData(0x100000)]
+        public void ReadLine_BackspaceRemovesCompleteCharacter(int codePoint)
+        {
+            var keys = new Queue<VsKeyInfo>();
+            keys.Enqueue(CreateKey('A'));
+            keys.Enqueue(CreateKey('B'));
+            keys.Enqueue(CreateKey('C'));
+
+            foreach (char character in char.ConvertFromUtf32(codePoint))
+            {
+                keys.Enqueue(CreateKey(character));
+            }
+
+            keys.Enqueue(CreateKey('\b', virtualKey: 8));
+            keys.Enqueue(VsKeyInfo.Enter);
+
+            var dispatcher = new Mock<IConsoleDispatcher>();
+            dispatcher.Setup(x => x.WaitKey()).Returns(() => keys.Dequeue());
+
+            var console = new TestConsole(dispatcher.Object);
+
+            var host = new NuGetPSHost("test")
+            {
+                ActiveConsole = console
+            };
+            var target = new TestNuGetHostUserInterface(host);
+
+            string result = target.ReadLine();
+
+            Assert.Equal(3, result.Length);
+            Assert.Equal("ABC", result);
+            Assert.Equal(1, console.WriteBackspaceCount);
+        }
+
+        private static VsKeyInfo CreateKey(char character, byte virtualKey = 0)
+        {
+            return VsKeyInfo.Create(
+                Key.None,
+                character,
+                virtualKey,
+                keyStates: KeyStates.Down);
+        }
+
+        private sealed class TestConsole : IConsole
+        {
+            public TestConsole(IConsoleDispatcher dispatcher)
+            {
+                Dispatcher = dispatcher;
+                Host = Mock.Of<IHost>();
+            }
+
+            public int WriteBackspaceCount { get; private set; }
+            public IHost Host { get; set; }
+            public bool ShowDisclaimerHeader => false;
+            public IConsoleDispatcher Dispatcher { get; }
+            public int ConsoleWidth => 80;
+
+            public Task ActivateAsync() => Task.CompletedTask;
+            public Task ClearAsync() => Task.CompletedTask;
+            public Task WriteProgressAsync(string currentOperation, int percentComplete) => Task.CompletedTask;
+            public Task WriteAsync(string text) => Task.CompletedTask;
+            public Task WriteLineAsync(string text) => Task.CompletedTask;
+            public Task WriteLineAsync(string format, params object[] args) => Task.CompletedTask;
+            public Task WriteAsync(string text, Color? foreground, Color? background) => Task.CompletedTask;
+
+            public Task WriteBackspaceAsync()
+            {
+                WriteBackspaceCount++;
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class TestNuGetHostUserInterface : NuGetHostUserInterface
+        {
+            public TestNuGetHostUserInterface(NuGetPSHost host)
+                : base(host)
+            {
+            }
+
+            public override void Write(string value)
+            {
+            }
+
+            public override void WriteLine(string value)
+            {
+            }
+        }
+    }
+}

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
@@ -102,6 +102,26 @@ namespace NuGet.Console.TestContract
             NuGetUIThreadHelper.JoinableTaskFactory.Run(() => _wpfConsole.ClearAsync());
         }
 
+        public void Write(string text)
+        {
+            if (!EnsureInitilizeConsole())
+            {
+                return;
+            }
+
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(() => _wpfConsole.WriteAsync(text));
+        }
+
+        public void WriteBackspace()
+        {
+            if (!EnsureInitilizeConsole())
+            {
+                return;
+            }
+
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(() => _wpfConsole.WriteBackspaceAsync());
+        }
+
         public void RunCommand(string command, TimeSpan timeout)
         {
             WaitForActionComplete(() => RunCommandWithoutWait(command), timeout);

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetConsoleTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetConsoleTestExtension.cs
@@ -70,6 +70,16 @@ namespace NuGet.Tests.Apex
             _pmConsole.Clear();
         }
 
+        public void Write(string text)
+        {
+            _pmConsole.Write(text);
+        }
+
+        public void WriteBackspace()
+        {
+            _pmConsole.WriteBackspace();
+        }
+
         public string GetText()
         {
             return _pmConsole.GetText();

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetEndToEndTests/NuGetConsoleTestCase.cs
@@ -1268,6 +1268,25 @@ namespace NuGet.Tests.Apex
             pmcText.Should().NotContain("FullyQualifiedErrorId", because: pmcText);
         }
 
+        [DataTestMethod]
+        [DataRow(0x20000)]
+        [DataRow(0xE000)]
+        [Timeout(DefaultTimeout)]
+        public void Console_BackspaceRemovesCompleteCharacter(int codePoint)
+        {
+            using var testContext = new ApexTestContext(VisualStudio, ProjectTemplate.NetCoreConsoleApp, Logger);
+
+            var nugetConsole = GetConsole(testContext.Project);
+            string character = char.ConvertFromUtf32(codePoint);
+
+            nugetConsole.Clear();
+            nugetConsole.Write("ABC" + character);
+            nugetConsole.WriteBackspace();
+
+            string pmcText = nugetConsole.GetText();
+            pmcText.Should().Be("ABC", because: pmcText);
+        }
+
         public static IEnumerable<object[]> GetNetCoreTemplates()
         {
             yield return new object[] { ProjectTemplate.NetCoreConsoleApp };


### PR DESCRIPTION
# Bug

Fixes: https://github.com/NuGet/Home/issues/15025

## Description

Package Manager Console processed Backspace one UTF-16 code unit at a time. For supplementary-plane characters represented by surrogate pairs, this could leave an unpaired high surrogate in the visible console buffer and returned PowerShell input.

This change:
- Removes both UTF-16 code units when the trailing input is a valid surrogate pair in `WpfConsole` and `NuGetHostUserInterface.ReadLine()`.
- Preserves the existing single-code-unit behavior for BMP characters and malformed surrogate input.
- Adds direct unit coverage for the GB18030 certification sample code points and Apex coverage for the WPF console buffer with supplementary and BMP characters.

Validation:
- `NuGetConsole.Host.PowerShell.Test`: 38 passed.
- `NuGet.Tests.Apex` project build: succeeded.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.

Not applicable: this fix does not change settings, environment variables, or documented feature behavior.