### PR TITLE
Update release 6.8 Windows build pools

### DIFF
--- a/eng/pipelines/backup_build_artifacts.yml
+++ b/eng/pipelines/backup_build_artifacts.yml
@@ -12,7 +12,9 @@ jobs:
     displayName: "Backup Build Artifacts"
     timeoutInMinutes: 10
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands:
+      - ImageOverride -equals server2025-microbuildVS2022-1es
 
     steps:
       - checkout: none

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -68,7 +68,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -66,7 +66,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive,CFSClean,GitHub
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -77,7 +77,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -75,7 +75,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive,CFSClean,GitHub
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -110,7 +110,9 @@ stages:
       RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands:
+      - ImageOverride -equals server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:
@@ -218,7 +220,9 @@ stages:
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       BuildRTM: "true"
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands:
+      - ImageOverride -equals server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:
@@ -307,7 +311,9 @@ stages:
       MSBuildEnableWorkloadResolver: false
     condition: "and(succeeded(), ne(variables['RunFunctionalTestsOnWindows'], 'false'))"
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands:
+      - ImageOverride -equals server2025-microbuildVS2022-1es
     strategy:
       matrix:
         IsDesktop:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
## Bug

<!-- Search https://github.com/NuGet/Home/issues, and create one if you can't find a suitable issue. -->
<!-- Paste the full link, like https://github.com/nuget/home/issues/1000. GitHub will render is neatly. -->
Fixes: N/A

Regression? Last working version: N/A

## Description
<!-- Add details about the fix. Include any information that would help the maintainer review this change effective. -->

Updates the release-6.8.x pipelines ahead of the October 26, 2026 legacy pool deprecation:

- Replaces deprecated VSEngSS-MicroBuild2022-1ES job pools with VSEng-MicroBuildVSLegacy.
- Pins those Windows jobs to server2025-microbuildVS2022-1es through ImageOverride demands.
- Moves SDL source analysis to VSEng-MicroBuildVSStable, which accepts only a pool name.

## PR Checklist

- [x] PR has a meaningful title
- [ ] PR has a linked issue.
- [x] Described changes

- **Tests**
  - [ ] Automated tests added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [ ] Test exception
  - **OR**
  - [x] N/A <!-- Infrastructure, documentation etc. -->

- **Documentation**
  <!-- Please link the PR/issue if appropriate -->
  - [ ] Documentation PR or issue filled
  - **OR**
  - [x] N/A