### PR TITLE
Stop instantiating PackageSourceMappingService on NuGetPackage initialization

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/Commands/PackageSourceMapperCommand.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Commands/PackageSourceMapperCommand.cs
@@ -25,12 +25,12 @@ namespace NuGet.Tools.Commands
         public static readonly Guid CommandSet = GuidList.guidReviewPackageSourceMappingCmdSet;
 
         private readonly OleMenuCommandService _oleMenuCommandService;
-        private readonly IPackageSourceMappingService _packageSourceMappingService;
+        private readonly Lazy<IPackageSourceMappingService> _packageSourceMappingService;
         private readonly Lazy<IVsSolutionManager> _solutionManager;
 
         public PackageSourceMapperCommand(
             OleMenuCommandService oleMenuCommandService,
-            IPackageSourceMappingService packageSourceMappingService,
+            Lazy<IPackageSourceMappingService> packageSourceMappingService,
             Lazy<IVsSolutionManager> solutionManager)
         {
             _oleMenuCommandService = oleMenuCommandService ?? throw new ArgumentNullException(nameof(oleMenuCommandService));
@@ -58,7 +58,7 @@ namespace NuGet.Tools.Commands
         private void ExecutePackageSourceMapperCommand(object sender, EventArgs e)
         {
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(() =>
-                _packageSourceMappingService.LaunchReviewPackageSourceMappingAsync(CancellationToken.None))
+                _packageSourceMappingService.Value.LaunchReviewPackageSourceMappingAsync(CancellationToken.None))
                 .PostOnFailure(nameof(NuGetPackage), nameof(ExecutePackageSourceMapperCommand));
         }
     }

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -229,7 +229,7 @@ namespace NuGetVSExtension
             ClearNuGetLocalResourcesCommand clearNuGetLocalResourcesCommand = new(oleMenuCommandService: _mcs, OutputConsoleLogger);
             clearNuGetLocalResourcesCommand.Initialize();
 
-            PackageSourceMapperCommand packageSourceMapperCommand = new(_mcs, PackageSourceMappingService.Value, SolutionManager);
+            PackageSourceMapperCommand packageSourceMapperCommand = new(_mcs, PackageSourceMappingService, SolutionManager);
             packageSourceMapperCommand.Initialize();
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: bug introduced in https://github.com/NuGet/NuGet.Client/pull/7613

## Description

The Lazy service shouldn't be instantiated when NuGet's AsyncPackage is initialized in Visual Studio.

This is also an attempt to fix an RPS regression indicating we're causing the loading of GitHub Copilot to be earlier than before.

Validated that "Review with GitHub Copilot" button on Package Source Mappings VS Settings page still works as expected.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ RPS will either stop failing or continue catching the issue.
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
