### PR TITLE
Update release-5.11.x MicroBuild pools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 # review when someone opens a pull request.
 # For more on how to customize the CODEOWNERS file - https://help.github.com/en/articles/about-code-owners
 *       @NuGet/nuget-client
+*       @NuGet/nuget-client-pull-request-auto-assignment

--- a/eng/pipelines/backup_build_artifacts.yml
+++ b/eng/pipelines/backup_build_artifacts.yml
@@ -12,7 +12,9 @@ jobs:
     displayName: "Backup Build Artifacts"
     timeoutInMinutes: 10
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands:
+        - ImageOverride -equals server2025-microbuildVS2019-1es
 
     steps:
       - checkout: none

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -31,7 +31,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean,GitHub
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3,GitHub,AzureStorage
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -33,7 +33,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true
@@ -42,10 +42,10 @@ extends:
       credscan:
         enabled: false
     pool:
-      name: VSEngSS-MicroBuild2019-1ES
+      name: VSEng-MicroBuildVSLegacy
       os: windows
       demands:
-      - ImageOverride -equals server2022-microbuildVS2019-1es
+      - ImageOverride -equals server2025-microbuildVS2019-1es
     featureFlags:
       enablePrepareFilesForSbom: true
     customBuildTags:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -31,7 +31,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive,CFSClean,GitHub
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -38,8 +38,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals windows.vs2019.amd64.open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2019-1ES
-          agentDemands: ImageOverride -equals server2022-microbuildVS2019-1es
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2019-1es
         testType: Unit
         testTargetFramework: net472
 
@@ -55,8 +55,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals windows.vs2019.amd64.open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2019-1ES
-          agentDemands: ImageOverride -equals server2022-microbuildVS2019-1es
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2019-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: Msbuild.Integration.Test
@@ -73,8 +73,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals windows.vs2019.amd64.open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2019-1ES
-          agentDemands: ImageOverride -equals server2022-microbuildVS2019-1es
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2019-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.CommandLine.FuncTest
@@ -91,8 +91,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals windows.vs2019.amd64.open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2019-1ES
-          agentDemands: ImageOverride -equals server2022-microbuildVS2019-1es
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2019-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.CommandLine.Test
@@ -111,8 +111,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals windows.vs2019.amd64.open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2019-1ES
-          agentDemands: ImageOverride -equals server2022-microbuildVS2019-1es
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2019-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.Commands.FuncTest
@@ -129,8 +129,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals windows.vs2019.amd64.open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2019-1ES
-          agentDemands: ImageOverride -equals server2022-microbuildVS2019-1es
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2019-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.Packaging.FuncTest
@@ -147,8 +147,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals windows.vs2019.amd64.open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2019-1ES
-          agentDemands: ImageOverride -equals server2022-microbuildVS2019-1es
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2019-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.Protocol.FuncTest
@@ -165,8 +165,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals windows.vs2019.amd64.open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2019-1ES
-          agentDemands: ImageOverride -equals server2022-microbuildVS2019-1es
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2019-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.XPlat.FuncTest
@@ -183,8 +183,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals windows.vs2019.amd64.open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2019-1ES
-          agentDemands: ImageOverride -equals server2022-microbuildVS2019-1es
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2019-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.CommandLine.Xplat.Tests
@@ -201,8 +201,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals windows.vs2019.amd64.open
         ${{ else }}:
-          agentPool: VSEngSS-MicroBuild2019-1ES
-          agentDemands: ImageOverride -equals server2022-microbuildVS2019-1es
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2019-1es
         testType: Functional
         testTargetFramework: net472
         testProjectName: NuGet.MSSigning.Extensions.FuncTest

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -35,7 +35,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive,CFSClean,GitHub
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -35,7 +35,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean,GitHub
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3,GitHub,AzureStorage
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -37,7 +37,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true
@@ -46,10 +46,10 @@ extends:
       credscan:
         enabled: false
     pool:
-      name: VSEngSS-MicroBuild2019-1ES
+      name: VSEng-MicroBuildVSLegacy
       os: windows
       demands:
-        - ImageOverride -equals server2022-microbuildVS2019-1es
+        - ImageOverride -equals server2025-microbuildVS2019-1es
     featureFlags:
       enablePrepareFilesForSbom: true
     customBuildTags:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -27,10 +27,10 @@ stages:
         displayName: Get NuGet.Client semantic version
         timeoutInMinutes: 10
         pool:
-          name: VSEngSS-MicroBuild2019-1ES
+          name: VSEng-MicroBuildVSLegacy
           os: windows
           demands:
-            - ImageOverride -equals server2022-microbuildVS2019-1es
+            - ImageOverride -equals server2025-microbuildVS2019-1es
         steps:
           - template: /eng/pipelines/templates/Initialize_Build_SemanticVersion.yml@self
 
@@ -41,10 +41,10 @@ stages:
           SemanticVersion: $[dependencies.GetSemanticVersion.outputs['setsemanticversion.SemanticVersion']]
           BuildRevision: $[counter(format('{0}.{1}', variables['SemanticVersion'], variables['build.definitionname']), 1)]
         pool:
-          name: VSEngSS-MicroBuild2019-1ES
+          name: VSEng-MicroBuildVSLegacy
           os: windows
           demands:
-            - ImageOverride -equals server2022-microbuildVS2019-1es
+            - ImageOverride -equals server2025-microbuildVS2019-1es
         steps:
           - template: /eng/pipelines/templates/Initialize_Build.yml@self
 
@@ -67,10 +67,10 @@ stages:
           RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
           ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
         pool:
-          name: VSEngSS-MicroBuild2019-1ES
+          name: VSEng-MicroBuildVSLegacy
           os: windows
           demands:
-            - ImageOverride -equals server2022-microbuildVS2019-1es
+            - ImageOverride -equals server2025-microbuildVS2019-1es
         templateContext:
           mb:
             localization:
@@ -211,10 +211,10 @@ stages:
           LocalizedLanguageCount: "13"
           BuildRTM: "true"
         pool:
-          name: VSEngSS-MicroBuild2019-1ES
+          name: VSEng-MicroBuildVSLegacy
           os: windows
           demands:
-            - ImageOverride -equals server2022-microbuildVS2019-1es
+            - ImageOverride -equals server2025-microbuildVS2019-1es
         templateContext:
           mb:
             localization:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: N/A

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Updates the release-5.11.x pipelines ahead of the October 26, 2026 legacy pool deprecation:

- Replaces deprecated MicroBuild pool names with `VSEng-MicroBuildVSLegacy`.
- Pins Windows jobs to the VS2019 image via `ImageOverride -equals server2025-microbuildVS2019-1es`.
- Moves SDL source analysis to `VSEng-MicroBuildVSStable`, where image selection is not supported.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A