### PR TITLE
VSIX should not use codebase

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <Description>NuGet's Visual Studio Solution Restore Manager.</Description>
     <VSSDKBuildToolsAutoSetup>true</VSSDKBuildToolsAutoSetup>
+    <UseCodebase>false</UseCodebase>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <CreateVsixContainer>false</CreateVsixContainer>
     <DeployExtension>false</DeployExtension>

--- a/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
+++ b/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
@@ -5,6 +5,7 @@
     <IncludeInVSIX>true</IncludeInVSIX>
     <RootNamespace>NuGetVSExtension</RootNamespace>
     <VSSDKBuildToolsAutoSetup>true</VSSDKBuildToolsAutoSetup>
+    <UseCodebase>false</UseCodebase>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <TargetFramework>$(NETFXTargetFramework)</TargetFramework>
     <CreateVsixContainer>false</CreateVsixContainer>


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: VS perf test regression

## Description

The newer VS SDK build tools (introduced in [this PR](https://github.com/NuGet/NuGet.Client/pull/7645)) changed the generated PkgDef files to use `CodeBase=some.dll` instead of `Assembly=somd.dll`. This evidently causes VS to load assemblies in a different way. Setting the `<UseCodebase>false` property tells the build tools to generate an identical pkgdef file to the older build tools.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
