### PR TITLE
Fix restore failures when building after solution load

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -38,6 +38,7 @@ namespace NuGet.SolutionRestoreManager
         private const int RequestQueueLimit = 150;
         private const int PromoteAttemptsLimit = 150;
         private const int DelaySolutionLoadRetry = 100;
+        private const int MaxIdleWaitTimeMs = 30000;
         private static TimeSpan BulkRestoreCoordinationTimeout = new(hours: 0, minutes: 5, seconds: 0);
 
         private readonly object _lockPendingRequestsObj = new object();
@@ -57,6 +58,7 @@ namespace NuGet.SolutionRestoreManager
         private Task<bool> _activeRestoreTask;
         private int _initialized;
         private bool _isFirstRestore = true;
+        private bool _hasCompletedOnBuildRestoreCoordination;
         private DateTimeOffset _lastRestoreCompletedTime;
         private RestoreOperationSource _lastRestoreOperationSource;
 
@@ -285,6 +287,10 @@ namespace NuGet.SolutionRestoreManager
                 _pendingRestore = new BackgroundRestoreOperation();
                 _activeRestoreTask = TaskResult.True;
                 _restoreJobContext = new SolutionRestoreJobContext();
+                _isFirstRestore = true;
+                _hasCompletedOnBuildRestoreCoordination = false;
+                _lastRestoreCompletedTime = default;
+                _lastRestoreOperationSource = default;
 
                 // Set to signaled, restore is no longer busy
                 _isCompleteEvent.Set();
@@ -423,15 +429,33 @@ namespace NuGet.SolutionRestoreManager
                     using (var restoreOperation = new BackgroundRestoreOperation())
                     {
                         await PromoteTaskToActiveAsync(restoreOperation, token);
+                        RestoreReadinessResult restoreReadiness = new();
+                        bool waitForOnBuildRestoreReadiness = ShouldWaitForOnBuildRestoreReadiness(request);
+                        if (waitForOnBuildRestoreReadiness)
+                        {
+                            restoreReadiness = await WaitForOnBuildRestoreReadinessAsync(token);
+                            if (restoreReadiness.RestoreReason == ImplicitRestoreReason.ProjectsReadyCheckTimeout)
+                            {
+                                Logger.LogWarning(
+                                    $"Timed out after {BulkRestoreCoordinationTimeout} without restore readiness progress before an on-build restore. " +
+                                    $"Restore info sources: {restoreReadiness.ProjectRestoreInfoSourcesCount}; pending sources: {restoreReadiness.PendingProjectRestoreInfoSourcesCount}.");
+                            }
+                        }
+
                         var restoreTrackingData = GetRestoreTrackingData(
-                            restoreReason: ImplicitRestoreReason.None,
+                            restoreReason: restoreReadiness.RestoreReason,
                             requestCount: 1,
-                            projectRestoreInfoSourcesCount: -1,
-                            bulkRestoreCoordinationCheckStartTime: default,
-                            projectsReadyCheckCount: 0,
-                            projectReadyTimings: new List<TimeSpan>(),
+                            projectRestoreInfoSourcesCount: restoreReadiness.ProjectRestoreInfoSourcesCount,
+                            bulkRestoreCoordinationCheckStartTime: restoreReadiness.BulkRestoreCoordinationCheckStartTime,
+                            projectsReadyCheckCount: restoreReadiness.ProjectsReadyCheckCount,
+                            projectReadyTimings: restoreReadiness.ProjectReadyTimings,
                             request.ExplicitRestoreReason);
                         var result = await ProcessRestoreRequestAsync(restoreOperation, request, restoreTrackingData, token);
+                        if (waitForOnBuildRestoreReadiness &&
+                            restoreReadiness.RestoreReason == ImplicitRestoreReason.ProjectsReady)
+                        {
+                            _hasCompletedOnBuildRestoreCoordination = true;
+                        }
 
                         return result;
                     }
@@ -454,33 +478,112 @@ namespace NuGet.SolutionRestoreManager
             Interlocked.Exchange(ref _restoreJobContext, new SolutionRestoreJobContext());
         }
 
+        private bool ShouldWaitForOnBuildRestoreReadiness(SolutionRestoreRequest request)
+        {
+            return request.RestoreSource == RestoreOperationSource.OnBuild &&
+                !_hasCompletedOnBuildRestoreCoordination;
+        }
+
+        internal async Task<RestoreReadinessResult> WaitForOnBuildRestoreReadinessAsync(CancellationToken token)
+        {
+            return await WaitForOnBuildRestoreReadinessCoreAsync(
+                waitForSolutionLoadedAsync: WaitForSolutionLoadedAsync,
+                isAllProjectsNominatedAsync: () => _solutionManager.Value.IsAllProjectsNominatedAsync(),
+                checkProjectsReadyAsync: CheckProjectsReadyAsync,
+                getProjectRestoreInfoSourceCounts: GetProjectRestoreInfoSourceCounts,
+                delayAsync: (delay, cancellationToken) => Task.Delay(delay, cancellationToken),
+                getUtcNow: () => DateTime.UtcNow,
+                token: token);
+        }
+
+        internal static async Task<RestoreReadinessResult> WaitForOnBuildRestoreReadinessCoreAsync(
+            Func<CancellationToken, Task> waitForSolutionLoadedAsync,
+            Func<Task<bool>> isAllProjectsNominatedAsync,
+            Func<DateTime, CancellationToken, Task<(bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, TimeSpan projectReadyCheckTime)>> checkProjectsReadyAsync,
+            Func<(int projectRestoreInfoSourcesCount, int pendingProjectRestoreInfoSourcesCount)> getProjectRestoreInfoSourceCounts,
+            Func<TimeSpan, CancellationToken, Task> delayAsync,
+            Func<DateTime> getUtcNow,
+            CancellationToken token)
+        {
+            RestoreReadinessResult restoreReadiness = new();
+
+            await waitForSolutionLoadedAsync(token);
+
+            restoreReadiness.BulkRestoreCoordinationCheckStartTime = getUtcNow();
+            DateTime lastProgressTime = restoreReadiness.BulkRestoreCoordinationCheckStartTime.Value;
+            while (!token.IsCancellationRequested)
+            {
+                (int projectRestoreInfoSourcesCount, int pendingProjectRestoreInfoSourcesCount) = getProjectRestoreInfoSourceCounts();
+                if (restoreReadiness.ProjectRestoreInfoSourcesCount >= 0 &&
+                    (projectRestoreInfoSourcesCount != restoreReadiness.ProjectRestoreInfoSourcesCount ||
+                     pendingProjectRestoreInfoSourcesCount != restoreReadiness.PendingProjectRestoreInfoSourcesCount))
+                {
+                    lastProgressTime = getUtcNow();
+                }
+
+                restoreReadiness.ProjectRestoreInfoSourcesCount = projectRestoreInfoSourcesCount;
+                restoreReadiness.PendingProjectRestoreInfoSourcesCount = pendingProjectRestoreInfoSourcesCount;
+
+                var isAllProjectsNominated = await isAllProjectsNominatedAsync();
+                if (!isAllProjectsNominated)
+                {
+                    TimeSpan timeoutTime = CalculateTimeoutTime(
+                        lastProgressTime,
+                        getUtcNow(),
+                        BulkRestoreCoordinationTimeout);
+                    if (timeoutTime == TimeSpan.Zero)
+                    {
+                        restoreReadiness.RestoreReason = ImplicitRestoreReason.ProjectsReadyCheckTimeout;
+                        break;
+                    }
+
+                    await delayAsync(
+                        timeoutTime < TimeSpan.FromMilliseconds(IdleTimeoutMs)
+                            ? timeoutTime
+                            : TimeSpan.FromMilliseconds(IdleTimeoutMs),
+                        token);
+                    continue;
+                }
+
+                restoreReadiness.ProjectsReadyCheckCount++;
+                (bool allProjectsReady, bool bulkCheckTimeout, int checkedProjectRestoreInfoSourcesCount, TimeSpan projectReadyTiming) =
+                    await checkProjectsReadyAsync(
+                        lastProgressTime,
+                        token);
+                restoreReadiness.ProjectRestoreInfoSourcesCount = checkedProjectRestoreInfoSourcesCount;
+                restoreReadiness.ProjectReadyTimings.Add(projectReadyTiming);
+
+                if (allProjectsReady)
+                {
+                    restoreReadiness.RestoreReason = ImplicitRestoreReason.ProjectsReady;
+                    break;
+                }
+
+                if (bulkCheckTimeout)
+                {
+                    restoreReadiness.RestoreReason = ImplicitRestoreReason.ProjectsReadyCheckTimeout;
+                    break;
+                }
+
+                lastProgressTime = getUtcNow();
+            }
+
+            token.ThrowIfCancellationRequested();
+
+            return restoreReadiness;
+        }
+
         private async Task<bool> StartBackgroundJobRunnerAsync(CancellationToken token)
         {
             // Hops onto a background pool thread
             await TaskScheduler.Default;
 
             var status = false;
-            // Check if the solution is fully loaded
-            while (!_solutionLoadedEvent.IsSet)
-            {
-                // Needed when OnAfterBackgroundSolutionLoadComplete fires before
-                // Advise has been called.
-                if (await IsSolutionFullyLoadedAsync())
-                {
-                    _solutionLoadedEvent.Set();
-                    break;
-                }
-                else
-                {
-                    // Waits for 100ms to let solution fully load or canceled
-                    await _solutionLoadedEvent.WaitAsync()
-                        .WithTimeout(TimeSpan.FromMilliseconds(DelaySolutionLoadRetry))
-                        .WithCancellation(token);
-                }
-            }
+            await WaitForSolutionLoadedAsync(token);
 
             ImplicitRestoreReason restoreReason = ImplicitRestoreReason.None;
             DateTime? bulkRestoreCoordinationCheckStartTime = default;
+            DateTime lastRestoreReadinessProgressTime = default;
             // Loops until there are pending restore requests or it's get cancelled
             while (!token.IsCancellationRequested)
             {
@@ -501,6 +604,7 @@ namespace NuGet.SolutionRestoreManager
                         // Blocks the execution until first request is scheduled
                         // Monitors the cancelllation token as well.
                         var request = _pendingRequests.Value.Take(token);
+                        lastRestoreReadinessProgressTime = DateTime.UtcNow;
 
                         token.ThrowIfCancellationRequested();
 
@@ -529,41 +633,23 @@ namespace NuGet.SolutionRestoreManager
                             {
                                 if (isAllProjectsNominated)
                                 {
-                                    var projectReadyCheckMeasurement = Stopwatch.StartNew();
                                     if (bulkRestoreCoordinationCheckStartTime == default)
                                     {
                                         bulkRestoreCoordinationCheckStartTime = DateTime.UtcNow;
+                                        lastRestoreReadinessProgressTime = bulkRestoreCoordinationCheckStartTime.Value;
                                     }
+
                                     projectsReadyCheckCount++;
-                                    // If we are about to start restore, we should run through all the projects to ensure there isn't a pending nomination.
-                                    IReadOnlyList<object> restoreProjectInfoSources = _solutionManager.Value.GetAllProjectRestoreInfoSources();
-                                    projectRestoreInfoSourcesCount = restoreProjectInfoSources.Count;
-                                    var allProjectsReady = true;
-                                    var bulkCheckTimeout = false;
-                                    for (int i = 0; i < restoreProjectInfoSources.Count && !bulkCheckTimeout; i++)
-                                    {
-                                        var restoreInfoSource = (IVsProjectRestoreInfoSource)restoreProjectInfoSources[i];
-                                        if (restoreInfoSource.HasPendingNomination)
-                                        {
-                                            allProjectsReady = false;
-                                            TimeSpan timeoutTime = CalculateTimeoutTime(bulkRestoreCoordinationCheckStartTime.Value, DateTime.UtcNow, BulkRestoreCoordinationTimeout);
-                                            var timeoutTask = Task.Delay(timeoutTime, token);
-                                            var whenNominatedTask = restoreInfoSource.WhenNominated(token);
-
-                                            var result = await Task.WhenAny(whenNominatedTask, timeoutTask);
-                                            if (result == timeoutTask)
-                                            {
-                                                bulkCheckTimeout = true;
-                                            }
-                                        }
-                                    }
-
-                                    projectReadyCheckMeasurement.Stop();
+                                    (bool allProjectsReady, bool bulkCheckTimeout, int updatedProjectRestoreInfoSourcesCount, TimeSpan projectReadyCheckTime) =
+                                        await CheckProjectsReadyAsync(
+                                            lastRestoreReadinessProgressTime,
+                                            token);
+                                    projectRestoreInfoSourcesCount = updatedProjectRestoreInfoSourcesCount;
                                     if (projectReadyTimings == null)
                                     {
                                         projectReadyTimings = new();
                                     }
-                                    projectReadyTimings.Add(projectReadyCheckMeasurement.Elapsed);
+                                    projectReadyTimings.Add(projectReadyCheckTime);
 
                                     if (allProjectsReady)
                                     {
@@ -573,11 +659,24 @@ namespace NuGet.SolutionRestoreManager
                                     if (bulkCheckTimeout)
                                     {
                                         restoreReason = ImplicitRestoreReason.ProjectsReadyCheckTimeout;
+                                        Logger.LogWarning(
+                                            $"Timed out after {BulkRestoreCoordinationTimeout} without restore readiness progress during background restore. " +
+                                            $"Restore info sources: {projectRestoreInfoSourcesCount}.");
                                         break;
                                     }
+
+                                    lastRestoreReadinessProgressTime = DateTime.UtcNow;
                                 }
                                 else
                                 {
+                                    if (lastNominationReceived.AddMilliseconds(MaxIdleWaitTimeMs) < DateTime.UtcNow)
+                                    {
+                                        restoreReason = ImplicitRestoreReason.NominationsIdleTimeout;
+                                        Logger.LogWarning(
+                                            $"Timed out after {TimeSpan.FromMilliseconds(MaxIdleWaitTimeMs)} without receiving a project nomination during background restore.");
+                                        break;
+                                    }
+
                                     await Task.Delay(IdleTimeoutMs, token);
                                 }
                             }
@@ -585,6 +684,7 @@ namespace NuGet.SolutionRestoreManager
                             {
                                 requestCount++;
                                 lastNominationReceived = DateTime.UtcNow;
+                                lastRestoreReadinessProgressTime = lastNominationReceived;
                                 // Upgrade request if necessary
                                 if (next != null && next.RestoreSource != request.RestoreSource)
                                 {
@@ -639,6 +739,97 @@ namespace NuGet.SolutionRestoreManager
             }
 
             return status;
+        }
+
+        private async Task WaitForSolutionLoadedAsync(CancellationToken token)
+        {
+            while (!_solutionLoadedEvent.IsSet)
+            {
+                // Needed when OnAfterBackgroundSolutionLoadComplete fires before
+                // Advise has been called.
+                if (await IsSolutionFullyLoadedAsync())
+                {
+                    _solutionLoadedEvent.Set();
+                    break;
+                }
+
+                // Waits for the solution-loaded signal or polls again after 100ms.
+                await Task.WhenAny(
+                    _solutionLoadedEvent.WaitAsync(token),
+                    Task.Delay(DelaySolutionLoadRetry, token));
+                token.ThrowIfCancellationRequested();
+            }
+        }
+
+        private async Task<(bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, TimeSpan projectReadyCheckTime)> CheckProjectsReadyAsync(
+            DateTime bulkRestoreCoordinationCheckStartTime,
+            CancellationToken token)
+        {
+            IReadOnlyList<object> restoreProjectInfoSources = _solutionManager.Value.GetAllProjectRestoreInfoSources();
+            return await CheckProjectsReadyCoreAsync(
+                restoreProjectInfoSources,
+                bulkRestoreCoordinationCheckStartTime,
+                getUtcNow: () => DateTime.UtcNow,
+                delayAsync: (delay, cancellationToken) => Task.Delay(delay, cancellationToken),
+                token);
+        }
+
+        private (int projectRestoreInfoSourcesCount, int pendingProjectRestoreInfoSourcesCount) GetProjectRestoreInfoSourceCounts()
+        {
+            IReadOnlyList<object> restoreProjectInfoSources = _solutionManager.Value.GetAllProjectRestoreInfoSources();
+            int pendingProjectRestoreInfoSourcesCount = restoreProjectInfoSources
+                .Cast<IVsProjectRestoreInfoSource>()
+                .Count(source => source.HasPendingNomination);
+            return (restoreProjectInfoSources.Count, pendingProjectRestoreInfoSourcesCount);
+        }
+
+        internal static async Task<(bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, TimeSpan projectReadyCheckTime)> CheckProjectsReadyCoreAsync(
+            IReadOnlyList<object> restoreProjectInfoSources,
+            DateTime bulkRestoreCoordinationCheckStartTime,
+            Func<DateTime> getUtcNow,
+            Func<TimeSpan, CancellationToken, Task> delayAsync,
+            CancellationToken token)
+        {
+            var projectReadyCheckMeasurement = Stopwatch.StartNew();
+
+            // If we are about to start restore, we should run through all the projects to ensure there isn't a pending nomination.
+            int projectRestoreInfoSourcesCount = restoreProjectInfoSources.Count;
+            var allProjectsReady = true;
+            var bulkCheckTimeout = false;
+            DateTime lastProgressTime = bulkRestoreCoordinationCheckStartTime;
+            for (int i = 0; i < restoreProjectInfoSources.Count && !bulkCheckTimeout; i++)
+            {
+                var restoreInfoSource = (IVsProjectRestoreInfoSource)restoreProjectInfoSources[i];
+                if (restoreInfoSource.HasPendingNomination)
+                {
+                    allProjectsReady = false;
+                    TimeSpan timeoutTime = CalculateTimeoutTime(
+                        lastProgressTime,
+                        getUtcNow(),
+                        BulkRestoreCoordinationTimeout);
+                    var timeoutTask = delayAsync(timeoutTime, token);
+                    var whenNominatedTask = restoreInfoSource.WhenNominated(token);
+
+                    var result = await Task.WhenAny(whenNominatedTask, timeoutTask);
+                    if (result == timeoutTask)
+                    {
+                        bulkCheckTimeout = true;
+                    }
+                    else
+                    {
+                        await whenNominatedTask;
+                        lastProgressTime = getUtcNow();
+                    }
+                }
+            }
+
+            projectReadyCheckMeasurement.Stop();
+
+            return (
+                allProjectsReady,
+                bulkCheckTimeout,
+                projectRestoreInfoSourcesCount,
+                projectReadyCheckMeasurement.Elapsed);
         }
 
         /// <summary>
@@ -785,6 +976,29 @@ namespace NuGet.SolutionRestoreManager
             _solutionLoadedEvent.Set();
 
             return VSConstants.S_OK;
+        }
+
+        internal sealed class RestoreReadinessResult
+        {
+            public RestoreReadinessResult()
+            {
+                RestoreReason = ImplicitRestoreReason.None;
+                ProjectRestoreInfoSourcesCount = -1;
+                PendingProjectRestoreInfoSourcesCount = -1;
+                ProjectReadyTimings = new List<TimeSpan>();
+            }
+
+            public ImplicitRestoreReason RestoreReason { get; set; }
+
+            public DateTime? BulkRestoreCoordinationCheckStartTime { get; set; }
+
+            public int ProjectsReadyCheckCount { get; set; }
+
+            public int ProjectRestoreInfoSourcesCount { get; set; }
+
+            public int PendingProjectRestoreInfoSourcesCount { get; set; }
+
+            public List<TimeSpan> ProjectReadyTimings { get; }
         }
 
         private class BackgroundRestoreOperation

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
@@ -149,5 +149,44 @@ namespace NuGet.SolutionRestoreManager.Test
                 .Verify(x => x.RestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
+        [Fact]
+        public async Task QueryDelayBuildAction_RestoreInProgress_DelaysBuild()
+        {
+            var settings = Mock.Of<ISettings>();
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var restoreChecker = Mock.Of<ISolutionRestoreChecker>();
+            var restoreStarted = new TaskCompletionSource<bool>();
+            var restoreCompleted = new TaskCompletionSource<bool>();
+            var buildAction = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+
+            Mock.Get(settings)
+                .Setup(x => x.GetSection("packageRestore"))
+                .Returns(() => new VirtualSettingSection("packageRestore",
+                    new AddItem("automatic", bool.TrueString)));
+            Mock.Get(restoreWorker)
+                .SetupGet(x => x.JoinableTaskFactory)
+                .Returns(_jtf);
+            Mock.Get(restoreWorker)
+                .Setup(x => x.RestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    restoreStarted.SetResult(true);
+                    return restoreCompleted.Task;
+                });
+
+            using var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager, restoreChecker);
+            await _jtf.SwitchToMainThreadAsync();
+
+            Task<bool> buildDelayTask = handler.RestoreAsync(buildAction, CancellationToken.None);
+            await restoreStarted.Task;
+
+            Assert.False(buildDelayTask.IsCompleted);
+
+            restoreCompleted.SetResult(true);
+
+            Assert.True(await buildDelayTask);
+        }
+
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreWorkerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreWorkerTests.cs
@@ -2,7 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
+using Moq;
+using NuGet.VisualStudio.Telemetry;
 using Xunit;
 
 namespace NuGet.SolutionRestoreManager.Test
@@ -29,6 +33,218 @@ namespace NuGet.SolutionRestoreManager.Test
 
             var timeout = SolutionRestoreWorker.CalculateTimeoutTime(startTime: startTime, currentTime: currentTime, timeoutTime: timeoutSpan);
             timeout.TotalMilliseconds.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task WaitForOnBuildRestoreReadinessCoreAsync_WhenProjectHasPendingNomination_WaitsUntilNominated()
+        {
+            var whenNominatedStarted = new TaskCompletionSource<bool>();
+            var whenNominatedCompleted = new TaskCompletionSource<bool>();
+            var checkProjectsReadyCallCount = 0;
+
+            Task<SolutionRestoreWorker.RestoreReadinessResult> coordinationTask = SolutionRestoreWorker.WaitForOnBuildRestoreReadinessCoreAsync(
+                waitForSolutionLoadedAsync: _ => Task.CompletedTask,
+                isAllProjectsNominatedAsync: () => Task.FromResult(true),
+                checkProjectsReadyAsync: async (bulkRestoreCoordinationCheckStartTime, cancellationToken) =>
+                {
+                    checkProjectsReadyCallCount++;
+                    if (checkProjectsReadyCallCount == 1)
+                    {
+                        whenNominatedStarted.TrySetResult(true);
+                        await whenNominatedCompleted.Task;
+                        return (false, false, 1, TimeSpan.FromMilliseconds(10));
+                    }
+
+                    return (true, false, 1, TimeSpan.FromMilliseconds(5));
+                },
+                getProjectRestoreInfoSourceCounts: () => (1, 1),
+                delayAsync: (delay, cancellationToken) => Task.Delay(delay, cancellationToken),
+                getUtcNow: () => DateTime.UtcNow,
+                token: CancellationToken.None);
+
+            await whenNominatedStarted.Task;
+            coordinationTask.IsCompleted.Should().BeFalse();
+
+            whenNominatedCompleted.SetResult(true);
+
+            SolutionRestoreWorker.RestoreReadinessResult readiness = await coordinationTask;
+            readiness.RestoreReason.Should().Be(ImplicitRestoreReason.ProjectsReady);
+            readiness.ProjectsReadyCheckCount.Should().Be(2);
+            readiness.ProjectRestoreInfoSourcesCount.Should().Be(1);
+            readiness.ProjectReadyTimings.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public async Task WaitForOnBuildRestoreReadinessCoreAsync_WhenSolutionLoadCompletes_ThenChecksNomination()
+        {
+            var solutionLoadCompleted = new TaskCompletionSource<bool>();
+            int isAllProjectsNominatedCallCount = 0;
+
+            Task<SolutionRestoreWorker.RestoreReadinessResult> coordinationTask = SolutionRestoreWorker.WaitForOnBuildRestoreReadinessCoreAsync(
+                waitForSolutionLoadedAsync: _ => solutionLoadCompleted.Task,
+                isAllProjectsNominatedAsync: () =>
+                {
+                    Interlocked.Increment(ref isAllProjectsNominatedCallCount);
+                    return Task.FromResult(true);
+                },
+                checkProjectsReadyAsync: (bulkRestoreCoordinationCheckStartTime, cancellationToken) =>
+                    Task.FromResult((true, false, 0, TimeSpan.Zero)),
+                getProjectRestoreInfoSourceCounts: () => (0, 0),
+                delayAsync: (delay, cancellationToken) => Task.Delay(delay, cancellationToken),
+                getUtcNow: () => DateTime.UtcNow,
+                token: CancellationToken.None);
+
+            await Task.Delay(50);
+            isAllProjectsNominatedCallCount.Should().Be(0);
+
+            solutionLoadCompleted.SetResult(true);
+
+            SolutionRestoreWorker.RestoreReadinessResult readiness = await coordinationTask;
+            readiness.RestoreReason.Should().Be(ImplicitRestoreReason.ProjectsReady);
+            readiness.ProjectsReadyCheckCount.Should().Be(1);
+            isAllProjectsNominatedCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task WaitForOnBuildRestoreReadinessCoreAsync_WhenReadinessTimesOutBeforeNominations_ReturnsTimeoutReason()
+        {
+            var utcNow = new DateTime(year: 2026, month: 9, day: 11);
+
+            SolutionRestoreWorker.RestoreReadinessResult readiness = await SolutionRestoreWorker.WaitForOnBuildRestoreReadinessCoreAsync(
+                waitForSolutionLoadedAsync: _ => Task.CompletedTask,
+                isAllProjectsNominatedAsync: () => Task.FromResult(false),
+                checkProjectsReadyAsync: (bulkRestoreCoordinationCheckStartTime, cancellationToken) =>
+                    throw new InvalidOperationException("Projects cannot be ready before all projects are nominated."),
+                getProjectRestoreInfoSourceCounts: () => (1, 1),
+                delayAsync: (delay, cancellationToken) =>
+                {
+                    utcNow += TimeSpan.FromMinutes(6);
+                    return Task.CompletedTask;
+                },
+                getUtcNow: () => utcNow,
+                token: CancellationToken.None);
+
+            readiness.RestoreReason.Should().Be(ImplicitRestoreReason.ProjectsReadyCheckTimeout);
+            readiness.BulkRestoreCoordinationCheckStartTime.Should().NotBeNull();
+            readiness.ProjectsReadyCheckCount.Should().Be(0);
+            readiness.ProjectRestoreInfoSourcesCount.Should().Be(1);
+            readiness.PendingProjectRestoreInfoSourcesCount.Should().Be(1);
+            readiness.ProjectReadyTimings.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task WaitForOnBuildRestoreReadinessCoreAsync_WhenCanceledWhileWaitingForNominations_Throws()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            Func<Task> act = async () => await SolutionRestoreWorker.WaitForOnBuildRestoreReadinessCoreAsync(
+                waitForSolutionLoadedAsync: _ => Task.CompletedTask,
+                isAllProjectsNominatedAsync: () => Task.FromResult(false),
+                checkProjectsReadyAsync: (bulkRestoreCoordinationCheckStartTime, cancellationToken) =>
+                    throw new InvalidOperationException("Projects cannot be ready before all projects are nominated."),
+                getProjectRestoreInfoSourceCounts: () => (1, 1),
+                delayAsync: (delay, cancellationToken) =>
+                {
+                    cancellationTokenSource.Cancel();
+                    return Task.FromCanceled(cancellationToken);
+                },
+                getUtcNow: () => DateTime.UtcNow,
+                token: cancellationTokenSource.Token);
+
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+
+        [Fact]
+        public async Task WaitForOnBuildRestoreReadinessCoreAsync_WhenLargeSolutionMakesProgress_DoesNotTimeOut()
+        {
+            var utcNow = new DateTime(year: 2026, month: 9, day: 11);
+            int pendingSources = 3;
+
+            SolutionRestoreWorker.RestoreReadinessResult readiness = await SolutionRestoreWorker.WaitForOnBuildRestoreReadinessCoreAsync(
+                waitForSolutionLoadedAsync: _ => Task.CompletedTask,
+                isAllProjectsNominatedAsync: () => Task.FromResult(pendingSources == 0),
+                checkProjectsReadyAsync: (bulkRestoreCoordinationCheckStartTime, cancellationToken) =>
+                    Task.FromResult((true, false, 3, TimeSpan.Zero)),
+                getProjectRestoreInfoSourceCounts: () => (3, pendingSources),
+                delayAsync: (delay, cancellationToken) =>
+                {
+                    utcNow += TimeSpan.FromMinutes(4);
+                    pendingSources--;
+                    return Task.CompletedTask;
+                },
+                getUtcNow: () => utcNow,
+                token: CancellationToken.None);
+
+            readiness.RestoreReason.Should().Be(ImplicitRestoreReason.ProjectsReady);
+            readiness.PendingProjectRestoreInfoSourcesCount.Should().Be(0);
+            DateTime coordinationStartTime = readiness.BulkRestoreCoordinationCheckStartTime.GetValueOrDefault();
+            coordinationStartTime.Should().NotBe(default);
+            (utcNow - coordinationStartTime).Should().Be(TimeSpan.FromMinutes(12));
+        }
+
+        [Fact]
+        public async Task CheckProjectsReadyCoreAsync_WhenSourceHasPendingNomination_WaitsForNomination()
+        {
+            var nominationCompleted = new TaskCompletionSource<bool>();
+            var timeoutTask = new TaskCompletionSource<bool>();
+            var restoreInfoSource = new Mock<IVsProjectRestoreInfoSource>();
+            restoreInfoSource
+                .SetupGet(x => x.HasPendingNomination)
+                .Returns(true);
+            restoreInfoSource
+                .Setup(x => x.WhenNominated(It.IsAny<CancellationToken>()))
+                .Returns(nominationCompleted.Task);
+
+            Task<(bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, TimeSpan projectReadyCheckTime)> readinessTask =
+                SolutionRestoreWorker.CheckProjectsReadyCoreAsync(
+                    restoreProjectInfoSources: new object[] { restoreInfoSource.Object },
+                    bulkRestoreCoordinationCheckStartTime: DateTime.UtcNow,
+                    getUtcNow: () => DateTime.UtcNow,
+                    delayAsync: (delay, cancellationToken) => timeoutTask.Task,
+                    token: CancellationToken.None);
+
+            readinessTask.IsCompleted.Should().BeFalse();
+
+            nominationCompleted.SetResult(true);
+
+            (bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, _) = await readinessTask;
+            allProjectsReady.Should().BeFalse();
+            bulkCheckTimeout.Should().BeFalse();
+            projectRestoreInfoSourcesCount.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task CheckProjectsReadyCoreAsync_WhenSourcesMakeProgressLongerThanTimeout_DoesNotTimeOut()
+        {
+            var utcNow = new DateTime(year: 2026, month: 9, day: 11);
+            var restoreInfoSources = new object[3];
+            for (int i = 0; i < restoreInfoSources.Length; i++)
+            {
+                var restoreInfoSource = new Mock<IVsProjectRestoreInfoSource>();
+                restoreInfoSource
+                    .SetupGet(x => x.HasPendingNomination)
+                    .Returns(true);
+                restoreInfoSource
+                    .Setup(x => x.WhenNominated(It.IsAny<CancellationToken>()))
+                    .Returns(() =>
+                    {
+                        utcNow += TimeSpan.FromMinutes(4);
+                        return Task.CompletedTask;
+                    });
+                restoreInfoSources[i] = restoreInfoSource.Object;
+            }
+
+            (bool allProjectsReady, bool bulkCheckTimeout, int projectRestoreInfoSourcesCount, _) =
+                await SolutionRestoreWorker.CheckProjectsReadyCoreAsync(
+                    restoreProjectInfoSources: restoreInfoSources,
+                    bulkRestoreCoordinationCheckStartTime: utcNow,
+                    getUtcNow: () => utcNow,
+                    delayAsync: (delay, cancellationToken) => new TaskCompletionSource<bool>().Task,
+                    token: CancellationToken.None);
+
+            allProjectsReady.Should().BeFalse();
+            bulkCheckTimeout.Should().BeFalse();
+            projectRestoreInfoSourcesCount.Should().Be(3);
         }
     }
 }


### PR DESCRIPTION
# Bug

Fixes: https://github.com/NuGet/Home/issues/14927

## Description

Visual Studio can start its first build restore before project systems finish publishing restore inputs, causing restore failures when a solution is built immediately after opening.

This change waits for solution load and project nomination before the first on-build restore, and keeps the build delay active until restore finishes. The five-minute fallback is based on inactivity rather than total elapsed time, so large solutions can continue making progress, and timeout paths log enough state for diagnosis.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.
