### PR TITLE
Fix PackageSourceProvider.UpdatePackageSource when enabling sources

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -733,7 +733,7 @@ namespace NuGet.Configuration
                 {
                     // get list of disabled packages
                     var disabledSourcesSection = Settings.GetSection(ConfigurationConstants.DisabledPackageSources);
-                    disabledSourceItem = disabledSourcesSection?.GetFirstItemWithAttribute<AddItem>(ConfigurationConstants.KeyAttribute, sourceToUpdate.ElementName);
+                    disabledSourceItem = disabledSourcesSection?.GetFirstItemWithAttribute<AddItem>(ConfigurationConstants.KeyAttribute, sourceToUpdate.Key);
                 }
 
                 if (updateCredentials)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1772,6 +1772,71 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void UpdatePackageSource_WithUpdateEnabled_EnablesDisabledSource()
+        {
+            using var directory = TestDirectory.Create();
+
+            // Arrange
+            var configContents = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                    <packageSources>
+                        <add key="source" value="https://source.test" />
+                    </packageSources>
+                    <disabledPackageSources>
+                        <add key="source" value="true" />
+                    </disabledPackageSources>
+                </configuration>
+                """;
+
+            File.WriteAllText(Path.Combine(directory.Path, "NuGet.Config"), configContents);
+
+            var settings = new Settings(directory);
+            var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+            var source = packageSourceProvider.GetPackageSourceByName("source")!;
+
+            // Act
+            source.IsEnabled = true;
+            packageSourceProvider.UpdatePackageSource(source, updateCredentials: false, updateEnabled: true);
+
+            // Assert
+            settings = new Settings(directory);
+            source = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance).GetPackageSourceByName("source")!;
+            source.IsEnabled.Should().BeTrue();
+        }
+
+        [Fact]
+        public void UpdatePackageSource_WithUpdateEnabled_DisablesEnabledSource()
+        {
+            using var directory = TestDirectory.Create();
+
+            // Arrange
+            var configContents = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                    <packageSources>
+                        <add key="source" value="https://source.test" />
+                    </packageSources>
+                </configuration>
+                """;
+
+            File.WriteAllText(Path.Combine(directory.Path, "NuGet.Config"), configContents);
+
+            var settings = new Settings(directory);
+            var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+            var source = packageSourceProvider.GetPackageSourceByName("source")!;
+
+            // Act
+            source.IsEnabled = false;
+            packageSourceProvider.UpdatePackageSource(source, updateCredentials: false, updateEnabled: true);
+
+            // Assert
+            settings = new Settings(directory);
+            source = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance).GetPackageSourceByName("source")!;
+            source.IsEnabled.Should().BeFalse();
+        }
+
+        [Fact]
         public void UpdatePackageSource_ShouldUpdateAllowInsecureConnections()
         {
             using var directory = TestDirectory.Create();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/12008

## Description

The code was passing the wrong parameter, so enabling the disabled source didn't work.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/a
