### PR TITLE
Remove obsolete UI-thread dependency from credential setup

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
@@ -7,14 +7,12 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Common;
 using NuGet.Credentials;
 using NuGet.Protocol.Plugins;
-using NuGet.VisualStudio;
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -88,13 +86,11 @@ namespace NuGet.PackageManagement.VisualStudio
                 });
             }
 
-            // can only interact when VS is not in server mode.
-            bool nonInteractive = await VisualStudioContextHelper.IsInServerModeAsync(CancellationToken.None);
-
-            // Initialize the credential service.
+            // VSSM_Server was removed from Visual Studio. Preserve the behavior of all remaining modes
+            // without querying the UI thread.
             var credentialService = new CredentialService(
                 new AsyncLazy<IEnumerable<ICredentialProvider>>(() => Task.FromResult((IEnumerable<ICredentialProvider>)credentialProviders)),
-                nonInteractive: nonInteractive,
+                nonInteractive: false,
                 handlesDefaultCredentials: PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders);
 
             return credentialService;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
@@ -86,8 +86,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 });
             }
 
-            // VSSM_Server was removed from Visual Studio. Preserve the behavior of all remaining modes
-            // without querying the UI thread.
             var credentialService = new CredentialService(
                 new AsyncLazy<IEnumerable<ICredentialProvider>>(() => Task.FromResult((IEnumerable<ICredentialProvider>)credentialProviders)),
                 nonInteractive: false,


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes:

Related: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3053202

## Description

Visual Studio's Nexus server mode was removed, so `VSSM_Server` can no longer be returned. Credential-service initialization still queries that value on the UI thread even though all supported modes produce `nonInteractive: false`.

Remove the obsolete query and preserve `nonInteractive: false`, avoiding an unnecessary UI-thread dependency when credential setup is reached from project evaluation or design-time builds. This does not change credential-provider interactivity or address other UI-affine credential paths.

Tests are not added because the removed branch is unreachable in supported Visual Studio modes and the resulting `nonInteractive` value is unchanged.

## PR Checklist

- [ ] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.