### PR TITLE
Handle missing active Visual Studio project

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -694,11 +694,14 @@ namespace NuGetVSExtension
             }
 
             Project project = VsMonitorSelection.GetActiveProject();
+            NuGetProject nuGetProject = null;
+            if (project != null)
+            {
+                string uniqueName = await project.GetCustomUniqueNameAsync();
+                nuGetProject = await SolutionManager.Value.GetNuGetProjectAsync(uniqueName);
+            }
 
-            string uniqueName = await project.GetCustomUniqueNameAsync();
-            NuGetProject nuGetProject = await SolutionManager.Value.GetNuGetProjectAsync(uniqueName);
-
-            if (nuGetProject is not ProjectJsonNuGetProject)
+            if (project == null || nuGetProject is not ProjectJsonNuGetProject)
             {
                 MessageHelper.ShowWarningMessage(Resources.ProjectJsonMigrateErrorMessage, Resources.ErrorDialogBoxTitle);
                 return;
@@ -1211,8 +1214,10 @@ namespace NuGetVSExtension
                     isConsoleBusy = ConsoleStatus.Value.IsBusy;
                 }
 
-                string uniqueName = VsMonitorSelection.GetActiveProject().GetUniqueName();
-                NuGetProject nuGetProject = await SolutionManager.Value.GetNuGetProjectAsync(uniqueName);
+                Project project = VsMonitorSelection.GetActiveProject();
+                NuGetProject nuGetProject = project == null
+                    ? null
+                    : await SolutionManager.Value.GetNuGetProjectAsync(project.GetUniqueName());
 
                 command.Visible = GetIsSolutionOpen() && nuGetProject != null && nuGetProject is ProjectJsonNuGetProject;
 
@@ -1250,6 +1255,11 @@ namespace NuGetVSExtension
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var dteProject = VsMonitorSelection.GetActiveProject();
+
+            if (dteProject == null)
+            {
+                return false;
+            }
 
             var uniqueName = dteProject.GetUniqueName();
             var nuGetProject = await SolutionManager.Value.GetNuGetProjectAsync(uniqueName);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsMonitorSelectionExtensions.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/VsMonitorSelectionExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio;
@@ -15,18 +13,23 @@ namespace NuGet.VisualStudio
 {
     public static class VsMonitorSelectionExtensions
     {
-        public static EnvDTE.Project GetActiveProject(this IVsMonitorSelection vsMonitorSelection)
+        public static EnvDTE.Project? GetActiveProject(this IVsMonitorSelection vsMonitorSelection)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
+            if (vsMonitorSelection == null)
+            {
+                throw new ArgumentNullException(nameof(vsMonitorSelection));
+            }
+
             IntPtr ppHier = IntPtr.Zero;
             uint pitemid;
-            IVsMultiItemSelect ppMIS;
+            IVsMultiItemSelect? ppMIS;
             IntPtr ppSC = IntPtr.Zero;
 
             try
             {
-                IVsHierarchy hierarchy = null;
+                IVsHierarchy? hierarchy = null;
 
                 vsMonitorSelection.GetCurrentSelection(out ppHier, out pitemid, out ppMIS, out ppSC);
                 if (ppHier == IntPtr.Zero)
@@ -37,7 +40,7 @@ namespace NuGet.VisualStudio
                 // multiple items are selected.
                 if (pitemid == (uint)VSConstants.VSITEMID.Selection)
                 {
-                    VSITEMSELECTION[] vsItemSelections = ppMIS.GetSelectedItemsInSingleHierachy();
+                    VSITEMSELECTION[]? vsItemSelections = ppMIS?.GetSelectedItemsInSingleHierachy();
                     if (vsItemSelections != null && vsItemSelections.Length > 0)
                     {
                         VSITEMSELECTION sel = vsItemSelections[0];
@@ -51,7 +54,7 @@ namespace NuGet.VisualStudio
 
                 if (hierarchy != null)
                 {
-                    object project;
+                    object? project;
                     if (hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ExtObject, out project) >= 0)
                     {
                         return project as EnvDTE.Project;

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/IDE/VsMonitorSelectionExtensionsTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Common.Test/IDE/VsMonitorSelectionExtensionsTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Moq;
+using Xunit;
+
+namespace NuGet.VisualStudio.Common.Test.IDE
+{
+    [Collection(MockedVS.Collection)]
+    public class VsMonitorSelectionExtensionsTests
+    {
+        public VsMonitorSelectionExtensionsTests(GlobalServiceProvider globalServiceProvider)
+        {
+            globalServiceProvider.Reset();
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GetActiveProject_WhenSelectionHasNoHierarchy_ReturnsNull()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var monitorSelection = Mock.Of<IVsMonitorSelection>();
+
+            Assert.Null(monitorSelection.GetActiveProject());
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/15059

## Description

Annotates active project lookup as nullable and handles a missing project in NuGet migration command status and execution paths. This prevents null reference exceptions when Visual Studio has no active DTE project.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
