### PR TITLE
Migrate settings credential provider from NuGet.Core

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -243,7 +243,7 @@ namespace NuGet.CommandLine
                 .ToList();
             var securePluginProviders = await (new SecurePluginCredentialProviderBuilder(PluginManager.Instance, canShowDialog: true, logger: Console)).BuildAllAsync();
 
-            providers.Add(new CredentialProviderAdapter(new SettingsCredentialProvider(SourceProvider, Console)));
+            providers.Add(new SettingsCredentialProvider(SourceProvider, Console));
             providers.AddRange(securePluginProviders);
             providers.AddRange(pluginProviders);
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-extern alias CoreV2;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/NuGet.Clients/NuGet.CommandLine/SettingsCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/SettingsCredentialProvider.cs
@@ -1,15 +1,17 @@
 #nullable disable
 
-extern alias CoreV2;
-
 using System;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Credentials;
 
 namespace NuGet.CommandLine
 {
-    public class SettingsCredentialProvider : CoreV2.NuGet.ICredentialProvider
+    public class SettingsCredentialProvider : ICredentialProvider
     {
         private readonly Configuration.IPackageSourceProvider _packageSourceProvider;
         private readonly Common.ILogger _logger;
@@ -28,12 +30,43 @@ namespace NuGet.CommandLine
 
             _packageSourceProvider = packageSourceProvider;
             _logger = logger;
+            Id = $"{typeof(SettingsCredentialProvider).Name}_{Guid.NewGuid()}";
         }
 
-        public ICredentials GetCredentials(Uri uri, IWebProxy proxy, CoreV2.NuGet.CredentialType credentialType, bool retrying)
+        public string Id { get; }
+
+        public Task<CredentialResponse> GetAsync(
+            Uri uri,
+            IWebProxy proxy,
+            CredentialRequestType type,
+            string message,
+            bool isRetry,
+            bool nonInteractive,
+            CancellationToken cancellationToken)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ICredentials credentials = GetCredentials(
+                uri,
+                isRequestCredentials: type != CredentialRequestType.Proxy,
+                isRetry);
+
+            CredentialResponse response = credentials == null
+                ? new CredentialResponse(CredentialStatus.ProviderNotApplicable)
+                : new CredentialResponse(credentials);
+
+            return Task.FromResult(response);
+        }
+
+        private ICredentials GetCredentials(Uri uri, bool isRequestCredentials, bool retrying)
         {
             // If we are retrying, the stored credentials must be invalid.
-            if (!retrying && (credentialType == CoreV2.NuGet.CredentialType.RequestCredentials) && TryGetCredentials(uri, out var credentials, out var username))
+            if (!retrying && isRequestCredentials && TryGetCredentials(uri, out var credentials, out var username))
             {
                 _logger.LogMinimal(
                     string.Format(
@@ -42,6 +75,7 @@ namespace NuGet.CommandLine
                         username));
                 return credentials;
             }
+
             return null;
         }
 


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Related: https://github.com/nuget/home/issues/14754

## Description

Migrates `SettingsCredentialProvider` from the legacy `NuGet.Core` credential-provider interface to the current `NuGet.Credentials.ICredentialProvider` interface. The command-line credential pipeline now consumes the provider directly instead of routing it through the v2-to-current adapter.

The legacy `NuGet.Core` MEF imports and exports remain unchanged so command-line extension compatibility is preserved. This also removes an unused `CoreV2` alias from `UpdateCommand`.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
