### PR TITLE
VS Options Clear NuGet local resources action now uses OK/Cancel

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -2411,7 +2411,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Once started, this action cannot be cancelled..
+        ///   Looks up a localized string similar to Once started, this action cannot be cancelled. Select OK to continue..
         /// </summary>
         public static string VSOptions_Text_ClearLocalsPromptMessage {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -990,7 +990,7 @@ Error: {1}</value>
     <value>Close</value>
   </data>
   <data name="VSOptions_Text_ClearLocalsPromptMessage" xml:space="preserve">
-    <value>Once started, this action cannot be cancelled.</value>
+    <value>Once started, this action cannot be cancelled. Select OK to continue.</value>
   </data>
   <data name="CopyMenuCommandLabel" xml:space="preserve">
     <value>_Copy</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.cs.xlf
@@ -1287,8 +1287,8 @@ Chyba: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">Po zahájení se tato akce nedá zrušit.</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">Po zahájení se tato akce nedá zrušit.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.de.xlf
@@ -1287,8 +1287,8 @@ Fehler: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">Nach dem Starten kann diese Aktion nicht abgebrochen werden.</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">Nach dem Starten kann diese Aktion nicht abgebrochen werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.es.xlf
@@ -1287,8 +1287,8 @@ Error: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">Una vez iniciada, esta acción no se puede cancelar.</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">Una vez iniciada, esta acción no se puede cancelar.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.fr.xlf
@@ -1287,8 +1287,8 @@ Erreur : {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">Une fois démarrée, cette action ne peut pas être annulée.</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">Une fois démarrée, cette action ne peut pas être annulée.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.it.xlf
@@ -1287,8 +1287,8 @@ Errore: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">Una volta avviata, questa azione non può essere annullata.</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">Una volta avviata, questa azione non può essere annullata.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ja.xlf
@@ -1287,8 +1287,8 @@ Error: {1}</source>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">この操作は開始した後に取り消すことはできません。</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">この操作は開始した後に取り消すことはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ko.xlf
@@ -1287,8 +1287,8 @@ Error: {1}</source>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">일단 시작하면 이 작업은 취소할 수 없습니다.</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">일단 시작하면 이 작업은 취소할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pl.xlf
@@ -1287,8 +1287,8 @@ Błąd: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">Po uruchomieniu, tej akcji nie można anulować.</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">Po uruchomieniu, tej akcji nie można anulować.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.pt-BR.xlf
@@ -1287,8 +1287,8 @@ Erro: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">Depois de iniciada, esta ação não poderá ser cancelada.</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">Depois de iniciada, esta ação não poderá ser cancelada.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.ru.xlf
@@ -1287,8 +1287,8 @@ Error: {1}</source>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">После запуска это действие нельзя отменить.</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">После запуска это действие нельзя отменить.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.tr.xlf
@@ -1287,8 +1287,8 @@ Hata: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">Başlatıldıktan sonra bu eylem iptal edilemez.</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">Başlatıldıktan sonra bu eylem iptal edilemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hans.xlf
@@ -1287,8 +1287,8 @@ Error: {1}</source>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">启动后，无法取消此操作。</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">启动后，无法取消此操作。</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/xlf/Resources.zh-Hant.xlf
@@ -1287,8 +1287,8 @@ Error: {1}</source>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptMessage">
-        <source>Once started, this action cannot be cancelled.</source>
-        <target state="translated">一旦啟動，就無法取消此動作。</target>
+        <source>Once started, this action cannot be cancelled. Select OK to continue.</source>
+        <target state="needs-review-translation">一旦啟動，就無法取消此動作。</target>
         <note />
       </trans-unit>
       <trans-unit id="VSOptions_Text_ClearLocalsPromptTitle">

--- a/src/NuGet.Clients/NuGet.Tools/Commands/ClearNuGetLocalResourcesCommand.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Commands/ClearNuGetLocalResourcesCommand.cs
@@ -59,15 +59,14 @@ namespace NuGet.Tools.Commands
                 try
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                    var isUserContinuing = MessageHelper.ShowQueryMessage(
+                    var isUserContinuing = MessageHelper.ShowOkCancelMessage(
                         message: Resx.VSOptions_Text_ClearLocalsPromptMessage,
                         title: Resx.VSOptions_Text_ClearLocalsPromptTitle,
-                        showCancelButton: false,
                         defaultButton: OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_SECOND);
 
                     NavigatedTelemetryEvent evt;
 
-                    if (isUserContinuing == true)
+                    if (isUserContinuing)
                     {
                         var clearNuGetLocalsViewModel = new ClearNuGetLocalsViewModel(ClearNuGetLocalsCommandExecuteAsync);
                         OutputConsoleLogger.Start();

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/MessageHelper.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/MessageHelper.cs
@@ -70,6 +70,19 @@ namespace NuGet.VisualStudio
             return (result == NativeMethods.IDYES);
         }
 
+        public static bool ShowOkCancelMessage(string message, string title, OLEMSGDEFBUTTON defaultButton)
+        {
+            int result = VsShellUtilities.ShowMessageBox(
+                GetServiceProvider(),
+                message,
+                title,
+                OLEMSGICON.OLEMSGICON_QUERY,
+                OLEMSGBUTTON.OLEMSGBUTTON_OKCANCEL,
+                defaultButton);
+
+            return result == NativeMethods.IDOK;
+        }
+
         public static void ShowError(ErrorListProvider errorListProvider, TaskErrorCategory errorCategory, TaskPriority priority, string errorText, IVsHierarchy hierarchyItem)
         {
             ErrorTask errorTask = new ErrorTask();
@@ -90,6 +103,7 @@ namespace NuGet.VisualStudio
 
         internal static class NativeMethods
         {
+            public const int IDOK = 1;
             public const int IDCANCEL = 2;
             public const int IDYES = 6;
             public const int IDNO = 7;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/15020

## Description

The "Clear NuGet local resources" command on the General Visual Studio options page was previously using Yes/No options.
This means that using ESC (escape) key does not cancel the command.
Since the modal prompt is just a precaution to prevent unintentionally starting the clearing process, we can use OK/Cancel.

- Creates a helper for the OK/Cancel style of dialog
- Adds "Select OK to continue." to the original message for clarity.

<img width="659" height="293" alt="image" src="https://github.com/user-attachments/assets/27fd65a6-4e10-4f8d-99e6-f63e7c457f83" />


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc. **No VS options docs call out the explicit strings**
