### PR TITLE
Onboard NuGet MCP workflows to use Copilot SDK programmatic sessions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="18.0.0-preview-1-10827-020" />
     <PackageVersion Include="Microsoft.TestPlatform.Portable" Version="17.1.0" />
     <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost" Version="18.8.850" />
-    <PackageVersion Include="Microsoft.VisualStudio.Copilot" Version="18.0.848-alpha" />
+    <PackageVersion Include="Microsoft.VisualStudio.Copilot" Version="18.12.384" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServices" Version="4.3.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Markdown.Platform" Version="17.14.76-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem" Version="17.4.221-pre" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Copilot" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Markdown.Platform" />
     <PackageReference Include="Microsoft.VisualStudio.Sdk" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Styles" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/CopilotToolSessionError.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/CopilotToolSessionError.cs
@@ -17,5 +17,6 @@ namespace NuGet.PackageManagement.Telemetry
         ToolNotAvailable,
         McpServerInfoServiceNotAvailable,
         McpServerNotActive,
+        CopilotRequestFailed,
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/FixVulnerabilitiesWithCopilotErrorType.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/FixVulnerabilitiesWithCopilotErrorType.cs
@@ -14,5 +14,6 @@ namespace NuGet.PackageManagement.Telemetry
         NuGetSolverNotAvailable,
         McpServerInfoServiceNotAvailable,
         McpServerNotActive,
+        CopilotRequestFailed,
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/CopilotSolutionContext.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotSolutionContext.cs
@@ -1,0 +1,116 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.VisualStudio;
+
+namespace NuGetVSExtension
+{
+    internal static class CopilotSolutionContext
+    {
+        private static readonly IReadOnlyList<string> ConfigurationFileNames =
+        [
+            "NuGet.Config",
+            "Directory.Packages.props",
+            "Directory.Build.props",
+            "Directory.Build.targets",
+        ];
+
+        internal static async Task<string> CreateAsync(
+            IVsSolutionManager solutionManager,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            string solutionDirectory = solutionManager.SolutionDirectory;
+            string solutionFilePath = await solutionManager.GetSolutionFilePathAsync();
+            IEnumerable<IVsProjectAdapter> projects = await solutionManager.GetAllVsProjectAdaptersAsync();
+
+            IReadOnlyList<string> projectPaths = projects
+                .Select(project => project.FullProjectPath)
+                .Where(path => !string.IsNullOrEmpty(path))
+                .Select(path => Path.GetFullPath(path!))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            IReadOnlyList<string> configurationPaths = GetConfigurationPaths(solutionDirectory, projectPaths);
+
+            return JsonConvert.SerializeObject(
+                new
+                {
+                    solutionDirectory,
+                    solutionFilePath,
+                    projectPaths,
+                    otherMsbuildFilePaths = configurationPaths,
+                },
+                Formatting.Indented);
+        }
+
+        internal static IReadOnlyList<string> GetConfigurationPaths(
+            string solutionDirectory,
+            IReadOnlyList<string> projectPaths)
+        {
+            if (string.IsNullOrEmpty(solutionDirectory))
+            {
+                return [];
+            }
+
+            string normalizedSolutionDirectory = Path.GetFullPath(solutionDirectory)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var configurationPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            AddConfigurationFiles(normalizedSolutionDirectory, configurationPaths);
+
+            foreach (string projectPath in projectPaths)
+            {
+                DirectoryInfo? directory = new FileInfo(projectPath).Directory;
+                while (directory is not null && IsWithinSolution(directory.FullName, normalizedSolutionDirectory))
+                {
+                    AddConfigurationFiles(directory.FullName, configurationPaths);
+
+                    if (string.Equals(directory.FullName, normalizedSolutionDirectory, StringComparison.OrdinalIgnoreCase))
+                    {
+                        break;
+                    }
+
+                    directory = directory.Parent;
+                }
+            }
+
+            return configurationPaths
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static void AddConfigurationFiles(string directory, HashSet<string> configurationPaths)
+        {
+            foreach (string fileName in ConfigurationFileNames)
+            {
+                string path = Path.Combine(directory, fileName);
+                if (File.Exists(path))
+                {
+                    configurationPaths.Add(path);
+                }
+            }
+        }
+
+        private static bool IsWithinSolution(string directory, string solutionDirectory)
+        {
+            if (string.Equals(directory, solutionDirectory, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            string solutionDirectoryPrefix = solutionDirectory + Path.DirectorySeparatorChar;
+            return directory.StartsWith(solutionDirectoryPrefix, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
@@ -177,6 +177,7 @@ namespace NuGetVSExtension
                 CopilotToolSessionError.McpServerInfoServiceNotAvailable => Resources.Error_McpServerInfoServiceNotAvailable,
                 CopilotToolSessionError.McpServerNotActive => Resources.Error_McpServerNotActive,
                 CopilotToolSessionError.ToolNotAvailable => toolNotAvailableMessage,
+                CopilotToolSessionError.CopilotRequestFailed => Resources.Error_CopilotRequestFailed,
                 _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),
             };
 

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolInvocationService.cs
@@ -44,13 +44,75 @@ namespace NuGetVSExtension
             }
 
             // 2. Verify service broker is available
-            if (ServiceBroker == null)
+            IServiceBroker? serviceBroker = ServiceBroker;
+            if (serviceBroker == null)
             {
                 return CopilotToolSessionResult.Failure(CopilotToolSessionError.ServiceBrokerNotAvailable);
             }
 
-            // 3. Verify the required MCP server is registered and active
-            IMcpServerInfoService? mcpServerInfoService = await ServiceBroker.GetProxyAsync<IMcpServerInfoService>(McpServiceIdentities.ServerInfoService.Descriptor, cancellationToken);
+            // 3. Acquire Copilot service. Ownership transfers to CopilotToolSession on success.
+#pragma warning disable ISB001 // Dispose objects before losing scope - ownership is transferred to CopilotToolSession on success
+            ICopilotService? copilotService = await serviceBroker.GetProxyAsync<ICopilotService>(CopilotDescriptors.CopilotService, cancellationToken);
+#pragma warning restore ISB001
+
+            bool ownershipTransferred = false;
+            try
+            {
+                if (copilotService is null)
+                {
+                    return CopilotToolSessionResult.Failure(CopilotToolSessionError.CopilotServiceNotAvailable);
+                }
+
+#pragma warning disable VSCOPILOT_BACKEND // Experimental SDK harness contracts.
+                if (await copilotService.IsBackendModeEnabledAsync(cancellationToken))
+                {
+                    CopilotSessionId sessionId = await copilotService.CreateSessionAsync(
+                        new CreateSessionOptions
+                        {
+                            Feature = new CopilotFeatureId(clientId.Id),
+                            DefaultAgent = NuGetSdkAgent.AgentName,
+                            IsEphemeral = false,
+                        },
+                        cancellationToken);
+
+                    CopilotToolSession harnessSession = CopilotToolSession.CreateHarness(copilotService, sessionId);
+                    ownershipTransferred = true;
+                    return CopilotToolSessionResult.Success(harnessSession);
+                }
+#pragma warning restore VSCOPILOT_BACKEND
+
+                CopilotToolSessionResult result = await TryCreateLegacyToolSessionAsync(
+                    serviceBroker,
+                    copilotService,
+                    clientId,
+                    correlationId,
+                    mcpToolName,
+                    acceptableMcpServerNames,
+                    cancellationToken);
+
+                ownershipTransferred = result.IsSuccess;
+                return result;
+            }
+            finally
+            {
+                if (!ownershipTransferred)
+                {
+                    (copilotService as IDisposable)?.Dispose();
+                }
+            }
+        }
+
+        private static async Task<CopilotToolSessionResult> TryCreateLegacyToolSessionAsync(
+            IServiceBroker serviceBroker,
+            ICopilotService copilotService,
+            CopilotClientId clientId,
+            CopilotCorrelationId correlationId,
+            string mcpToolName,
+            IReadOnlyCollection<string> acceptableMcpServerNames,
+            CancellationToken cancellationToken)
+        {
+            // Verify the required MCP server is registered and active.
+            IMcpServerInfoService? mcpServerInfoService = await serviceBroker.GetProxyAsync<IMcpServerInfoService>(McpServiceIdentities.ServerInfoService.Descriptor, cancellationToken);
             using (mcpServerInfoService as IDisposable)
             {
                 if (mcpServerInfoService is null)
@@ -67,55 +129,29 @@ namespace NuGetVSExtension
                 }
             }
 
-            // 4. Acquire Copilot service, ownership transfers to CopilotToolSession on success
-#pragma warning disable ISB001 // Dispose objects before losing scope - ownership is transferred to CopilotToolSession on success
-            ICopilotService? copilotService = await ServiceBroker.GetProxyAsync<ICopilotService>(CopilotDescriptors.CopilotService, cancellationToken);
-#pragma warning restore ISB001
-
-            bool ownershipTransferred = false;
-            try
+            // Acquire MCP tool function provider and get available functions.
+            ICopilotFunctionProvider? cfp = await serviceBroker.GetProxyAsync<ICopilotFunctionProvider>(CopilotDescriptors.McpToolService, cancellationToken);
+            using (cfp as IDisposable)
             {
-                if (copilotService is null)
+                if (cfp is null)
                 {
-                    return CopilotToolSessionResult.Failure(CopilotToolSessionError.CopilotServiceNotAvailable);
+                    return CopilotToolSessionResult.Failure(CopilotToolSessionError.McpToolServiceNotAvailable);
                 }
 
-                // 5. Acquire MCP tool function provider and get available functions
-                ICopilotFunctionProvider? cfp = await ServiceBroker.GetProxyAsync<ICopilotFunctionProvider>(CopilotDescriptors.McpToolService, cancellationToken);
-                using (cfp as IDisposable)
+                // Verify the required tool is available. We match on ServerNameOfFunction + Group
+                // (the same logical NuGet MCP tool can be exposed under different Group values
+                // depending on how it was installed - in-VS vs. Anthropic/GitHub MCP registry).
+                IReadOnlyList<CopilotFunctionDescriptor>? functions = await cfp.GetFunctionsAsync(correlationId, cancellationToken);
+                if (!IsToolAvailable(functions, mcpToolName, acceptableMcpServerNames))
                 {
-                    if (cfp is null)
-                    {
-                        return CopilotToolSessionResult.Failure(CopilotToolSessionError.McpToolServiceNotAvailable);
-                    }
-
-                    // 6. Verify the required tool is available. We match on ServerNameOfFunction + Group
-                    //    (the same logical NuGet MCP tool can be exposed under different Group values
-                    //    depending on how it was installed - in-VS vs. Anthropic/GitHub MCP registry).
-                    IReadOnlyList<CopilotFunctionDescriptor>? functions = await cfp.GetFunctionsAsync(correlationId, cancellationToken);
-                    if (!IsToolAvailable(functions, mcpToolName, acceptableMcpServerNames))
-                    {
-                        return CopilotToolSessionResult.Failure(CopilotToolSessionError.ToolNotAvailable);
-                    }
-
-                    // 7. Start Copilot thread
-                    CopilotThreadOptions options = new(clientId);
-                    CopilotThread thread = await copilotService.StartThreadAsync(options, cancellationToken);
-
-                    CopilotToolSession session = new(
-                        thread,
-                        functions,
-                        copilotServiceDisposable: copilotService as IDisposable);
-                    ownershipTransferred = true;
-                    return CopilotToolSessionResult.Success(session);
+                    return CopilotToolSessionResult.Failure(CopilotToolSessionError.ToolNotAvailable);
                 }
-            }
-            finally
-            {
-                if (!ownershipTransferred)
-                {
-                    (copilotService as IDisposable)?.Dispose();
-                }
+
+                CopilotThreadOptions options = new(clientId);
+                CopilotThread thread = await copilotService.StartThreadAsync(options, cancellationToken);
+
+                return CopilotToolSessionResult.Success(
+                    CopilotToolSession.CreateLegacy(copilotService, thread, functions));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolSession.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolSession.cs
@@ -75,12 +75,29 @@ namespace NuGetVSExtension
             if (_harnessSessionId is CopilotSessionId harnessSessionId)
             {
 #pragma warning disable VSCOPILOT_BACKEND // Experimental SDK harness contracts.
-                _ = await _copilotService.SendRequestAsync(harnessSessionId, harnessRequest, cancellationToken);
+                CopilotMessageResponse response = await _copilotService.SendRequestAsync(harnessSessionId, harnessRequest, cancellationToken);
+                EnsureSuccessfulHarnessResponse(response);
 #pragma warning restore VSCOPILOT_BACKEND
                 return;
             }
 
             _ = await Thread!.Session.SendRequestAsync(legacyRequest, cancellationToken);
+        }
+
+        internal static void EnsureSuccessfulHarnessResponse(CopilotMessageResponse response)
+        {
+            if (response.Status == CopilotResponseStatus.Success)
+            {
+                return;
+            }
+
+            string? errorMessage = response.Error?.Message;
+            if (response.Status == CopilotResponseStatus.UserHasNoChatAccess)
+            {
+                throw new UnauthorizedAccessException(errorMessage);
+            }
+
+            throw new CopilotRequestException(response.Status, errorMessage);
         }
 
         public async ValueTask DisposeAsync()
@@ -96,6 +113,23 @@ namespace NuGetVSExtension
             {
                 _copilotServiceDisposable?.Dispose();
             }
+        }
+    }
+
+    internal sealed class CopilotRequestException : Exception
+    {
+        internal CopilotRequestException(CopilotResponseStatus status, string? errorMessage)
+            : base(CreateMessage(status, errorMessage))
+        {
+            Status = status;
+        }
+
+        internal CopilotResponseStatus Status { get; }
+
+        private static string CreateMessage(CopilotResponseStatus status, string? errorMessage)
+        {
+            string message = $"Copilot request failed with status '{status}'.";
+            return string.IsNullOrEmpty(errorMessage) ? message : $"{message} {errorMessage}";
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/CopilotToolSession.cs
+++ b/src/NuGet.Clients/NuGet.Tools/CopilotToolSession.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Copilot;
 
@@ -20,26 +21,81 @@ namespace NuGetVSExtension
     /// </remarks>
     internal sealed class CopilotToolSession : IAsyncDisposable
     {
+        private readonly ICopilotService _copilotService;
         private readonly IDisposable? _copilotServiceDisposable;
+        private readonly CopilotSessionId? _harnessSessionId;
 
-        internal CopilotToolSession(
+        private CopilotToolSession(
+            ICopilotService copilotService,
             CopilotThread thread,
             IReadOnlyList<CopilotFunctionDescriptor> functions,
             IDisposable? copilotServiceDisposable)
         {
+            _copilotService = copilotService;
             Thread = thread;
             Functions = functions;
             _copilotServiceDisposable = copilotServiceDisposable;
         }
 
-        public CopilotThread Thread { get; }
+        private CopilotToolSession(
+            ICopilotService copilotService,
+            CopilotSessionId harnessSessionId,
+            IDisposable? copilotServiceDisposable)
+        {
+            _copilotService = copilotService;
+            _harnessSessionId = harnessSessionId;
+            Functions = Array.Empty<CopilotFunctionDescriptor>();
+            _copilotServiceDisposable = copilotServiceDisposable;
+        }
+
+        public CopilotThread? Thread { get; }
 
         public IReadOnlyList<CopilotFunctionDescriptor> Functions { get; }
 
+        internal static CopilotToolSession CreateLegacy(
+            ICopilotService copilotService,
+            CopilotThread thread,
+            IReadOnlyList<CopilotFunctionDescriptor> functions)
+        {
+            return new CopilotToolSession(copilotService, thread, functions, copilotService as IDisposable);
+        }
+
+        internal static CopilotToolSession CreateHarness(
+            ICopilotService copilotService,
+            CopilotSessionId harnessSessionId)
+        {
+            return new CopilotToolSession(copilotService, harnessSessionId, copilotService as IDisposable);
+        }
+
+        internal async Task SendRequestAsync(
+            CopilotRequest legacyRequest,
+            CopilotUserMessage harnessRequest,
+            CancellationToken cancellationToken)
+        {
+            if (_harnessSessionId is CopilotSessionId harnessSessionId)
+            {
+#pragma warning disable VSCOPILOT_BACKEND // Experimental SDK harness contracts.
+                _ = await _copilotService.SendRequestAsync(harnessSessionId, harnessRequest, cancellationToken);
+#pragma warning restore VSCOPILOT_BACKEND
+                return;
+            }
+
+            _ = await Thread!.Session.SendRequestAsync(legacyRequest, cancellationToken);
+        }
+
         public async ValueTask DisposeAsync()
         {
-            await Thread.DisposeAsync();
-            _copilotServiceDisposable?.Dispose();
+            try
+            {
+                if (_harnessSessionId is null && Thread is not null)
+                {
+                    await Thread.DisposeAsync();
+                }
+            }
+            finally
+            {
+                _copilotServiceDisposable?.Dispose();
+            }
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
@@ -102,6 +102,12 @@ namespace NuGetVSExtension
                 ActivityLogger?.LogError(ex.Message);
                 MessageHelper.ShowWarningMessage(Resources.Error_CopilotAccessDenied, Resources.Title_FixVulnerabilitiesWithCopilot);
             }
+            catch (CopilotRequestException ex)
+            {
+                SendTelemetryEvent(FixVulnerabilitiesWithCopilotErrorType.CopilotRequestFailed, navigationOrigin);
+                ActivityLogger?.LogError(ex.ToString());
+                MessageHelper.ShowWarningMessage(Resources.Error_CopilotRequestFailed, Resources.Title_FixVulnerabilitiesWithCopilot);
+            }
         }
 
         private static void SendTelemetryEvent(FixVulnerabilitiesWithCopilotErrorType errorType, NavigationOrigin navigationOrigin)
@@ -123,6 +129,7 @@ namespace NuGetVSExtension
                 CopilotToolSessionError.ToolNotAvailable => FixVulnerabilitiesWithCopilotErrorType.NuGetSolverNotAvailable,
                 CopilotToolSessionError.McpServerInfoServiceNotAvailable => FixVulnerabilitiesWithCopilotErrorType.McpServerInfoServiceNotAvailable,
                 CopilotToolSessionError.McpServerNotActive => FixVulnerabilitiesWithCopilotErrorType.McpServerNotActive,
+                CopilotToolSessionError.CopilotRequestFailed => FixVulnerabilitiesWithCopilotErrorType.CopilotRequestFailed,
                 _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),
             };
         }

--- a/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/FixVulnerabilitiesService.cs
@@ -80,13 +80,20 @@ namespace NuGetVSExtension
             await using CopilotToolSession session = result.Session!;
 
             // Attach solution context and available functions to the request
-            string solutionPathContext = $"The current solution file path is: {GetSolutionPath()}.";
-            CopilotContext context = new CopilotContext(ProviderDescriptor.Moniker, ContextDescriptor, request.CorrelationId, solutionPathContext);
+            Assumes.Present(SolutionManager);
+            string solutionContext = await CopilotSolutionContext.CreateAsync(SolutionManager, cancellationToken);
+            CopilotContext context = new CopilotContext(ProviderDescriptor.Moniker, ContextDescriptor, request.CorrelationId, solutionContext);
             CopilotRequest requestWithFunctionsAndContext = request.WithFunctions(session.Functions).WithContext(context);
+            CopilotUserMessage harnessRequest = new()
+            {
+                DisplayPrompt = Resources.Prompt_FixNuGetPackageVulnerabilities,
+                Prompt = Resources.Prompt_FixNuGetPackageVulnerabilities,
+                Agent = NuGetSdkAgent.AgentName,
+            };
 
             try
             {
-                _ = await session.Thread.Session.SendRequestAsync(requestWithFunctionsAndContext, cancellationToken);
+                await session.SendRequestAsync(requestWithFunctionsAndContext, harnessRequest, cancellationToken);
                 SendTelemetryEvent(FixVulnerabilitiesWithCopilotErrorType.None, navigationOrigin);
             }
             catch (UnauthorizedAccessException ex)
@@ -119,7 +126,5 @@ namespace NuGetVSExtension
                 _ => throw new ArgumentOutOfRangeException(nameof(error), error, null),
             };
         }
-
-        private string GetSolutionPath() => SolutionManager?.SolutionDirectory ?? string.Empty;
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
+++ b/src/NuGet.Clients/NuGet.Tools/NuGet.Tools.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Copilot" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Sdk" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" NoWarn="NU1605" />

--- a/src/NuGet.Clients/NuGet.Tools/NuGetSdkAgent.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetSdkAgent.cs
@@ -1,0 +1,98 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Copilot;
+using Microsoft.VisualStudio.Copilot.Sdk;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using NuGet.PackageManagement.VisualStudio;
+
+namespace NuGetVSExtension
+{
+#pragma warning disable VSCOPILOT_BACKEND // Experimental SDK harness contracts.
+    [CopilotSdkAgent(
+        AgentName,
+        DisplayName = "NuGet",
+        Description = "Helps resolve NuGet package management issues.",
+        IncludeBuiltInContributions = false,
+        Usage = AgentUsage.Programmatic)]
+    internal sealed class NuGetSdkAgent : CopilotSdkAgentHooks, ICopilotSdkAgent
+    {
+        internal const string AgentName = "nuget";
+
+        [Import(typeof(SVsFullAccessServiceBroker), AllowDefault = true)]
+        public IServiceBroker? ServiceBroker { get; set; }
+
+        [Import(typeof(IVsSolutionManager), AllowDefault = true)]
+        public IVsSolutionManager? SolutionManager { get; set; }
+
+        public Task<string> GetSystemPromptAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(
+                "Use the available NuGet MCP tools to address the user's NuGet package management request. " +
+                "Use absolute paths when invoking MCP tools.");
+        }
+
+        public async Task<IReadOnlyList<CopilotFunctionDescriptor>> GetToolsAsync(CancellationToken cancellationToken)
+        {
+            IServiceBroker serviceBroker = ServiceBroker
+                ?? throw new InvalidOperationException("The Visual Studio service broker is unavailable.");
+
+            ICopilotFunctionProvider? functionProvider = await serviceBroker.GetProxyAsync<ICopilotFunctionProvider>(
+                CopilotDescriptors.McpToolService,
+                cancellationToken);
+
+            using (functionProvider as IDisposable)
+            {
+                if (functionProvider is null)
+                {
+                    throw new InvalidOperationException("The Copilot MCP tool service is unavailable.");
+                }
+
+                IReadOnlyList<CopilotFunctionDescriptor>? functions = await functionProvider.GetFunctionsAsync(
+                    CopilotCorrelationId.New(),
+                    cancellationToken);
+
+                return SelectInBoxNuGetMcpTools(functions);
+            }
+        }
+
+        internal static IReadOnlyList<CopilotMcpFunctionDescriptor> SelectInBoxNuGetMcpTools(
+            IReadOnlyList<CopilotFunctionDescriptor>? functions)
+        {
+            if (functions is null)
+            {
+                return [];
+            }
+
+            return functions
+                .OfType<CopilotMcpFunctionDescriptor>()
+                .Where(function => string.Equals(
+                    function.Group,
+                    McpServerConstants.NuGetMcpServerName,
+                    StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        protected override async ValueTask<CopilotSdkRequestSubmittedResult> OnRequestSubmittedAsync(
+            CopilotSdkRequestSubmittedArgs args,
+            CancellationToken cancellationToken)
+        {
+            IVsSolutionManager solutionManager = SolutionManager
+                ?? throw new InvalidOperationException("The Visual Studio solution manager is unavailable.");
+
+            string solutionContext = await CopilotSolutionContext.CreateAsync(solutionManager, cancellationToken);
+            return new CopilotSdkRequestSubmittedResult
+            {
+                AdditionalContext = solutionContext,
+            };
+        }
+    }
+#pragma warning restore VSCOPILOT_BACKEND
+}

--- a/src/NuGet.Clients/NuGet.Tools/ResolveSupplyChainSecurityService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/ResolveSupplyChainSecurityService.cs
@@ -81,13 +81,20 @@ namespace NuGetVSExtension
 
             await using CopilotToolSession session = result.Session!;
 
-            string solutionPathContext = $"The current solution file path is: {GetSolutionPath()}.";
-            CopilotContext context = new CopilotContext(ProviderDescriptor.Moniker, ContextDescriptor, request.CorrelationId, solutionPathContext);
+            Assumes.Present(SolutionManager);
+            string solutionContext = await CopilotSolutionContext.CreateAsync(SolutionManager, cancellationToken);
+            CopilotContext context = new CopilotContext(ProviderDescriptor.Moniker, ContextDescriptor, request.CorrelationId, solutionContext);
             CopilotRequest requestWithFunctionsAndContext = request.WithFunctions(session.Functions).WithContext(context);
+            CopilotUserMessage harnessRequest = new()
+            {
+                DisplayPrompt = prompt,
+                Prompt = prompt,
+                Agent = NuGetSdkAgent.AgentName,
+            };
 
             try
             {
-                _ = await session.Thread.Session.SendRequestAsync(requestWithFunctionsAndContext, cancellationToken);
+                await session.SendRequestAsync(requestWithFunctionsAndContext, harnessRequest, cancellationToken);
                 TelemetryActivity.EmitTelemetryEvent(
                     NavigatedTelemetryEvent.CreateWithResolveSupplyChainSecurity(source.NavigationOrigin, CopilotToolSessionError.None));
             }
@@ -101,7 +108,5 @@ namespace NuGetVSExtension
                 MessageHelper.ShowWarningMessage(Resources.Error_CopilotAccessDenied, Resources.Title_ResolveSupplyChainSecurityWithCopilot);
             }
         }
-
-        private string GetSolutionPath() => SolutionManager?.SolutionDirectory ?? string.Empty;
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/ResolveSupplyChainSecurityService.cs
+++ b/src/NuGet.Clients/NuGet.Tools/ResolveSupplyChainSecurityService.cs
@@ -107,6 +107,15 @@ namespace NuGetVSExtension
                 ActivityLogger?.LogError(ex.Message);
                 MessageHelper.ShowWarningMessage(Resources.Error_CopilotAccessDenied, Resources.Title_ResolveSupplyChainSecurityWithCopilot);
             }
+            catch (CopilotRequestException ex)
+            {
+                TelemetryActivity.EmitTelemetryEvent(
+                    NavigatedTelemetryEvent.CreateWithResolveSupplyChainSecurity(
+                        source.NavigationOrigin,
+                        CopilotToolSessionError.CopilotRequestFailed));
+                ActivityLogger?.LogError(ex.ToString());
+                MessageHelper.ShowWarningMessage(Resources.Error_CopilotRequestFailed, Resources.Title_ResolveSupplyChainSecurityWithCopilot);
+            }
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to GitHub Copilot was unable to complete the request. See the Activity Log for details..
+        /// </summary>
+        internal static string Error_CopilotRequestFailed {
+            get {
+                return ResourceManager.GetString("Error_CopilotRequestFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in..
         /// </summary>
         internal static string Error_CopilotServiceNotAvailable {

--- a/src/NuGet.Clients/NuGet.Tools/Resources.resx
+++ b/src/NuGet.Clients/NuGet.Tools/Resources.resx
@@ -292,6 +292,10 @@
     <value>Access denied. Ensure you are signed in to GitHub Copilot.</value>
     <comment>Do not translate GitHub or Copilot</comment>
   </data>
+  <data name="Error_CopilotRequestFailed" xml:space="preserve">
+    <value>GitHub Copilot was unable to complete the request. See the Activity Log for details.</value>
+    <comment>Do not translate GitHub or Copilot</comment>
+  </data>
   <data name="Error_NuGetSolverNotAvailable" xml:space="preserve">
     <value>The NuGet Solver tool is unavailable. Enable the NuGet MCP Server in the GitHub Copilot chat window and try again.</value>
     <comment>Do not translate GitHub or Copilot</comment>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">GitHub Copilot není připravený. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">Služba GitHub Copilot není k dispozici. Ujistěte se, že je GitHub Copilot nainstalovaný a že jste přihlášení.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">GitHub Copilot ist nicht verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">Der GitHub Copilot-Dienst ist nicht verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert ist und eine Anmeldung erfolgt ist.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">GitHub Copilot no está listo. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">El servicio de GitHub Copilot no está disponible. Asegúrese de que GitHub Copilot está instalado e iniciado sesión.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Désolé, GitHub Copilot n’est pas prêt. Vérifiez que GitHub Copilot est installé et connecté.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">Désolé, le service de GitHub Copilot n’est pas disponible. Vérifiez que GitHub Copilot est installé et connecté.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">GitHub Copilot non è pronto. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">Il servizio GitHub Copilot non è disponibile. Assicurati di aver installato ed eseguito l'accesso a GitHub Copilot.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">GitHub Copilot の準備ができていません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">GitHub Copilot サービスを利用できません。GitHub Copilot がインストールされ、サインインしていることを確認してください。</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">GitHub Copilot이 준비되지 않았습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">GitHub Copilot 서비스를 사용할 수 없습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Narzędzie GitHub Copilot nie jest gotowe. Upewnij się, że narzędzie GitHub Copilot jest zainstalowane i zalogowano się.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">Narzędzie GitHub Copilot jest niedostępne. Upewnij się, że narzędzie GitHub Copilot jest zainstalowane i zalogowano się.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">O GitHub Copilot não está pronto. Certifique-se de que o GitHub Copilot esteja instalado e conectado.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">O serviço GitHub Copilot não está disponível. Certifique-se de que o GitHub Copilot esteja instalado e conectado.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">GitHub Copilot не готов. Убедитесь, что GitHub Copilot установлен и выполнен вход в систему.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">Служба GitHub Copilot недоступна. Убедитесь, что GitHub Copilot установлен и выполнен вход в систему.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">GitHub Copilot hazır değil. GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">GitHub Copilot Hizmeti kullanılamıyor. GitHub Copilot’un yüklü ve oturum açıldığından emin olun.</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">GitHub Copilot 未就绪。请确保已安装并登录 GitHub Copilot。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">GitHub Copilot 服务不可用。请确保已安装并登录 GitHub Copilot。</target>

--- a/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.Tools/xlf/Resources.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">GitHub Copilot 尚未就緒。確保已安裝並登入 GitHub Copilot。</target>
         <note>Do not translate GitHub or Copilot</note>
       </trans-unit>
+      <trans-unit id="Error_CopilotRequestFailed">
+        <source>GitHub Copilot was unable to complete the request. See the Activity Log for details.</source>
+        <target state="new">GitHub Copilot was unable to complete the request. See the Activity Log for details.</target>
+        <note>Do not translate GitHub or Copilot</note>
+      </trans-unit>
       <trans-unit id="Error_CopilotServiceNotAvailable">
         <source>GitHub Copilot Service is not available. Ensure GitHub Copilot is installed and signed in.</source>
         <target state="translated">GitHub Copilot 服務無法使用。確保已安裝並登入 GitHub Copilot。</target>

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/CopilotSolutionContextTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/CopilotSolutionContextTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.VisualStudio;
+using NuGetVSExtension;
+using Xunit;
+
+namespace NuGet.Tools.Test
+{
+    public class CopilotSolutionContextTests
+    {
+        [Fact]
+        public async Task CreateAsync_IncludesExactProjectAndConfigurationPaths()
+        {
+            string solutionDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string projectDirectory = Path.Combine(solutionDirectory, "src", "App");
+            string solutionFilePath = Path.Combine(solutionDirectory, "App.sln");
+            string projectPath = Path.Combine(projectDirectory, "App.csproj");
+            string nuGetConfigPath = Path.Combine(solutionDirectory, "NuGet.Config");
+            string directoryPackagesPropsPath = Path.Combine(solutionDirectory, "Directory.Packages.props");
+            string directoryBuildPropsPath = Path.Combine(solutionDirectory, "src", "Directory.Build.props");
+
+            try
+            {
+                Directory.CreateDirectory(projectDirectory);
+                File.WriteAllText(solutionFilePath, string.Empty);
+                File.WriteAllText(projectPath, string.Empty);
+                File.WriteAllText(nuGetConfigPath, string.Empty);
+                File.WriteAllText(directoryPackagesPropsPath, string.Empty);
+                File.WriteAllText(directoryBuildPropsPath, string.Empty);
+
+                var project = new Mock<IVsProjectAdapter>();
+                project.SetupGet(adapter => adapter.FullProjectPath).Returns(projectPath);
+
+                var solutionManager = new Mock<IVsSolutionManager>();
+                solutionManager.SetupGet(manager => manager.SolutionDirectory).Returns(solutionDirectory);
+                solutionManager.Setup(manager => manager.GetSolutionFilePathAsync()).ReturnsAsync(solutionFilePath);
+                solutionManager.Setup(manager => manager.GetAllVsProjectAdaptersAsync()).ReturnsAsync([project.Object]);
+
+                string context = await CopilotSolutionContext.CreateAsync(solutionManager.Object, CancellationToken.None);
+                JObject json = JObject.Parse(context);
+
+                Assert.Equal(solutionDirectory, json["solutionDirectory"]!.Value<string>());
+                Assert.Equal(solutionFilePath, json["solutionFilePath"]!.Value<string>());
+                Assert.Equal([projectPath], json["projectPaths"]!.Values<string>());
+                Assert.Equal(
+                    [directoryPackagesPropsPath, nuGetConfigPath, directoryBuildPropsPath],
+                    json["otherMsbuildFilePaths"]!.Values<string>());
+            }
+            finally
+            {
+                if (Directory.Exists(solutionDirectory))
+                {
+                    Directory.Delete(solutionDirectory, recursive: true);
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/CopilotToolSessionTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/CopilotToolSessionTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using Microsoft.VisualStudio.Copilot;
+using NuGetVSExtension;
+using Xunit;
+
+namespace NuGet.Tools.Test
+{
+    public class CopilotToolSessionTests
+    {
+        [Fact]
+        public void EnsureSuccessfulHarnessResponse_WithSuccess_DoesNotThrow()
+        {
+            var response = new CopilotMessageResponse
+            {
+                Content = string.Empty,
+                Model = string.Empty,
+                Status = CopilotResponseStatus.Success,
+            };
+
+            CopilotToolSession.EnsureSuccessfulHarnessResponse(response);
+        }
+
+        [Fact]
+        public void EnsureSuccessfulHarnessResponse_WithFailure_ThrowsTypedExceptionWithStatusAndError()
+        {
+            var response = new CopilotMessageResponse
+            {
+                Content = string.Empty,
+                Model = string.Empty,
+                Status = CopilotResponseStatus.QuotaExceeded,
+                Error = new CopilotMessageError
+                {
+                    Message = "Quota has been exhausted.",
+                },
+            };
+
+            CopilotRequestException exception = Assert.Throws<CopilotRequestException>(
+                () => CopilotToolSession.EnsureSuccessfulHarnessResponse(response));
+
+            Assert.Equal(CopilotResponseStatus.QuotaExceeded, exception.Status);
+            Assert.Contains(nameof(CopilotResponseStatus.QuotaExceeded), exception.Message);
+            Assert.Contains("Quota has been exhausted.", exception.Message);
+        }
+
+        [Fact]
+        public void EnsureSuccessfulHarnessResponse_WithoutChatAccess_ThrowsUnauthorizedAccessException()
+        {
+            var response = new CopilotMessageResponse
+            {
+                Content = string.Empty,
+                Model = string.Empty,
+                Status = CopilotResponseStatus.UserHasNoChatAccess,
+                Error = new CopilotMessageError
+                {
+                    Message = "Chat access is unavailable.",
+                },
+            };
+
+            UnauthorizedAccessException exception = Assert.Throws<UnauthorizedAccessException>(
+                () => CopilotToolSession.EnsureSuccessfulHarnessResponse(response));
+
+            Assert.Equal("Chat access is unavailable.", exception.Message);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetSdkAgentTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Tools.Test/NuGetSdkAgentTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Copilot;
+using NuGet.PackageManagement.VisualStudio;
+using NuGetVSExtension;
+using Xunit;
+
+namespace NuGet.Tools.Test
+{
+    public class NuGetSdkAgentTests
+    {
+        private static readonly ServiceMoniker TestServiceMoniker = new("test.moniker");
+
+        [Fact]
+        public void SelectInBoxNuGetMcpTools_InBoxAndRegistryTools_ReturnsInBoxTools()
+        {
+            CopilotMcpFunctionDescriptor inBoxTool = CreateMcpDescriptor(
+                McpServerConstants.NuGetMcpServerName,
+                McpServerConstants.NuGetSolverToolName);
+            CopilotMcpFunctionDescriptor registryTool = CreateMcpDescriptor(
+                McpServerConstants.ComMicrosoftNuGetMcpServerName,
+                McpServerConstants.NuGetSolverToolName);
+
+            IReadOnlyList<CopilotMcpFunctionDescriptor> result = NuGetSdkAgent.SelectInBoxNuGetMcpTools(
+                [registryTool, inBoxTool]);
+
+            Assert.Collection(result, tool => Assert.Same(inBoxTool, tool));
+        }
+
+        [Fact]
+        public void SelectInBoxNuGetMcpTools_OnlyRegistryTools_ReturnsEmpty()
+        {
+            CopilotMcpFunctionDescriptor registryTool = CreateMcpDescriptor(
+                McpServerConstants.ComMicrosoftNuGetMcpServerName,
+                McpServerConstants.NuGetSolverToolName);
+
+            IReadOnlyList<CopilotMcpFunctionDescriptor> result = NuGetSdkAgent.SelectInBoxNuGetMcpTools(
+                [registryTool]);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void SelectInBoxNuGetMcpTools_MultipleInBoxTools_ReturnsAllInBoxTools()
+        {
+            CopilotMcpFunctionDescriptor fixTool = CreateMcpDescriptor(
+                McpServerConstants.NuGetMcpServerName,
+                McpServerConstants.NuGetSolverToolName);
+            CopilotMcpFunctionDescriptor reviewTool = CreateMcpDescriptor(
+                McpServerConstants.NuGetMcpServerName,
+                McpServerConstants.PackageSourceMappingToolName);
+
+            IReadOnlyList<CopilotMcpFunctionDescriptor> result = NuGetSdkAgent.SelectInBoxNuGetMcpTools(
+                [fixTool, reviewTool]);
+
+            Assert.Equal([fixTool, reviewTool], result);
+        }
+
+        [Fact]
+        public void SelectInBoxNuGetMcpTools_NullFunctions_ReturnsEmpty()
+        {
+            IReadOnlyList<CopilotMcpFunctionDescriptor> result = NuGetSdkAgent.SelectInBoxNuGetMcpTools(
+                functions: null);
+
+            Assert.Empty(result);
+        }
+
+        private static CopilotMcpFunctionDescriptor CreateMcpDescriptor(string group, string toolName)
+        {
+            return new CopilotMcpFunctionDescriptor(
+                providerMoniker: TestServiceMoniker,
+                serverNameOfFunction: toolName,
+                configurationPath: string.Empty,
+                name: $"mcp_{group}_{toolName}",
+                displayName: toolName,
+                description: "desc",
+                confirmation: CopilotConfirmationRequirement.NotRequired)
+            {
+                Group = group,
+            };
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Client.Engineering/issues/3945

## Description

Updates the NuGet Visual Studio Copilot workflows to use the new Copilot SDK harness, when enabled.
If disabled, we retain the legacy implementation for the legacy VS Copilot experience.

### Implementation

- Uses SDK programmatic sessions when `IsBackendModeEnabledAsync` returns `true`. Otherwise, use the existing Copilot Thread-based APIs.
- Adds a programmatic NuGet agent with:
  - `IncludeBuiltInContributions = false`
  - In-box `NuGet` MCP tool descriptors
  - Per-request solution context supplied through agent hooks
- Supplies exact solution and project paths, plus applicable `NuGet.Config`, `Directory.Packages.props`, `Directory.Build.props`, and `Directory.Build.targets` files between each project directory and the solution root.
- Creates persistent SDK sessions so conversations remain available after the initiating request completes.

- Validates `CopilotMessageResponse.Status`:
  - Failures are logged, display a localized warning, and emit `CopilotRequestFailed` telemetry.
  - Success telemetry is emitted only after a successful response.

- Updates the Copilot SDK package to 18.12.384 to obtain the required APIs.
  - Removes the unused Copilot package reference from `NuGet.PackageManagement.UI` which was causing type conflicts.

### Design decisions and known limitations

- Routing is determined before session creation. The SDK path is used when backend mode is enabled; SDK activation or request failures do not silently fall back to the legacy implementation.
- SDK sessions intentionally select only the in-box `NuGet` MCP registration. 
  - The `com.microsoft/nuget` registry registration is not used as a fallback because no supported session-aware API was found for determining the effective MCP server selection.

### Validation

- Verified the vulnerability Fixer & "Fix with Copilot" links end-to-end using the in-box NuGet MCP server in SDK mode.
- Verified the legacy path remains available.
- Added tests for:
  - In-box NuGet tool selection and registry exclusion
  - Exact solution, project, and configuration paths
  - Successful, failed, and no-chat-access SDK responses

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [ ] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~
