### PR TITLE
Add Native AOT compatibility coverage for core libraries

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -65,6 +65,7 @@
       <package pattern="Microsoft.DotNet.PlatformAbstractions" />
       <package pattern="Microsoft.VisualStudio.SDK.EmbedInteropTypes" />
       <package pattern="Microsoft.DataAI.NuGetRecommender.Contracts" />
+      <package pattern="Microsoft.DotNet.ILCompiler" />
       <package pattern="Microsoft.TeamFoundationServer.ExtendedClient" />
       <package pattern="Microsoft.VisualStudio.TaskRunnerExplorer.14.0" />
       <package pattern="Microsoft.VisualStudio.Web.BrowserLink.12.0" />

--- a/NuGet.sln
+++ b/NuGet.sln
@@ -344,6 +344,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualStudio.Test.Utility",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Benchmarks", "test\TestExtensions\NuGet.Benchmarks\NuGet.Benchmarks.csproj", "{83DBAC1F-F248-474A-B5C3-DB13B6256567}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.AotCompatibility.TestApp", "test\NuGet.AotCompatibility.TestApp\NuGet.AotCompatibility.TestApp.csproj", "{DC68EEBB-6285-4F56-9506-34B26E6668BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1471,6 +1473,18 @@ Global
 		{83DBAC1F-F248-474A-B5C3-DB13B6256567}.Release|x64.Build.0 = Release|Any CPU
 		{83DBAC1F-F248-474A-B5C3-DB13B6256567}.Release|x86.ActiveCfg = Release|Any CPU
 		{83DBAC1F-F248-474A-B5C3-DB13B6256567}.Release|x86.Build.0 = Release|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Debug|x64.Build.0 = Debug|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Debug|x86.Build.0 = Debug|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Release|x64.ActiveCfg = Release|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Release|x64.Build.0 = Release|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Release|x86.ActiveCfg = Release|Any CPU
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1587,6 +1601,7 @@ Global
 		{E41384AA-ED2D-4251-A571-F5C924CE2913} = {79266117-FEDD-45B3-B603-33A4B6E9F12F}
 		{905A8AD5-46C7-A612-22CC-B2962D4CB40E} = {79266117-FEDD-45B3-B603-33A4B6E9F12F}
 		{83DBAC1F-F248-474A-B5C3-DB13B6256567} = {23CEFC88-9365-4464-A517-700224ECA033}
+		{DC68EEBB-6285-4F56-9506-34B26E6668BD} = {D1549653-9631-4E16-9967-55427174A0DC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3747A66A-00D1-41B8-A9C5-ED0D7BEA9D25}

--- a/build/common.targets
+++ b/build/common.targets
@@ -271,7 +271,9 @@
     EnsureNewtonsoftJsonVersion ensures that the resolved version of Newtonsoft.Json is the version that ships with VS/.NET Core SDK
     ============================================================
   -->
-  <Target Name="EnsureNewtonsoftJsonVersion" AfterTargets="ResolveAssemblyReferences">
+  <Target Name="EnsureNewtonsoftJsonVersion"
+          AfterTargets="ResolveAssemblyReferences"
+          Condition="'$(SkipEnsureNewtonsoftJsonVersion)' != 'true'">
     <Error
       Text="Newtonsoft.Json must be version $(NewtonsoftJsonPackageVersion) but resolved %(Reference.NuGetPackageVersion)"
       Condition=" %(Reference.NuGetPackageId) == 'Newtonsoft.Json' AND %(Reference.NuGetPackageVersion) != '$(NewtonsoftJsonPackageVersion)' " />

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -337,6 +337,10 @@ stages:
             filePath: configure.ps1
         - script: SET | SORT
           displayName: Log Environment Variables
+        - script: dotnet publish test\NuGet.AotCompatibility.TestApp\NuGet.AotCompatibility.TestApp.csproj --configuration Release --output artifacts\AotCompatibility
+          displayName: Publish AOT compatibility test app
+        - script: artifacts\AotCompatibility\NuGet.AotCompatibility.TestApp.exe
+          displayName: Run AOT compatibility test app
         - script: dotnet format whitespace --verify-no-changes NuGet.sln
           displayName: Run dotnet format whitespace
           condition: succeededOrFailed()

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -337,10 +337,6 @@ stages:
             filePath: configure.ps1
         - script: SET | SORT
           displayName: Log Environment Variables
-        - script: dotnet publish test\NuGet.AotCompatibility.TestApp\NuGet.AotCompatibility.TestApp.csproj --configuration Release --output artifacts\AotCompatibility
-          displayName: Publish AOT compatibility test app
-        - script: artifacts\AotCompatibility\NuGet.AotCompatibility.TestApp.exe
-          displayName: Run AOT compatibility test app
         - script: dotnet format whitespace --verify-no-changes NuGet.sln
           displayName: Run dotnet format whitespace
           condition: succeededOrFailed()
@@ -367,6 +363,13 @@ stages:
                 Write-Host "##vso[task.LogIssue type=error;]$Error[0]"
                 exit 1
               }
+
+        - script: dotnet publish test\NuGet.AotCompatibility.TestApp\NuGet.AotCompatibility.TestApp.csproj --configuration Release --output artifacts\AotCompatibility
+          displayName: Publish AOT compatibility test app
+          condition: succeededOrFailed()
+        - script: artifacts\AotCompatibility\NuGet.AotCompatibility.TestApp.exe
+          displayName: Run AOT compatibility test app
+          condition: succeededOrFailed()
 
         - task: MSBuild@1
           displayName: Restore and Build

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileFormat.cs
@@ -5,6 +5,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -161,6 +164,10 @@ namespace NuGet.ProjectModel
             }
         }
 
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "WriteTo without converters is safe. See https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.4/Src/Newtonsoft.Json/Linq/JToken.cs")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "WriteTo without converters is safe. See https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.4/Src/Newtonsoft.Json/Linq/JToken.cs")]
+#endif
         public static void Write(TextWriter textWriter, PackagesLockFile lockFile)
         {
             using (var jsonWriter = new JsonTextWriter(textWriter))
@@ -168,9 +175,7 @@ namespace NuGet.ProjectModel
                 jsonWriter.Formatting = Formatting.Indented;
 
                 var json = WriteLockFile(lockFile);
-#pragma warning disable IL2026, IL3050 // WriteTo without converters is safe. See https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.4/Src/Newtonsoft.Json/Linq/JToken.cs
                 json.WriteTo(jsonWriter, Array.Empty<JsonConverter>());
-#pragma warning restore IL2026, IL3050
             }
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetOperationClaimsRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetOperationClaimsRequest.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -55,10 +58,12 @@ namespace NuGet.Protocol.Plugins
         /// <param name="packageSourceRepository">The package source location.</param>
         /// <param name="serviceIndex">The service index (index.json).</param>
         [Obsolete("Use GetOperationClaimsRequest(string, string) instead.")]
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "ToString without converters is safe. See https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.4/Src/Newtonsoft.Json/Linq/JToken.cs")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "ToString without converters is safe. See https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.4/Src/Newtonsoft.Json/Linq/JToken.cs")]
+#endif
         public GetOperationClaimsRequest(string? packageSourceRepository, JObject? serviceIndex)
-#pragma warning disable IL2026, IL3050 // WriteTo without converters is safe. See https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.4/Src/Newtonsoft.Json/Linq/JToken.cs
             : this(packageSourceRepository, serviceIndex?.ToString(Formatting.None, Array.Empty<JsonConverter>()))
-#pragma warning restore IL2026, IL3050
         {
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetServiceIndexResponse.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/Messages/GetServiceIndexResponse.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -75,10 +78,12 @@ namespace NuGet.Protocol.Plugins
         /// <param name="responseCode">The response code.</param>
         /// <param name="serviceIndex">The service index (index.json) for the package source repository.</param>
         [Obsolete("Use GetServiceIndexResponse(MessageResponseCode, string) instead.")]
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "ToString without converters is safe. See https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.4/Src/Newtonsoft.Json/Linq/JToken.cs")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "ToString without converters is safe. See https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.4/Src/Newtonsoft.Json/Linq/JToken.cs")]
+#endif
         public GetServiceIndexResponse(MessageResponseCode responseCode, JObject? serviceIndex)
-#pragma warning disable IL2026, IL3050 // WriteTo without converters is safe. See https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.4/Src/Newtonsoft.Json/Linq/JToken.cs
             : this(responseCode, serviceIndex?.ToString(Formatting.None, Array.Empty<JsonConverter>()))
-#pragma warning restore IL2026, IL3050
         {
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/NsjRawJsonStringConverter.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/NsjRawJsonStringConverter.cs
@@ -2,12 +2,19 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace NuGet.Protocol.Plugins
 {
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based serialization.")]
+    [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based serialization.")]
+#endif
     internal sealed class NsjRawJsonStringConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType) => objectType == typeof(string);
@@ -26,18 +33,14 @@ namespace NuGet.Protocol.Plugins
             }
 
             var obj = JObject.Load(reader);
-#pragma warning disable IL2026, IL3050 // WriteTo without converters is safe. See https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.4/Src/Newtonsoft.Json/Linq/JToken.cs
             return obj.ToString(Formatting.None, Array.Empty<JsonConverter>());
-#pragma warning restore IL2026, IL3050
         }
 
         public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             if (value is string s)
             {
-#pragma warning disable IL2026, IL3050 // WriteTo without converters is safe. See https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.4/Src/Newtonsoft.Json/Linq/JToken.cs
                 JObject.Parse(s).WriteTo(writer, Array.Empty<JsonConverter>());
-#pragma warning restore IL2026, IL3050
             }
             else
             {

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Concurrent;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using System.IO;
 using System.Text.Json;
@@ -204,7 +207,9 @@ namespace NuGet.Protocol
             }
             else
             {
+#pragma warning disable IL2026, IL3050 // The source analyzer cannot see the app's trim-time feature switch; Native AOT removes this branch when the switch is true.
                 return await ConsumeServiceIndexStreamNsjAsync(stream, utcNow, source, token);
+#pragma warning restore IL2026, IL3050
             }
         }
 
@@ -243,6 +248,10 @@ namespace NuGet.Protocol
             return new ServiceIndexResourceV3(index, utcNow, source);
         }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         private static async Task<ServiceIndexResourceV3> ConsumeServiceIndexStreamNsjAsync(Stream stream, DateTime utcNow, PackageSource source, CancellationToken token)
         {
             // Parse the JSON
@@ -258,9 +267,7 @@ namespace NuGet.Protocol
                 if (SemanticVersion.TryParse((string)versionToken!, out version) &&
                     version.Major == 3)
                 {
-#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
                     return new ServiceIndexResourceV3(json, utcNow, source);
-#pragma warning restore IL2026, IL3050
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageSearchResourceV3.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -249,7 +252,9 @@ namespace NuGet.Protocol
             }
             else
             {
+#pragma warning disable IL2026, IL3050 // The source analyzer cannot see the app's trim-time feature switch; Native AOT removes this branch when the switch is true.
                 return await ProcessHttpStreamWithNsjAsync(httpInitialResponse, take, token);
+#pragma warning restore IL2026, IL3050
             }
         }
 
@@ -270,12 +275,14 @@ namespace NuGet.Protocol
             return results;
         }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+        [RequiresDynamicCode("Uses Newtonsoft.Json reflection-based deserialization.")]
+#endif
         private static async Task<V3SearchResults?> ProcessHttpStreamWithNsjAsync(HttpResponseMessage httpInitialResponse, uint take, CancellationToken token)
         {
-#pragma warning disable IL2026, IL3050 // Legacy Newtonsoft.Json code path is unreachable when feature switch is true; ILC trims this branch in AOT
             var _newtonsoftConvertersSerializer = JsonSerializer.Create(JsonExtensions.ObjectSerializationSettings);
             _newtonsoftConvertersSerializer.Converters.Add(new Converters.V3SearchResultsConverter(take));
-#pragma warning restore IL2026, IL3050
 
 #if NETCOREAPP2_0_OR_GREATER
             using (var stream = await httpInitialResponse.Content.ReadAsStreamAsync(token))

--- a/test/NuGet.AotCompatibility.TestApp/NuGet.AotCompatibility.TestApp.csproj
+++ b/test/NuGet.AotCompatibility.TestApp/NuGet.AotCompatibility.TestApp.csproj
@@ -16,9 +16,15 @@
           BeforeTargets="PrepareForILLink">
     <!-- Single warn the following assemblies (produces IL2104 and IL3053), which have known warnings, so the warnings can be suppressed. -->
     <ItemGroup>
-      <IlcArg Include="--singlewarnassembly:Newtonsoft.Json" />
-      <IlcArg Include="--singlewarnassembly:Microsoft.CSharp" />
-      <IlcArg Include="--singlewarnassembly:System.Linq.Expressions" />
+      <ManagedAssemblyToLink Condition="'%(Filename)' == 'Microsoft.CSharp'">
+        <TrimmerSingleWarn>true</TrimmerSingleWarn>
+      </ManagedAssemblyToLink>
+      <ManagedAssemblyToLink Condition="'%(Filename)' == 'Newtonsoft.Json'">
+        <TrimmerSingleWarn>true</TrimmerSingleWarn>
+      </ManagedAssemblyToLink>
+      <ManagedAssemblyToLink Condition="'%(Filename)' == 'System.Linq.Expressions'">
+        <TrimmerSingleWarn>true</TrimmerSingleWarn>
+      </ManagedAssemblyToLink>
     </ItemGroup>
   </Target>
 

--- a/test/NuGet.AotCompatibility.TestApp/NuGet.AotCompatibility.TestApp.csproj
+++ b/test/NuGet.AotCompatibility.TestApp/NuGet.AotCompatibility.TestApp.csproj
@@ -1,0 +1,49 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(LatestNETCoreTargetFramework)</TargetFramework>
+    <TargetFrameworks />
+    <!-- Newtonsoft.Json 13.0.4 includes the AOT annotations this compatibility test needs. -->
+    <SkipEnsureNewtonsoftJsonVersion>true</SkipEnsureNewtonsoftJsonVersion>
+    <PublishAot>true</PublishAot>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <!-- Ignore the single warn files marked below to suppress their known warnings. -->
+    <NoWarn>$(NoWarn);IL2104;IL3053</NoWarn>
+  </PropertyGroup>
+
+  <Target Name="ConfigureTrimming"
+          BeforeTargets="PrepareForILLink">
+    <!-- Single warn the following assemblies (produces IL2104 and IL3053), which have known warnings, so the warnings can be suppressed. -->
+    <ItemGroup>
+      <IlcArg Include="--singlewarnassembly:Newtonsoft.Json" />
+      <IlcArg Include="--singlewarnassembly:Microsoft.CSharp" />
+      <IlcArg Include="--singlewarnassembly:System.Linq.Expressions" />
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <!-- Newtonsoft.Json 13.0.4 includes the AOT annotations this compatibility test needs. -->
+    <PackageReference Include="Newtonsoft.Json" VersionOverride="13.0.4" />
+
+    <RuntimeHostConfigurationOption Include="NuGet.UseSystemTextJsonDeserialization"
+                                    Value="true"
+                                    Trim="true" />
+
+    <CoreLibraryProjects Include="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj" />
+    <CoreLibraryProjects Include="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Common\NuGet.Common.csproj" />
+    <CoreLibraryProjects Include="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Configuration\NuGet.Configuration.csproj" />
+    <CoreLibraryProjects Include="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Credentials\NuGet.Credentials.csproj" />
+    <CoreLibraryProjects Include="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Frameworks\NuGet.Frameworks.csproj" />
+    <CoreLibraryProjects Include="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.LibraryModel\NuGet.LibraryModel.csproj" />
+    <CoreLibraryProjects Include="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Packaging\NuGet.Packaging.csproj" />
+    <CoreLibraryProjects Include="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.ProjectModel\NuGet.ProjectModel.csproj" />
+    <CoreLibraryProjects Include="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Protocol\NuGet.Protocol.csproj" />
+    <CoreLibraryProjects Include="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Resolver\NuGet.Resolver.csproj" />
+    <CoreLibraryProjects Include="$(RepositoryRootDirectory)src\NuGet.Core\NuGet.Versioning\NuGet.Versioning.csproj" />
+
+    <TrimmerRootAssembly Include="@(CoreLibraryProjects->'%(FileName)')" />
+    <ProjectReference Include="@(CoreLibraryProjects)" />
+  </ItemGroup>
+
+</Project>

--- a/test/NuGet.AotCompatibility.TestApp/Program.cs
+++ b/test/NuGet.AotCompatibility.TestApp/Program.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+if (!AppContext.TryGetSwitch("NuGet.UseSystemTextJsonDeserialization", out bool isEnabled) || !isEnabled)
+{
+    return 1;
+}
+
+Console.WriteLine("Passed.");
+return 0;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:

## Description

Add a Native AOT compatibility test app that roots a subset of NuGet's core libraries, publishes them with AOT analysis enabled, and runs the resulting executable in PR validation. This establishes a warning-free baseline that prevents AOT regressions while additional libraries are made compatible and added incrementally over time.

The test enables the existing System.Text.Json feature switch and uses the AOT annotations available in Newtonsoft.Json 13.0.4. Known warnings originating within Newtonsoft.Json and its dynamic runtime dependencies are reduced to assembly-level warnings and suppressed so diagnostics in NuGet-owned code remain actionable.

Replace source-only `IL2026` and `IL3050` pragmas with durable annotations where appropriate. Calls known to be safe use `UnconditionalSuppressMessage`; legacy Newtonsoft.Json paths use `RequiresUnreferencedCode` and `RequiresDynamicCode`, with narrowly scoped suppressions at feature-gated call sites that Native AOT removes.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
