### PR TITLE
Show vulnerabilities consistently in PM UI versions and package details

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -256,6 +256,31 @@ namespace NuGet.PackageManagement.UI
                 .Select(GetVersion)
                 .ToList();
 
+            // When audit sources are configured, their vulnerability data is authoritative. Otherwise, use
+            // the package sources' VulnerabilityInfo data.
+            if (_allPackageVersions != null && _allPackageVersions.Count > 0)
+            {
+                IReadOnlyCollection<NuGetVersion> versionsToEvaluate = _allPackageVersions.Select(v => v.version).ToList();
+                IReadOnlyDictionary<NuGetVersion, int> vulnerableVersions =
+                    await searchResultPackage.GetVulnerableVersionsAsync(versionsToEvaluate, cancellationToken);
+
+                if (getPackageItemViewModel() != searchResultPackage)
+                {
+                    return;
+                }
+
+                for (int i = 0; i < _allPackageVersions.Count; i++)
+                {
+                    (NuGetVersion version, bool isDeprecated, bool isVulnerable) = _allPackageVersions[i];
+                    bool isVulnerableFromSelectedSources = vulnerableVersions.ContainsKey(version);
+                    bool effectiveIsVulnerable = searchResultPackage.IsAuditSourceConfigured
+                        ? isVulnerableFromSelectedSources
+                        : isVulnerable || isVulnerableFromSelectedSources;
+
+                    _allPackageVersions[i] = (version, isDeprecated, effectiveIsVulnerable);
+                }
+            }
+
             await CreateVersionsAsync(cancellationToken);
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(OnCurrentPackageChanged)
                 .PostOnFailure(nameof(DetailControlModel), nameof(OnCurrentPackageChanged));
@@ -638,7 +663,7 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private async ValueTask SelectedVersionChangedAsync(PackageItemViewModel packageItemViewModel, NuGetVersion nugetVersion, CancellationToken cancellationToken)
+        internal async ValueTask SelectedVersionChangedAsync(PackageItemViewModel packageItemViewModel, NuGetVersion nugetVersion, CancellationToken cancellationToken)
         {
             // Load the detailed metadata that we already have and check to see if this matches what is selected, we cannot use the _metadataDict here unfortunately as it won't be populated yet
             (PackageSearchMetadataContextInfo packageSearchMetadata, PackageDeprecationMetadataContextInfo packageDeprecationMetadata) =
@@ -650,12 +675,27 @@ namespace NuGet.PackageManagement.UI
                     return;
                 }
 
+                IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo> vulnerabilities =
+                    await GetMergedVulnerabilitiesAsync(
+                        packageItemViewModel,
+                        packageSearchMetadata,
+                        packageItemViewModel.Vulnerabilities,
+                        nugetVersion,
+                        cancellationToken);
+
+                if (cancellationToken.IsCancellationRequested
+                    || _searchResultPackage != packageItemViewModel
+                    || SelectedVersion?.Version != nugetVersion)
+                {
+                    return;
+                }
+
                 PackageMetadata = new DetailedPackageMetadata(
                     packageSearchMetadata,
                     packageDeprecationMetadata,
                     packageItemViewModel.KnownOwnerViewModels,
                     packageItemViewModel.DownloadCount,
-                    packageItemViewModel.Vulnerabilities);
+                    vulnerabilities);
             }
             else
             {
@@ -671,18 +711,58 @@ namespace NuGet.PackageManagement.UI
                         return;
                     }
 
+                    IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo> vulnerabilities =
+                        await GetMergedVulnerabilitiesAsync(
+                            packageItemViewModel,
+                            searchMetadata,
+                            Array.Empty<PackageVulnerabilityMetadataContextInfo>(),
+                            nugetVersion,
+                            cancellationToken);
+
+                    if (cancellationToken.IsCancellationRequested
+                        || _searchResultPackage != packageItemViewModel
+                        || SelectedVersion?.Version != nugetVersion)
+                    {
+                        return;
+                    }
+
                     var detailedPackageMetadata = new DetailedPackageMetadata(
                         searchMetadata,
                         deprecationData,
                         knownOwnerViewModels: null,
                         searchMetadata.DownloadCount,
-                        PackageVulnerabilities);
+                        vulnerabilities);
 
                     _metadataDict[detailedPackageMetadata.Version] = detailedPackageMetadata;
 
                     PackageMetadata = detailedPackageMetadata;
                 }
             }
+        }
+
+        private static async Task<IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo>> GetMergedVulnerabilitiesAsync(
+            PackageItemViewModel packageItemViewModel,
+            PackageSearchMetadataContextInfo packageSearchMetadata,
+            IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo> existingVulnerabilities,
+            NuGetVersion version,
+            CancellationToken cancellationToken)
+        {
+            IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo> auditVulnerabilities =
+                await packageItemViewModel.GetVulnerabilityInfoAsync(version, cancellationToken);
+
+            if (packageItemViewModel.IsAuditSourceConfigured)
+            {
+                return auditVulnerabilities
+                    .OrderByDescending(vulnerability => vulnerability.Severity)
+                    .ToList();
+            }
+
+            return (packageSearchMetadata.Vulnerabilities ?? Array.Empty<PackageVulnerabilityMetadataContextInfo>())
+                .Concat(existingVulnerabilities)
+                .Concat(auditVulnerabilities)
+                .Distinct()
+                .OrderByDescending(vulnerability => vulnerability.Severity)
+                .ToList();
         }
 
         // Calculate the version to select among _versions and select it

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -752,15 +752,23 @@ namespace NuGet.PackageManagement.UI
 
             if (packageItemViewModel.IsAuditSourceConfigured)
             {
-                return auditVulnerabilities
-                    .OrderByDescending(vulnerability => vulnerability.Severity)
-                    .ToList();
+                return NormalizeVulnerabilities(auditVulnerabilities);
             }
 
-            return (packageSearchMetadata.Vulnerabilities ?? Array.Empty<PackageVulnerabilityMetadataContextInfo>())
-                .Concat(existingVulnerabilities)
-                .Concat(auditVulnerabilities)
-                .Distinct()
+            return NormalizeVulnerabilities(
+                (packageSearchMetadata.Vulnerabilities ?? Array.Empty<PackageVulnerabilityMetadataContextInfo>())
+                    .Concat(existingVulnerabilities)
+                    .Concat(auditVulnerabilities));
+        }
+
+        internal static IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo> NormalizeVulnerabilities(
+            IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilities)
+        {
+            return vulnerabilities
+                .GroupBy(vulnerability => vulnerability.AdvisoryUrl)
+                .Select(group => new PackageVulnerabilityMetadataContextInfo(
+                    group.Key,
+                    group.Max(vulnerability => vulnerability.Severity)))
                 .OrderByDescending(vulnerability => vulnerability.Severity)
                 .ToList();
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/ViewModels/PackageItemViewModel.cs
@@ -518,6 +518,8 @@ namespace NuGet.PackageManagement.UI
 
         public IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo> Vulnerabilities => (_packageModel as IVulnerableCapable)?.Vulnerabilities ?? [];
 
+        public bool IsAuditSourceConfigured => _vulnerabilityService?.IsAuditSourceConfigured ?? false;
+
         public void UpdateTransitiveInfo(PackageSearchMetadataContextInfo metadataContextInfo)
         {
             if (metadataContextInfo.TransitiveOrigins == null)
@@ -818,6 +820,35 @@ namespace NuGet.PackageManagement.UI
             NuGetUIThreadHelper.JoinableTaskFactory
                 .RunAsync(() => UpdatePackageMaxVulnerabilityAsync(packageIdentity, _cancellationToken))
                 .PostOnFailure(nameof(PackageItemViewModel), nameof(UpdatePackageMaxVulnerabilityAsync));
+        }
+
+        public async Task<IReadOnlyDictionary<NuGetVersion, int>> GetVulnerableVersionsAsync(
+            IReadOnlyCollection<NuGetVersion> versions,
+            CancellationToken cancellationToken)
+        {
+            if (_vulnerabilityService is null || versions is null || versions.Count == 0)
+            {
+                return ImmutableDictionary<NuGetVersion, int>.Empty;
+            }
+
+            return await _vulnerabilityService.GetVulnerableVersionsAsync(Id, versions, cancellationToken);
+        }
+
+        public async Task<IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo>> GetVulnerabilityInfoAsync(
+            NuGetVersion version,
+            CancellationToken cancellationToken)
+        {
+            if (_vulnerabilityService is null)
+            {
+                return Array.Empty<PackageVulnerabilityMetadataContextInfo>();
+            }
+
+            List<PackageVulnerabilityMetadataContextInfo> vulnerabilities =
+                await _vulnerabilityService.GetVulnerabilityInfoAsync(
+                    new PackageIdentity(Id, version),
+                    cancellationToken);
+
+            return vulnerabilities ?? (IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo>)Array.Empty<PackageVulnerabilityMetadataContextInfo>();
         }
 
         public async Task UpdatePackageStatusAsync(IEnumerable<PackageCollectionItem> installedPackages, CancellationToken cancellationToken, bool clearCache = false)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -1129,33 +1129,44 @@ namespace NuGet.PackageManagement.UI
             IInstalledAndTransitivePackages installedAndTransitivePackages = await PackageCollection.GetInstalledAndTransitivePackagesAsync(loadContext.ServiceBroker, loadContext.Projects, includeTransitiveOrigins: true, token);
             installedPackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.InstalledPackages);
             PackageCollection transitivePackageCollection = PackageCollection.FromPackageReferences(installedAndTransitivePackages.TransitivePackages.Where(p => p.TransitiveOrigins.Any()));
-            //Use ShutdownToken to ensure the operation is canceled if it's still running when VS shuts down.
-            IEnumerable<PackageVulnerabilityMetadataContextInfo>[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(p => vulnerabilityService.GetVulnerabilityInfoAsync(p, VsShellUtilities.ShutdownToken)));
 
-            foreach (IEnumerable<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo in transitivePackageVulnerabilities)
+            async Task<bool> IsVulnerableAsync(
+                PackageIdentity packageIdentity,
+                PackageSearchMetadataContextInfo packageMetadata)
             {
-                if (vulnerabilityInfo != null && vulnerabilityInfo.Any())
+                if (!vulnerabilityService.IsAuditSourceConfigured
+                    && packageMetadata?.Vulnerabilities != null
+                    && packageMetadata.Vulnerabilities.Any())
                 {
-                    vulnerablePackagesCount++;
+                    return true;
                 }
+
+                List<PackageVulnerabilityMetadataContextInfo> vulnerabilityInfo =
+                    await vulnerabilityService.GetVulnerabilityInfoAsync(packageIdentity, token);
+                return vulnerabilityInfo.Count > 0;
             }
+
+            bool[] transitivePackageVulnerabilities = await Task.WhenAll(transitivePackageCollection.Select(async package =>
+            {
+                PackageSearchMetadataContextInfo packageMetadata = null;
+                if (!vulnerabilityService.IsAuditSourceConfigured)
+                {
+                    (packageMetadata, _) = await GetPackageMetadataAsync(package, packageSources, token);
+                }
+
+                return await IsVulnerableAsync(package, packageMetadata);
+            }));
+            vulnerablePackagesCount += transitivePackageVulnerabilities.Count(isVulnerable => isVulnerable);
 
             var installedPackageMetadata = await Task.WhenAll(installedPackageCollection.Select(p => GetPackageMetadataAsync(p, packageSources, token)));
 
             foreach ((PackageSearchMetadataContextInfo s, PackageDeprecationMetadataContextInfo d) in installedPackageMetadata)
             {
-                if (s.Vulnerabilities != null && s.Vulnerabilities.Any())
+                if (await IsVulnerableAsync(s.Identity, s))
                 {
                     vulnerablePackagesCount++;
                 }
-                else // Fallback to checking audit sources.
-                {
-                    List<PackageVulnerabilityMetadataContextInfo> auditSourceVulnerabilityContextInfo = await _packageVulnerabilityService.GetVulnerabilityInfoAsync(s.Identity, token);
-                    if (auditSourceVulnerabilityContextInfo.Count > 0)
-                    {
-                        vulnerablePackagesCount++;
-                    }
-                }
+
                 if (d != null)
                 {
                     deprecatedPackagesCount++;
@@ -1981,4 +1992,3 @@ namespace NuGet.PackageManagement.UI
         }
     }
 }
-

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/IPackageVulnerabilityService.cs
@@ -5,13 +5,30 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using NuGet.VisualStudio.Internal.Contracts;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
     public interface IPackageVulnerabilityService
     {
+        bool IsAuditSourceConfigured { get; }
+
         Task<List<PackageVulnerabilityMetadataContextInfo>?> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Evaluates a set of versions of a single package against the (cached) vulnerability database
+        /// obtained from the configured audit sources (or the package sources when no audit source is configured).
+        /// </summary>
+        /// <param name="packageId">The package id whose versions should be evaluated.</param>
+        /// <param name="versions">The versions to evaluate.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>
+        /// A dictionary mapping each vulnerable version to its maximum vulnerability severity.
+        /// Versions with no known vulnerabilities are omitted.
+        /// </returns>
+        Task<IReadOnlyDictionary<NuGetVersion, int>> GetVulnerableVersionsAsync(string packageId, IReadOnlyCollection<NuGetVersion> versions, CancellationToken cancellationToken);
+
         void ResetVulnerabilityData();
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/PackageVulnerabilityService.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Model;
@@ -32,17 +34,11 @@ namespace NuGet.PackageManagement.VisualStudio
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
+        public bool IsAuditSourceConfigured => _auditSourceRepositories.Count > 0;
+
         public async Task<List<PackageVulnerabilityMetadataContextInfo>?> GetVulnerabilityInfoAsync(PackageIdentity packageId, CancellationToken cancellationToken)
         {
-            if (_vulnerabilitiesTask == null)
-            {
-                lock (_lock)
-                {
-                    _vulnerabilitiesTask ??= GetAllVulnerabilityDataAsync(cancellationToken);
-                }
-            }
-
-            GetVulnerabilityInfoResult? vulnerabilities = await _vulnerabilitiesTask;
+            GetVulnerabilityInfoResult? vulnerabilities = await GetCachedVulnerabilityDataAsync(cancellationToken);
 
             IEnumerable<PackageVulnerabilityInfo>? packageVulnerabilities = Enumerable.Empty<PackageVulnerabilityInfo>();
 
@@ -58,6 +54,70 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             return ConvertToPackageVulnerabilityMetadataContextInfo(packageVulnerabilities);
+        }
+
+        public async Task<IReadOnlyDictionary<NuGetVersion, int>> GetVulnerableVersionsAsync(string packageId, IReadOnlyCollection<NuGetVersion> versions, CancellationToken cancellationToken)
+        {
+            var result = new Dictionary<NuGetVersion, int>();
+
+            if (string.IsNullOrEmpty(packageId) || versions is null || versions.Count == 0)
+            {
+                return result;
+            }
+
+            GetVulnerabilityInfoResult? vulnerabilities = await GetCachedVulnerabilityDataAsync(cancellationToken);
+
+            // Errors are surfaced by GetVulnerabilityInfoAsync (used by the item badge/details icon);
+            // don't replay them here to avoid duplicate warnings for the same shared, cached data.
+
+            IReadOnlyList<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>? allVulnerabilities = vulnerabilities?.KnownVulnerabilities;
+            if (allVulnerabilities is null || allVulnerabilities.Count == 0)
+            {
+                return result;
+            }
+
+            // Single pass over the cached database: for each file, look up the package id once,
+            // then match its (few) advisory version ranges against the requested versions.
+            foreach (IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>> file in allVulnerabilities)
+            {
+                if (!file.TryGetValue(packageId, out IReadOnlyList<PackageVulnerabilityInfo>? packageVulnerabilities))
+                {
+                    continue;
+                }
+
+                foreach (PackageVulnerabilityInfo vulnerabilityInfo in packageVulnerabilities)
+                {
+                    int severity = (int)vulnerabilityInfo.Severity;
+                    foreach (NuGetVersion version in versions)
+                    {
+                        if (vulnerabilityInfo.Versions.Satisfies(version))
+                        {
+                            if (!result.TryGetValue(version, out int existingSeverity) || severity > existingSeverity)
+                            {
+                                result[version] = severity;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private async Task<GetVulnerabilityInfoResult?> GetCachedVulnerabilityDataAsync(CancellationToken cancellationToken)
+        {
+            Task<GetVulnerabilityInfoResult?>? vulnerabilitiesTask = _vulnerabilitiesTask;
+            if (vulnerabilitiesTask == null)
+            {
+                lock (_lock)
+                {
+                    // The cached load is shared by all package selections. A selection cancellation should
+                    // abandon only that caller's wait, while VS shutdown still cancels the shared operation.
+                    vulnerabilitiesTask = _vulnerabilitiesTask ??= GetAllVulnerabilityDataAsync(VsShellUtilities.ShutdownToken);
+                }
+            }
+
+            return await vulnerabilitiesTask.WithCancellation(cancellationToken);
         }
 
         public void ResetVulnerabilityData()

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -25,6 +25,8 @@ using NuGet.PackageManagement.UI.ViewModels;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using NuGet.VisualStudio;
@@ -415,6 +417,274 @@ namespace NuGet.PackageManagement.UI.Test.Models
             };
 
             Assert.Equal(expectedVersions, actualVersions);
+        }
+
+        [Fact]
+        public async Task AuditVulnerabilities_AreShownPerVersionWithoutChangingPackageState()
+        {
+            // Arrange
+            var safeVersion = new NuGetVersion("3.10.2");
+            var vulnerableVersion = new NuGetVersion("3.5.3");
+            var packageIdentity = new PackageIdentity("Microsoft.OpenApi", safeVersion);
+            var vulnerableIdentity = new PackageIdentity(packageIdentity.Id, vulnerableVersion);
+            var advisory = new PackageVulnerabilityMetadataContextInfo(
+                new Uri("https://example.test/advisory"),
+                (int)PackageVulnerabilitySeverity.High);
+            var packageSourceAdvisory = new PackageVulnerabilityMetadata(
+                new Uri("https://example.test/package-source-advisory"),
+                (int)PackageVulnerabilitySeverity.Low);
+
+            PackageSearchMetadataContextInfo safeMetadata = PackageSearchMetadataContextInfo.Create(
+                PackageSearchMetadataBuilder.FromIdentity(packageIdentity).Build());
+            PackageSearchMetadataContextInfo vulnerableMetadata = PackageSearchMetadataContextInfo.Create(
+                new PackageSearchMetadataBuilder.ClonedPackageSearchMetadata
+                {
+                    Identity = vulnerableIdentity,
+                    Vulnerabilities = new[] { packageSourceAdvisory }
+                });
+
+            VersionInfoContextInfo safeVersionInfo = await VersionInfoContextInfo.CreateAsync(
+                new VersionInfo(safeVersion)
+                {
+                    PackageSearchMetadata = new PackageSearchMetadataBuilder.ClonedPackageSearchMetadata
+                    {
+                        Identity = packageIdentity,
+                        Vulnerabilities = new[] { packageSourceAdvisory }
+                    }
+                });
+            VersionInfoContextInfo vulnerableVersionInfo = await VersionInfoContextInfo.CreateAsync(
+                new VersionInfo(vulnerableVersion)
+                {
+                    PackageSearchMetadata = new PackageSearchMetadataBuilder.ClonedPackageSearchMetadata
+                    {
+                        Identity = vulnerableIdentity,
+                        Vulnerabilities = new[] { packageSourceAdvisory }
+                    }
+                });
+
+            var searchService = new Mock<INuGetSearchService>();
+            searchService.Setup(service => service.GetPackageVersionsAsync(
+                    It.IsAny<PackageIdentity>(),
+                    It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<IEnumerable<IProjectContextInfo>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[]
+                {
+                    safeVersionInfo,
+                    vulnerableVersionInfo
+                });
+            searchService.Setup(service => service.GetPackageMetadataAsync(
+                    packageIdentity,
+                    It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo)>((safeMetadata, null)));
+
+            var vulnerabilityService = new Mock<IPackageVulnerabilityService>();
+            vulnerabilityService.SetupGet(service => service.IsAuditSourceConfigured).Returns(true);
+            vulnerabilityService.Setup(service => service.GetVulnerableVersionsAsync(
+                    packageIdentity.Id,
+                    It.IsAny<IReadOnlyCollection<NuGetVersion>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Dictionary<NuGetVersion, int>
+                {
+                    [vulnerableVersion] = advisory.Severity
+                });
+            vulnerabilityService.Setup(service => service.GetVulnerabilityInfoAsync(
+                    It.Is<PackageIdentity>(identity => identity.Equals(vulnerableIdentity)),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PackageVulnerabilityMetadataContextInfo> { advisory });
+            vulnerabilityService.Setup(service => service.GetVulnerabilityInfoAsync(
+                    It.Is<PackageIdentity>(identity => identity.Equals(packageIdentity)),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PackageVulnerabilityMetadataContextInfo>());
+
+            var packageModel = PackageModelCreationTestHelper.CreateLocalPackageModel(
+                packageIdentity,
+                "C:\\TestPackage",
+                Mock.Of<IEmbeddedResourcesCapable>());
+            var packageItemViewModel = new PackageItemViewModel(
+                searchService.Object,
+                packageModel,
+                vulnerabilityService.Object);
+
+            var brokeredSearchService = new Mock<INuGetSearchService>();
+            brokeredSearchService.Setup(service => service.GetPackageMetadataAsync(
+                    vulnerableIdentity,
+                    It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo)>((vulnerableMetadata, null)));
+
+            var serviceBroker = new Mock<IServiceBroker>();
+#pragma warning disable ISB001 // Dispose of proxies
+            serviceBroker.Setup(broker => broker.GetProxyAsync<INuGetSearchService>(
+                    NuGetServices.SearchService,
+                    It.IsAny<ServiceActivationOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<INuGetSearchService>(brokeredSearchService.Object));
+#pragma warning restore ISB001 // Dispose of proxies
+
+            var model = new PackageDetailControlModel(
+                serviceBroker.Object,
+                Mock.Of<INuGetSolutionManagerService>(),
+                Array.Empty<IProjectContextInfo>(),
+                _mockNuGetUI.Object);
+
+            // Act
+            await model.SetCurrentPackageAsync(
+                packageItemViewModel,
+                ItemFilter.All,
+                () => packageItemViewModel,
+                CancellationToken.None);
+
+            DisplayVersion vulnerableDisplayVersion = model.Versions.Single(
+                version => version?.Version == vulnerableVersion && version.AdditionalInfo == null);
+            DisplayVersion safeDisplayVersion = model.Versions.Single(
+                version => version?.Version == safeVersion && version.AdditionalInfo == null);
+
+            model.SelectedVersion = vulnerableDisplayVersion;
+            await model.SelectedVersionChangedAsync(packageItemViewModel, vulnerableVersion, CancellationToken.None);
+
+            // Assert
+            Assert.True(vulnerableDisplayVersion.IsVulnerable);
+            Assert.False(safeDisplayVersion.IsVulnerable);
+            Assert.Empty(packageItemViewModel.VulnerableVersions);
+            Assert.False(packageItemViewModel.IsPackageVulnerable);
+            Assert.Equal(vulnerableVersion, model.PackageMetadata.Version);
+            Assert.Equal(new[] { advisory }, model.PackageVulnerabilities);
+        }
+
+        [Fact]
+        public async Task SelectedVersion_WhenChangedBeforeVulnerabilityLookupCompletes_CancelsPreviousSelectionAndKeepsLatestDetails()
+        {
+            // Arrange
+            var safeVersion = new NuGetVersion("3.10.2");
+            var vulnerableVersion = new NuGetVersion("3.5.3");
+            var safeIdentity = new PackageIdentity("Microsoft.OpenApi", safeVersion);
+            var vulnerableIdentity = new PackageIdentity(safeIdentity.Id, vulnerableVersion);
+            var advisory = new PackageVulnerabilityMetadataContextInfo(
+                new Uri("https://example.test/advisory"),
+                (int)PackageVulnerabilitySeverity.High);
+
+            PackageSearchMetadataContextInfo safeMetadata = PackageSearchMetadataContextInfo.Create(
+                PackageSearchMetadataBuilder.FromIdentity(safeIdentity).Build());
+            PackageSearchMetadataContextInfo vulnerableMetadata = PackageSearchMetadataContextInfo.Create(
+                PackageSearchMetadataBuilder.FromIdentity(vulnerableIdentity).Build());
+
+            VersionInfoContextInfo safeVersionInfo = await VersionInfoContextInfo.CreateAsync(new VersionInfo(safeVersion));
+            VersionInfoContextInfo vulnerableVersionInfo = await VersionInfoContextInfo.CreateAsync(new VersionInfo(vulnerableVersion));
+
+            var searchService = new Mock<INuGetSearchService>();
+            searchService.Setup(service => service.GetPackageVersionsAsync(
+                    It.IsAny<PackageIdentity>(),
+                    It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<IEnumerable<IProjectContextInfo>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[]
+                {
+                    safeVersionInfo,
+                    vulnerableVersionInfo
+                });
+            searchService.Setup(service => service.GetPackageMetadataAsync(
+                    safeIdentity,
+                    It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo)>((safeMetadata, null)));
+
+            var vulnerabilityService = new Mock<IPackageVulnerabilityService>();
+            vulnerabilityService.SetupGet(service => service.IsAuditSourceConfigured).Returns(true);
+            vulnerabilityService.Setup(service => service.GetVulnerableVersionsAsync(
+                    safeIdentity.Id,
+                    It.IsAny<IReadOnlyCollection<NuGetVersion>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Dictionary<NuGetVersion, int>
+                {
+                    [vulnerableVersion] = advisory.Severity
+                });
+            vulnerabilityService.Setup(service => service.GetVulnerabilityInfoAsync(
+                    It.IsAny<PackageIdentity>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PackageVulnerabilityMetadataContextInfo>());
+
+            var packageModel = PackageModelCreationTestHelper.CreateLocalPackageModel(
+                packageIdentity: safeIdentity,
+                packagePath: "C:\\TestPackage",
+                embeddedResourceCapable: Mock.Of<IEmbeddedResourcesCapable>());
+            var packageItemViewModel = new PackageItemViewModel(
+                searchService.Object,
+                packageModel,
+                vulnerabilityService.Object);
+
+            var brokeredSearchService = new Mock<INuGetSearchService>();
+            brokeredSearchService.Setup(service => service.GetPackageMetadataAsync(
+                    vulnerableIdentity,
+                    It.IsAny<IReadOnlyCollection<PackageSourceContextInfo>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<(PackageSearchMetadataContextInfo, PackageDeprecationMetadataContextInfo)>((vulnerableMetadata, null)));
+
+            var serviceBroker = new Mock<IServiceBroker>();
+#pragma warning disable ISB001 // Dispose of proxies
+            serviceBroker.Setup(broker => broker.GetProxyAsync<INuGetSearchService>(
+                    NuGetServices.SearchService,
+                    It.IsAny<ServiceActivationOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<INuGetSearchService>(brokeredSearchService.Object));
+#pragma warning restore ISB001 // Dispose of proxies
+
+            var model = new PackageDetailControlModel(
+                serviceBroker.Object,
+                Mock.Of<INuGetSolutionManagerService>(),
+                Array.Empty<IProjectContextInfo>(),
+                _mockNuGetUI.Object);
+
+            await model.SetCurrentPackageAsync(
+                packageItemViewModel,
+                ItemFilter.All,
+                () => packageItemViewModel,
+                CancellationToken.None);
+
+            var vulnerableResultSource = new TaskCompletionSource<List<PackageVulnerabilityMetadataContextInfo>>();
+            CancellationToken? vulnerableLookupToken = null;
+            vulnerabilityService.Setup(service => service.GetVulnerabilityInfoAsync(
+                    It.Is<PackageIdentity>(identity => identity.Equals(vulnerableIdentity)),
+                    It.IsAny<CancellationToken>()))
+                .Callback<PackageIdentity, CancellationToken>((_, token) => vulnerableLookupToken = token)
+                .Returns(vulnerableResultSource.Task);
+            vulnerabilityService.Setup(service => service.GetVulnerabilityInfoAsync(
+                    It.Is<PackageIdentity>(identity => identity.Equals(safeIdentity)),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PackageVulnerabilityMetadataContextInfo>());
+
+            DisplayVersion vulnerableDisplayVersion = model.Versions.Single(
+                version => version?.Version == vulnerableVersion && version.AdditionalInfo == null);
+            DisplayVersion safeDisplayVersion = model.Versions.Single(
+                version => version?.Version == safeVersion && version.AdditionalInfo == null);
+
+            // Act
+            model.SelectedVersion = vulnerableDisplayVersion;
+            Assert.True(vulnerableLookupToken.HasValue);
+            Assert.False(vulnerableLookupToken.Value.IsCancellationRequested);
+
+            model.SelectedVersion = safeDisplayVersion;
+
+            // Assert
+            Assert.True(vulnerableLookupToken.Value.IsCancellationRequested);
+            Assert.Equal(safeVersion, model.SelectedVersion.Version);
+            Assert.Equal(safeVersion, model.PackageMetadata.Version);
+            Assert.Empty(model.PackageVulnerabilities);
+
+            vulnerableResultSource.SetResult(new List<PackageVulnerabilityMetadataContextInfo> { advisory });
+
+            Assert.Equal(safeVersion, model.SelectedVersion.Version);
+            Assert.Equal(safeVersion, model.PackageMetadata.Version);
+            Assert.Empty(model.PackageVulnerabilities);
         }
 
         [Theory]
@@ -1848,4 +2118,3 @@ namespace NuGet.PackageManagement.UI.Test.Models
         void PropertyChanged(object sender, PropertyChangedEventArgs e);
     }
 }
-

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Models/V3DetailControlModelTests.cs
@@ -312,6 +312,44 @@ namespace NuGet.PackageManagement.UI.Test.Models
         }
 
         [Fact]
+        public void NormalizeVulnerabilities_WhenAdvisorySeveritiesConflict_KeepsHighestSeverity()
+        {
+            // Arrange
+            var duplicateAdvisoryUrl = new Uri("https://example.test/duplicate-advisory");
+            var otherAdvisoryUrl = new Uri("https://example.test/other-advisory");
+            var vulnerabilities = new[]
+            {
+                new PackageVulnerabilityMetadataContextInfo(
+                    duplicateAdvisoryUrl,
+                    (int)PackageVulnerabilitySeverity.Low),
+                new PackageVulnerabilityMetadataContextInfo(
+                    otherAdvisoryUrl,
+                    (int)PackageVulnerabilitySeverity.Moderate),
+                new PackageVulnerabilityMetadataContextInfo(
+                    duplicateAdvisoryUrl,
+                    (int)PackageVulnerabilitySeverity.High)
+            };
+
+            // Act
+            IReadOnlyCollection<PackageVulnerabilityMetadataContextInfo> normalizedVulnerabilities =
+                DetailControlModel.NormalizeVulnerabilities(vulnerabilities);
+
+            // Assert
+            Assert.Collection(
+                normalizedVulnerabilities,
+                vulnerability =>
+                {
+                    Assert.Equal(duplicateAdvisoryUrl, vulnerability.AdvisoryUrl);
+                    Assert.Equal((int)PackageVulnerabilitySeverity.High, vulnerability.Severity);
+                },
+                vulnerability =>
+                {
+                    Assert.Equal(otherAdvisoryUrl, vulnerability.AdvisoryUrl);
+                    Assert.Equal((int)PackageVulnerabilitySeverity.Moderate, vulnerability.Severity);
+                });
+        }
+
+        [Fact]
         public async Task SetCurrentPackageAsync_SortsVersions_ByNuGetVersionDesc()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageItemViewModelTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/ViewModels/PackageItemViewModelTests.cs
@@ -688,6 +688,47 @@ namespace NuGet.PackageManagement.UI.Test.ViewModels
                 because: $"vulnerability data was queried for version {queriedVersion}, " +
                          $"but VulnerableVersions only contains: [{string.Join(", ", viewModel.VulnerableVersions.Keys)}]");
         }
+
+        [Fact]
+        public async Task GetVulnerableVersionsAsync_ReturnsVulnerableVersionsWithoutUpdatingPackageState()
+        {
+            // Arrange
+            var modelIdentity = new PackageIdentity("Newtonsoft.Json", new NuGetVersion("12.0.1"));
+            var vulnerableVersion = new NuGetVersion("12.0.2");
+            var safeVersion = new NuGetVersion("13.0.1");
+
+            var mockVulnService = new Mock<IPackageVulnerabilityService>();
+            mockVulnService
+                .Setup(s => s.GetVulnerableVersionsAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IReadOnlyCollection<NuGetVersion>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Dictionary<NuGetVersion, int>
+                {
+                    { vulnerableVersion, (int)PackageVulnerabilitySeverity.High }
+                });
+
+            PackageModel packageModel = PackageModelCreationTestHelper.CreateRemotePackageModel(
+                modelIdentity,
+                vulnerableCapability: Mock.Of<IVulnerableCapable>(),
+                deprecationCapability: Mock.Of<IDeprecationCapable>(),
+                embeddedResourcesCapability: Mock.Of<IEmbeddedResourcesCapable>());
+
+            var viewModel = new PackageItemViewModel(
+                _searchService.Object,
+                packageModel,
+                mockVulnService.Object);
+
+            // Act
+            IReadOnlyDictionary<NuGetVersion, int> result = await viewModel.GetVulnerableVersionsAsync(
+                new[] { vulnerableVersion, safeVersion },
+                CancellationToken.None);
+
+            // Assert
+            result.Should().ContainKey(vulnerableVersion);
+            result.Should().NotContainKey(safeVersion);
+            viewModel.VulnerableVersions.Should().BeEmpty();
+            viewModel.IsPackageVulnerable.Should().BeFalse();
+        }
     }
 }
-

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Microsoft.VisualStudio.Shell;
 using Moq;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -19,12 +21,14 @@ using Xunit.Abstractions;
 
 namespace NuGet.PackageManagement.VisualStudio.Test
 {
-    public class PackageVulnerabilityServiceTests
+    [Collection(MockedVS.Collection)]
+    public class PackageVulnerabilityServiceTests : MockedVSCollectionTests
     {
         TestNuGetUILogger _testLogger;
         ITestOutputHelper _testOutputHelper;
 
-        public PackageVulnerabilityServiceTests(ITestOutputHelper testOutputHelper)
+        public PackageVulnerabilityServiceTests(GlobalServiceProvider globalServiceProvider, ITestOutputHelper testOutputHelper)
+            : base(globalServiceProvider)
         {
             _testOutputHelper = testOutputHelper;
             _testLogger = new TestNuGetUILogger(_testOutputHelper);
@@ -165,6 +169,84 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Equal(1, getVulnerabilityCallCount);
         }
 
+        /// <summary>
+        /// Verifies that canceling one caller stops only that caller's wait. A second caller joins the same
+        /// in-progress vulnerability download and receives its result after the shared operation completes.
+        /// </summary>
+        [Fact]
+        public async Task GetVulnerabilityInfoAsync_CanceledCaller_DoesNotCancelCachedVulnerabilityData()
+        {
+            // Arrange
+            PackageSource source = new PackageSource("https://contoso.test/vulnerability/v3/index.json");
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new()
+            {
+                new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
+                {
+                    {
+                        "Package1",
+                        new PackageVulnerabilityInfo[]
+                        {
+                            new PackageVulnerabilityInfo(
+                                new Uri("https://vulnerability1"),
+                                PackageVulnerabilitySeverity.Low,
+                                VersionRange.Parse("[1.0.0,2.0.0)"))
+                        }
+                    }
+                }
+            };
+            GetVulnerabilityInfoResult result = new GetVulnerabilityInfoResult(knownVulnerabilities, exceptions: null);
+            var resultSource = new TaskCompletionSource<GetVulnerabilityInfoResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int getVulnerabilityCallCount = 0;
+
+            var vulnerabilityResource = new Mock<IVulnerabilityInfoResource>();
+            vulnerabilityResource.Setup(resource => resource.GetVulnerabilityInfoAsync(
+                    It.IsAny<SourceCacheContext>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => getVulnerabilityCallCount++)
+                .Returns(resultSource.Task);
+
+            var sourceRepository = new Mock<SourceRepository>();
+            sourceRepository.Setup(s => s.GetResourceAsync<IVulnerabilityInfoResource>(VsShellUtilities.ShutdownToken))
+                .ReturnsAsync(vulnerabilityResource.Object);
+
+            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(
+                new List<SourceRepository> { sourceRepository.Object },
+                new List<SourceRepository>().AsReadOnly(),
+                _testLogger);
+
+            var packageIdentity = new PackageIdentity("Package1", new NuGetVersion("1.0.0"));
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            // Act
+            Task<List<PackageVulnerabilityMetadataContextInfo>?> canceledCall =
+                packageVulnerabilityService.GetVulnerabilityInfoAsync(
+                    packageIdentity,
+                    cancellationTokenSource.Token);
+
+            Assert.Equal(1, getVulnerabilityCallCount);
+            Assert.False(resultSource.Task.IsCompleted);
+
+            cancellationTokenSource.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledCall);
+            Assert.True(canceledCall.IsCanceled);
+            Assert.False(resultSource.Task.IsCompleted);
+
+            Task<List<PackageVulnerabilityMetadataContextInfo>?> secondCall =
+                packageVulnerabilityService.GetVulnerabilityInfoAsync(
+                    packageIdentity,
+                    CancellationToken.None);
+            Assert.False(secondCall.IsCompleted);
+            Assert.Equal(1, getVulnerabilityCallCount);
+
+            resultSource.SetResult(result);
+            List<PackageVulnerabilityMetadataContextInfo>? vulnerabilities = await secondCall;
+
+            Assert.NotNull(vulnerabilities);
+            Assert.Single(vulnerabilities);
+            Assert.Equal(1, getVulnerabilityCallCount);
+        }
+
         [Fact]
         public async Task GetVulnerabilityInfoAsync_ResetVulnerabilityData_ResetsVulnerabilityData()
         {
@@ -220,6 +302,69 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.NotNull(vulnerabilities);
             Assert.Equal(1, vulnerabilities.Count);
             Assert.Equal(3, getVulnerabilityCallCount);
+        }
+
+        [Fact]
+        public async Task GetVulnerableVersionsAsync_ReturnsMaxSeverityForVulnerableVersionsOnly()
+        {
+            // Arrange
+            PackageSource source = new PackageSource("https://contoso.test/vulnerability/v3/index.json");
+            List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>> knownVulnerabilities = new List<IReadOnlyDictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>>()
+            {
+                new Dictionary<string, IReadOnlyList<PackageVulnerabilityInfo>>
+                {
+                    {
+                        "Package1",
+                        new PackageVulnerabilityInfo[] {
+                            new PackageVulnerabilityInfo(new Uri("https://vulnerability1"), PackageVulnerabilitySeverity.Low, VersionRange.Parse("[1.0.0,2.0.0)")),
+                            new PackageVulnerabilityInfo(new Uri("https://vulnerability2"), PackageVulnerabilitySeverity.Critical, VersionRange.Parse("[1.5.0,2.0.0)"))
+                        }
+                    }
+                }
+            };
+
+            Dictionary<string, GetVulnerabilityInfoResult> vulnerabilityResults = new()
+            {
+                { source.Name, new GetVulnerabilityInfoResult(knownVulnerabilities, exceptions: null) }
+            };
+
+            var providers = new List<INuGetResourceProvider> { new VulnerabilityInfoResourceProvider(vulnerabilityResults) };
+            var sourceRepository = new SourceRepository(source, providers);
+            IReadOnlyList<SourceRepository> auditSourceRepositories = new List<SourceRepository>().AsReadOnly();
+            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository }, auditSourceRepositories, _testLogger);
+
+            var versions = new List<NuGetVersion>
+            {
+                new NuGetVersion("1.0.0"), // Low only
+                new NuGetVersion("1.5.0"), // Low + Critical => Critical
+                new NuGetVersion("2.0.0"), // not vulnerable (exclusive upper bound)
+            };
+
+            // Act
+            IReadOnlyDictionary<NuGetVersion, int> result = await packageVulnerabilityService.GetVulnerableVersionsAsync("Package1", versions, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Equal((int)PackageVulnerabilitySeverity.Low, result[new NuGetVersion("1.0.0")]);
+            Assert.Equal((int)PackageVulnerabilitySeverity.Critical, result[new NuGetVersion("1.5.0")]);
+            Assert.False(result.ContainsKey(new NuGetVersion("2.0.0")));
+        }
+
+        [Fact]
+        public async Task GetVulnerableVersionsAsync_EmptyVersions_ReturnsEmpty()
+        {
+            // Arrange
+            PackageSource source = new PackageSource("https://contoso.test/vulnerability/v3/index.json");
+            var providers = new List<INuGetResourceProvider>();
+            var sourceRepository = new SourceRepository(source, providers);
+            IReadOnlyList<SourceRepository> auditSourceRepositories = new List<SourceRepository>().AsReadOnly();
+            PackageVulnerabilityService packageVulnerabilityService = new PackageVulnerabilityService(new List<SourceRepository> { sourceRepository }, auditSourceRepositories, _testLogger);
+
+            // Act
+            IReadOnlyDictionary<NuGetVersion, int> result = await packageVulnerabilityService.GetVulnerableVersionsAsync("Package1", new List<NuGetVersion>(), CancellationToken.None);
+
+            // Assert
+            Assert.Empty(result);
         }
 
         internal class VulnerabilityInfoResourceProvider : ResourceProvider

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/PackageVulnerabilityServiceTests.cs
@@ -148,7 +148,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             var sourceRepository = new Mock<SourceRepository>();
 
-            sourceRepository.Setup(s => s.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None))
+            sourceRepository.Setup(s => s.GetResourceAsync<IVulnerabilityInfoResource>(VsShellUtilities.ShutdownToken))
                 .ReturnsAsync(vulnerabilityResource.Object);
 
             IReadOnlyList<SourceRepository> auditSourceRepositories = new List<SourceRepository>().AsReadOnly();
@@ -279,7 +279,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             var sourceRepository = new Mock<SourceRepository>();
 
-            sourceRepository.Setup(s => s.GetResourceAsync<IVulnerabilityInfoResource>(CancellationToken.None))
+            sourceRepository.Setup(s => s.GetResourceAsync<IVulnerabilityInfoResource>(VsShellUtilities.ShutdownToken))
                 .ReturnsAsync(vulnerabilityResource.Object);
 
             IReadOnlyList<SourceRepository> auditSourceRepositories = new List<SourceRepository>().AsReadOnly();


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/15071 
(Developer Community ticket: https://developercommunity.visualstudio.com/t/NuGet-Package-Manager-version-dropdown-o/11104121)

Fixes: https://github.com/NuGet/Home/issues/13051
Fixes: https://github.com/NuGet/Home/issues/14253
Fixes: https://github.com/NuGet/Home/issues/14724
Fixes: https://github.com/NuGet/Home/issues/14004
Progress: https://github.com/NuGet/Home/issues/14138

## Description

Makes vulnerability information consistent across the PM UI version dropdown, package details, and Installed-tab warnings.

When audit sources are configured, they are now authoritative. Otherwise, PM UI uses vulnerability data from package sources

### Audit Sources reflected in Version dropdown

Here, the audit source was previously ignored in the Version dropdown on the Left (before this PR).
After this PR (right side), we can see the version `3.5.3 (Vulnerable)` is properly indicated.
<img width="2973" height="1655" alt="image" src="https://github.com/user-attachments/assets/f7407037-9934-4af5-b169-977d766fc7e2" />

### Local source versions

This avoids losing vulnerability indicators when local and remote package metadata are merged.

In this example, the left (Before this PR) is missing a vulnerability indicator for 12.0.1 because a local package source has this package. 
With this PR (right side) shows it is now reflected properly:
<img width="1160" height="766" alt="image" src="https://github.com/user-attachments/assets/165d1a37-3522-468f-84a8-45e3d23de061" />

### Refresh and Cache/Cancellation fix

- The shared vulnerability database load now uses the Visual Studio shutdown token for its lifetime. 
- Refresh and package selection tokens cancel only the individual caller’s wait, preventing stale UI updates without canceling the cached operation needed by subsequent requests
- Adds a test that cancels the first request, and proves that the second request gets vulnerability data as expected.


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
