### PR TITLE
[7.0.x] Fix flakey MockServer test (#7296)

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -340,7 +340,15 @@ namespace NuGet.CommandLine.Test
                 new Action<HttpListenerResponse>(response =>
                 {
                     response.ContentType = "application/atom+xml;type=feed;charset=utf-8";
-                    string feed = server.ToODataFeed(packages, "FindPackagesById");
+                    var requestedId = r.QueryString["id"]?.Trim('\'');
+                    var filteredPackages = string.IsNullOrEmpty(requestedId)
+                        ? packages
+                        : packages.Where(p =>
+                        {
+                            using var reader = new PackageArchiveReader(p.OpenRead());
+                            return string.Equals(reader.NuspecReader.GetId(), requestedId, StringComparison.OrdinalIgnoreCase);
+                        }).ToList();
+                    string feed = server.ToODataFeed(filteredPackages, "FindPackagesById");
                     MockServer.SetResponseContent(response, feed);
                 }));
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: failing CI test

## Description

The release/7.0.x branch is failing a test, which prevents maestro's auto-approve bot from approving backflow PRs. This test was fixed on dev a while ago, so cherry-picking the fix onto the release branch.

## PR Checklist

- [x] Meaningful title, helpful description ~and a linked NuGet/Home issue~
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
