### PR TITLE
Prevent invalid PackageReference errors caused by package ID casing

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -825,7 +825,7 @@ namespace NuGet.CommandLine.XPlat
                         {
                             try
                             { // In case proj and assets file are not in sync and some refs were deleted
-                                installedPackage = projectPackages.First(p => p.Name.Equals(topLevelPackage.Name, StringComparison.Ordinal));
+                                installedPackage = projectPackages.First(p => p.Name.Equals(topLevelPackage.Name, StringComparison.OrdinalIgnoreCase));
                             }
                             catch (Exception)
                             {

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/MSBuildAPIUtilityTests.cs
@@ -809,6 +809,65 @@ namespace NuGet.CommandLine.Xplat.Tests
         }
 
         [Fact]
+        public void GetResolvedVersions_WithPackageReferenceCasingDifferentFromAssetsFile_GetsVersion()
+        {
+            // Arrange
+            var pathContext = new SimpleTestPathContext();
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+            var net8 = NuGetFramework.Parse("net8.0");
+            string targetAlias = net8.GetShortFolderName();
+            var projectA = SimpleTestProjectContext.CreateNETCore("a", pathContext.SolutionRoot, net8);
+            projectA.AddPackageToAllFrameworks(new SimpleTestPackageContext("myPackage", "1.1.1"));
+            solution.Projects.Add(projectA);
+            solution.Create();
+
+            var project = Project.FromFile(projectA.ProjectPath, new ProjectOptions());
+            var lockFile = new LockFile
+            {
+                Version = 3,
+                Targets =
+                [
+                    new LockFileTarget
+                    {
+                        TargetFramework = net8,
+                        TargetAlias = targetAlias,
+                        Libraries =
+                        [
+                            new LockFileTargetLibrary
+                            {
+                                Name = "myPackage",
+                                Version = new NuGetVersion("1.1.1")
+                            }
+                        ]
+                    }
+                ],
+                PackageSpec = new PackageSpec(
+                [
+                    new TargetFrameworkInformation
+                    {
+                        FrameworkName = net8,
+                        TargetAlias = targetAlias,
+                        Dependencies =
+                        [
+                            new LibraryDependency
+                            {
+                                LibraryRange = new LibraryRange("MYPACKAGE")
+                            }
+                        ]
+                    }
+                ])
+            };
+
+            // Act
+            var result = MSBuildAPIUtility.GetResolvedVersions(project, new List<string>(), lockFile, transitive: false);
+
+            // Assert
+            var package = Assert.Single(Assert.Single(result).TopLevelPackages);
+            Assert.Equal("myPackage", package.Name);
+            Assert.Equal("1.1.1", package.OriginalRequestedVersion);
+        }
+
+        [Fact]
         public void GetResolvedVersions_WithAPackageInDirectoryPackageProps_GetsVersion()
         {
             // Arrange


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/15079

## Description

NuGet compares package IDs case-insensitive. However, one place assumed that casing in the assets file would match the casing in the PackageReference. 

This makes the comparison always case-insensitive. Adds a test for the scenario.

### Before this change

Error is shown. After this PR (right), the list succeeds for the same project.
> Unable to read a package reference from the project `C:\NuGet.Client-C\.test\PackageCasingRepro\PackageCasingRepro.csproj`. Make sure that your project file and project.assets.json file are in sync by running restore.
<img width="772" height="286" alt="image" src="https://github.com/user-attachments/assets/29f57505-12ce-4791-9a0b-ebf4a46197a1" />

### After this change

List package works properly.

<img width="637" height="305" alt="image" src="https://github.com/user-attachments/assets/2d169b7a-0b98-417e-9c14-19c347c075fa" />


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
