### PR TITLE
Migrate release/7.0.x to VS stable build pool

### DIFF
--- a/eng/pipelines/backup_build_artifacts.yml
+++ b/eng/pipelines/backup_build_artifacts.yml
@@ -12,7 +12,7 @@ jobs:
     displayName: "Backup Build Artifacts"
     timeoutInMinutes: 10
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
 
     steps:
       - checkout: none

--- a/eng/pipelines/compliance.yml
+++ b/eng/pipelines/compliance.yml
@@ -14,7 +14,7 @@ jobs:
     displayName: "Static Analysis"
     timeoutInMinutes: 180
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
 
     steps:
       - task: CredScan@2

--- a/eng/pipelines/dailytests.yml
+++ b/eng/pipelines/dailytests.yml
@@ -46,7 +46,7 @@ stages:
   - job: Build
     timeoutInMinutes: 170
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
     steps:
     - template: vs-test/build.yml
 

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -33,7 +33,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -62,7 +62,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Unit
         testTargetFramework: net472
 
@@ -79,7 +79,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Unit
         testTargetFramework: net9.0
 
@@ -96,7 +96,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net472
         testProjectName: Msbuild.Integration.Test
@@ -114,7 +114,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.CommandLine.FuncTest
@@ -133,7 +133,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.CommandLine.Test
@@ -153,7 +153,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.Packaging.FuncTest
@@ -171,7 +171,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net9.0
         testProjectName: Dotnet.Integration.Test
@@ -190,7 +190,7 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSStable
         testType: Functional
         testTargetFramework: net9.0
         testProjectName: NuGet.Packaging.FuncTest

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -30,7 +30,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -76,7 +76,7 @@ stages:
       RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
     templateContext:
       mb:
         localization:
@@ -181,7 +181,7 @@ stages:
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       BuildRTM: "true"
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
     templateContext:
       mb:
         localization:

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -71,7 +71,7 @@ stages:
   - job: Build
     timeoutInMinutes: 170
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
     steps:
     - template: vs-test/build.yml
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:

## Description

Migrates all `release/7.0.x` pipeline references from the deprecated `VSEngSS-MicroBuild2022-1ES` pool to the recommended `VSEng-MicroBuildVSStable` pool.

This updates direct pool objects, `agentPool` template parameters, and SDL `sourceAnalysisPool` settings without adding legacy image overrides or changing existing YAML structure.

## PR Checklist

- [x] Meaningful title and helpful description; this is an engineering-only change, so no NuGet/Home issue is required
- [x] Tests are not applicable for a pipeline pool configuration-only change
- [x] Documentation updates are not applicable