### PR TITLE
[release-6.11.x] Update legacy MicroBuild pools

### DIFF
--- a/eng/pipelines/backup_build_artifacts.yml
+++ b/eng/pipelines/backup_build_artifacts.yml
@@ -12,7 +12,8 @@ jobs:
     displayName: "Backup Build Artifacts"
     timeoutInMinutes: 10
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
 
     steps:
       - checkout: none

--- a/eng/pipelines/compliance.yml
+++ b/eng/pipelines/compliance.yml
@@ -14,7 +14,8 @@ jobs:
     displayName: "Static Analysis"
     timeoutInMinutes: 180
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
 
     steps:
       - task: CredScan@2

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -36,7 +36,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive,CFSClean,GitHub
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -38,7 +38,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -60,7 +60,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Unit
         testTargetFramework: net472
 
@@ -77,7 +78,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Unit
         testTargetFramework: net8.0
 
@@ -94,7 +96,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Unit
         testTargetFramework: netcoreapp3.1
 
@@ -111,7 +114,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Functional
         testTargetFramework: net472
         timeoutInMinutes: 60
@@ -129,7 +133,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Functional
         testTargetFramework: net8.0
         timeoutInMinutes: 60
@@ -147,7 +152,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2022-1ES
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Functional
         testTargetFramework: netcoreapp3.1
         timeoutInMinutes: 60

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -45,7 +45,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive,CFSClean,GitHub
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -47,7 +47,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -90,7 +90,8 @@ stages:
       RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      image: server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:
@@ -225,7 +226,8 @@ stages:
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       BuildRTM: "true"
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      image: server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -91,7 +91,7 @@ stages:
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
     pool:
       name: VSEng-MicroBuildVSLegacy
-      image: server2025-microbuildVS2022-1es
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:
@@ -227,7 +227,7 @@ stages:
       BuildRTM: "true"
     pool:
       name: VSEng-MicroBuildVSLegacy
-      image: server2025-microbuildVS2022-1es
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: N/A

Regression? Last working version: N/A

## Description
Updates the release-6.11.x Windows pipeline jobs ahead of the October 26, 2026 legacy pool deprecation:

- Replaces deprecated VSEngSS MicroBuild pools with `VSEng-MicroBuildVSLegacy`.
- Selects the VS2022 image `server2025-microbuildVS2022-1es` using `ImageOverride` demands.
- Uses `VSEng-MicroBuildVSStable` only for `sdl.sourceAnalysisPool`.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A
