### PR TITLE
Introduce 'Fix with GitHub Copilot' vulnerabilities InfoBar to PM UI with reusable InfoBar service

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/InstalledVulnerablePackagesWarningConverter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Converters/InstalledVulnerablePackagesWarningConverter.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace NuGet.PackageManagement.UI
+{
+    /// <summary>
+    /// Converts an installed vulnerable package count into the warning tooltip text, using the correct
+    /// singular/plural form via <see cref="UIUtility.GetInstalledVulnerablePackagesWarningText(int)"/>.
+    /// </summary>
+    public class InstalledVulnerablePackagesWarningConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var count = (int)value;
+            return UIUtility.GetInstalledVulnerablePackagesWarningText(count);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            // no op
+            Debug.Fail("Not Implemented");
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerInfoBarService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerInfoBarService.cs
@@ -1,0 +1,215 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace NuGet.PackageManagement.UI
+{
+    /// <summary>
+    /// Manages VS InfoBars displayed at the top of a window frame that exposes an <see cref="IVsInfoBarHost"/>.
+    /// This is a generic, keyed host/registry: each notification scenario owns a key and supplies the
+    /// <see cref="InfoBarModel"/> plus per-key callbacks for action clicks and user close. All scenario
+    /// policy (when to show/hide, message text, suppression) lives in the calling scenario, not here.
+    /// </summary>
+    internal sealed class PackageManagerInfoBarService : IVsInfoBarUIEvents, IDisposable
+    {
+        private readonly IVsInfoBarHost _infoBarHost;
+        private readonly IVsInfoBarUIFactory _infoBarFactory;
+        private readonly Dictionary<string, InfoBarEntry> _activeInfoBars = new();
+        private bool _disposed;
+
+        private PackageManagerInfoBarService(IVsInfoBarHost infoBarHost, IVsInfoBarUIFactory infoBarFactory)
+        {
+            _infoBarHost = infoBarHost;
+            _infoBarFactory = infoBarFactory;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="PackageManagerInfoBarService"/> for the given window frame, or returns null if the frame doesn't support InfoBars.
+        /// </summary>
+        public static PackageManagerInfoBarService? TryCreate(IVsWindowFrame windowFrame, IVsInfoBarUIFactory infoBarFactory)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (windowFrame == null || infoBarFactory == null)
+            {
+                return null;
+            }
+
+            int hr = windowFrame.GetProperty((int)__VSFPROPID7.VSFPROPID_InfoBarHost, out object hostObj);
+            if (ErrorHandler.Failed(hr) || hostObj is not IVsInfoBarHost infoBarHost)
+            {
+                return null;
+            }
+
+            return new PackageManagerInfoBarService(infoBarHost, infoBarFactory);
+        }
+
+        /// <summary>
+        /// Shows an InfoBar with the given key. If an InfoBar with that key is already visible, this is a no-op
+        /// (use <see cref="UpdateInfoBar"/> to change its content).
+        /// </summary>
+        /// <param name="key">Stable identifier for the scenario owning this InfoBar.</param>
+        /// <param name="model">The InfoBar content to display.</param>
+        /// <param name="onActionClicked">Invoked when the user clicks an action item (hyperlink/button) in this InfoBar.</param>
+        /// <param name="onClosed">Invoked when the user dismisses this InfoBar with the close ('x') button. Not raised for programmatic hide/update.</param>
+        public void ShowInfoBar(string key, InfoBarModel model, Action<IVsInfoBarActionItem>? onActionClicked = null, Action? onClosed = null)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (_disposed || _activeInfoBars.ContainsKey(key))
+            {
+                return;
+            }
+
+            CreateAndAdd(key, model, onActionClicked, onClosed);
+        }
+
+        /// <summary>
+        /// Replaces the content of an existing InfoBar in place, preserving its callbacks. If the key isn't
+        /// currently visible, this is a no-op (callers should <see cref="ShowInfoBar"/> first).
+        /// </summary>
+        public void UpdateInfoBar(string key, InfoBarModel model)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (_disposed || !_activeInfoBars.TryGetValue(key, out InfoBarEntry existing))
+            {
+                return;
+            }
+
+            // Programmatic close: unadvise first so VS doesn't raise OnClosed (which would fire the user-close callback).
+            existing.UIElement.Unadvise(existing.Cookie);
+            existing.UIElement.Close();
+            _activeInfoBars.Remove(key);
+
+            CreateAndAdd(key, model, existing.OnActionClicked, existing.OnClosed);
+        }
+
+        /// <summary>
+        /// Hides and removes the InfoBar with the given key. Does not raise the scenario's onClosed callback,
+        /// since this is a programmatic hide rather than a user dismissal.
+        /// </summary>
+        public void HideInfoBar(string key)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (_activeInfoBars.TryGetValue(key, out InfoBarEntry entry))
+            {
+                entry.UIElement.Unadvise(entry.Cookie);
+                entry.UIElement.Close();
+                _activeInfoBars.Remove(key);
+            }
+        }
+
+        /// <summary>
+        /// Returns whether an InfoBar with the given key is currently displayed.
+        /// </summary>
+        public bool IsInfoBarVisible(string key) => _activeInfoBars.ContainsKey(key);
+
+        private void CreateAndAdd(string key, InfoBarModel model, Action<IVsInfoBarActionItem>? onActionClicked, Action? onClosed)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            IVsInfoBarUIElement uiElement = _infoBarFactory.CreateInfoBar(model);
+            if (uiElement == null)
+            {
+                return;
+            }
+
+            uiElement.Advise(this, out uint cookie);
+            _infoBarHost.AddInfoBar(uiElement);
+
+            _activeInfoBars[key] = new InfoBarEntry(uiElement, cookie, onActionClicked, onClosed);
+        }
+
+        private bool TryFindKey(IVsInfoBarUIElement uiElement, out string key)
+        {
+            foreach (KeyValuePair<string, InfoBarEntry> kvp in _activeInfoBars)
+            {
+                if (kvp.Value.UIElement == uiElement)
+                {
+                    key = kvp.Key;
+                    return true;
+                }
+            }
+
+            key = string.Empty;
+            return false;
+        }
+
+        void IVsInfoBarUIEvents.OnClosed(IVsInfoBarUIElement infoBarUIElement)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (!TryFindKey(infoBarUIElement, out string key))
+            {
+                return;
+            }
+
+            InfoBarEntry entry = _activeInfoBars[key];
+            entry.UIElement.Unadvise(entry.Cookie);
+            _activeInfoBars.Remove(key);
+
+            // User dismissed the InfoBar; let the scenario react (e.g. suppress for the session).
+            entry.OnClosed?.Invoke();
+        }
+
+        void IVsInfoBarUIEvents.OnActionItemClicked(IVsInfoBarUIElement infoBarUIElement, IVsInfoBarActionItem actionItem)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (TryFindKey(infoBarUIElement, out string key))
+            {
+                _activeInfoBars[key].OnActionClicked?.Invoke(actionItem);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            // InfoBar cleanup requires the UI thread. If called off-thread (rare), skip cleanup —
+            // the window frame closing will release the InfoBars.
+            if (!ThreadHelper.CheckAccess())
+            {
+                return;
+            }
+
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread — guarded by CheckAccess() above
+            foreach (InfoBarEntry entry in _activeInfoBars.Values)
+            {
+                entry.UIElement.Unadvise(entry.Cookie);
+                entry.UIElement.Close();
+            }
+#pragma warning restore VSTHRD010
+
+            _activeInfoBars.Clear();
+        }
+
+        private sealed class InfoBarEntry
+        {
+            public InfoBarEntry(IVsInfoBarUIElement uiElement, uint cookie, Action<IVsInfoBarActionItem>? onActionClicked, Action? onClosed)
+            {
+                UIElement = uiElement;
+                Cookie = cookie;
+                OnActionClicked = onActionClicked;
+                OnClosed = onClosed;
+            }
+
+            public IVsInfoBarUIElement UIElement { get; }
+            public uint Cookie { get; }
+            public Action<IVsInfoBarActionItem>? OnActionClicked { get; }
+            public Action? OnClosed { get; }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerVulnerabilitiesInfoBar.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageManagerVulnerabilitiesInfoBar.cs
@@ -1,0 +1,101 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.VisualStudio;
+using NuGet.VisualStudio.Telemetry;
+
+namespace NuGet.PackageManagement.UI
+{
+    /// <summary>
+    /// Show/hide policy for the Package Manager UI "packages have vulnerabilities" InfoBar.
+    /// Owns the scenario state (session suppression) and the InfoBar content; the actual hosting
+    /// is delegated to <see cref="PackageManagerInfoBarService"/>.
+    /// </summary>
+    internal sealed class PackageManagerVulnerabilitiesInfoBar
+    {
+        internal const string InfoBarKey = "vulnerabilities";
+
+        private readonly PackageManagerInfoBarService _infoBarService;
+        private readonly Func<FixVulnerabilitiesSource, CancellationToken, Task> _launchFixVulnerabilitiesAsync;
+
+        // The user dismissed the InfoBar with the close ('x') button; don't show it again for this window's session.
+        private bool _userClosed;
+
+        // The vulnerable count currently reflected in the visible InfoBar, so we only rebuild it when it changes.
+        private int _lastShownCount;
+
+        public PackageManagerVulnerabilitiesInfoBar(PackageManagerInfoBarService infoBarService, Func<FixVulnerabilitiesSource, CancellationToken, Task> launchFixVulnerabilitiesAsync)
+        {
+            _infoBarService = infoBarService ?? throw new ArgumentNullException(nameof(infoBarService));
+            _launchFixVulnerabilitiesAsync = launchFixVulnerabilitiesAsync ?? throw new ArgumentNullException(nameof(launchFixVulnerabilitiesAsync));
+        }
+
+        /// <summary>
+        /// Shows the InfoBar when there are vulnerable packages installed, and hides it when there are none.
+        /// Reflects the current count and updates in place when it changes. Idempotent: safe to call on every refresh.
+        /// </summary>
+        public async Task UpdateAsync(int vulnerablePackagesCount)
+        {
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            if (_userClosed)
+            {
+                return;
+            }
+
+            if (vulnerablePackagesCount <= 0)
+            {
+                _infoBarService.HideInfoBar(InfoBarKey);
+                _lastShownCount = 0;
+                return;
+            }
+
+            if (_infoBarService.IsInfoBarVisible(InfoBarKey))
+            {
+                if (vulnerablePackagesCount != _lastShownCount)
+                {
+                    _infoBarService.UpdateInfoBar(InfoBarKey, GetInfoBarModel(vulnerablePackagesCount));
+                }
+            }
+            else
+            {
+                _infoBarService.ShowInfoBar(InfoBarKey, GetInfoBarModel(vulnerablePackagesCount), OnActionClicked, OnClosed);
+            }
+
+            _lastShownCount = vulnerablePackagesCount;
+        }
+
+        internal static InfoBarModel GetInfoBarModel(int vulnerablePackagesCount)
+        {
+            IVsInfoBarTextSpan[] textSpans =
+            [
+                new InfoBarTextSpan(UIUtility.GetInstalledVulnerablePackagesWarningText(vulnerablePackagesCount) + " "),
+                new InfoBarHyperlink(Resources.InfoBar_FixVulnerabilitiesWithCopilot),
+            ];
+
+            return new InfoBarModel(
+                textSpans,
+                KnownMonikers.StatusWarning,
+                isCloseButtonVisible: true);
+        }
+
+        private void OnActionClicked(IVsInfoBarActionItem actionItem)
+        {
+            // Only action item is the "Fix with GitHub Copilot" hyperlink.
+            NuGetUIThreadHelper.JoinableTaskFactory
+                .RunAsync(() => _launchFixVulnerabilitiesAsync(FixVulnerabilitiesSource.PackageManagerInfoBar, CancellationToken.None))
+                .PostOnFailure(nameof(PackageManagerVulnerabilitiesInfoBar));
+        }
+
+        private void OnClosed()
+        {
+            _userClosed = true;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -259,15 +259,6 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Consider migrating this project&apos;s NuGet package management format from &apos;packages.config&apos; to &apos;PackageReference&apos;..
-        /// </summary>
-        public static string AskForPRMigrator {
-            get {
-                return ResourceManager.GetString("AskForPRMigrator", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Some NuGet packages are missing from this solution. Click to restore from your online package sources..
         /// </summary>
         public static string AskForRestoreMessage {
@@ -889,6 +880,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix with GitHub Copilot.
+        /// </summary>
+        public static string InfoBar_FixVulnerabilitiesWithCopilot {
+            get {
+                return ResourceManager.GetString("InfoBar_FixVulnerabilitiesWithCopilot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Action:.
         /// </summary>
         public static string Label_Action {
@@ -1083,6 +1083,15 @@ namespace NuGet.PackageManagement.UI {
         public static string Label_Installed_VulnerableWarning {
             get {
                 return ResourceManager.GetString("Label_Installed_VulnerableWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You have 1 vulnerable package version installed..
+        /// </summary>
+        public static string Label_Installed_VulnerableWarning_Single {
+            get {
+                return ResourceManager.GetString("Label_Installed_VulnerableWarning_Single", resourceCulture);
             }
         }
         
@@ -1402,15 +1411,6 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Don&apos;t show again.
-        /// </summary>
-        public static string Link_DoNotShowAgain {
-            get {
-                return ResourceManager.GetString("Link_DoNotShowAgain", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Learn about Install Options.
         /// </summary>
         public static string Link_LearnAboutInstallOptions {
@@ -1425,24 +1425,6 @@ namespace NuGet.PackageManagement.UI {
         public static string Link_LearnAboutUninstallOptions {
             get {
                 return ResourceManager.GetString("Link_LearnAboutUninstallOptions", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Why should I migrate?.
-        /// </summary>
-        public static string Link_MigratorHelp {
-            get {
-                return ResourceManager.GetString("Link_MigratorHelp", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Migrate Now.
-        /// </summary>
-        public static string Link_UpgradeOption {
-            get {
-                return ResourceManager.GetString("Link_UpgradeOption", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -820,7 +820,14 @@ Error: {1}</value>
   </data>
   <data name="Label_Installed_VulnerableWarning" xml:space="preserve">
     <value>You have {0} vulnerable package versions installed.</value>
-    <comment>{0} is the number of installed package versions</comment>
+    <comment>{0} is the number of installed package versions (always more than 1)</comment>
+  </data>
+  <data name="Label_Installed_VulnerableWarning_Single" xml:space="preserve">
+    <value>You have 1 vulnerable package version installed.</value>
+  </data>
+  <data name="InfoBar_FixVulnerabilitiesWithCopilot" xml:space="preserve">
+    <value>Fix with GitHub Copilot</value>
+    <comment>Do not translate GitHub or Copilot</comment>
   </data>
   <data name="Deprecation_MoreInfo" xml:space="preserve">
     <value>More info</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/UIUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Utility/UIUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.VisualStudio.Shell;
 using ContractsItemFilter = NuGet.VisualStudio.Internal.Contracts.ItemFilter;
 
@@ -10,6 +11,21 @@ namespace NuGet.PackageManagement.UI
 {
     public static class UIUtility
     {
+        /// <summary>
+        /// Builds the "You have N vulnerable package versions installed." warning text with the correct
+        /// singular/plural form. Shared by the Installed tab warning tooltip and the vulnerabilities InfoBar
+        /// so both stay consistent.
+        /// </summary>
+        internal static string GetInstalledVulnerablePackagesWarningText(int vulnerablePackagesCount)
+        {
+            if (vulnerablePackagesCount == 1)
+            {
+                return Resources.Label_Installed_VulnerableWarning_Single;
+            }
+
+            return string.Format(CultureInfo.CurrentCulture, Resources.Label_Installed_VulnerableWarning, vulnerablePackagesCount);
+        }
+
         public static void LaunchExternalLink(Uri url)
         {
             if (url == null

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -77,6 +77,8 @@ namespace NuGet.PackageManagement.UI
         private IPackageVulnerabilityService _packageVulnerabilityService;
         private INuGetPackageFileService _nugetPackageFileService;
         private bool _isReadmeTabEnabled;
+        private PackageManagerInfoBarService _infoBarService;
+        private PackageManagerVulnerabilitiesInfoBar _vulnerabilitiesInfoBar;
 
         private SearchControl SearchControl
         {
@@ -850,6 +852,29 @@ namespace NuGet.PackageManagement.UI
             _missingPackageStatus = e.PackagesMissing;
         }
 
+        /// <summary>
+        /// Initializes the InfoBar service for this PM UI instance using the hosting window frame.
+        /// Must be called on the UI thread after the window frame is created.
+        /// </summary>
+        public async Task SetWindowFrameAsync(IVsWindowFrame windowFrame)
+        {
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var infoBarFactory = await AsyncServiceProvider.GlobalProvider.GetServiceAsync<SVsInfoBarUIFactory, IVsInfoBarUIFactory>(throwOnFailure: false);
+            _infoBarService = PackageManagerInfoBarService.TryCreate(windowFrame, infoBarFactory);
+
+            if (_infoBarService != null)
+            {
+                var fixVulnerabilitiesService = await ServiceLocator.GetComponentModelServiceAsync<IFixVulnerabilitiesService>();
+                if (fixVulnerabilitiesService != null)
+                {
+                    _vulnerabilitiesInfoBar = new PackageManagerVulnerabilitiesInfoBar(
+                        _infoBarService,
+                        fixVulnerabilitiesService.LaunchFixVulnerabilitiesAsync);
+                }
+            }
+        }
+
         private async Task SetTitleAsync(IProjectMetadataContextInfo projectMetadata = null)
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -1074,6 +1099,12 @@ namespace NuGet.PackageManagement.UI
             // Update installed tab warning icon
             (int vulnerablePackages, int deprecatedPackages) = await GetInstalledVulnerableAndDeprecatedPackagesCountAsync(loadContext, SelectedSource.PackageSources, _packageVulnerabilityService, refreshCts.Token);
             _topPanel.UpdateWarningStatusOnInstalledTab(vulnerablePackages, deprecatedPackages);
+
+            // Show/hide the vulnerabilities InfoBar based on the installed vulnerable package count.
+            if (_vulnerabilitiesInfoBar != null)
+            {
+                await _vulnerabilitiesInfoBar.UpdateAsync(vulnerablePackages);
+            }
 
             // Update updates tab count
             Model.CachedUpdates = new PackageSearchMetadataCache
@@ -1935,6 +1966,7 @@ namespace NuGet.PackageManagement.UI
 
             if (disposing)
             {
+                _infoBarService?.Dispose();
                 _nugetPackageFileService.Dispose();
                 CleanUp();
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml.cs
@@ -141,10 +141,7 @@ namespace NuGet.PackageManagement.UI
             }
             else if (hasInstalledVulnerablePackages)
             {
-                warningTooltip = string.Format(
-                    CultureInfo.CurrentCulture,
-                    Resx.Label_Installed_VulnerableWarning,
-                    installedVulnerablePackagesCount);
+                warningTooltip = UIUtility.GetInstalledVulnerablePackagesWarningText(installedVulnerablePackagesCount);
             }
             else if (hasInstalledDeprecatedPackages)
             {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/SolutionView.xaml
@@ -25,6 +25,8 @@
         x:Key="IntToVulnerabilitySeverityConverter" />
       <local:StringFormatConverter
         x:Key="StringFormatConverter" />
+      <local:InstalledVulnerablePackagesWarningConverter
+        x:Key="InstalledVulnerablePackagesWarningConverter" />
       <!-- style of the list view headers -->
       <Style x:Uid="Style_1" x:Key="GridViewColumnHeaderGripper" TargetType="{x:Type Thumb}">
         <Setter x:Uid="Setter_1" Property="Canvas.Right" Value="-8.5" />
@@ -311,14 +313,7 @@
                     Visibility="{Binding InstalledVulnerabilitiesCount, Converter={StaticResource GreaterThanThresholdToVisibilityConverter}, ConverterParameter=0}"
                     Moniker="{x:Static catalog:KnownMonikers.StatusWarning}">
                     <imaging:CrispImage.ToolTip>
-                      <TextBlock>
-                        <TextBlock.Text>
-                          <MultiBinding Converter="{StaticResource StringFormatConverter}">
-                            <Binding Source="{x:Static local:Resources.Label_Installed_VulnerableWarning}" />
-                            <Binding Path="InstalledVulnerabilitiesCount" />
-                          </MultiBinding>
-                        </TextBlock.Text>
-                      </TextBlock>
+                      <TextBlock Text="{Binding InstalledVulnerabilitiesCount, Converter={StaticResource InstalledVulnerablePackagesWarningConverter}}" />
                     </imaging:CrispImage.ToolTip>
                   </imaging:CrispImage>
                 </StackPanel>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.cs.xlf
@@ -457,6 +457,11 @@
         <target state="translated">Ikona nápovědy</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">Akce:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">Máte nainstalovaný tento počet zranitelných verzí balíčků: {0}</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">Máte nainstalovaný tento počet zranitelných verzí balíčků: {0}</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.de.xlf
@@ -457,6 +457,11 @@
         <target state="translated">Hilfesymbol</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">Aktion:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">Sie haben {0} anfällige Paketversionen installiert.</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">Sie haben {0} anfällige Paketversionen installiert.</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.es.xlf
@@ -457,6 +457,11 @@
         <target state="translated">Icono de ayuda</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">Acción:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">Tiene instaladas {0} versiones de paquetes vulnerables.</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">Tiene instaladas {0} versiones de paquetes vulnerables.</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.fr.xlf
@@ -457,6 +457,11 @@
         <target state="translated">Icône d'aide</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">Action :</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">Vous avez {0} versions de package(s) vulnérable(s) installé(s).</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">Vous avez {0} versions de package(s) vulnérable(s) installé(s).</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.it.xlf
@@ -457,6 +457,11 @@
         <target state="translated">Icona Guida</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">Azione:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">Sono state installate {0} versioni vulnerabili dei pacchetti.</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">Sono state installate {0} versioni vulnerabili dei pacchetti.</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ja.xlf
@@ -457,6 +457,11 @@
         <target state="translated">ヘルプ アイコン</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">アクション:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">脆弱性のあるパッケージが {0} 個インストールされています。</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">脆弱性のあるパッケージが {0} 個インストールされています。</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ko.xlf
@@ -457,6 +457,11 @@
         <target state="translated">도움말 아이콘</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">작업:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">취약한 패키지 버전 {0}개가 설치되어 있습니다.</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">취약한 패키지 버전 {0}개가 설치되어 있습니다.</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pl.xlf
@@ -457,6 +457,11 @@
         <target state="translated">Ikona pomocy</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">Akcja:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">Masz zainstalowane narażone na ataki wersje pakietów: {0}.</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">Masz zainstalowane narażone na ataki wersje pakietów: {0}.</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pt-BR.xlf
@@ -457,6 +457,11 @@
         <target state="translated">Ícone Ajuda</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">Ação:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">Você tem {0} versões de pacote vulneráveis instaladas.</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">Você tem {0} versões de pacote vulneráveis instaladas.</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ru.xlf
@@ -457,6 +457,11 @@
         <target state="translated">Значок справки</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">Действие:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">Установлены уязвимые версии пакетов ({0}).</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">Установлены уязвимые версии пакетов ({0}).</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.tr.xlf
@@ -457,6 +457,11 @@
         <target state="translated">Yardım simgesi</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">Eylem:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">Güvenlik açığı bulunan {0} yüklü paket sürümünüz var.</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">Güvenlik açığı bulunan {0} yüklü paket sürümünüz var.</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hans.xlf
@@ -457,6 +457,11 @@
         <target state="translated">“帮助”图标</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">操作:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">已安装 {0} 个易受攻击的包版本。</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">已安装 {0} 个易受攻击的包版本。</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hant.xlf
@@ -457,6 +457,11 @@
         <target state="translated">說明圖示</target>
         <note />
       </trans-unit>
+      <trans-unit id="InfoBar_FixVulnerabilitiesWithCopilot">
+        <source>Fix with GitHub Copilot</source>
+        <target state="new">Fix with GitHub Copilot</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Label_Action">
         <source>Action:</source>
         <target state="translated">動作:</target>
@@ -579,8 +584,13 @@
       </trans-unit>
       <trans-unit id="Label_Installed_VulnerableWarning">
         <source>You have {0} vulnerable package versions installed.</source>
-        <target state="translated">您安裝了 {0} 個有弱點的套件。</target>
-        <note>{0} is the number of installed package versions</note>
+        <target state="needs-review-translation">您安裝了 {0} 個有弱點的套件。</target>
+        <note>{0} is the number of installed package versions (always more than 1)</note>
+      </trans-unit>
+      <trans-unit id="Label_Installed_VulnerableWarning_Single">
+        <source>You have 1 vulnerable package version installed.</source>
+        <target state="new">You have 1 vulnerable package version installed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Label_License">
         <source>License:</source>

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -613,6 +613,7 @@ namespace NuGetVSExtension
                 {
                     WindowFrameHelper.AddF1HelpKeyword(windowFrame, keywordValue: F1KeywordValuePmUI);
                     WindowFrameHelper.DisableWindowAutoReopen(windowFrame);
+                    await control.SetWindowFrameAsync(windowFrame);
                 }
             }
             finally
@@ -1007,6 +1008,7 @@ namespace NuGetVSExtension
                 {
                     WindowFrameHelper.AddF1HelpKeyword(windowFrame, keywordValue: F1KeywordValuePmUI);
                     WindowFrameHelper.DisableWindowAutoReopen(windowFrame);
+                    await control.SetWindowFrameAsync(windowFrame);
                 }
             }
             finally

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/FixVulnerabilitiesSource.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/FixVulnerabilitiesSource.cs
@@ -25,6 +25,11 @@ namespace NuGet.VisualStudio
             NavigationOrigin.ErrorList_FixVulnerabilitiesWithCopilot,
             CopilotClientIdPrefix + "ErrorList");
 
+        /// <summary>The Package Manager UI vulnerabilities info bar.</summary>
+        public static readonly FixVulnerabilitiesSource PackageManagerInfoBar = new(
+            NavigationOrigin.PMUI_FixVulnerabilitiesWithCopilot,
+            CopilotClientIdPrefix + "PackageManagerInfoBar");
+
         private FixVulnerabilitiesSource(NavigationOrigin navigationOrigin, string copilotClientId)
         {
             NavigationOrigin = navigationOrigin;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NavigationOrigin.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/NavigationOrigin.cs
@@ -16,5 +16,6 @@ namespace NuGet.PackageManagement.Telemetry
         VulnerabilityInfoBar_ManagePackages,
         VulnerabilityInfoBar_FixVulnerabilitiesWithCopilot,
         ErrorList_FixVulnerabilitiesWithCopilot,
+        PMUI_FixVulnerabilitiesWithCopilot,
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

Fixes: https://github.com/NuGet/Home/issues/15080
Fixes: https://github.com/NuGet/Client.Engineering/issues/3798

## Description

Adds a Fluent VS InfoBar to the Package Manager UI that warns when the current
project/solution has installed vulnerable package versions, with a
"Fix with GitHub Copilot" action.

<img width="1198" height="716" alt="image" src="https://github.com/user-attachments/assets/24fc5431-89ad-4ec8-b01f-6bd8ce4f26c6" />

- Created a reusable InfoBar service that utilizes VS InfoBar UI without new UI code. This sets us up to replace our custom XAML with the standard VS INfoBars in other areas of PM UI.
  - Keyed InfoBar host (`ShowInfoBar` / `UpdateInfoBar` / `HideInfoBar` with per-key
  action/close callbacks). The vulnerabilities bar is the first consumer; the
  service is designed to also back the LoadingStatus, PackageRestore, and
  RestartRequest bars in future work.
- **Vulnerabilities InfoBar**:  `PackageManagerVulnerabilitiesInfoBar` shows when
  the installed vulnerable-package count is > 0, updates the count live, hides at
  0, and stays dismissed for the session if the user closes it. 
  - **Reuses the Installed-tab tooltip verbiage**: the InfoBar message is built
  from the same text as the Installed-tab warning tooltip via the shared
  `UIUtility.GetInstalledVulnerablePackagesWarningText(count)` helper, so both
  stay consistent.

  - The telemetry event reuses existing patterns, with `FixVulnerabilitiesSource.PackageManagerInfoBar` /
  `NavigationOrigin.PMUI_FixVulnerabilitiesWithCopilot`.

<img width="1198" height="716" alt="image" src="https://github.com/user-attachments/assets/a565e8d2-a9d6-4026-8a06-9e587e2817f7" />


- **Pluralization fix ("1 versions" → "1 version")**: 
  - This corrects the pre-existing tooltip bug and applies everywhere the text is shown (project
  and solution Installed-tab tooltips + the InfoBar).
<img width="467" height="100" alt="image" src="https://github.com/user-attachments/assets/edee34f0-71e6-4be8-b5fa-782fda7db508" />


### Validation

- Installed a vulnerable package version, confirmed the InfoBar appears in both
  **Solution** and **Project** PM UI.
- Edited `Directory.Packages.props` to a non-vulnerable version externally; after
  the PM UI refresh, the InfoBar **auto-closes** (count recomputes to 0 →
  `HideInfoBar`), matching the Installed-tab warning icon clearing.
- Verified via debugger that the close happens through the normal refresh path
  with no exceptions thrown.
- Confirmed the singular/plural text renders correctly for counts of 1 vs. many.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
