### PR TITLE
Preserve restore no-op for case-equivalent project paths

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -384,7 +384,7 @@ namespace NuGet.ProjectModel
             // Preserve default sort order
             foreach (var restoreName in _restore)
             {
-                writer.WriteObjectStart(restoreName);
+                writer.WriteObjectStart(PackageSpecWriter.NormalizePathForHashing(restoreName, hashing));
                 writer.WriteObjectEnd();
             }
 
@@ -397,7 +397,7 @@ namespace NuGet.ProjectModel
             {
                 var project = pair.Value;
 
-                writer.WriteObjectStart(project.RestoreMetadata.ProjectUniqueName);
+                writer.WriteObjectStart(PackageSpecWriter.NormalizePathForHashing(project.RestoreMetadata.ProjectUniqueName, hashing));
                 writeAction.Invoke(project, writer, hashing, EnvironmentVariableWrapper.Instance);
                 writer.WriteObjectEnd();
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -104,8 +104,8 @@ namespace NuGet.ProjectModel
             SetValue(writer, "projectUniqueName", NormalizePathForHashing(msbuildMetadata.ProjectUniqueName, hashing));
             SetValue(writer, "projectName", msbuildMetadata.ProjectName);
             SetValue(writer, "projectPath", NormalizePathForHashing(msbuildMetadata.ProjectPath, hashing));
-            SetValue(writer, "projectJsonPath", NormalizePathForHashing(msbuildMetadata.ProjectJsonPath, hashing));
-            SetValue(writer, "packagesPath", NormalizePathForHashing(ApplyMacro(msbuildMetadata.PackagesPath, userSettingsDirectory, useMacros), hashing));
+            SetValue(writer, "projectJsonPath", msbuildMetadata.ProjectJsonPath);
+            SetValue(writer, "packagesPath", ApplyMacro(msbuildMetadata.PackagesPath, userSettingsDirectory, useMacros));
             SetValue(writer, "outputPath", NormalizePathForHashing(msbuildMetadata.OutputPath, hashing));
 
             if (msbuildMetadata.ProjectStyle != ProjectStyle.Unknown)
@@ -122,24 +122,24 @@ namespace NuGet.ProjectModel
                 MacroStringsUtility.ApplyMacros(fallbackFolderCopy, userSettingsDirectory, MacroStringsUtility.UserMacro, PathUtility.GetStringComparisonBasedOnOS());
                 MacroStringsUtility.ApplyMacros(configFilePathsCopy, userSettingsDirectory, MacroStringsUtility.UserMacro, PathUtility.GetStringComparisonBasedOnOS());
 
-                SetArrayValue(writer, "fallbackFolders", fallbackFolderCopy.Select(path => NormalizePathForHashing(path, hashing)));
-                SetArrayValue(writer, "configFilePaths", configFilePathsCopy.Select(path => NormalizePathForHashing(path, hashing)));
+                SetArrayValue(writer, "fallbackFolders", fallbackFolderCopy);
+                SetArrayValue(writer, "configFilePaths", configFilePathsCopy);
             }
             else
             {
-                SetArrayValue(writer, "fallbackFolders", msbuildMetadata.FallbackFolders?.Select(path => NormalizePathForHashing(path, hashing)));
-                SetArrayValue(writer, "configFilePaths", msbuildMetadata.ConfigFilePaths?.Select(path => NormalizePathForHashing(path, hashing)));
+                SetArrayValue(writer, "fallbackFolders", msbuildMetadata.FallbackFolders);
+                SetArrayValue(writer, "configFilePaths", msbuildMetadata.ConfigFilePaths);
             }
 
             // This need to stay the original strings because the nuget.g.targets have conditional imports based on the original framework name
             SetArrayValue(writer, "originalTargetFrameworks", msbuildMetadata.OriginalTargetFrameworks.OrderBy(c => c, StringComparer.Ordinal));
 
             WriteMetadataSources(writer, msbuildMetadata);
-            WriteMetadataFiles(writer, msbuildMetadata, hashing);
+            WriteMetadataFiles(writer, msbuildMetadata);
             WriteMetadataTargetFrameworks(writer, msbuildMetadata, hashing, useTargetFrameworkAsKey);
             SetWarningProperties(writer, msbuildMetadata);
 
-            WriteNuGetLockFileProperties(writer, msbuildMetadata, hashing);
+            WriteNuGetLockFileProperties(writer, msbuildMetadata);
             WriteNuGetAuditProperties(writer, msbuildMetadata.RestoreAuditProperties);
 
             if (msbuildMetadata is PackagesConfigProjectRestoreMetadata pcMsbuildMetadata)
@@ -181,7 +181,7 @@ namespace NuGet.ProjectModel
         }
 
 
-        private static void WriteNuGetLockFileProperties(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata, bool hashing)
+        private static void WriteNuGetLockFileProperties(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata)
         {
             if (msbuildMetadata.RestoreLockProperties != null &&
                 (!string.IsNullOrEmpty(msbuildMetadata.RestoreLockProperties.RestorePackagesWithLockFile) ||
@@ -191,7 +191,7 @@ namespace NuGet.ProjectModel
                 writer.WriteObjectStart("restoreLockProperties");
 
                 SetValue(writer, "restorePackagesWithLockFile", msbuildMetadata.RestoreLockProperties.RestorePackagesWithLockFile);
-                SetValue(writer, "nuGetLockFilePath", NormalizePathForHashing(msbuildMetadata.RestoreLockProperties.NuGetLockFilePath, hashing));
+                SetValue(writer, "nuGetLockFilePath", msbuildMetadata.RestoreLockProperties.NuGetLockFilePath);
                 SetValueIfTrue(writer, "restoreLockedMode", msbuildMetadata.RestoreLockProperties.RestoreLockedMode);
 
                 writer.WriteObjectEnd();
@@ -280,7 +280,7 @@ namespace NuGet.ProjectModel
             }
         }
 
-        private static void WriteMetadataFiles(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata, bool hashing)
+        private static void WriteMetadataFiles(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata)
         {
             if (msbuildMetadata.Files?.Count > 0)
             {
@@ -288,7 +288,7 @@ namespace NuGet.ProjectModel
 
                 foreach (var file in msbuildMetadata.Files)
                 {
-                    SetValue(writer, file.PackagePath, NormalizePathForHashing(file.AbsolutePath, hashing));
+                    SetValue(writer, file.PackagePath, file.AbsolutePath);
                 }
 
                 writer.WriteObjectEnd();
@@ -547,7 +547,7 @@ namespace NuGet.ProjectModel
                     SetValueIfTrue(writer, "warn", framework.Warn);
                     SetDownloadDependencies(writer, framework.DownloadDependencies);
                     SetFrameworkReferences(writer, framework.FrameworkReferences);
-                    SetValueIfNotNull(writer, "runtimeIdentifierGraphPath", NormalizePathForHashing(framework.RuntimeIdentifierGraphPath, hashing));
+                    SetValueIfNotNull(writer, "runtimeIdentifierGraphPath", framework.RuntimeIdentifierGraphPath);
                     SetPackagesToPrune(writer, framework.PackagesToPrune, hashing);
                     writer.WriteObjectEnd();
                 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -55,11 +55,16 @@ namespace NuGet.ProjectModel
                 SetValue(writer, "version", packageSpec.Version?.ToFullString());
             }
 
-            SetMSBuildMetadata(writer, packageSpec, environmentVariableReader, useLegacyWriter);
+            SetMSBuildMetadata(writer, packageSpec, hashing, environmentVariableReader, useLegacyWriter);
 
             SetFrameworks(writer, packageSpec.TargetFrameworks, hashing, useLegacyWriter);
 
             JsonRuntimeFormat.WriteRuntimeGraph(writer, packageSpec.RuntimeGraph);
+        }
+
+        internal static string NormalizePathForHashing(string path, bool hashing)
+        {
+            return hashing && PathUtility.IsFileSystemCaseInsensitive ? path?.ToUpperInvariant() : path;
         }
 
         private static bool IsMetadataValid(ProjectRestoreMetadata msbuildMetadata)
@@ -82,7 +87,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// This method sets the msbuild metadata that's important for restore. Ensures that frameworks regardless of which way they're stores in the metadata(full name or short tfm name) are written out the same.
         /// </summary>
-        private static void SetMSBuildMetadata(IObjectWriter writer, PackageSpec packageSpec, IEnvironmentVariableReader environmentVariableReader, bool useTargetFrameworkAsKey)
+        private static void SetMSBuildMetadata(IObjectWriter writer, PackageSpec packageSpec, bool hashing, IEnvironmentVariableReader environmentVariableReader, bool useTargetFrameworkAsKey)
         {
             var msbuildMetadata = packageSpec.RestoreMetadata;
 
@@ -96,12 +101,12 @@ namespace NuGet.ProjectModel
 
             writer.WriteObjectStart(JsonPackageSpecReader.RestoreOptions);
 
-            SetValue(writer, "projectUniqueName", msbuildMetadata.ProjectUniqueName);
+            SetValue(writer, "projectUniqueName", NormalizePathForHashing(msbuildMetadata.ProjectUniqueName, hashing));
             SetValue(writer, "projectName", msbuildMetadata.ProjectName);
-            SetValue(writer, "projectPath", msbuildMetadata.ProjectPath);
-            SetValue(writer, "projectJsonPath", msbuildMetadata.ProjectJsonPath);
-            SetValue(writer, "packagesPath", ApplyMacro(msbuildMetadata.PackagesPath, userSettingsDirectory, useMacros));
-            SetValue(writer, "outputPath", msbuildMetadata.OutputPath);
+            SetValue(writer, "projectPath", NormalizePathForHashing(msbuildMetadata.ProjectPath, hashing));
+            SetValue(writer, "projectJsonPath", NormalizePathForHashing(msbuildMetadata.ProjectJsonPath, hashing));
+            SetValue(writer, "packagesPath", NormalizePathForHashing(ApplyMacro(msbuildMetadata.PackagesPath, userSettingsDirectory, useMacros), hashing));
+            SetValue(writer, "outputPath", NormalizePathForHashing(msbuildMetadata.OutputPath, hashing));
 
             if (msbuildMetadata.ProjectStyle != ProjectStyle.Unknown)
             {
@@ -117,24 +122,24 @@ namespace NuGet.ProjectModel
                 MacroStringsUtility.ApplyMacros(fallbackFolderCopy, userSettingsDirectory, MacroStringsUtility.UserMacro, PathUtility.GetStringComparisonBasedOnOS());
                 MacroStringsUtility.ApplyMacros(configFilePathsCopy, userSettingsDirectory, MacroStringsUtility.UserMacro, PathUtility.GetStringComparisonBasedOnOS());
 
-                SetArrayValue(writer, "fallbackFolders", fallbackFolderCopy);
-                SetArrayValue(writer, "configFilePaths", configFilePathsCopy);
+                SetArrayValue(writer, "fallbackFolders", fallbackFolderCopy.Select(path => NormalizePathForHashing(path, hashing)));
+                SetArrayValue(writer, "configFilePaths", configFilePathsCopy.Select(path => NormalizePathForHashing(path, hashing)));
             }
             else
             {
-                SetArrayValue(writer, "fallbackFolders", msbuildMetadata.FallbackFolders);
-                SetArrayValue(writer, "configFilePaths", msbuildMetadata.ConfigFilePaths);
+                SetArrayValue(writer, "fallbackFolders", msbuildMetadata.FallbackFolders?.Select(path => NormalizePathForHashing(path, hashing)));
+                SetArrayValue(writer, "configFilePaths", msbuildMetadata.ConfigFilePaths?.Select(path => NormalizePathForHashing(path, hashing)));
             }
 
             // This need to stay the original strings because the nuget.g.targets have conditional imports based on the original framework name
             SetArrayValue(writer, "originalTargetFrameworks", msbuildMetadata.OriginalTargetFrameworks.OrderBy(c => c, StringComparer.Ordinal));
 
             WriteMetadataSources(writer, msbuildMetadata);
-            WriteMetadataFiles(writer, msbuildMetadata);
-            WriteMetadataTargetFrameworks(writer, msbuildMetadata, useTargetFrameworkAsKey);
+            WriteMetadataFiles(writer, msbuildMetadata, hashing);
+            WriteMetadataTargetFrameworks(writer, msbuildMetadata, hashing, useTargetFrameworkAsKey);
             SetWarningProperties(writer, msbuildMetadata);
 
-            WriteNuGetLockFileProperties(writer, msbuildMetadata);
+            WriteNuGetLockFileProperties(writer, msbuildMetadata, hashing);
             WriteNuGetAuditProperties(writer, msbuildMetadata.RestoreAuditProperties);
 
             if (msbuildMetadata is PackagesConfigProjectRestoreMetadata pcMsbuildMetadata)
@@ -176,7 +181,7 @@ namespace NuGet.ProjectModel
         }
 
 
-        private static void WriteNuGetLockFileProperties(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata)
+        private static void WriteNuGetLockFileProperties(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata, bool hashing)
         {
             if (msbuildMetadata.RestoreLockProperties != null &&
                 (!string.IsNullOrEmpty(msbuildMetadata.RestoreLockProperties.RestorePackagesWithLockFile) ||
@@ -186,7 +191,7 @@ namespace NuGet.ProjectModel
                 writer.WriteObjectStart("restoreLockProperties");
 
                 SetValue(writer, "restorePackagesWithLockFile", msbuildMetadata.RestoreLockProperties.RestorePackagesWithLockFile);
-                SetValue(writer, "nuGetLockFilePath", msbuildMetadata.RestoreLockProperties.NuGetLockFilePath);
+                SetValue(writer, "nuGetLockFilePath", NormalizePathForHashing(msbuildMetadata.RestoreLockProperties.NuGetLockFilePath, hashing));
                 SetValueIfTrue(writer, "restoreLockedMode", msbuildMetadata.RestoreLockProperties.RestoreLockedMode);
 
                 writer.WriteObjectEnd();
@@ -218,7 +223,7 @@ namespace NuGet.ProjectModel
             writer.WriteObjectEnd();
         }
 
-        private static void WriteMetadataTargetFrameworks(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata, bool useTargetFrameworkAsKey)
+        private static void WriteMetadataTargetFrameworks(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata, bool hashing, bool useTargetFrameworkAsKey)
         {
             if (msbuildMetadata.TargetFrameworks?.Count > 0)
             {
@@ -244,9 +249,9 @@ namespace NuGet.ProjectModel
 
                         foreach (var project in framework.ProjectReferences.OrderBy(e => e.ProjectPath, PathUtility.GetStringComparerBasedOnOS()))
                         {
-                            writer.WriteObjectStart(project.ProjectUniqueName);
+                            writer.WriteObjectStart(NormalizePathForHashing(project.ProjectUniqueName, hashing));
 
-                            writer.WriteNameValue("projectPath", project.ProjectPath);
+                            writer.WriteNameValue("projectPath", NormalizePathForHashing(project.ProjectPath, hashing));
 
                             if (project.IncludeAssets != LibraryIncludeFlags.All)
                             {
@@ -275,7 +280,7 @@ namespace NuGet.ProjectModel
             }
         }
 
-        private static void WriteMetadataFiles(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata)
+        private static void WriteMetadataFiles(IObjectWriter writer, ProjectRestoreMetadata msbuildMetadata, bool hashing)
         {
             if (msbuildMetadata.Files?.Count > 0)
             {
@@ -283,7 +288,7 @@ namespace NuGet.ProjectModel
 
                 foreach (var file in msbuildMetadata.Files)
                 {
-                    SetValue(writer, file.PackagePath, file.AbsolutePath);
+                    SetValue(writer, file.PackagePath, NormalizePathForHashing(file.AbsolutePath, hashing));
                 }
 
                 writer.WriteObjectEnd();
@@ -542,7 +547,7 @@ namespace NuGet.ProjectModel
                     SetValueIfTrue(writer, "warn", framework.Warn);
                     SetDownloadDependencies(writer, framework.DownloadDependencies);
                     SetFrameworkReferences(writer, framework.FrameworkReferences);
-                    SetValueIfNotNull(writer, "runtimeIdentifierGraphPath", framework.RuntimeIdentifierGraphPath);
+                    SetValueIfNotNull(writer, "runtimeIdentifierGraphPath", NormalizePathForHashing(framework.RuntimeIdentifierGraphPath, hashing));
                     SetPackagesToPrune(writer, framework.PackagesToPrune, hashing);
                     writer.WriteObjectEnd();
                 }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -3123,6 +3123,64 @@ namespace NuGet.Commands.FuncTest
             }
         }
 
+        [PlatformFact(Platform.Windows)]
+        public async Task RestoreCommand_WithDifferentProjectPathCasings_NoOpsAsync()
+        {
+            using var pathContext = new SimpleTestPathContext();
+            var package = new SimpleTestPackageContext("Package", "1.0.0");
+            package.Files.Clear();
+            package.AddFile("lib/net10.0/Package.dll");
+            await SimpleTestPackageUtility.CreateFolderFeedV3Async(pathContext.PackageSource, PackageSaveMode.Defaultv3, package);
+
+            const string projectJson = @"{
+                ""frameworks"": {
+                    ""net10.0"": {
+                        ""dependencies"": {
+                            ""Package"": ""1.0.0""
+                        }
+                    }
+                }
+            }";
+            var logger = new TestLogger();
+            var sources = new[] { new PackageSource(pathContext.PackageSource) };
+            string firstPath = Path.Combine(pathContext.SolutionRoot, "Projects", "Project.csproj");
+            var firstSpec = JsonPackageSpecReader.GetPackageSpec(projectJson, "Project", firstPath).WithTestRestoreMetadata();
+            firstSpec.RestoreMetadata.CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(firstSpec.RestoreMetadata.OutputPath);
+            var firstRequest = new TestRestoreRequest(firstSpec, sources, pathContext.UserPackagesFolder, logger)
+            {
+                ProjectStyle = ProjectStyle.PackageReference,
+                DependencyGraphSpec = ProjectTestHelpers.GetDGSpecForFirstProject(firstSpec),
+                AllowNoOp = true
+            };
+
+            string originalHash = firstRequest.DependencyGraphSpec.GetHash();
+            RestoreResult firstResult = await new RestoreCommand(firstRequest).ExecuteAsync();
+            firstResult.Success.Should().BeTrue(because: logger.ShowMessages());
+            firstResult.Should().NotBeOfType<NoOpRestoreResult>();
+            await firstResult.CommitAsync(logger, CancellationToken.None);
+            string assetsPath = Path.Combine(firstSpec.RestoreMetadata.OutputPath, "project.assets.json");
+            byte[] originalAssets = File.ReadAllBytes(assetsPath);
+            DateTime originalWriteTime = File.GetLastWriteTimeUtc(assetsPath);
+
+            string secondPath = Path.Combine(pathContext.SolutionRoot, "projects", "Project.csproj");
+            var secondSpec = JsonPackageSpecReader.GetPackageSpec(projectJson, "Project", secondPath).WithTestRestoreMetadata();
+            secondSpec.RestoreMetadata.CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(secondSpec.RestoreMetadata.OutputPath);
+            var secondRequest = new TestRestoreRequest(secondSpec, sources, pathContext.UserPackagesFolder, logger)
+            {
+                ProjectStyle = ProjectStyle.PackageReference,
+                DependencyGraphSpec = ProjectTestHelpers.GetDGSpecForFirstProject(secondSpec),
+                AllowNoOp = true
+            };
+
+            secondRequest.DependencyGraphSpec.GetHash().Should().Be(originalHash);
+            RestoreResult secondResult = await new RestoreCommand(secondRequest).ExecuteAsync();
+            secondResult.Success.Should().BeTrue(because: logger.ShowMessages());
+            secondResult.Should().BeOfType<NoOpRestoreResult>(because: "only the casing of the project directory changed: {0}", logger.ShowMessages());
+            await secondResult.CommitAsync(logger, CancellationToken.None);
+            File.ReadAllBytes(assetsPath).Should().Equal(originalAssets);
+            File.GetLastWriteTimeUtc(assetsPath).Should().Be(originalWriteTime);
+        }
+
         [Fact]
         public async Task RestoreCommand_WhenRestoreNoOps_TheAssetsFileIsNotRead()
         {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Internal.NuGet.Testing.SignedPackages;
 using NuGet.Commands.Test;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -452,6 +453,104 @@ namespace NuGet.ProjectModel.Test
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        public void GetHash_WithDifferentProjectPathCasings_UsesFileSystemCaseSensitivity(bool useLegacyHashFunction)
+        {
+            PackageSpec firstProject = CreatePackageSpecWithPaths(Path.Combine(Path.GetTempPath(), "Projects"));
+            PackageSpec secondProject = CreatePackageSpecWithPaths(Path.Combine(Path.GetTempPath(), "projects"));
+            DependencyGraphSpec first = ProjectTestHelpers.GetDGSpecForFirstProject(firstProject);
+            DependencyGraphSpec second = ProjectTestHelpers.GetDGSpecForFirstProject(secondProject);
+            string firstJson = GetJson(first);
+            string secondJson = GetJson(second);
+
+            string firstHash = GetHash(first, useLegacyHashFunction);
+            string secondHash = GetHash(second, useLegacyHashFunction);
+
+            Assert.Equal(PathUtility.IsFileSystemCaseInsensitive, StringComparer.Ordinal.Equals(firstHash, secondHash));
+            Assert.Equal(firstJson, GetJson(first));
+            Assert.Equal(secondJson, GetJson(second));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GetHash_WithDifferentReferencedProjectPathCasings_UsesFileSystemCaseSensitivity(bool useLegacyHashFunction)
+        {
+            PackageSpec firstRoot = CreatePackageSpecWithPaths(Path.Combine(Path.GetTempPath(), "Root"));
+            PackageSpec secondRoot = firstRoot.Clone();
+            PackageSpec firstChild = CreatePackageSpecWithPaths(Path.Combine(Path.GetTempPath(), "Referenced"), "Child");
+            PackageSpec secondChild = CreatePackageSpecWithPaths(Path.Combine(Path.GetTempPath(), "referenced"), "Child");
+            firstRoot = firstRoot.WithTestProjectReference(firstChild);
+            secondRoot = secondRoot.WithTestProjectReference(secondChild);
+            DependencyGraphSpec first = ProjectTestHelpers.GetDGSpecForFirstProject(firstRoot, firstChild);
+            DependencyGraphSpec second = ProjectTestHelpers.GetDGSpecForFirstProject(secondRoot, secondChild);
+
+            DependencyGraphSpec firstClosure = first.WithProjectClosure(firstRoot.RestoreMetadata.ProjectUniqueName);
+            DependencyGraphSpec secondClosure = second.WithProjectClosure(secondRoot.RestoreMetadata.ProjectUniqueName);
+            Assert.Equal(2, firstClosure.Projects.Count);
+            Assert.Equal(2, secondClosure.Projects.Count);
+            string firstJson = GetJson(firstClosure);
+            string secondJson = GetJson(secondClosure);
+
+            string firstHash = GetHash(firstClosure, useLegacyHashFunction);
+            string secondHash = GetHash(secondClosure, useLegacyHashFunction);
+
+            Assert.Equal(PathUtility.IsFileSystemCaseInsensitive, StringComparer.Ordinal.Equals(firstHash, secondHash));
+            Assert.Equal(firstJson, GetJson(firstClosure));
+            Assert.Equal(secondJson, GetJson(secondClosure));
+        }
+
+        [Theory]
+        [InlineData(false, "ProjectName")]
+        [InlineData(true, "ProjectName")]
+        [InlineData(false, "Source")]
+        [InlineData(true, "Source")]
+        [InlineData(false, "PackagePath")]
+        [InlineData(true, "PackagePath")]
+        [InlineData(false, "OutputPath")]
+        [InlineData(true, "OutputPath")]
+        [InlineData(false, "DependencyVersion")]
+        [InlineData(true, "DependencyVersion")]
+        public void GetHash_WithMeaningfulChanges_ReturnsDifferentHashes(bool useLegacyHashFunction, string changedValue)
+        {
+            PackageSpec first = CreatePackageSpecWithPaths(Path.Combine(Path.GetTempPath(), "Projects"));
+            PackageSpec second = first.Clone();
+
+            switch (changedValue)
+            {
+                case "ProjectName":
+                    second.RestoreMetadata.ProjectName = "project";
+                    break;
+                case "Source":
+                    second.RestoreMetadata.Sources = [new PackageSource("https://example.test/feed/index.json")];
+                    break;
+                case "PackagePath":
+                    second.RestoreMetadata.Files = [new ProjectRestoreMetadataFile("lib/net10.0/project.dll", first.RestoreMetadata.Files[0].AbsolutePath)];
+                    break;
+                case "OutputPath":
+                    second.RestoreMetadata.OutputPath = Path.Combine(Path.GetTempPath(), "OtherOutput");
+                    break;
+                case "DependencyVersion":
+                    second.TargetFrameworks[0] = new TargetFrameworkInformation(second.TargetFrameworks[0])
+                    {
+                        Dependencies = [new LibraryDependency
+                        {
+                            LibraryRange = new LibraryRange("Package", VersionRange.Parse("2.0.0"), LibraryDependencyTarget.Package)
+                        }]
+                    };
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(changedValue));
+            }
+
+            string firstHash = GetHash(ProjectTestHelpers.GetDGSpecForFirstProject(first), useLegacyHashFunction);
+            string secondHash = GetHash(ProjectTestHelpers.GetDGSpecForFirstProject(second), useLegacyHashFunction);
+
+            Assert.NotEqual(firstHash, secondHash);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public void GetHash_WithCentralPackageVersionsAndPackagesToPrune_IgnoresDictionaryCreationOrder(bool useLegacyHashFunction)
         {
             // Arrange
@@ -747,6 +846,42 @@ namespace NuGet.ProjectModel.Test
                     Assert.True(expectedResult.Equals(actualResult));
                     Assert.NotSame(expectedResult, actualResult);
                 });
+        }
+
+        private static PackageSpec CreatePackageSpecWithPaths(string directory, string projectName = "Project")
+        {
+            string projectPath = Path.Combine(directory, projectName + ".csproj");
+            var framework = new TargetFrameworkInformation
+            {
+                FrameworkName = NuGetFramework.Parse("net10.0"),
+                RuntimeIdentifierGraphPath = Path.Combine(directory, "RuntimeIdentifierGraph.json"),
+                Dependencies = [new LibraryDependency
+                {
+                    LibraryRange = new LibraryRange("Package", VersionRange.Parse("1.0.0"), LibraryDependencyTarget.Package)
+                }]
+            };
+
+            return new PackageSpec([framework])
+            {
+                Name = projectName,
+                FilePath = projectPath,
+                RestoreMetadata = new ProjectRestoreMetadata
+                {
+                    ProjectStyle = ProjectStyle.PackageReference,
+                    ProjectUniqueName = projectPath,
+                    ProjectName = projectName,
+                    ProjectPath = projectPath,
+                    ProjectJsonPath = Path.Combine(directory, "project.json"),
+                    OutputPath = Path.Combine(directory, "obj"),
+                    PackagesPath = Path.Combine(directory, "Packages"),
+                    ConfigFilePaths = [Path.Combine(directory, "NuGet.Config")],
+                    FallbackFolders = [Path.Combine(directory, "Fallback")],
+                    Sources = [new PackageSource("https://example.test/Feed/index.json")],
+                    TargetFrameworks = [new ProjectRestoreMetadataFrameworkInfo(framework.FrameworkName)],
+                    Files = [new ProjectRestoreMetadataFile("lib/net10.0/Project.dll", Path.Combine(directory, "bin", "Project.dll"))],
+                    RestoreLockProperties = new RestoreLockProperties("true", Path.Combine(directory, "packages.lock.json"), false)
+                }
+            };
         }
 
         private static DependencyGraphSpec CreateDependencyGraphSpec()

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -510,7 +510,21 @@ namespace NuGet.ProjectModel.Test
         [InlineData(true, "OutputPath")]
         [InlineData(false, "DependencyVersion")]
         [InlineData(true, "DependencyVersion")]
-        public void GetHash_WithMeaningfulChanges_ReturnsDifferentHashes(bool useLegacyHashFunction, string changedValue)
+        [InlineData(false, "ProjectJsonPath")]
+        [InlineData(true, "ProjectJsonPath")]
+        [InlineData(false, "PackagesPath")]
+        [InlineData(true, "PackagesPath")]
+        [InlineData(false, "ConfigFilePath")]
+        [InlineData(true, "ConfigFilePath")]
+        [InlineData(false, "FallbackFolder")]
+        [InlineData(true, "FallbackFolder")]
+        [InlineData(false, "LockFilePath")]
+        [InlineData(true, "LockFilePath")]
+        [InlineData(false, "RuntimeIdentifierGraphPath")]
+        [InlineData(true, "RuntimeIdentifierGraphPath")]
+        [InlineData(false, "AbsolutePath")]
+        [InlineData(true, "AbsolutePath")]
+        public void GetHash_WithOtherRestoreInputChanges_ReturnsDifferentHashes(bool useLegacyHashFunction, string changedValue)
         {
             PackageSpec first = CreatePackageSpecWithPaths(Path.Combine(Path.GetTempPath(), "Projects"));
             PackageSpec second = first.Clone();
@@ -537,6 +551,32 @@ namespace NuGet.ProjectModel.Test
                             LibraryRange = new LibraryRange("Package", VersionRange.Parse("2.0.0"), LibraryDependencyTarget.Package)
                         }]
                     };
+                    break;
+                case "ProjectJsonPath":
+                    second.RestoreMetadata.ProjectJsonPath = second.RestoreMetadata.ProjectJsonPath.ToUpperInvariant();
+                    break;
+                case "PackagesPath":
+                    second.RestoreMetadata.PackagesPath = second.RestoreMetadata.PackagesPath.ToUpperInvariant();
+                    break;
+                case "ConfigFilePath":
+                    second.RestoreMetadata.ConfigFilePaths[0] = second.RestoreMetadata.ConfigFilePaths[0].ToUpperInvariant();
+                    break;
+                case "FallbackFolder":
+                    second.RestoreMetadata.FallbackFolders[0] = second.RestoreMetadata.FallbackFolders[0].ToUpperInvariant();
+                    break;
+                case "LockFilePath":
+                    second.RestoreMetadata.RestoreLockProperties = new RestoreLockProperties(
+                        "true", second.RestoreMetadata.RestoreLockProperties.NuGetLockFilePath.ToUpperInvariant(), false);
+                    break;
+                case "RuntimeIdentifierGraphPath":
+                    second.TargetFrameworks[0] = new TargetFrameworkInformation(second.TargetFrameworks[0])
+                    {
+                        RuntimeIdentifierGraphPath = second.TargetFrameworks[0].RuntimeIdentifierGraphPath.ToUpperInvariant()
+                    };
+                    break;
+                case "AbsolutePath":
+                    second.RestoreMetadata.Files = [new ProjectRestoreMetadataFile(
+                        first.RestoreMetadata.Files[0].PackagePath, first.RestoreMetadata.Files[0].AbsolutePath.ToUpperInvariant())];
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(changedValue));
@@ -851,10 +891,11 @@ namespace NuGet.ProjectModel.Test
         private static PackageSpec CreatePackageSpecWithPaths(string directory, string projectName = "Project")
         {
             string projectPath = Path.Combine(directory, projectName + ".csproj");
+            string restoreSettingsDirectory = Path.Combine(Path.GetTempPath(), "RestoreSettings");
             var framework = new TargetFrameworkInformation
             {
                 FrameworkName = NuGetFramework.Parse("net10.0"),
-                RuntimeIdentifierGraphPath = Path.Combine(directory, "RuntimeIdentifierGraph.json"),
+                RuntimeIdentifierGraphPath = Path.Combine(restoreSettingsDirectory, "RuntimeIdentifierGraph.json"),
                 Dependencies = [new LibraryDependency
                 {
                     LibraryRange = new LibraryRange("Package", VersionRange.Parse("1.0.0"), LibraryDependencyTarget.Package)
@@ -871,15 +912,15 @@ namespace NuGet.ProjectModel.Test
                     ProjectUniqueName = projectPath,
                     ProjectName = projectName,
                     ProjectPath = projectPath,
-                    ProjectJsonPath = Path.Combine(directory, "project.json"),
+                    ProjectJsonPath = Path.Combine(restoreSettingsDirectory, "project.json"),
                     OutputPath = Path.Combine(directory, "obj"),
-                    PackagesPath = Path.Combine(directory, "Packages"),
-                    ConfigFilePaths = [Path.Combine(directory, "NuGet.Config")],
-                    FallbackFolders = [Path.Combine(directory, "Fallback")],
+                    PackagesPath = Path.Combine(restoreSettingsDirectory, "Packages"),
+                    ConfigFilePaths = [Path.Combine(restoreSettingsDirectory, "NuGet.Config")],
+                    FallbackFolders = [Path.Combine(restoreSettingsDirectory, "Fallback")],
                     Sources = [new PackageSource("https://example.test/Feed/index.json")],
                     TargetFrameworks = [new ProjectRestoreMetadataFrameworkInfo(framework.FrameworkName)],
-                    Files = [new ProjectRestoreMetadataFile("lib/net10.0/Project.dll", Path.Combine(directory, "bin", "Project.dll"))],
-                    RestoreLockProperties = new RestoreLockProperties("true", Path.Combine(directory, "packages.lock.json"), false)
+                    Files = [new ProjectRestoreMetadataFile("lib/net10.0/Project.dll", Path.Combine(restoreSettingsDirectory, "bin", "Project.dll"))],
+                    RestoreLockProperties = new RestoreLockProperties("true", Path.Combine(restoreSettingsDirectory, "packages.lock.json"), false)
                 }
             };
         }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/15081

## Description

Preserve restore's no-op cache when dependency graphs differ only in project-path casing on case-insensitive platforms. Project identity lookup already uses the OS-dependent path comparer, but hash serialization retained the original spelling, allowing equivalent paths to invalidate the cache across graph evaluations.

Normalize only project/restore identity keys, project paths, project-reference keys and paths, and the derived output path while hashing. The output path is needed because it inherits the project directory's casing; removing its normalization breaks the case-only hash and second-restore regressions. Other restore paths retain their existing hash behavior, and the production diff introduces no LINQ. Normal serialized output and graph objects retain their original spelling. Both FNV and legacy SHA512 use the same normalization.

Added regression coverage for root and referenced-project paths, unchanged serialized output, and continued invalidation for other restore-input changes. Unrelated config, package-cache, fallback, lock-file, runtime-graph, and asset paths are held fixed in the casing reproduction. A Windows local-feed test verifies that changing only the project-directory casing between restores returns `NoOpRestoreResult` without rewriting the assets file.

Validation on Windows:
- ProjectModel tests: 1,419 passed and 4 skipped on each of `net472` and `net10.0`.
- The new two-restore regression and the existing no-op cache test: 2 passed on each target.
- Solution-wide `dotnet format whitespace --verify-no-changes NuGet.sln --no-restore` completed successfully with workspace-load warnings; `git diff --check` passed.
- Linux and full CI were not run locally.

No public APIs, settings, environment variables, or output schemas are added or changed, so a documentation issue or PR is not applicable.

## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.