### PR TITLE
Fix NRE opening Solution PM UI for many projects caused by race condition

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -82,8 +82,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public INuGetProjectContext NuGetProjectContext { get; set; }
 
-        public Task InitializationTask { get; set; }
-
         public bool IsInitialized
         {
             get
@@ -322,8 +320,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public async Task<IEnumerable<NuGetProject>> GetNuGetProjectsAsync()
         {
-            InitializationTask = EnsureInitializeAsync();
-            await InitializationTask;
+            await EnsureInitializeAsync();
 
             // In certain cases project cache is populated with incomplete project data
             // Filter out null entries here.
@@ -332,7 +329,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 .Where(p => p != null)
                 .ToList();
 
-            InitializationTask = null;
             return projects;
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -31,11 +31,6 @@ namespace NuGet.PackageManagement.VisualStudio
         bool IsInitialized { get; }
 
         /// <summary>
-        /// Gets the SolutionManager initialization task, if there is one running.
-        /// </summary>
-        Task InitializationTask { get; set; }
-
-        /// <summary>
         /// Retrieves <see cref="NuGetProject"/> instance associated with VS project.
         /// Creates new instance if not found in project system cache.
         /// </summary>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetProjectManagerServiceTests.cs
@@ -1789,8 +1789,6 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             public bool IsInitialized => throw new NotImplementedException();
 
-            public Task InitializationTask { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
             public string SolutionDirectory => _directory.Path;
 
             public CancellationToken VsShutdownToken => CancellationToken.None;


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->

Fixes: https://github.com/NuGet/Home/issues/15073

## Description

Opening the Solution Package Manager UI (PM UI) in a solution with many projects could intermittently fail with an error bar and a `NullReferenceException` in the output window, originating at `VSSolutionManager.GetNuGetProjectsAsync`.

### Root cause:

- InitializationTask was a shared field meant to be a shared signal meaning "an initialization is currently in progress, and callers should wait on it".
- `null` meant no initialization is running right now
- A task value mean initialization is in progress

The `InitializationTask` sentinel existed so an external consumer could observe an in-flight initialization and await it.
That consumer (in `PackageItemLoader`) was removed in 2020 by `6aeb27caae5` ("PM UI: enable CodeSpaces support", #3649).
Since then the field has been written but never read — dead code for ~6 years.
The real, idempotent initialization is already handled by `EnsureInitializeAsync()`, so the field adds nothing but risk.

### Fix

Solution PM UI uses this task per project, via `NuGetPackageSearchService.GetAllPackageFoldersAsync`.

- Issue is, one invocation can execute `InitializationTask = null` in the window between another invocation's assignment
- We could fix that by awaiting on the local field, not the shared InitializationTask.
- Even better, we can remove the shared field entirely because its consumers were removed in #3649!
 
No behavior is lost, initialization is still awaited, just without the racy shared sentinel value.

### Validation

Used https://github.com/OrchardCMS/OrchardCore (200+ projects) which repro'd for me in the Issue, but did not repro after several trials using this fix.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [ ] ~Added tests~ behavior-preserving dead-code/race removal. The concurrency race isn't practical to cover with a deterministic unit test.
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
