### PR TITLE
Use Windows UI to prompt for package source credentials in VS

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/DefaultVSCredentialServiceProvider.cs
@@ -43,6 +43,7 @@ namespace NuGet.PackageManagement.VisualStudio
             // Initialize the credential providers.
             var credentialProviders = new List<ICredentialProvider>();
             var webProxy = await _asyncServiceProvider.GetServiceAsync<SVsWebProxy, IVsWebProxy>();
+            var uiShell = await _asyncServiceProvider.GetServiceAsync<SVsUIShell, IVsUIShell>();
 
             await TryAddCredentialProvidersAsync(
                 credentialProviders,
@@ -63,7 +64,9 @@ namespace NuGet.PackageManagement.VisualStudio
                     Debug.Assert(webProxy != null);
 
                     return new ICredentialProvider[] {
-                        new VisualStudioCredentialProvider(webProxy)
+                        new VisualStudioCredentialProvider(
+                            webProxy,
+                            uiShell)
                     };
                 });
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IPackageSourceCredentialPrompt.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IPackageSourceCredentialPrompt.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    internal interface IPackageSourceCredentialPrompt
+    {
+        NetworkCredential? PromptForCredentials(Uri packageSourceUri, bool isRetry, IntPtr parentWindow);
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageSourceCredentialPrompt.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageSourceCredentialPrompt.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Net;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    internal sealed class PackageSourceCredentialPrompt : IPackageSourceCredentialPrompt
+    {
+        public NetworkCredential? PromptForCredentials(Uri packageSourceUri, bool isRetry, IntPtr parentWindow)
+        {
+            string source = GetDisplayName(packageSourceUri);
+            string message = string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.CredentialPrompt_PackageSourceMessage,
+                source);
+
+            return NativeMethods.PromptForCredentials(
+                Strings.CredentialPrompt_PackageSourceCaption,
+                message,
+                source,
+                isRetry,
+                parentWindow);
+        }
+
+        internal static string GetDisplayName(Uri packageSourceUri)
+        {
+            return packageSourceUri.GetComponents(
+                UriComponents.SchemeAndServer | UriComponents.Path,
+                UriFormat.SafeUnescaped);
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
@@ -23,9 +23,9 @@ namespace NuGet.PackageManagement.VisualStudio {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
@@ -96,6 +96,24 @@ namespace NuGet.PackageManagement.VisualStudio {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to NuGet Package Source Authentication.
+        /// </summary>
+        public static string CredentialPrompt_PackageSourceCaption {
+            get {
+                return ResourceManager.GetString("CredentialPrompt_PackageSourceCaption", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enter credentials for the package source &apos;{0}&apos;..
+        /// </summary>
+        public static string CredentialPrompt_PackageSourceMessage {
+            get {
+                return ResourceManager.GetString("CredentialPrompt_PackageSourceMessage", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The default credentials credential provider failed to load..
         /// </summary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.resx
@@ -208,6 +208,13 @@
   <data name="CredentialProviderFailed_VisualStudioCredentialProvider" xml:space="preserve">
     <value>The Visual Studio credential provider failed to load.</value>
   </data>
+  <data name="CredentialPrompt_PackageSourceCaption" xml:space="preserve">
+    <value>NuGet Package Source Authentication</value>
+  </data>
+  <data name="CredentialPrompt_PackageSourceMessage" xml:space="preserve">
+    <value>Enter credentials for the package source '{0}'.</value>
+    <comment>{0} is the package source URI.</comment>
+  </data>
   <data name="CredentialProviderFailed_VisualStudioAccountProvider" xml:space="preserve">
     <value>The Visual Studio or VSTS account provider failed to load.</value>
   </data>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NativeMethods.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/NativeMethods.cs
@@ -1,6 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.ComponentModel;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+
 namespace NuGet.PackageManagement.VisualStudio
 {
     internal static class NativeMethods
@@ -8,5 +15,114 @@ namespace NuGet.PackageManagement.VisualStudio
         public const int IDCANCEL = 2;
         public const int IDYES = 6;
         public const int IDNO = 7;
+
+        private const int ErrorCancelled = 1223;
+        private const int MaxPasswordLength = 256;
+        private const int MaxUserNameLength = 513;
+
+        [Flags]
+        private enum CredUiFlags
+        {
+            IncorrectPassword = 0x1,
+            DoNotPersist = 0x2,
+            AlwaysShowUi = 0x80,
+            GenericCredentials = 0x40000,
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct CredUiInfo
+        {
+            public int Size;
+            public IntPtr ParentWindow;
+
+            [MarshalAs(UnmanagedType.LPWStr)]
+            public string MessageText;
+
+            [MarshalAs(UnmanagedType.LPWStr)]
+            public string CaptionText;
+
+            public IntPtr Banner;
+        }
+
+        [DllImport("credui.dll", EntryPoint = "CredUIPromptForCredentialsW", CharSet = CharSet.Unicode)]
+        private static extern int CredUIPromptForCredentials(
+            ref CredUiInfo info,
+            string targetName,
+            IntPtr reserved,
+            int authenticationError,
+            StringBuilder userName,
+            int maxUserNameCharacters,
+            StringBuilder password,
+            int maxPasswordCharacters,
+            ref int save,
+            CredUiFlags flags);
+
+        internal static NetworkCredential? PromptForCredentials(
+            string caption,
+            string message,
+            string targetName,
+            bool isRetry,
+            IntPtr parentWindow)
+        {
+            var info = new CredUiInfo
+            {
+                Size = Marshal.SizeOf<CredUiInfo>(),
+                ParentWindow = parentWindow,
+                MessageText = message,
+                CaptionText = caption,
+            };
+            var userName = new StringBuilder(MaxUserNameLength);
+            var password = new StringBuilder(MaxPasswordLength);
+            var save = 0;
+            var flags = CredUiFlags.AlwaysShowUi | CredUiFlags.DoNotPersist | CredUiFlags.GenericCredentials;
+
+            if (isRetry)
+            {
+                flags |= CredUiFlags.IncorrectPassword;
+            }
+
+            try
+            {
+                int result = CredUIPromptForCredentials(
+                    ref info,
+                    targetName,
+                    IntPtr.Zero,
+                    authenticationError: 0,
+                    userName,
+                    MaxUserNameLength,
+                    password,
+                    MaxPasswordLength,
+                    ref save,
+                    flags);
+
+                if (result == ErrorCancelled)
+                {
+                    return null;
+                }
+
+                if (result != 0)
+                {
+                    throw new Win32Exception(result);
+                }
+
+                using (var securePassword = new SecureString())
+                {
+                    for (var index = 0; index < password.Length; index++)
+                    {
+                        securePassword.AppendChar(password[index]);
+                    }
+
+                    securePassword.MakeReadOnly();
+                    return new NetworkCredential(userName.ToString(), securePassword);
+                }
+            }
+            finally
+            {
+                for (var index = 0; index < password.Length; index++)
+                {
+                    password[index] = '\0';
+                }
+            }
+        }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VisualStudioCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VisualStudioCredentialProvider.cs
@@ -19,14 +19,38 @@ namespace NuGet.PackageManagement.VisualStudio
     public class VisualStudioCredentialProvider : ICredentialProvider
     {
         private readonly Lazy<JoinableTaskFactory> _joinableTaskFactory;
+        private readonly IPackageSourceCredentialPrompt _packageSourceCredentialPrompt;
+        private readonly IVsUIShell _uiShell;
         private readonly IVsWebProxy _webProxyService;
 
         public VisualStudioCredentialProvider(IVsWebProxy webProxyService)
-            : this(webProxyService, new Lazy<JoinableTaskFactory>(() => NuGetUIThreadHelper.JoinableTaskFactory))
+            : this(
+                  webProxyService,
+                  uiShell: null,
+                  new Lazy<JoinableTaskFactory>(() => NuGetUIThreadHelper.JoinableTaskFactory),
+                  new PackageSourceCredentialPrompt())
         {
         }
 
         internal VisualStudioCredentialProvider(IVsWebProxy webProxyService, Lazy<JoinableTaskFactory> joinableTaskFactory)
+            : this(webProxyService, uiShell: null, joinableTaskFactory, new PackageSourceCredentialPrompt())
+        {
+        }
+
+        internal VisualStudioCredentialProvider(IVsWebProxy webProxyService, IVsUIShell uiShell)
+            : this(
+                  webProxyService,
+                  uiShell,
+                  new Lazy<JoinableTaskFactory>(() => NuGetUIThreadHelper.JoinableTaskFactory),
+                  new PackageSourceCredentialPrompt())
+        {
+        }
+
+        internal VisualStudioCredentialProvider(
+            IVsWebProxy webProxyService,
+            IVsUIShell uiShell,
+            Lazy<JoinableTaskFactory> joinableTaskFactory,
+            IPackageSourceCredentialPrompt packageSourceCredentialPrompt)
         {
             if (webProxyService == null)
             {
@@ -38,8 +62,15 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException(nameof(joinableTaskFactory));
             }
 
+            if (packageSourceCredentialPrompt == null)
+            {
+                throw new ArgumentNullException(nameof(packageSourceCredentialPrompt));
+            }
+
             _webProxyService = webProxyService;
+            _uiShell = uiShell;
             _joinableTaskFactory = joinableTaskFactory;
+            _packageSourceCredentialPrompt = packageSourceCredentialPrompt;
             Id = $"{typeof(VisualStudioCredentialProvider).Name}_{Guid.NewGuid()}";
         }
 
@@ -67,6 +98,11 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException(nameof(uri));
             }
 
+            if (type != CredentialRequestType.Proxy)
+            {
+                return await PromptForPackageSourceCredentialsAsync(uri, isRetry, cancellationToken);
+            }
+
             // Capture the original proxy before we do anything
             // so that we can re-set it once we get the credentials for the given Uri.
             IWebProxy originalProxy = null;
@@ -92,20 +128,13 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 // The cached credentials that we found are not valid so let's ask the user
                 // until they abort or give us valid credentials.
-                var uriToDisplay = uri;
-                if (type == CredentialRequestType.Proxy && proxy != null)
-                {
-                    // Display the proxy server's host name when asking for proxy credentials
-                    uriToDisplay = proxy.GetProxy(uri);
-                }
+                var uriToDisplay = proxy == null ? uri : proxy.GetProxy(uri);
 
                 // Set the static property WebRequest.DefaultWebProxy so that the right host name
-                // is displayed in the UI by IVsWebProxy. Note that this is just a UI thing, 
-                // so this is needed no matter wether we're prompting for proxy credentials 
-                // or request credentials. 
+                // is displayed in the UI by IVsWebProxy.
                 WebRequest.DefaultWebProxy = new WebProxy(uriToDisplay);
 
-                return await PromptForCredentialsAsync(uri, cancellationToken);
+                return await PromptForProxyCredentialsAsync(uri, cancellationToken);
             }
             finally
             {
@@ -119,7 +148,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// This method is responsible for retrieving either cached credentials
         /// or forcing a prompt if we need the user to give us new credentials.
         /// </summary>
-        private async Task<CredentialResponse> PromptForCredentialsAsync(Uri uri, CancellationToken cancellationToken)
+        private async Task<CredentialResponse> PromptForProxyCredentialsAsync(Uri uri, CancellationToken cancellationToken)
         {
             // This value will cause the web proxy service to first attempt to retrieve
             // credentials from its cache and fall back to prompting if necessary.
@@ -153,6 +182,33 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // Get the new credentials from the proxy instance
             return new CredentialResponse(WebRequest.DefaultWebProxy.Credentials);
+        }
+
+        private async Task<CredentialResponse> PromptForPackageSourceCredentialsAsync(
+            Uri uri,
+            bool isRetry,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            NetworkCredential credentials = null;
+
+            await _joinableTaskFactory.Value.RunAsync(async () =>
+            {
+                await _joinableTaskFactory.Value.SwitchToMainThreadAsync(cancellationToken);
+
+                var parentWindow = IntPtr.Zero;
+                _uiShell?.GetDialogOwnerHwnd(out parentWindow);
+
+                credentials = _packageSourceCredentialPrompt.PromptForCredentials(
+                    uri,
+                    isRetry,
+                    parentWindow);
+            });
+
+            return credentials == null
+                ? new CredentialResponse(CredentialStatus.UserCanceled)
+                : new CredentialResponse(credentials);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.cs.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.cs.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Operace NuGet selhala.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">Nepovedlo se načíst poskytovatele přihlašovacích údajů pro výchozí přihlašovací údaje.</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.de.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.de.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Fehler bei NuGet-Vorgang</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">Der standardmäßige Anmeldeinformationsanbieter konnte nicht geladen werden.</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.es.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.es.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Error en la operación NuGet</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">No se pudo cargar el proveedor de las credenciales predeterminadas.</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.fr.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.fr.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Échec de l'opération NuGet</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">Échec du chargement du fournisseur d'informations d'identification par défaut.</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.it.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.it.xlf
@@ -22,6 +22,16 @@
         <target state="translated">L'operazione NuGet non è riuscita</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">Il caricamento del provider di credenziali delle credenziali predefinite non è riuscito.</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ja.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ja.xlf
@@ -22,6 +22,16 @@
         <target state="translated">NuGet 操作が失敗しました</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">既定の資格情報プロバイダーが読み込めませんでした。</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ko.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ko.xlf
@@ -22,6 +22,16 @@
         <target state="translated">NuGet 작업이 실패했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">기본 자격 증명의 자격 증명 공급자를 로드하지 못했습니다.</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.pl.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.pl.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Operacja narzędzia NuGet nie powiodła się</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">Nie można załadować dostawcy poświadczeń domyślnych.</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.pt-BR.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.pt-BR.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Falha na operação NuGet</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">Falha ao carregar o provedor de credenciais padrão.</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ru.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.ru.xlf
@@ -22,6 +22,16 @@
         <target state="translated">Сбой операции NuGet</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">Не удалось загрузить поставщик учетных данных с учетными данными по умолчанию.</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.tr.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.tr.xlf
@@ -22,6 +22,16 @@
         <target state="translated">NuGet işlemi başarısız oldu</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">Varsayılan kimlik bilgisi sağlayıcısı yüklenemedi.</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.zh-Hans.xlf
@@ -22,6 +22,16 @@
         <target state="translated">NuGet 操作失败</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">未能加载默认凭据的凭据提供程序。</target>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/xlf/Strings.zh-Hant.xlf
@@ -22,6 +22,16 @@
         <target state="translated">NuGet 作業失敗</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceCaption">
+        <source>NuGet Package Source Authentication</source>
+        <target state="new">NuGet Package Source Authentication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CredentialPrompt_PackageSourceMessage">
+        <source>Enter credentials for the package source '{0}'.</source>
+        <target state="new">Enter credentials for the package source '{0}'.</target>
+        <note>{0} is the package source URI.</note>
+      </trans-unit>
       <trans-unit id="CredentialProviderFailed_DefaultCredentialsCredentialProvider">
         <source>The default credentials credential provider failed to load.</source>
         <target state="translated">無法載入預設認證的認證提供者。</target>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/PackageSourceCredentialPromptTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/PackageSourceCredentialPromptTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    public class PackageSourceCredentialPromptTests
+    {
+        [Fact]
+        public void GetDisplayName_WithCredentialsAndQuery_DoesNotExposeSecrets()
+        {
+            var uri = new Uri("https://user:secret@unit.test/v3/index.json?token=secret");
+
+            string source = PackageSourceCredentialPrompt.GetDisplayName(uri);
+
+            Assert.Equal("https://unit.test/v3/index.json", source);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VisualStudioCredentialProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VisualStudioCredentialProviderTests.cs
@@ -22,6 +22,23 @@ namespace NuGet.PackageManagement.VisualStudio.Test
     {
         private static readonly Uri _uri = new Uri("http://unit.test");
 
+        private sealed class TestPackageSourceCredentialPrompt : IPackageSourceCredentialPrompt
+        {
+            internal required NetworkCredential? CredentialsToReturn { get; set; }
+            internal bool IsRetry { get; private set; }
+            internal IntPtr ParentWindow { get; private set; }
+            internal Uri? PackageSourceUri { get; private set; }
+
+            public NetworkCredential? PromptForCredentials(Uri packageSourceUri, bool isRetry, IntPtr parentWindow)
+            {
+                PackageSourceUri = packageSourceUri;
+                IsRetry = isRetry;
+                ParentWindow = parentWindow;
+
+                return CredentialsToReturn;
+            }
+        }
+
         public VisualStudioCredentialProviderTests(GlobalServiceProvider globalServiceProvider)
             : base(globalServiceProvider)
         {
@@ -123,7 +140,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             var response = await provider.GetAsync(
                 _uri,
                 proxy: null,
-                type: CredentialRequestType.Unauthorized,
+                type: CredentialRequestType.Proxy,
                 message: "a",
                 isRetry: false,
                 nonInteractive: true,
@@ -134,6 +151,74 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Same(expectedCredentials, response.Credentials);
 
             vsWebProxy.Verify();
+        }
+
+        [Fact]
+        public async Task GetAsync_ForPackageSource_PromptsWithPackageSourceDetails()
+        {
+            var vsWebProxy = new Mock<IVsWebProxy>(MockBehavior.Strict);
+            var uiShell = new Mock<IVsUIShell>(MockBehavior.Strict);
+            var parentWindow = new IntPtr(42);
+            var expectedCredentials = new NetworkCredential("user", "password");
+            var credentialPrompt = new TestPackageSourceCredentialPrompt
+            {
+                CredentialsToReturn = expectedCredentials,
+            };
+            var uri = new Uri("https://user:secret@unit.test/v3/index.json?token=secret");
+
+            uiShell.Setup(x => x.GetDialogOwnerHwnd(out parentWindow))
+                .Returns(0);
+
+            var provider = new VisualStudioCredentialProvider(
+                vsWebProxy.Object,
+                uiShell.Object,
+                new Lazy<JoinableTaskFactory>(() => NuGetUIThreadHelper.JoinableTaskFactory),
+                credentialPrompt);
+
+            CredentialResponse response = await provider.GetAsync(
+                uri,
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
+                isRetry: true,
+                nonInteractive: false,
+                cancellationToken: CancellationToken.None);
+
+            Assert.Equal(CredentialStatus.Success, response.Status);
+            Assert.Same(expectedCredentials, response.Credentials);
+            Assert.Same(uri, credentialPrompt.PackageSourceUri);
+            Assert.True(credentialPrompt.IsRetry);
+            Assert.Equal(parentWindow, credentialPrompt.ParentWindow);
+            vsWebProxy.VerifyNoOtherCalls();
+            uiShell.VerifyAll();
+        }
+
+        [Fact]
+        public async Task GetAsync_ForPackageSource_WhenUserCancels_ReturnsUserCanceled()
+        {
+            var credentialPrompt = new TestPackageSourceCredentialPrompt
+            {
+                CredentialsToReturn = null,
+            };
+            var provider = new VisualStudioCredentialProvider(
+                Mock.Of<IVsWebProxy>(),
+                uiShell: null,
+                new Lazy<JoinableTaskFactory>(() => NuGetUIThreadHelper.JoinableTaskFactory),
+                credentialPrompt);
+
+            CredentialResponse response = await provider.GetAsync(
+                _uri,
+                proxy: null,
+                type: CredentialRequestType.Forbidden,
+                message: null,
+                isRetry: false,
+                nonInteractive: false,
+                cancellationToken: CancellationToken.None);
+
+            Assert.Equal(CredentialStatus.UserCanceled, response.Status);
+            Assert.Same(_uri, credentialPrompt.PackageSourceUri);
+            Assert.False(credentialPrompt.IsRetry);
+            Assert.Equal(IntPtr.Zero, credentialPrompt.ParentWindow);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT MODIFY OR DELETE THIS TEMPLATE. IT IS USED IN AUTOMATION. -->
<!-- Keep all section headings and checklist items when filling out this PR description. -->

# Bug

<!-- If this is an engineering change or test change only, you do not need an issue. -->
<!-- Find or create an issue in NuGet/Home and paste the full url. -->
<!-- At the maintainers discretion, multiple changes may apply to a single issue, but only when the PRs are all created within a short period of time. -->
Fixes: https://github.com/NuGet/Home/issues/14791


## Description

Neither I, nor copilot, could find a generic "ask for credentials" API in the VS SDK, so P/Invoke Windows' CredUIPromptForCredentialsW API to prompt for credentials, with messages that we control. The [docs on the api](https://learn.microsoft.com/en-us/windows/win32/api/wincred/nf-wincred-creduipromptforcredentialsw) say that it's available from Windows XP and Windows Server 2003, while [Visual Studio 2026's system requirements docs](https://learn.microsoft.com/en-us/visualstudio/releases/2026/vs-system-requirements) lists Windows 11 and Windows Server 2019 as the oldest versions, so the API should always be available. Given the dialog windows look the same, it's probable that VS's "get proxy creds" API uses it as well.

<img width="322" height="274" alt="image" src="https://github.com/user-attachments/assets/ceef523b-e1d4-4d35-ba5e-12e0b129430c" />

<details>
<summary>comparison to existing prompt</summary>

<img width="322" height="289" alt="image" src="https://github.com/user-attachments/assets/06d7c5fd-9fbd-48e8-b616-7e8e9c1f6d6a" />

</details>


## PR Checklist

- [x] Meaningful title, helpful description and a linked NuGet/Home issue
- [x] Added tests
- [x] ~Link to an issue or pull request to update docs if this PR changes settings, environment variables, new feature, etc.~ N/A
