### PR TITLE
Split Apex tests across 2 machines

### DIFF
--- a/eng/pipelines/vs-test/apex.yml
+++ b/eng/pipelines/vs-test/apex.yml
@@ -16,6 +16,9 @@ parameters:
   - name: testMachineTotalCount
     type: string
     default: '1'
+  - name: testCaseDistributionBatchingStrategy
+    type: string
+    default: OptimizeDurationForBalance
   - name: testDeploymentCleanupMode
     type: string
     default: OnSuccess
@@ -37,6 +40,7 @@ stages:
       owner: nugetclienteng
       testMachineLab: "NuGet"
       testMachineTotalCount: ${{parameters.testMachineTotalCount}}
+      testCaseDistributionBatchingStrategy: ${{parameters.testCaseDistributionBatchingStrategy}}
       runSettingsURI: ${{parameters.runSettingsURI}}
       visualStudioBootstrapperURI: ${{parameters.bootstrapperUrl}}
       visualStudioSigning: Test

--- a/eng/pipelines/vs-test/apex.yml
+++ b/eng/pipelines/vs-test/apex.yml
@@ -13,6 +13,9 @@ parameters:
     type: object
   - name: testExecutionJobTimeoutInMinutes
     type: number
+  - name: testMachineTotalCount
+    type: string
+    default: '1'
   - name: testDeploymentCleanupMode
     type: string
     default: OnSuccess
@@ -33,6 +36,7 @@ stages:
           - ${{parameters.variables}}
       owner: nugetclienteng
       testMachineLab: "NuGet"
+      testMachineTotalCount: ${{parameters.testMachineTotalCount}}
       runSettingsURI: ${{parameters.runSettingsURI}}
       visualStudioBootstrapperURI: ${{parameters.bootstrapperUrl}}
       visualStudioSigning: Test

--- a/eng/pipelines/vs-test/end_to_end.yml
+++ b/eng/pipelines/vs-test/end_to_end.yml
@@ -1,6 +1,4 @@
 parameters:
-- name: part
-  type: string
 - name: stageName
   type: string
 - name: stageDisplayName
@@ -44,8 +42,6 @@ stages:
       value: ${{parameters.bootstrapperUrl}}
     - name: runSettingsURI
       value: ${{parameters.runSettingsURI}}
-    - name: Part
-      value: ${{parameters.part}}
     - ${{if gt(length(parameters.variables), 0)}}:
       - ${{parameters.variables}}
     visualStudioBootstrapperURI: $(bootstrapperUrl)
@@ -76,8 +72,8 @@ stages:
       inputs:
         scriptType: "inlineScript"
         inlineScript: |
-          $EndToEndTestCommandToRunPart = '"' + "Run-Test -Exclude '${env:PART}' -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" +'"'
-          Write-Host "##vso[task.setvariable variable=EndToEndTestCommandToRunPart]$EndToEndTestCommandToRunPart"
+          $endToEndTestCommand = '"' + "Run-Test -Verbose *>&1 | Tee-Object $(System.DefaultWorkingDirectory)\artifacts\EndToEnd\FullLog_$(Build.BuildNumber).txt" + '"'
+          Write-Host "##vso[task.setvariable variable=EndToEndTestCommandToRunPart]$endToEndTestCommand"
 
     - task: PowerShell@1
       displayName: "Print Environment Variables"

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -144,5 +144,6 @@ stages:
     bootstrapperUrl: $(bootstrapperUrl)
     runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/$(RunSettingsDrop);NuGet.Tests.Apex.runsettings
     testExecutionJobTimeoutInMinutes: 412 # cloud test minimum
+    testMachineTotalCount: '2'
     testDeploymentCleanupMode: ${{parameters.ApexAgentCleanup}}
     VsBootstrapperBranch: $(VsBootstrapperBranch)

--- a/eng/pipelines/vs-tests.yml
+++ b/eng/pipelines/vs-tests.yml
@@ -29,15 +29,8 @@ parameters:
   values:
   - Production
   - Staging
-- name: E2EPart1AgentCleanup
-  displayName: Delete or keep E2E Part 1 machine for debugging
-  type: string
-  default: delete
-  values:
-  - delete
-  - stop
-- name: E2EPart2AgentCleanup
-  displayName: Delete or keep E2E Part 2 machine for debugging
+- name: E2EAgentCleanup
+  displayName: Delete or keep E2E machine for debugging
   type: string
   default: delete
   values:
@@ -88,11 +81,10 @@ stages:
       parameters:
         enableApexBlameHangDumpCollector: ${{parameters.EnableApexBlameHangDumpCollector}}
 
-# Dartlab's template defines this in its own stage
 - template: vs-test/end_to_end.yml
   parameters:
-    stageName: VS_EndToEnd_Part1
-    stageDisplayName: Part 1
+    stageName: VS_EndToEnd
+    stageDisplayName: On Windows
     condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
     dependsOn:
     - Build
@@ -103,30 +95,9 @@ stages:
       value: $[stageDependencies.Build.Build.outputs['dartlab_variables.RunSettingsDrop']]
     bootstrapperUrl: $(VsBootstrapperUrl)
     DartLabEnvironment: ${{parameters.DartLabEnvironment}}
-    part: "InstallPackageTest.ps1,UninstallPackageTest.ps1,UpdatePackageTest.ps1"
     runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/$(RunSettingsDrop);NuGet.Tests.Apex.runsettings
     testExecutionJobTimeoutInMinutes: 100
-    testMachineCleanUpStrategy: ${{parameters.E2EPart1AgentCleanup}}
-
-# Dartlab's template defines this in its own stage
-- template: vs-test/end_to_end.yml
-  parameters:
-    stageName: VS_EndToEnd_Part2
-    stageDisplayName: Part 2
-    condition: "and(succeeded(), ne(variables['RunEndToEndTests'], 'false'))"
-    dependsOn:
-    - Build
-    variables:
-    - name: VsBootstrapperUrl
-      value: $[stageDependencies.Build.Build.outputs['dartlab_variables.bootstrapperUrl']]
-    - name: RunSettingsDrop
-      value: $[stageDependencies.Build.Build.outputs['dartlab_variables.RunSettingsDrop']]
-    bootstrapperUrl: $(VsBootstrapperUrl)
-    DartLabEnvironment: ${{parameters.DartLabEnvironment}}
-    part: "BuildIntegratedTest.ps1,ExecuteInitScriptTest.ps1,FindPackageTest.ps1,GetPackageTest.ps1,GetProjectTest.ps1,LegacyPackageRefProjectTest.ps1,NativeProjectTest.ps1,NetCoreProjectTest.ps1,PackTest.ps1,ProjectRetargeting.ps1,ServicesTest.ps1,Settings.ps1,SyncPackageTest.ps1,TabExpansionTest.ps1,UniversalWindowsProjectTest.ps1"
-    runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/$(RunSettingsDrop);NuGet.Tests.Apex.runsettings
-    testExecutionJobTimeoutInMinutes: 100
-    testMachineCleanUpStrategy: ${{parameters.E2EPart2AgentCleanup}}
+    testMachineCleanUpStrategy: ${{parameters.E2EAgentCleanup}}
 
 # Dartlab's template defines this in its own stage
 - template: vs-test/apex.yml
@@ -145,5 +116,6 @@ stages:
     runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/$(RunSettingsDrop);NuGet.Tests.Apex.runsettings
     testExecutionJobTimeoutInMinutes: 412 # cloud test minimum
     testMachineTotalCount: '2'
+    testCaseDistributionBatchingStrategy: OptimizeDurationForPerformance
     testDeploymentCleanupMode: ${{parameters.ApexAgentCleanup}}
     VsBootstrapperBranch: $(VsBootstrapperBranch)


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: infrastructure

## Description

As we're moving more and more E2E tests to Apex tests, the E2E tests are finishing more quickly, and the Apex tests are taking longer and longer.  Luckily CloudTest already has functionality to automatically split test execution across a number of machines.

This PR makes the NuGet.Client-VS pipeline use only 1 machine for E2E tests, and 2 machines for Apex.  The VS "daily" tests still uses 1 apex machine.

## PR Checklist

- [x] Meaningful title, helpful description and ~a linked NuGet/Home issue~
- [x] ~Added tests~ N/A
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
