### PR TITLE
Update release-6.14.x Windows build pools

### DIFF
--- a/eng/pipelines/backup_build_artifacts.yml
+++ b/eng/pipelines/backup_build_artifacts.yml
@@ -12,7 +12,8 @@ jobs:
     displayName: "Backup Build Artifacts"
     timeoutInMinutes: 10
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      image: server2025-microbuildVS2022-1es
 
     steps:
       - checkout: none

--- a/eng/pipelines/backup_build_artifacts.yml
+++ b/eng/pipelines/backup_build_artifacts.yml
@@ -13,7 +13,7 @@ jobs:
     timeoutInMinutes: 10
     pool:
       name: VSEng-MicroBuildVSLegacy
-      image: server2025-microbuildVS2022-1es
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
 
     steps:
       - checkout: none

--- a/eng/pipelines/compliance.yml
+++ b/eng/pipelines/compliance.yml
@@ -14,7 +14,8 @@ jobs:
     displayName: "Static Analysis"
     timeoutInMinutes: 180
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      image: server2025-microbuildVS2022-1es
 
     steps:
       - task: CredScan@2

--- a/eng/pipelines/compliance.yml
+++ b/eng/pipelines/compliance.yml
@@ -15,7 +15,7 @@ jobs:
     timeoutInMinutes: 180
     pool:
       name: VSEng-MicroBuildVSLegacy
-      image: server2025-microbuildVS2022-1es
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
 
     steps:
       - task: CredScan@2

--- a/eng/pipelines/dailytests.yml
+++ b/eng/pipelines/dailytests.yml
@@ -55,7 +55,8 @@ stages:
   - job: Build
     timeoutInMinutes: 170
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      image: server2025-microbuildVS2022-1es
     steps:
     - template: vs-test/build.yml
       parameters:

--- a/eng/pipelines/dailytests.yml
+++ b/eng/pipelines/dailytests.yml
@@ -56,7 +56,7 @@ stages:
     timeoutInMinutes: 170
     pool:
       name: VSEng-MicroBuildVSLegacy
-      image: server2025-microbuildVS2022-1es
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
     steps:
     - template: vs-test/build.yml
       parameters:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -31,7 +31,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean,GitHub
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3,GitHub,AzureStorage
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -33,7 +33,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -31,7 +31,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive,CFSClean,GitHub
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -62,7 +62,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Unit
         testTargetFramework: net472
 
@@ -79,7 +80,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Unit
         testTargetFramework: net9.0
 
@@ -96,7 +98,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: Msbuild.Integration.Test
@@ -114,7 +117,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.CommandLine.FuncTest
@@ -133,7 +137,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.CommandLine.Test
@@ -153,7 +158,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.Packaging.FuncTest
@@ -171,7 +177,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Functional
         testTargetFramework: net9.0
         testProjectName: Dotnet.Integration.Test
@@ -190,7 +197,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Functional
         testTargetFramework: net9.0
         testProjectName: NuGet.Packaging.FuncTest

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -35,7 +35,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive,CFSClean,GitHub
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -35,7 +35,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean,GitHub
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3,GitHub,AzureStorage
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -37,7 +37,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -66,7 +66,7 @@ stages:
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
     pool:
       name: VSEng-MicroBuildVSLegacy
-      image: server2025-microbuildVS2022-1es
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:
@@ -194,7 +194,7 @@ stages:
       BuildRTM: "true"
     pool:
       name: VSEng-MicroBuildVSLegacy
-      image: server2025-microbuildVS2022-1es
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -65,7 +65,8 @@ stages:
       RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      image: server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:
@@ -192,7 +193,8 @@ stages:
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       BuildRTM: "true"
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      image: server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -217,10 +217,13 @@ steps:
 - task: MicroBuildBuildVSBootstrapper@3
   displayName: 'Build a Visual Studio bootstrapper for tests'
   inputs:
+    azureSubscription: "VSEng-VSDrop-MI"
     channelName: "$(VsTargetChannelForTests)"
     vsMajorVersion: "$(VsTargetMajorVersion)"
     manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
     outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
 - task: PowerShell@1
   displayName: "Set DartLab variables for tests"

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -80,7 +80,8 @@ stages:
   - job: Build
     timeoutInMinutes: 170
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      image: server2025-microbuildVS2022-1es
     steps:
     - template: vs-test/build.yml
       parameters:

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -81,7 +81,7 @@ stages:
     timeoutInMinutes: 170
     pool:
       name: VSEng-MicroBuildVSLegacy
-      image: server2025-microbuildVS2022-1es
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
     steps:
     - template: vs-test/build.yml
       parameters:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:

## Description

Updates the release-6.14.x Windows build and test pipelines ahead of the October 26, 2026 legacy pool deprecation.

- Moves Windows jobs to `VSEng-MicroBuildVSLegacy` with the `server2025-microbuildVS2022-1es` image/demand.
- Moves name-only SDL source analysis pools to `VSEng-MicroBuildVSStable`.
- Removes all references to the deprecated VSEngSS MicroBuild pools.

## PR Checklist

- [x] Meaningful title and helpful description; no NuGet/Home issue is required for this engineering-only change
- [x] Tests are not applicable to YAML-only pool configuration changes
- [x] Documentation is not required for an internal pipeline pool migration