### PR TITLE
Update release 6.12 Windows build pools

### DIFF
--- a/eng/pipelines/backup_build_artifacts.yml
+++ b/eng/pipelines/backup_build_artifacts.yml
@@ -12,7 +12,8 @@ jobs:
     displayName: "Backup Build Artifacts"
     timeoutInMinutes: 10
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
 
     steps:
       - checkout: none

--- a/eng/pipelines/compliance.yml
+++ b/eng/pipelines/compliance.yml
@@ -14,7 +14,8 @@ jobs:
     displayName: "Static Analysis"
     timeoutInMinutes: 180
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
 
     steps:
       - task: CredScan@2

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -33,7 +33,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -31,7 +31,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive,CFSClean,GitHub
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -62,7 +62,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEng-MicroBuildVSStable
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Unit
         testTargetFramework: net472
 
@@ -79,7 +80,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEng-MicroBuildVSStable
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Unit
         testTargetFramework: net8.0
 
@@ -96,7 +98,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEng-MicroBuildVSStable
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Functional
         testTargetFramework: net472
         timeoutInMinutes: 60
@@ -114,7 +117,8 @@ stages:
           agentPool: NetCore-Public
           agentDemands: ImageOverride -equals Windows.VS2022.Amd64.Open
         ${{ else }}:
-          agentPool: VSEng-MicroBuildVSStable
+          agentPool: VSEng-MicroBuildVSLegacy
+          agentDemands: ImageOverride -equals server2025-microbuildVS2022-1es
         testType: Functional
         testTargetFramework: net8.0
         timeoutInMinutes: 60

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -35,7 +35,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive,CFSClean,GitHub
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:

--- a/eng/pipelines/pull_request.yml
+++ b/eng/pipelines/pull_request.yml
@@ -37,7 +37,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true

--- a/eng/pipelines/templates/pipeline.yml
+++ b/eng/pipelines/templates/pipeline.yml
@@ -65,7 +65,8 @@ stages:
       RunSettingsDropName: 'RunSettings/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
       ProfilingInputsDropName: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranch)/$(Build.BuildId)'
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:
@@ -190,7 +191,8 @@ stages:
       VsTargetMajorVersion: $[stageDependencies.Initialize.Initialize_Build.outputs['updatebuildnumber.VsTargetMajorVersion']]
       BuildRTM: "true"
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
     templateContext:
       mb:
         localization:

--- a/eng/pipelines/vs-test/build.yml
+++ b/eng/pipelines/vs-test/build.yml
@@ -218,10 +218,13 @@ steps:
 - task: MicroBuildBuildVSBootstrapper@3
   displayName: 'Build a Visual Studio bootstrapper for tests'
   inputs:
+    azureSubscription: "VSEng-VSDrop-MI"
     channelName: "$(VsTargetChannelForTests)"
     vsMajorVersion: "$(VsTargetMajorVersion)"
     manifests: '$(Build.Repository.LocalPath)\artifacts\VS15\Microsoft.VisualStudio.NuGet.Core.vsman'
     outputFolder: '$(Build.Repository.LocalPath)\artifacts\VS15'
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
 - task: PowerShell@1
   displayName: "Set DartLab variables for tests"

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -80,7 +80,8 @@ stages:
   - job: Build
     timeoutInMinutes: 170
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSLegacy
+      demands: ImageOverride -equals server2025-microbuildVS2022-1es
     steps:
     - template: vs-test/build.yml
       parameters:


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: N/A (engineering-only change)

## Description

Updates release-6.12.x Windows build and test jobs ahead of the October 26, 2026 legacy MicroBuild pool deprecation.

- Uses `VSEng-MicroBuildVSLegacy` with `server2025-microbuildVS2022-1es` for private Windows build and test jobs.
- Uses `VSEng-MicroBuildVSStable` for name-only `sdl.sourceAnalysisPool` settings.
- Removes all deprecated `VSEngSS-MicroBuild2022-1ES`, `VSEngSS-MicroBuild2019-1ES`, and `VSEngSS-MicroBuild2017-1ES` references.

## PR Checklist

- [x] Meaningful title and helpful description; no issue required for this engineering-only change
- [x] Tests are not applicable to this pipeline-only configuration change
- [x] Documentation updates are not applicable